### PR TITLE
Add payroll and POS integration fetch utilities

### DIFF
--- a/src/components/PayrollIntegration.tsx
+++ b/src/components/PayrollIntegration.tsx
@@ -1,70 +1,228 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  ApiError,
+  PayrollEntry,
+  PayrollIntegrationData,
+  PayrollProvider,
+  connectPayrollProvider,
+  fetchPayrollData,
+} from "../utils/payrollApi";
 
-interface PayrollIntegrationProps {
-  payroll: { employee: string; gross: number; withheld: number }[];
-  onAdd: (employee: string, gross: number, withheld: number) => void;
+interface IntegrationState {
+  entries: PayrollEntry[];
+  connectedProviders: PayrollProvider[];
+  availableProviders: PayrollProvider[];
 }
 
-export default function PayrollIntegration({ payroll, onAdd }: PayrollIntegrationProps) {
-  const [employee, setEmployee] = useState("");
-  const [gross, setGross] = useState(0);
-  const [withheld, setWithheld] = useState(0);
+const initialState: IntegrationState = {
+  entries: [],
+  connectedProviders: [],
+  availableProviders: [],
+};
 
-  function handleAdd() {
-    if (employee && gross > 0) {
-      onAdd(employee, gross, withheld);
-      setEmployee("");
-      setGross(0);
-      setWithheld(0);
+export default function PayrollIntegration() {
+  const [state, setState] = useState<IntegrationState>(initialState);
+  const [selectedProvider, setSelectedProvider] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(true);
+  const [syncing, setSyncing] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchPayrollData();
+        if (!isMounted) return;
+        applyData(data);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(normalizeError(err));
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!selectedProvider && state.availableProviders.length > 0) {
+      const next = state.availableProviders.find((provider) => !provider.connected)?.id ?? state.availableProviders[0]?.id ?? "";
+      setSelectedProvider(next);
+    }
+  }, [state.availableProviders, selectedProvider]);
+
+  const statusMessage = useMemo(() => {
+    if (error) {
+      return {
+        label: "Error",
+        tone: "#b00020",
+        description: error,
+      };
+    }
+    if (loading) {
+      return {
+        label: "Loading",
+        tone: "#00695c",
+        description: "Fetching payroll data from connected providers...",
+      };
+    }
+    if (state.entries.length === 0) {
+      return {
+        label: "No data",
+        tone: "#555",
+        description: "Connect a payroll provider to pull employee records automatically.",
+      };
+    }
+    return {
+      label: "Synced",
+      tone: "#2e7d32",
+      description: `Retrieved ${state.entries.length} employee payroll entries${
+        lastUpdated ? ` · Last updated ${lastUpdated}` : ""
+      }`,
+    };
+  }, [error, loading, state.entries.length, lastUpdated]);
+
+  async function handleRefresh() {
+    setError(null);
+    setLoading(true);
+    try {
+      const data = await fetchPayrollData();
+      applyData(data);
+    } catch (err) {
+      setError(normalizeError(err));
+    } finally {
+      setLoading(false);
     }
   }
+
+  async function handleConnect() {
+    if (!selectedProvider) return;
+    setSyncing(true);
+    setError(null);
+    try {
+      const data = await connectPayrollProvider(selectedProvider);
+      applyData(data);
+    } catch (err) {
+      setError(normalizeError(err));
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  function applyData(data: PayrollIntegrationData) {
+    setState({
+      entries: data.entries,
+      connectedProviders: data.connectedProviders,
+      availableProviders: data.availableProviders,
+    });
+    setLastUpdated(new Date().toLocaleTimeString());
+  }
+
+  const availableOptions = state.availableProviders.map((provider) => (
+    <option key={provider.id} value={provider.id}>
+      {provider.name} {provider.connected ? "(Connected)" : ""}
+    </option>
+  ));
 
   return (
     <div className="card">
       <h3>Payroll Integration</h3>
       <p>
-        <b>Add a payroll entry for an employee.</b> <br />
+        <b>Automatically ingest payroll data from connected providers.</b>
+        <br />
         <span style={{ color: "#444", fontSize: "0.97em" }}>
-          This is used for PAYGW calculations. Enter each employee’s details below.
+          Connect services such as Xero, MYOB, or QuickBooks to stream PAYGW data into APGMS.
         </span>
       </p>
-      <label>
-        Employee Name:
-        <input
-          type="text"
-          placeholder="e.g. John Smith"
-          value={employee}
-          onChange={(e) => setEmployee(e.target.value)}
-        />
-      </label>
-      <label>
-        Gross Income (before tax):
-        <input
-          type="number"
-          placeholder="e.g. 1500"
-          value={gross}
-          min={0}
-          onChange={(e) => setGross(Number(e.target.value))}
-        />
-      </label>
-      <label>
-        Tax Withheld (PAYGW):
-        <input
-          type="number"
-          placeholder="e.g. 200"
-          value={withheld}
-          min={0}
-          onChange={(e) => setWithheld(Number(e.target.value))}
-        />
-      </label>
-      <button onClick={handleAdd}>Add Payroll Entry</button>
-      {payroll.length > 0 && (
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem",
+          alignItems: "center",
+          marginBottom: "1rem",
+        }}
+      >
+        <label style={{ display: "flex", flexDirection: "column", fontSize: "0.95em" }}>
+          Provider
+          <select
+            value={selectedProvider}
+            onChange={(event) => setSelectedProvider(event.target.value)}
+            disabled={loading || syncing || state.availableProviders.length === 0}
+            style={{ minWidth: 200, padding: "0.4rem" }}
+          >
+            {availableOptions}
+          </select>
+        </label>
+        <button
+          onClick={handleConnect}
+          className="button"
+          disabled={!selectedProvider || syncing || loading}
+        >
+          {syncing ? "Connecting..." : "Connect Provider"}
+        </button>
+        <button onClick={handleRefresh} className="button" disabled={loading || syncing}>
+          Refresh
+        </button>
+        <span
+          style={{
+            padding: "0.35rem 0.65rem",
+            borderRadius: "999px",
+            backgroundColor: "#e0f2f1",
+            color: statusMessage.tone,
+            fontSize: "0.85em",
+            fontWeight: 600,
+          }}
+        >
+          {statusMessage.label}
+        </span>
+      </div>
+
+      <div style={{ marginBottom: "0.75rem", color: statusMessage.tone, fontSize: "0.9em" }}>
+        {statusMessage.description}
+      </div>
+
+      {state.connectedProviders.length > 0 && (
+        <div style={{ marginBottom: "1rem" }}>
+          <h4>Connected Providers</h4>
+          <ul>
+            {state.connectedProviders.map((provider) => (
+              <li key={provider.id}>
+                <b>{provider.name}</b>
+                {provider.status ? ` · ${provider.status}` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {error && (
+        <div style={{ color: "#b00020", fontSize: "0.9em", marginBottom: "1rem" }}>
+          Unable to retrieve payroll data. {error}
+        </div>
+      )}
+
+      {!loading && state.entries.length > 0 && (
         <>
           <h4>Payroll Entries</h4>
           <ul>
-            {payroll.map((p, i) => (
-              <li key={i}>
-                <b>{p.employee}</b>: Gross ${p.gross} | Withheld ${p.withheld}
+            {state.entries.map((entry, index) => (
+              <li key={`${entry.employee}-${index}`}>
+                <b>{entry.employee}</b>: Gross ${entry.gross.toLocaleString(undefined, { minimumFractionDigits: 2 })} | Withheld ${
+                  entry.withheld.toLocaleString(undefined, { minimumFractionDigits: 2 })
+                }
+                {entry.providerId ? ` · ${entry.providerId}` : ""}
               </li>
             ))}
           </ul>
@@ -72,4 +230,12 @@ export default function PayrollIntegration({ payroll, onAdd }: PayrollIntegratio
       )}
     </div>
   );
+}
+
+function normalizeError(err: unknown): string {
+  if (err instanceof ApiError) {
+    return `${err.message} (status ${err.status})`;
+  }
+  if (err instanceof Error) return err.message;
+  return "An unexpected error occurred.";
 }

--- a/src/components/PosIntegration.tsx
+++ b/src/components/PosIntegration.tsx
@@ -1,73 +1,223 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  ApiError,
+  PosIntegrationData,
+  PosProvider,
+  PosSale,
+  connectPosProvider,
+  fetchPosData,
+} from "../utils/posApi";
 
-interface Sale {
-  id: string;
-  amount: number;
-  exempt: boolean;
+interface IntegrationState {
+  sales: PosSale[];
+  connectedProviders: PosProvider[];
+  availableProviders: PosProvider[];
 }
-interface PosIntegrationProps {
-  sales: Sale[];
-  onAdd: (id: string, amount: number, exempt: boolean) => void;
-}
 
-export default function PosIntegration({ sales, onAdd }: PosIntegrationProps) {
-  const [id, setId] = useState("");
-  const [amount, setAmount] = useState(0);
-  const [exempt, setExempt] = useState(false);
+const initialState: IntegrationState = {
+  sales: [],
+  connectedProviders: [],
+  availableProviders: [],
+};
 
-  function handleAdd() {
-    if (id && amount > 0) {
-      onAdd(id, amount, exempt);
-      setId("");
-      setAmount(0);
-      setExempt(false);
+export default function PosIntegration() {
+  const [state, setState] = useState<IntegrationState>(initialState);
+  const [selectedProvider, setSelectedProvider] = useState<string>("");
+  const [loading, setLoading] = useState<boolean>(true);
+  const [syncing, setSyncing] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await fetchPosData();
+        if (!isMounted) return;
+        applyData(data);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(normalizeError(err));
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    load();
+
+    return () => {
+      isMounted = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (!selectedProvider && state.availableProviders.length > 0) {
+      const next = state.availableProviders.find((provider) => !provider.connected)?.id ?? state.availableProviders[0]?.id ?? "";
+      setSelectedProvider(next);
+    }
+  }, [state.availableProviders, selectedProvider]);
+
+  const statusMessage = useMemo(() => {
+    if (error) {
+      return {
+        label: "Error",
+        tone: "#b00020",
+        description: error,
+      };
+    }
+    if (loading) {
+      return {
+        label: "Loading",
+        tone: "#00695c",
+        description: "Retrieving transactions from POS integrations...",
+      };
+    }
+    if (state.sales.length === 0) {
+      return {
+        label: "No data",
+        tone: "#555",
+        description: "Connect your POS to ingest GST-relevant sales automatically.",
+      };
+    }
+    return {
+      label: "Synced",
+      tone: "#2e7d32",
+      description: `Retrieved ${state.sales.length} sales records${lastUpdated ? ` · Last updated ${lastUpdated}` : ""}`,
+    };
+  }, [error, lastUpdated, loading, state.sales.length]);
+
+  async function handleRefresh() {
+    setError(null);
+    setLoading(true);
+    try {
+      const data = await fetchPosData();
+      applyData(data);
+    } catch (err) {
+      setError(normalizeError(err));
+    } finally {
+      setLoading(false);
     }
   }
+
+  async function handleConnect() {
+    if (!selectedProvider) return;
+    setSyncing(true);
+    setError(null);
+    try {
+      const data = await connectPosProvider(selectedProvider);
+      applyData(data);
+    } catch (err) {
+      setError(normalizeError(err));
+    } finally {
+      setSyncing(false);
+    }
+  }
+
+  function applyData(data: PosIntegrationData) {
+    setState({
+      sales: data.sales,
+      connectedProviders: data.connectedProviders,
+      availableProviders: data.availableProviders,
+    });
+    setLastUpdated(new Date().toLocaleTimeString());
+  }
+
+  const providerOptions = state.availableProviders.map((provider) => (
+    <option key={provider.id} value={provider.id}>
+      {provider.name} {provider.connected ? "(Connected)" : ""}
+    </option>
+  ));
 
   return (
     <div className="card">
       <h3>Point-of-Sale (POS) Integration</h3>
       <p>
-        <b>Add a sale transaction.</b> <br />
+        <b>Stream POS sales data for GST calculations.</b>
+        <br />
         <span style={{ color: "#444", fontSize: "0.97em" }}>
-          This is used for GST calculation. Use “GST Exempt” for transactions that are not subject to GST.
+          Connect commerce providers like Square, Vend, or Shopify to keep GST reporting accurate.
         </span>
       </p>
-      <label>
-        Sale ID or Reference:
-        <input
-          type="text"
-          placeholder="e.g. INV-12345"
-          value={id}
-          onChange={(e) => setId(e.target.value)}
-        />
-      </label>
-      <label>
-        Sale Amount (including GST):
-        <input
-          type="number"
-          placeholder="e.g. 440"
-          value={amount}
-          min={0}
-          onChange={(e) => setAmount(Number(e.target.value))}
-        />
-      </label>
-      <label style={{ display: "inline-flex", alignItems: "center", gap: "0.5em" }}>
-        <input
-          type="checkbox"
-          checked={exempt}
-          onChange={(e) => setExempt(e.target.checked)}
-        />
-        GST Exempt
-      </label>
-      <button onClick={handleAdd}>Add Sale</button>
-      {sales.length > 0 && (
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: "0.75rem",
+          alignItems: "center",
+          marginBottom: "1rem",
+        }}
+      >
+        <label style={{ display: "flex", flexDirection: "column", fontSize: "0.95em" }}>
+          Provider
+          <select
+            value={selectedProvider}
+            onChange={(event) => setSelectedProvider(event.target.value)}
+            disabled={loading || syncing || state.availableProviders.length === 0}
+            style={{ minWidth: 200, padding: "0.4rem" }}
+          >
+            {providerOptions}
+          </select>
+        </label>
+        <button className="button" onClick={handleConnect} disabled={!selectedProvider || syncing || loading}>
+          {syncing ? "Connecting..." : "Connect Provider"}
+        </button>
+        <button className="button" onClick={handleRefresh} disabled={loading || syncing}>
+          Refresh
+        </button>
+        <span
+          style={{
+            padding: "0.35rem 0.65rem",
+            borderRadius: "999px",
+            backgroundColor: "#e0f2f1",
+            color: statusMessage.tone,
+            fontSize: "0.85em",
+            fontWeight: 600,
+          }}
+        >
+          {statusMessage.label}
+        </span>
+      </div>
+
+      <div style={{ marginBottom: "0.75rem", color: statusMessage.tone, fontSize: "0.9em" }}>
+        {statusMessage.description}
+      </div>
+
+      {state.connectedProviders.length > 0 && (
+        <div style={{ marginBottom: "1rem" }}>
+          <h4>Connected Providers</h4>
+          <ul>
+            {state.connectedProviders.map((provider) => (
+              <li key={provider.id}>
+                <b>{provider.name}</b>
+                {provider.status ? ` · ${provider.status}` : ""}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {error && (
+        <div style={{ color: "#b00020", fontSize: "0.9em", marginBottom: "1rem" }}>
+          Unable to retrieve POS transactions. {error}
+        </div>
+      )}
+
+      {!loading && state.sales.length > 0 && (
         <>
           <h4>Sales Transactions</h4>
           <ul>
-            {sales.map((s, i) => (
-              <li key={i}>
-                <b>{s.id}</b>: ${s.amount} {s.exempt ? "(GST Exempt)" : ""}
+            {state.sales.map((sale, index) => (
+              <li key={`${sale.id}-${index}`}>
+                <b>{sale.id}</b>: ${sale.amount.toLocaleString(undefined, { minimumFractionDigits: 2 })}{" "}
+                {sale.exempt ? "(GST Exempt)" : ""}
+                {sale.providerId ? ` · ${sale.providerId}` : ""}
               </li>
             ))}
           </ul>
@@ -75,4 +225,12 @@ export default function PosIntegration({ sales, onAdd }: PosIntegrationProps) {
       )}
     </div>
   );
+}
+
+function normalizeError(err: unknown): string {
+  if (err instanceof ApiError) {
+    return `${err.message} (status ${err.status})`;
+  }
+  if (err instanceof Error) return err.message;
+  return "An unexpected error occurred.";
 }

--- a/src/utils/payrollApi.ts
+++ b/src/utils/payrollApi.ts
@@ -1,3 +1,278 @@
-// Placeholder for payroll API integration logic
+export interface PayrollEntry {
+  employee: string;
+  gross: number;
+  withheld: number;
+  providerId?: string;
+}
 
-export {};
+export interface PayrollProvider {
+  id: string;
+  name: string;
+  status?: string;
+  connected: boolean;
+}
+
+export interface PayrollIntegrationData {
+  entries: PayrollEntry[];
+  connectedProviders: PayrollProvider[];
+  availableProviders: PayrollProvider[];
+}
+
+class ApiError extends Error {
+  status: number;
+  data: unknown;
+
+  constructor(message: string, status: number, data: unknown) {
+    super(message);
+    this.status = status;
+    this.data = data;
+  }
+}
+
+const DEFAULT_PROVIDERS: PayrollProvider[] = [
+  { id: "xero", name: "Xero", connected: false },
+  { id: "myob", name: "MYOB", connected: false },
+  { id: "quickbooks", name: "QuickBooks", connected: false },
+  { id: "payroll-relay", name: "Payroll Relay", connected: false },
+];
+
+const API_BASE = (process.env.REACT_APP_BACKEND_URL || "").replace(/\/$/, "");
+
+function buildUrl(path: string) {
+  if (path.startsWith("http")) return path;
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${API_BASE}${normalized}` || normalized;
+}
+
+function mergeHeaders(headers?: HeadersInit): HeadersInit {
+  if (typeof Headers !== "undefined") {
+    const merged = new Headers({ Accept: "application/json" });
+    if (headers) {
+      const incoming = headers instanceof Headers ? headers : new Headers(headers);
+      incoming.forEach((value, key) => merged.set(key, value));
+    }
+    return merged;
+  }
+
+  const base: Record<string, string> = { Accept: "application/json" };
+  if (!headers) return base;
+  if (Array.isArray(headers)) {
+    headers.forEach(([key, value]) => {
+      base[key] = value;
+    });
+    return base;
+  }
+  return { ...base, ...(headers as Record<string, string>) };
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const { headers, ...rest } = init || {};
+  const mergedHeaders = mergeHeaders(headers);
+
+  const res = await fetch(buildUrl(path), {
+    ...rest,
+    headers: mergedHeaders,
+  });
+
+  const text = await res.text();
+  let payload: unknown = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch (err) {
+      payload = text;
+    }
+  }
+
+  if (!res.ok) {
+    const message =
+      (typeof payload === "object" && payload && "message" in payload && typeof (payload as any).message === "string"
+        ? (payload as any).message
+        : undefined) ||
+      (typeof payload === "object" && payload && "error" in payload && typeof (payload as any).error === "string"
+        ? (payload as any).error
+        : undefined) ||
+      `Request failed with status ${res.status}`;
+    throw new ApiError(message, res.status, payload);
+  }
+
+  return payload as T;
+}
+
+function parseAmount(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return undefined;
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const normalized = Number(value.replace(/[,\s]/g, ""));
+    return Number.isFinite(normalized) ? normalized : undefined;
+  }
+  return undefined;
+}
+
+function normalizeProvider(raw: any): PayrollProvider {
+  const rawName =
+    raw?.name ??
+    raw?.display_name ??
+    raw?.label ??
+    raw?.provider ??
+    (typeof raw === "string" ? raw : undefined) ??
+    raw?.id ??
+    "Unknown Provider";
+
+  const rawId =
+    raw?.id ??
+    raw?.provider_id ??
+    raw?.slug ??
+    (typeof rawName === "string"
+      ? rawName
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/gi, "-")
+          .replace(/^-+|-+$/g, "")
+      : undefined) ??
+    (typeof raw === "string" ? raw.toLowerCase() : "unknown");
+
+  const status = raw?.status ?? raw?.connection_status ?? (raw?.connected ? "connected" : undefined);
+  const connected = Boolean(
+    raw?.connected ||
+      status === "connected" ||
+      status === "active" ||
+      raw?.state === "connected" ||
+      raw?.state === "active"
+  );
+
+  return {
+    id: rawId,
+    name: typeof rawName === "string" ? rawName : String(rawName ?? rawId ?? "Unknown Provider"),
+    status,
+    connected,
+  };
+}
+
+function normalizeEntry(raw: any, providerId?: string): PayrollEntry | null {
+  if (!raw) return null;
+  const employeeValue =
+    raw.employee ??
+    raw.employeeName ??
+    raw.employee_name ??
+    raw.employee_id ??
+    raw.worker ??
+    raw.name ??
+    raw.id;
+
+  if (!employeeValue) return null;
+
+  const grossValue =
+    parseAmount(raw.gross) ??
+    parseAmount(raw.grossIncome) ??
+    parseAmount(raw.gross_amount) ??
+    parseAmount(raw.amount) ??
+    (typeof raw.gross_cents === "number" ? raw.gross_cents / 100 : undefined) ??
+    (typeof raw.grossCents === "number" ? raw.grossCents / 100 : undefined);
+
+  const withheldValue =
+    parseAmount(raw.withheld) ??
+    parseAmount(raw.taxWithheld) ??
+    parseAmount(raw.withholding) ??
+    (typeof raw.withholding_cents === "number" ? raw.withholding_cents / 100 : undefined) ??
+    (typeof raw.withheld_cents === "number" ? raw.withheld_cents / 100 : undefined) ??
+    (typeof raw.tax_withheld_cents === "number" ? raw.tax_withheld_cents / 100 : undefined);
+
+  return {
+    employee: String(employeeValue),
+    gross: grossValue ?? 0,
+    withheld: withheldValue ?? 0,
+    providerId: providerId ?? raw.providerId ?? raw.provider_id ?? raw.provider ?? undefined,
+  };
+}
+
+function ensureProviders(uniqueProviders: PayrollProvider[]): PayrollProvider[] {
+  const map = new Map<string, PayrollProvider>();
+  [...DEFAULT_PROVIDERS, ...uniqueProviders].forEach((p) => {
+    const existing = map.get(p.id);
+    if (!existing) {
+      map.set(p.id, { ...p });
+    } else {
+      map.set(p.id, {
+        ...existing,
+        ...p,
+        connected: existing.connected || p.connected,
+        status: p.status ?? existing.status,
+      });
+    }
+  });
+  return Array.from(map.values());
+}
+
+function normalizePayrollResponse(raw: any): PayrollIntegrationData {
+  const providersRaw: any[] = Array.isArray(raw?.providers)
+    ? raw.providers
+    : Array.isArray(raw?.connections)
+    ? raw.connections
+    : [];
+
+  const entriesFromProviders: PayrollEntry[] = providersRaw
+    .flatMap((providerRaw: any) => {
+      const entries =
+        providerRaw?.entries ??
+        providerRaw?.payroll ??
+        providerRaw?.items ??
+        providerRaw?.data ??
+        [];
+      if (!Array.isArray(entries)) return [];
+      const provider = normalizeProvider(providerRaw);
+      return entries
+        .map((entry: any) => normalizeEntry(entry, provider.id))
+        .filter((entry: PayrollEntry | null): entry is PayrollEntry => Boolean(entry));
+    })
+    .filter(Boolean);
+
+  const standaloneEntriesSource = raw?.entries ?? raw?.payroll ?? raw?.items ?? [];
+  const standaloneEntries: PayrollEntry[] = Array.isArray(standaloneEntriesSource)
+    ? standaloneEntriesSource
+        .map((entry: any) => normalizeEntry(entry))
+        .filter((entry: PayrollEntry | null): entry is PayrollEntry => Boolean(entry))
+    : [];
+
+  const combinedEntries = [...entriesFromProviders, ...standaloneEntries];
+
+  const normalizedProviders = providersRaw.map((p) => normalizeProvider(p));
+
+  const connectedProviders = normalizedProviders.filter((provider) => provider.connected);
+
+  const availableProviders = ensureProviders(normalizedProviders);
+
+  return {
+    entries: combinedEntries,
+    connectedProviders,
+    availableProviders,
+  };
+}
+
+export async function fetchPayrollData(): Promise<PayrollIntegrationData> {
+  const response = await request<any>("/api/integrations/payroll");
+  return normalizePayrollResponse(response);
+}
+
+export async function connectPayrollProvider(providerId: string): Promise<PayrollIntegrationData> {
+  const body = JSON.stringify({ providerId });
+  try {
+    const response = await request<any>("/api/integrations/payroll", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    const normalized = normalizePayrollResponse(response);
+    if (normalized.entries.length || normalized.connectedProviders.length) {
+      return normalized;
+    }
+  } catch (error) {
+    throw error;
+  }
+  // Fallback to re-fetch current state if POST response did not contain useful payload
+  return fetchPayrollData();
+}
+
+export { ApiError };

--- a/src/utils/posApi.ts
+++ b/src/utils/posApi.ts
@@ -1,6 +1,262 @@
-// Placeholder for POS API integration logic
+export interface PosSale {
+  id: string;
+  amount: number;
+  exempt: boolean;
+  providerId?: string;
+}
 
-export {};
-// Placeholder for POS API integration logic
+export interface PosProvider {
+  id: string;
+  name: string;
+  status?: string;
+  connected: boolean;
+}
 
-export {};
+export interface PosIntegrationData {
+  sales: PosSale[];
+  connectedProviders: PosProvider[];
+  availableProviders: PosProvider[];
+}
+
+class ApiError extends Error {
+  status: number;
+  data: unknown;
+
+  constructor(message: string, status: number, data: unknown) {
+    super(message);
+    this.status = status;
+    this.data = data;
+  }
+}
+
+const DEFAULT_POS_PROVIDERS: PosProvider[] = [
+  { id: "square", name: "Square", connected: false },
+  { id: "vend", name: "Vend", connected: false },
+  { id: "shopify", name: "Shopify", connected: false },
+  { id: "lightspeed", name: "Lightspeed", connected: false },
+];
+
+const API_BASE = (process.env.REACT_APP_BACKEND_URL || "").replace(/\/$/, "");
+
+function buildUrl(path: string) {
+  if (path.startsWith("http")) return path;
+  const normalized = path.startsWith("/") ? path : `/${path}`;
+  return `${API_BASE}${normalized}` || normalized;
+}
+
+function mergeHeaders(headers?: HeadersInit): HeadersInit {
+  if (typeof Headers !== "undefined") {
+    const merged = new Headers({ Accept: "application/json" });
+    if (headers) {
+      const incoming = headers instanceof Headers ? headers : new Headers(headers);
+      incoming.forEach((value, key) => merged.set(key, value));
+    }
+    return merged;
+  }
+
+  const base: Record<string, string> = { Accept: "application/json" };
+  if (!headers) return base;
+  if (Array.isArray(headers)) {
+    headers.forEach(([key, value]) => {
+      base[key] = value;
+    });
+    return base;
+  }
+  return { ...base, ...(headers as Record<string, string>) };
+}
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const { headers, ...rest } = init || {};
+  const mergedHeaders = mergeHeaders(headers);
+
+  const res = await fetch(buildUrl(path), {
+    ...rest,
+    headers: mergedHeaders,
+  });
+
+  const text = await res.text();
+  let payload: unknown = null;
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch (error) {
+      payload = text;
+    }
+  }
+
+  if (!res.ok) {
+    const message =
+      (typeof payload === "object" && payload && "message" in payload && typeof (payload as any).message === "string"
+        ? (payload as any).message
+        : undefined) ||
+      (typeof payload === "object" && payload && "error" in payload && typeof (payload as any).error === "string"
+        ? (payload as any).error
+        : undefined) ||
+      `Request failed with status ${res.status}`;
+    throw new ApiError(message, res.status, payload);
+  }
+
+  return payload as T;
+}
+
+function parseAmount(value: unknown): number | undefined {
+  if (value == null) return undefined;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return undefined;
+    return value;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const normalized = Number(value.replace(/[,\s]/g, ""));
+    return Number.isFinite(normalized) ? normalized : undefined;
+  }
+  return undefined;
+}
+
+function normalizeProvider(raw: any): PosProvider {
+  const rawName =
+    raw?.name ??
+    raw?.display_name ??
+    raw?.label ??
+    raw?.provider ??
+    (typeof raw === "string" ? raw : undefined) ??
+    raw?.id ??
+    "Unknown Provider";
+
+  const rawId =
+    raw?.id ??
+    raw?.provider_id ??
+    raw?.slug ??
+    (typeof rawName === "string"
+      ? rawName
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/gi, "-")
+          .replace(/^-+|-+$/g, "")
+      : undefined) ??
+    (typeof raw === "string" ? raw.toLowerCase() : "unknown");
+
+  const status = raw?.status ?? raw?.connection_status ?? (raw?.connected ? "connected" : undefined);
+  const connected = Boolean(
+    raw?.connected ||
+      status === "connected" ||
+      status === "active" ||
+      raw?.state === "connected" ||
+      raw?.state === "active"
+  );
+
+  return {
+    id: rawId,
+    name: typeof rawName === "string" ? rawName : String(rawName ?? rawId ?? "Unknown Provider"),
+    status,
+    connected,
+  };
+}
+
+function normalizeSale(raw: any, providerId?: string): PosSale | null {
+  if (!raw) return null;
+  const identifier = raw.id ?? raw.saleId ?? raw.reference ?? raw.transaction_id ?? raw.invoice ?? raw.receipt;
+  if (!identifier) return null;
+
+  const amountValue =
+    parseAmount(raw.amount) ??
+    parseAmount(raw.total) ??
+    parseAmount(raw.gross) ??
+    (typeof raw.amount_cents === "number" ? raw.amount_cents / 100 : undefined) ??
+    (typeof raw.total_cents === "number" ? raw.total_cents / 100 : undefined);
+
+  const exemptValue = Boolean(
+    raw.exempt ??
+      raw.gstExempt ??
+      raw.tax_exempt ??
+      raw.zero_rated ??
+      (Array.isArray(raw.taxes) ? raw.taxes.every((tax: any) => !tax || tax.rate === 0) : undefined)
+  );
+
+  return {
+    id: String(identifier),
+    amount: amountValue ?? 0,
+    exempt: exemptValue,
+    providerId: providerId ?? raw.providerId ?? raw.provider_id ?? raw.source ?? undefined,
+  };
+}
+
+function ensureProviders(uniqueProviders: PosProvider[]): PosProvider[] {
+  const map = new Map<string, PosProvider>();
+  [...DEFAULT_POS_PROVIDERS, ...uniqueProviders].forEach((provider) => {
+    const existing = map.get(provider.id);
+    if (!existing) {
+      map.set(provider.id, { ...provider });
+    } else {
+      map.set(provider.id, {
+        ...existing,
+        ...provider,
+        connected: existing.connected || provider.connected,
+        status: provider.status ?? existing.status,
+      });
+    }
+  });
+  return Array.from(map.values());
+}
+
+function normalizePosResponse(raw: any): PosIntegrationData {
+  const providersRaw: any[] = Array.isArray(raw?.providers)
+    ? raw.providers
+    : Array.isArray(raw?.connections)
+    ? raw.connections
+    : [];
+
+  const normalizedProviders = providersRaw.map((provider) => normalizeProvider(provider));
+
+  const salesFromProviders: PosSale[] = providersRaw
+    .flatMap((providerRaw: any) => {
+      const sales = providerRaw?.sales ?? providerRaw?.transactions ?? providerRaw?.items ?? providerRaw?.data ?? [];
+      if (!Array.isArray(sales)) return [];
+      const provider = normalizeProvider(providerRaw);
+      return sales
+        .map((sale: any) => normalizeSale(sale, provider.id))
+        .filter((sale: PosSale | null): sale is PosSale => Boolean(sale));
+    })
+    .filter(Boolean);
+
+  const standaloneSalesSource = raw?.sales ?? raw?.transactions ?? raw?.items ?? [];
+  const standaloneSales: PosSale[] = Array.isArray(standaloneSalesSource)
+    ? standaloneSalesSource
+        .map((sale: any) => normalizeSale(sale))
+        .filter((sale: PosSale | null): sale is PosSale => Boolean(sale))
+    : [];
+
+  const combinedSales = [...salesFromProviders, ...standaloneSales];
+
+  const connectedProviders = normalizedProviders.filter((provider) => provider.connected);
+  const availableProviders = ensureProviders(normalizedProviders);
+
+  return {
+    sales: combinedSales,
+    connectedProviders,
+    availableProviders,
+  };
+}
+
+export async function fetchPosData(): Promise<PosIntegrationData> {
+  const response = await request<any>("/api/integrations/pos");
+  return normalizePosResponse(response);
+}
+
+export async function connectPosProvider(providerId: string): Promise<PosIntegrationData> {
+  const body = JSON.stringify({ providerId });
+  try {
+    const response = await request<any>("/api/integrations/pos", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body,
+    });
+    const normalized = normalizePosResponse(response);
+    if (normalized.sales.length || normalized.connectedProviders.length) {
+      return normalized;
+    }
+  } catch (error) {
+    throw error;
+  }
+  return fetchPosData();
+}
+
+export { ApiError };


### PR DESCRIPTION
## Summary
- add payroll integration utility with backend fetch helpers and normalization logic
- implement POS integration client utilities mirroring payroll handling
- refactor payroll and POS integration components to load data via the new APIs and surface status/error states

## Testing
- `npx tsc --noEmit` *(fails: existing syntax errors in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2029eba7883278c7e642f97c5c86d