### PR TITLE
Fix server SQL parameterization and add RPT flow tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "node --test"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/server.js
+++ b/server.js
@@ -5,211 +5,290 @@ const { Pool } = require('pg');
 const nacl = require('tweetnacl');
 const crypto = require('crypto');
 
-const app = express();
-app.use(bodyParser.json());
+const textEncoder = new TextEncoder();
 
 const {
-  PGHOST='127.0.0.1', PGUSER='apgms', PGPASSWORD='apgms_pw', PGDATABASE='apgms', PGPORT='5432',
-  RPT_ED25519_SECRET_BASE64, RPT_PUBLIC_BASE64, ATO_PRN='1234567890'
+  PGHOST = '127.0.0.1',
+  PGUSER = 'apgms',
+  PGPASSWORD = 'apgms_pw',
+  PGDATABASE = 'apgms',
+  PGPORT = '5432'
 } = process.env;
 
-const pool = new Pool({
-  host: PGHOST, user: PGUSER, password: PGPASSWORD, database: PGDATABASE, port: +PGPORT
+const defaultPool = () => new Pool({
+  host: PGHOST,
+  user: PGUSER,
+  password: PGPASSWORD,
+  database: PGDATABASE,
+  port: Number(PGPORT)
 });
 
-// small async handler wrapper
-const ah = fn => (req,res)=>fn(req,res).catch(e=>{
-  console.error(e);
-  if (e.code === '08P01') return res.status(500).json({error:'INTERNAL', message:e.message});
-  res.status(400).json({error: e.message || 'BAD_REQUEST'});
-});
-
-// ---------- HEALTH ----------
-app.get('/health', ah(async (req,res)=>{
-  await pool.query('select now()');
-  res.json(['ok','db', true, 'up']);
-}));
-
-// ---------- PERIOD STATUS ----------
-app.get('/period/status', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.query;
-  const r = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (r.rowCount===0) return res.status(404).json({error:'NOT_FOUND'});
-  res.json({ period: r.rows[0] });
-}));
-
-// ---------- RPT ISSUE ----------
-app.post('/rpt/issue', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.body;
-  const pr = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (pr.rowCount===0) throw new Error('PERIOD_NOT_FOUND');
-  const p = pr.rows[0];
-
-  if (p.state !== 'CLOSING') return res.status(409).json({error:'BAD_STATE', state:p.state});
-
-  // simple anomaly thresholds (demo)
-  const thresholds = { epsilon_cents: 0, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
-  const v = p.anomaly_vector || {};
-  const exceeds =
-    (v.variance_ratio || 0) > thresholds.variance_ratio ||
-    (v.dup_rate || 0) > thresholds.dup_rate ||
-    (v.gap_minutes || 0) > thresholds.gap_minutes ||
-    Math.abs((v.delta_vs_baseline || 0)) > thresholds.delta_vs_baseline;
-
-  if (exceeds) {
-    await pool.query(update periods set state='BLOCKED_ANOMALY' where id=, [p.id]);
-    return res.status(409).json({error:'BLOCKED_ANOMALY'});
+const wrapHandler = (pool, env) => fn => async (req, res) => {
+  try {
+    await fn(req, res, pool, env);
+  } catch (e) {
+    console.error(e);
+    if (e && e.code === '08P01') {
+      return res.status(500).json({ error: 'INTERNAL', message: e.message });
+    }
+    res.status(400).json({ error: e.message || 'BAD_REQUEST' });
   }
+};
 
-  const epsilon = Math.abs(Number(p.final_liability_cents) - Number(p.credited_to_owa_cents));
-  if (epsilon > thresholds.epsilon_cents) {
-    await pool.query(update periods set state='BLOCKED_DISCREPANCY' where id=, [p.id]);
-    return res.status(409).json({error:'BLOCKED_DISCREPANCY', epsilon});
-  }
+function buildApp(pool = defaultPool(), env = process.env) {
+  const {
+    RPT_ED25519_SECRET_BASE64,
+    ATO_PRN = '1234567890'
+  } = env;
 
-  // patent-critical: canonical payload string + sha256 saved alongside signature
-  const payload = {
-    entity_id: p.abn,
-    period_id: p.period_id,
-    tax_type: p.tax_type,
-    amount_cents: Number(p.final_liability_cents),
-    merkle_root: p.merkle_root || null,
-    running_balance_hash: p.running_balance_hash || null,
-    anomaly_vector: v,
-    thresholds,
-    rail_id: "EFT",
-    reference: ATO_PRN,
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(),
-    nonce: crypto.randomUUID()
-  };
+  const app = express();
+  app.use(bodyParser.json());
 
-  const payloadStr = JSON.stringify(payload);
-  const payloadSha256 = crypto.createHash('sha256').update(payloadStr).digest('hex');
-  const msg = new TextEncoder().encode(payloadStr);
+  const ah = wrapHandler(pool, env);
 
-  if (!RPT_ED25519_SECRET_BASE64) throw new Error('NO_SK');
-  const skBuf = Buffer.from(RPT_ED25519_SECRET_BASE64, 'base64');
-  const sig = nacl.sign.detached(msg, new Uint8Array(skBuf));
-  const signature = Buffer.from(sig).toString('base64');
+  // ---------- HEALTH ----------
+  app.get('/health', ah(async (req, res, db) => {
+    await db.query('SELECT now()');
+    res.json(['ok', 'db', true, 'up']);
+  }));
 
-  // 7 params insert (payload_c14n + payload_sha256)
-  await pool.query(
-    insert into rpt_tokens(abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256)
-     values (,,,,,,),
-    [abn, taxType, periodId, payload, signature, payloadStr, payloadSha256]
-  );
-
-  await pool.query(update periods set state='READY_RPT' where id=, [p.id]);
-  res.json({ payload, signature, payload_sha256: payloadSha256 });
-}));
-
-// ---------- RELEASE (debit from OWA; uses owa_append OUT cols) ----------
-app.post('/release', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.body;
-
-  const pr = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (pr.rowCount===0) throw new Error('PERIOD_NOT_FOUND');
-  const p = pr.rows[0];
-
-  // need latest token
-  const rr = await pool.query(
-    select payload, signature from rpt_tokens
-     where abn= and tax_type= and period_id=
-     order by id desc limit 1,
-    [abn, taxType, periodId]
-  );
-  if (rr.rowCount===0) return res.status(400).json({error:'NO_RPT'});
-
-  // ensure funds exist
-  const lr = await pool.query(
-    select balance_after_cents from owa_ledger
-       where abn= and tax_type= and period_id=
-       order by id desc limit 1,
-    [abn, taxType, periodId]
-  );
-  const prevBal = lr.rows[0]?.balance_after_cents ?? 0;
-  const amt = Number(p.final_liability_cents);
-  if (prevBal < amt) return res.status(422).json({error:'INSUFFICIENT_OWA', prevBal: String(prevBal), needed: amt});
-
-  // do the debit
-  const synthetic = 'rpt_debit:' + crypto.randomUUID().slice(0,12);
-  const r = await pool.query(select * from owa_append(,,,,),
-    [abn, taxType, periodId, -amt, synthetic]);
-
-  let newBalance = null;
-  if (r.rowCount && r.rows[0] && r.rows[0].out_balance_after != null) {
-    newBalance = r.rows[0].out_balance_after;
-  } else {
-    // fallback: read back most recent balance if no row returned
-    const fr = await pool.query(
-      select balance_after_cents as bal from owa_ledger
-       where abn= and tax_type= and period_id=
-       order by id desc limit 1,
+  const findPeriod = async (db, abn, taxType, periodId) => {
+    const result = await db.query(
+      'SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3',
       [abn, taxType, periodId]
     );
-    newBalance = fr.rows[0]?.bal ?? (prevBal - amt);
-  }
+    return result.rows[0] || null;
+  };
 
-  await pool.query(update periods set state='RELEASED' where id=, [p.id]);
-  res.json({ released: true, bank_receipt_hash: synthetic, new_balance: newBalance });
-}));
+  const updatePeriodState = async (db, periodId, state) => {
+    const result = await db.query(
+      'UPDATE periods SET state=$1 WHERE id=$2 RETURNING *',
+      [state, periodId]
+    );
+    if (result.rowCount === 0) {
+      throw new Error('PERIOD_UPDATE_FAILED');
+    }
+    return result.rows[0];
+  };
 
-// ---------- EVIDENCE ----------
-app.get('/evidence', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.query;
-  const pr = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (pr.rowCount===0) return res.status(404).json({error:'NOT_FOUND'});
-  const p = pr.rows[0];
+  // ---------- PERIOD STATUS ----------
+  app.get('/period/status', ah(async (req, res, db) => {
+    const { abn, taxType, periodId } = req.query;
+    const period = await findPeriod(db, abn, taxType, periodId);
+    if (!period) {
+      return res.status(404).json({ error: 'NOT_FOUND' });
+    }
+    res.json({ period });
+  }));
 
-  const rr = await pool.query(
-    select payload, payload_c14n, payload_sha256, signature, created_at
-       from rpt_tokens
-      where abn= and tax_type= and period_id=
-      order by id desc limit 1,
-    [abn, taxType, periodId]
-  );
-  const rpt = rr.rows[0] || null;
+  // ---------- RPT ISSUE ----------
+  app.post('/rpt/issue', ah(async (req, res, db) => {
+    const { abn, taxType, periodId } = req.body;
+    const period = await findPeriod(db, abn, taxType, periodId);
+    if (!period) {
+      throw new Error('PERIOD_NOT_FOUND');
+    }
 
-  const lr = await pool.query(
-    select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at
-       from owa_ledger
-      where abn= and tax_type= and period_id=
-      order by id,
-    [abn, taxType, periodId]
-  );
+    if (period.state !== 'CLOSING') {
+      return res.status(409).json({ error: 'BAD_STATE', state: period.state });
+    }
 
-  const basLabels = { W1:null, W2:null, "1A":null, "1B":null };
+    const thresholds = {
+      epsilon_cents: 0,
+      variance_ratio: 0.25,
+      dup_rate: 0.01,
+      gap_minutes: 60,
+      delta_vs_baseline: 0.2
+    };
 
-  res.json({
-    meta: { generated_at: new Date().toISOString(), abn, taxType, periodId },
-    period: {
-      state: p.state,
-      accrued_cents: Number(p.accrued_cents||0),
-      credited_to_owa_cents: Number(p.credited_to_owa_cents||0),
-      final_liability_cents: Number(p.final_liability_cents||0),
-      merkle_root: p.merkle_root,
-      running_balance_hash: p.running_balance_hash,
-      anomaly_vector: p.anomaly_vector,
-      thresholds: p.thresholds
-    },
-    rpt,
-    owa_ledger: lr.rows,
-    bas_labels: basLabels,
-    discrepancy_log: []
+    const v = period.anomaly_vector || {};
+    const exceeds =
+      (v.variance_ratio || 0) > thresholds.variance_ratio ||
+      (v.dup_rate || 0) > thresholds.dup_rate ||
+      (v.gap_minutes || 0) > thresholds.gap_minutes ||
+      Math.abs(v.delta_vs_baseline || 0) > thresholds.delta_vs_baseline;
+
+    if (exceeds) {
+      await updatePeriodState(db, period.id, 'BLOCKED_ANOMALY');
+      return res.status(409).json({ error: 'BLOCKED_ANOMALY' });
+    }
+
+    const epsilon = Math.abs(Number(period.final_liability_cents) - Number(period.credited_to_owa_cents));
+    if (epsilon > thresholds.epsilon_cents) {
+      await updatePeriodState(db, period.id, 'BLOCKED_DISCREPANCY');
+      return res.status(409).json({ error: 'BLOCKED_DISCREPANCY', epsilon });
+    }
+
+    if (!RPT_ED25519_SECRET_BASE64) {
+      throw new Error('NO_SK');
+    }
+
+    const payload = {
+      entity_id: period.abn,
+      period_id: period.period_id,
+      tax_type: period.tax_type,
+      amount_cents: Number(period.final_liability_cents),
+      merkle_root: period.merkle_root || null,
+      running_balance_hash: period.running_balance_hash || null,
+      anomaly_vector: v,
+      thresholds,
+      rail_id: 'EFT',
+      reference: ATO_PRN,
+      expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      nonce: crypto.randomUUID()
+    };
+
+    const payloadStr = JSON.stringify(payload);
+    const payloadSha256 = crypto.createHash('sha256').update(payloadStr).digest('hex');
+    const msg = textEncoder.encode(payloadStr);
+
+    const skBuf = Buffer.from(RPT_ED25519_SECRET_BASE64, 'base64');
+    const sig = nacl.sign.detached(msg, new Uint8Array(skBuf));
+    const signature = Buffer.from(sig).toString('base64');
+
+    const insertToken = await db.query(
+      `INSERT INTO rpt_tokens (abn, tax_type, period_id, payload, signature, payload_c14n, payload_sha256)
+       VALUES ($1, $2, $3, $4::jsonb, $5, $6, $7)
+       RETURNING id, abn, tax_type, period_id, payload, signature, payload_c14n, payload_sha256, created_at`,
+      [abn, taxType, periodId, payloadStr, signature, payloadStr, payloadSha256]
+    );
+
+    if (insertToken.rowCount === 0) {
+      throw new Error('RPT_INSERT_FAILED');
+    }
+
+    await updatePeriodState(db, period.id, 'READY_RPT');
+
+    res.json({
+      payload,
+      signature,
+      payload_sha256: payloadSha256,
+      token: insertToken.rows[0]
+    });
+  }));
+
+  // ---------- RELEASE (debit from OWA; uses owa_append OUT cols) ----------
+  app.post('/release', ah(async (req, res, db) => {
+    const { abn, taxType, periodId } = req.body;
+
+    const period = await findPeriod(db, abn, taxType, periodId);
+    if (!period) {
+      throw new Error('PERIOD_NOT_FOUND');
+    }
+
+    const rptResult = await db.query(
+      `SELECT payload, signature FROM rpt_tokens
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+       ORDER BY id DESC LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    if (rptResult.rowCount === 0) {
+      return res.status(400).json({ error: 'NO_RPT' });
+    }
+
+    const ledgerResult = await db.query(
+      `SELECT balance_after_cents FROM owa_ledger
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+       ORDER BY id DESC LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+
+    const prevBal = ledgerResult.rows[0]?.balance_after_cents ?? 0;
+    const amt = Number(period.final_liability_cents);
+    if (prevBal < amt) {
+      return res.status(422).json({
+        error: 'INSUFFICIENT_OWA',
+        prevBal: String(prevBal),
+        needed: amt
+      });
+    }
+
+    const synthetic = 'rpt_debit:' + crypto.randomUUID().slice(0, 12);
+    const debitResult = await db.query(
+      'SELECT * FROM owa_append($1, $2, $3, $4, $5)',
+      [abn, taxType, periodId, -amt, synthetic]
+    );
+
+    let newBalance = null;
+    if (debitResult.rowCount && debitResult.rows[0] && debitResult.rows[0].balance_after != null) {
+      newBalance = Number(debitResult.rows[0].balance_after);
+    }
+
+    if (newBalance === null) {
+      const fallback = await db.query(
+        `SELECT balance_after_cents AS bal FROM owa_ledger
+         WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+         ORDER BY id DESC LIMIT 1`,
+        [abn, taxType, periodId]
+      );
+      newBalance = fallback.rows[0]?.bal ?? (prevBal - amt);
+    }
+
+    await updatePeriodState(db, period.id, 'RELEASED');
+
+    res.json({ released: true, bank_receipt_hash: synthetic, new_balance: newBalance });
+  }));
+
+  // ---------- EVIDENCE ----------
+  app.get('/evidence', ah(async (req, res, db) => {
+    const { abn, taxType, periodId } = req.query;
+    const period = await findPeriod(db, abn, taxType, periodId);
+    if (!period) {
+      return res.status(404).json({ error: 'NOT_FOUND' });
+    }
+
+    const rptResult = await db.query(
+      `SELECT payload, payload_c14n, payload_sha256, signature, created_at
+       FROM rpt_tokens
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+       ORDER BY id DESC LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const rpt = rptResult.rows[0] || null;
+
+    const ledgerResult = await db.query(
+      `SELECT id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at
+       FROM owa_ledger
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+       ORDER BY id`,
+      [abn, taxType, periodId]
+    );
+
+    const basLabels = { W1: null, W2: null, '1A': null, '1B': null };
+
+    res.json({
+      meta: { generated_at: new Date().toISOString(), abn, taxType, periodId },
+      period: {
+        state: period.state,
+        accrued_cents: Number(period.accrued_cents || 0),
+        credited_to_owa_cents: Number(period.credited_to_owa_cents || 0),
+        final_liability_cents: Number(period.final_liability_cents || 0),
+        merkle_root: period.merkle_root,
+        running_balance_hash: period.running_balance_hash,
+        anomaly_vector: period.anomaly_vector,
+        thresholds: period.thresholds
+      },
+      rpt,
+      owa_ledger: ledgerResult.rows,
+      bas_labels: basLabels,
+      discrepancy_log: []
+    });
+  }));
+
+  return app;
+}
+
+if (require.main === module) {
+  const pool = defaultPool();
+  const port = process.env.PORT ? Number(process.env.PORT) : 8080;
+  const app = buildApp(pool, process.env);
+  const server = app.listen(port, () => console.log(`APGMS demo API listening on :${port}`));
+
+  process.on('SIGINT', async () => {
+    server.close();
+    await pool.end();
+    process.exit(0);
   });
-}));
+}
 
-const port = process.env.PORT ? +process.env.PORT : 8080;
-app.listen(port, ()=> console.log(APGMS demo API listening on :));
+module.exports = { buildApp, defaultPool };

--- a/tests/server.test.js
+++ b/tests/server.test.js
@@ -1,0 +1,163 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const nacl = require('tweetnacl');
+
+const { InMemoryPool } = require('./support/inMemoryPool');
+
+const keyPair = nacl.sign.keyPair();
+process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString('base64');
+process.env.RPT_PUBLIC_BASE64 = Buffer.from(keyPair.publicKey).toString('base64');
+process.env.ATO_PRN = 'TEST-PRN-123';
+
+const { buildApp } = require('../server');
+
+function startServer(app) {
+  return new Promise(resolve => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+async function stopServer(server) {
+  await new Promise(resolve => server.close(resolve));
+}
+
+async function requestJson(server, method, path, body) {
+  const baseUrl = `http://127.0.0.1:${server.address().port}`;
+  const res = await fetch(baseUrl + path, {
+    method,
+    headers: body ? { 'content-type': 'application/json' } : undefined,
+    body: body ? JSON.stringify(body) : undefined
+  });
+  let data = null;
+  try {
+    data = await res.json();
+  } catch (err) {
+    data = null;
+  }
+  return { status: res.status, data };
+}
+
+function createAppWithPool(pool) {
+  const app = buildApp(pool, process.env);
+  return app;
+}
+
+test('blocks RPT issue when anomaly thresholds are exceeded', async t => {
+  const pool = new InMemoryPool();
+  pool.addPeriod({
+    abn: '12345678901',
+    tax_type: 'GST',
+    period_id: '2025-09',
+    state: 'CLOSING',
+    credited_to_owa_cents: 1000,
+    final_liability_cents: 1000,
+    anomaly_vector: { variance_ratio: 0.5 }
+  });
+
+  const app = createAppWithPool(pool);
+  const server = await startServer(app);
+  await t.after(() => stopServer(server));
+
+  const resp = await requestJson(server, 'POST', '/rpt/issue', {
+    abn: '12345678901',
+    taxType: 'GST',
+    periodId: '2025-09'
+  });
+
+  assert.equal(resp.status, 409);
+  assert.deepEqual(resp.data, { error: 'BLOCKED_ANOMALY' });
+
+  const period = pool.getPeriod('12345678901', 'GST', '2025-09');
+  assert.equal(period.state, 'BLOCKED_ANOMALY');
+  assert.equal(pool.rptTokens.length, 0);
+});
+
+test('blocks RPT issue when OWA shortfall exists', async t => {
+  const pool = new InMemoryPool();
+  pool.addPeriod({
+    abn: '12345678901',
+    tax_type: 'GST',
+    period_id: '2025-10',
+    state: 'CLOSING',
+    credited_to_owa_cents: 0,
+    final_liability_cents: 1234,
+    anomaly_vector: {}
+  });
+
+  const app = createAppWithPool(pool);
+  const server = await startServer(app);
+  await t.after(() => stopServer(server));
+
+  const resp = await requestJson(server, 'POST', '/rpt/issue', {
+    abn: '12345678901',
+    taxType: 'GST',
+    periodId: '2025-10'
+  });
+
+  assert.equal(resp.status, 409);
+  assert.equal(resp.data.error, 'BLOCKED_DISCREPANCY');
+  assert.equal(resp.data.epsilon, 1234);
+
+  const period = pool.getPeriod('12345678901', 'GST', '2025-10');
+  assert.equal(period.state, 'BLOCKED_DISCREPANCY');
+  assert.equal(pool.rptTokens.length, 0);
+});
+
+test('issues RPT, releases funds, and returns evidence bundle', async t => {
+  const pool = new InMemoryPool();
+  pool.addPeriod({
+    abn: '12345678901',
+    tax_type: 'GST',
+    period_id: '2025-11',
+    state: 'CLOSING',
+    credited_to_owa_cents: 5000,
+    final_liability_cents: 5000,
+    anomaly_vector: {}
+  });
+
+  // seed credit in OWA ledger so release can succeed
+  await pool.query('SELECT * FROM owa_append($1, $2, $3, $4, $5)', [
+    '12345678901',
+    'GST',
+    '2025-11',
+    5000,
+    'seed-credit'
+  ]);
+
+  const app = createAppWithPool(pool);
+  const server = await startServer(app);
+  await t.after(() => stopServer(server));
+
+  const issueResp = await requestJson(server, 'POST', '/rpt/issue', {
+    abn: '12345678901',
+    taxType: 'GST',
+    periodId: '2025-11'
+  });
+
+  assert.equal(issueResp.status, 200);
+  assert.ok(issueResp.data.token);
+  assert.equal(issueResp.data.token.payload_sha256, issueResp.data.payload_sha256);
+  assert.equal(pool.rptTokens.length, 1);
+  const issuedPeriod = pool.getPeriod('12345678901', 'GST', '2025-11');
+  assert.equal(issuedPeriod.state, 'READY_RPT');
+
+  const releaseResp = await requestJson(server, 'POST', '/release', {
+    abn: '12345678901',
+    taxType: 'GST',
+    periodId: '2025-11'
+  });
+
+  assert.equal(releaseResp.status, 200);
+  assert.equal(releaseResp.data.released, true);
+  assert.equal(releaseResp.data.new_balance, 0);
+  const releasedPeriod = pool.getPeriod('12345678901', 'GST', '2025-11');
+  assert.equal(releasedPeriod.state, 'RELEASED');
+  assert.equal(pool.owaLedger.length, 2);
+  assert.equal(pool.owaLedger[1].amount_cents, -5000);
+
+  const evidenceResp = await requestJson(server, 'GET', '/evidence?abn=12345678901&taxType=GST&periodId=2025-11');
+  assert.equal(evidenceResp.status, 200);
+  assert.equal(evidenceResp.data.period.state, 'RELEASED');
+  assert.ok(evidenceResp.data.rpt);
+  assert.equal(evidenceResp.data.owa_ledger.length, 2);
+});

--- a/tests/support/inMemoryPool.js
+++ b/tests/support/inMemoryPool.js
@@ -1,0 +1,211 @@
+const crypto = require('crypto');
+
+class InMemoryPool {
+  constructor() {
+    this.periods = [];
+    this.rptTokens = [];
+    this.owaLedger = [];
+    this.periodSeq = 1;
+    this.rptSeq = 1;
+    this.ledgerSeq = 1;
+  }
+
+  reset() {
+    this.periods = [];
+    this.rptTokens = [];
+    this.owaLedger = [];
+    this.periodSeq = 1;
+    this.rptSeq = 1;
+    this.ledgerSeq = 1;
+  }
+
+  addPeriod(data) {
+    const period = {
+      id: this.periodSeq++,
+      abn: data.abn,
+      tax_type: data.tax_type,
+      period_id: data.period_id,
+      state: data.state ?? 'OPEN',
+      basis: data.basis ?? 'ACCRUAL',
+      accrued_cents: data.accrued_cents ?? 0,
+      credited_to_owa_cents: data.credited_to_owa_cents ?? 0,
+      final_liability_cents: data.final_liability_cents ?? 0,
+      merkle_root: data.merkle_root ?? null,
+      running_balance_hash: data.running_balance_hash ?? null,
+      anomaly_vector: data.anomaly_vector ?? {},
+      thresholds: data.thresholds ?? {}
+    };
+    this.periods.push(period);
+    return period;
+  }
+
+  getPeriod(abn, taxType, periodId) {
+    return this.periods.find(
+      p => p.abn === abn && p.tax_type === taxType && p.period_id === periodId
+    ) || null;
+  }
+
+  async query(text, params = []) {
+    const normalized = text.replace(/\s+/g, ' ').trim().toLowerCase();
+
+    if (normalized === 'select now()') {
+      return { rowCount: 1, rows: [{ now: new Date() }] };
+    }
+
+    if (normalized === 'select * from periods where abn=$1 and tax_type=$2 and period_id=$3') {
+      const [abn, taxType, periodId] = params;
+      const period = this.getPeriod(abn, taxType, periodId);
+      return { rowCount: period ? 1 : 0, rows: period ? [clone(period)] : [] };
+    }
+
+    if (normalized === 'update periods set state=$1 where id=$2 returning *') {
+      const [state, id] = params;
+      const period = this.periods.find(p => p.id === id);
+      if (!period) {
+        return { rowCount: 0, rows: [] };
+      }
+      period.state = state;
+      return { rowCount: 1, rows: [clone(period)] };
+    }
+
+    if (normalized.startsWith('insert into rpt_tokens')) {
+      const [abn, taxType, periodId, payloadJson, signature, payloadC14n, payloadSha256] = params;
+      const payload = JSON.parse(payloadJson);
+      const createdAt = new Date();
+      const token = {
+        id: this.rptSeq++,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        payload,
+        signature,
+        payload_c14n: payloadC14n,
+        payload_sha256: payloadSha256,
+        status: 'ISSUED',
+        created_at: createdAt
+      };
+      this.rptTokens.push(token);
+      return {
+        rowCount: 1,
+        rows: [clone(token)]
+      };
+    }
+
+    if (normalized.startsWith('select payload, signature from rpt_tokens')) {
+      const [abn, taxType, periodId] = params;
+      const filtered = this.rptTokens
+        .filter(t => t.abn === abn && t.tax_type === taxType && t.period_id === periodId)
+        .sort((a, b) => b.id - a.id);
+      const rows = filtered.slice(0, 1).map(t => ({ payload: t.payload, signature: t.signature }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith('select balance_after_cents from owa_ledger')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter(l => l.abn === abn && l.tax_type === taxType && l.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(l => ({ balance_after_cents: l.balance_after_cents }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith('select * from owa_append(')) {
+      const [abn, taxType, periodId, amount, bankReceipt] = params;
+      if (bankReceipt) {
+        const existing = this.owaLedger.find(
+          l => l.abn === abn && l.tax_type === taxType && l.period_id === periodId && l.bank_receipt_hash === bankReceipt
+        );
+        if (existing) {
+          return {
+            rowCount: 1,
+            rows: [{ id: existing.id, balance_after: existing.balance_after_cents, hash_after: existing.hash_after }]
+          };
+        }
+      }
+
+      const prev = this.owaLedger
+        .filter(l => l.abn === abn && l.tax_type === taxType && l.period_id === periodId)
+        .sort((a, b) => b.id - a.id)[0];
+      const prevBal = prev ? prev.balance_after_cents : 0;
+      const prevHash = prev ? prev.hash_after : '';
+      const newBalance = prevBal + Number(amount);
+      const hash = crypto
+        .createHash('sha256')
+        .update(`${prevHash || ''}${bankReceipt || ''}${newBalance}`)
+        .digest('hex');
+      const ledgerEntry = {
+        id: this.ledgerSeq++,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        transfer_uuid: crypto.randomUUID(),
+        amount_cents: Number(amount),
+        balance_after_cents: newBalance,
+        bank_receipt_hash: bankReceipt ?? null,
+        prev_hash: prevHash || null,
+        hash_after: hash,
+        created_at: new Date()
+      };
+      this.owaLedger.push(ledgerEntry);
+      return {
+        rowCount: 1,
+        rows: [{ id: ledgerEntry.id, balance_after: ledgerEntry.balance_after_cents, hash_after: ledgerEntry.hash_after }]
+      };
+    }
+
+    if (normalized.startsWith('select balance_after_cents as bal from owa_ledger')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter(l => l.abn === abn && l.tax_type === taxType && l.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(l => ({ bal: l.balance_after_cents }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith('select payload, payload_c14n, payload_sha256, signature, created_at from rpt_tokens')) {
+      const [abn, taxType, periodId] = params;
+      const filtered = this.rptTokens
+        .filter(t => t.abn === abn && t.tax_type === taxType && t.period_id === periodId)
+        .sort((a, b) => b.id - a.id);
+      const rows = filtered.slice(0, 1).map(t => ({
+        payload: t.payload,
+        payload_c14n: t.payload_c14n,
+        payload_sha256: t.payload_sha256,
+        signature: t.signature,
+        created_at: t.created_at
+      }));
+      return { rowCount: rows.length, rows };
+    }
+
+    if (normalized.startsWith('select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at from owa_ledger')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter(l => l.abn === abn && l.tax_type === taxType && l.period_id === periodId)
+        .sort((a, b) => a.id - b.id)
+        .map(l => ({
+          id: l.id,
+          amount_cents: l.amount_cents,
+          balance_after_cents: l.balance_after_cents,
+          bank_receipt_hash: l.bank_receipt_hash,
+          prev_hash: l.prev_hash,
+          hash_after: l.hash_after,
+          created_at: l.created_at
+        }));
+      return { rowCount: rows.length, rows };
+    }
+
+    throw new Error(`Unsupported query: ${text}`);
+  }
+
+  async end() {
+    return;
+  }
+}
+
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+module.exports = { InMemoryPool };


### PR DESCRIPTION
## Summary
- rewrite the express server to build on a configurable pool with parameterized SQL for every query
- ensure insert/update statements return rows and surface structured results for RPT issuance and release flows
- add node:test coverage for /rpt/issue, /release, and /evidence using an in-memory pool that enforces anomaly and balance gates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2029b6cd0832782d17395ff1433c1