### PR TITLE
Expand help centre with comprehensive guidance

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -197,3 +197,321 @@ th {
   font-weight: 600;
   color: #00205b;
 }
+
+/* Help Centre */
+.help-wrapper {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 28px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 20px 60px;
+}
+
+.help-sidebar {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 12px 32px rgba(0, 32, 91, 0.08);
+  padding: 24px;
+  height: fit-content;
+  position: sticky;
+  top: 110px;
+}
+
+.help-sidebar-header h1 {
+  margin: 0 0 6px;
+  font-size: 1.6rem;
+  color: #00205b;
+}
+
+.help-sidebar-header p {
+  margin: 0 0 20px;
+  font-size: 0.95rem;
+  color: #4a5a7c;
+}
+
+.help-sidebar nav ul {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 26px;
+  display: grid;
+  gap: 10px;
+}
+
+.help-sidebar nav a {
+  color: #00716b;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.help-sidebar nav a:hover,
+.help-sidebar nav a:focus {
+  text-decoration: underline;
+}
+
+.help-sidebar-card {
+  background: #f5f7fa;
+  border-radius: 14px;
+  padding: 18px;
+  color: #1d2b49;
+  font-size: 0.92rem;
+}
+
+.help-sidebar-card h2 {
+  margin: 0 0 10px;
+  font-size: 1.05rem;
+}
+
+.help-sidebar-card a {
+  color: #00205b;
+  font-weight: 600;
+}
+
+.help-sidebar-note {
+  margin-top: 10px;
+  color: #617199;
+  font-size: 0.85rem;
+}
+
+.help-main {
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+}
+
+.help-section {
+  background: #fff;
+  border-radius: 20px;
+  box-shadow: 0 12px 32px rgba(0, 32, 91, 0.08);
+  padding: 28px 32px;
+}
+
+.help-section-header h2 {
+  margin: 0 0 6px;
+  color: #00205b;
+  font-size: 1.5rem;
+}
+
+.help-section-header p {
+  margin: 0 0 18px;
+  color: #415170;
+  font-size: 0.98rem;
+}
+
+.help-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.help-card {
+  background: #f8fbff;
+  border-radius: 16px;
+  padding: 20px;
+  border: 1px solid rgba(0, 113, 107, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.help-card h3 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #00205b;
+}
+
+.help-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #3b4a6a;
+  line-height: 1.4;
+}
+
+.help-link {
+  font-weight: 600;
+  font-size: 0.9rem;
+  color: #00716b;
+  text-decoration: none;
+}
+
+.help-link:hover,
+.help-link:focus {
+  text-decoration: underline;
+}
+
+.help-checklist {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 14px;
+  font-size: 0.97rem;
+}
+
+.help-checklist li {
+  line-height: 1.45;
+}
+
+.help-step-title {
+  font-weight: 700;
+  color: #00205b;
+  display: block;
+  margin-bottom: 2px;
+}
+
+.help-workflow-grid {
+  display: grid;
+  gap: 18px;
+}
+
+.help-workflow {
+  border: 1px solid rgba(0, 32, 91, 0.1);
+  border-radius: 16px;
+  padding: 22px;
+  background: #f9fafc;
+}
+
+.help-workflow h3 {
+  margin: 0 0 12px;
+  color: #00205b;
+}
+
+.help-workflow ol {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 10px;
+  color: #384a6c;
+}
+
+.help-workflow-outcome {
+  margin-top: 16px;
+  font-size: 0.95rem;
+  color: #2d3e5f;
+}
+
+.help-table-wrapper {
+  overflow-x: auto;
+}
+
+.help-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.help-table th,
+.help-table td {
+  border: 1px solid #dde3ef;
+  padding: 12px 10px;
+  text-align: left;
+  font-size: 0.95rem;
+}
+
+.help-troubleshooting-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+  color: #2f3f60;
+  font-size: 0.95rem;
+}
+
+.help-faq-list {
+  display: grid;
+  gap: 16px;
+}
+
+.help-faq {
+  border-left: 4px solid #00716b;
+  padding: 12px 18px;
+  background: #f6fbfb;
+  border-radius: 12px;
+}
+
+.help-faq h3 {
+  margin: 0 0 6px;
+  font-size: 1.05rem;
+  color: #00205b;
+}
+
+.help-faq p {
+  margin: 0;
+  color: #374a6a;
+  font-size: 0.95rem;
+}
+
+.help-glossary {
+  display: grid;
+  gap: 16px;
+  margin: 0;
+}
+
+.help-glossary-item dt {
+  font-weight: 700;
+  color: #00205b;
+}
+
+.help-glossary-item dd {
+  margin: 4px 0 0;
+  color: #334563;
+  line-height: 1.45;
+}
+
+.help-support-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 18px;
+}
+
+.help-support-card {
+  background: #f8fbff;
+  border-radius: 16px;
+  padding: 18px;
+  border: 1px solid rgba(0, 32, 91, 0.12);
+}
+
+.help-support-card h3 {
+  margin: 0 0 10px;
+  color: #00205b;
+}
+
+.help-support-card ul {
+  margin: 0;
+  padding-left: 18px;
+  color: #384a6c;
+  display: grid;
+  gap: 8px;
+  font-size: 0.94rem;
+}
+
+.help-support-card a {
+  color: #00716b;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.help-support-card a:hover,
+.help-support-card a:focus {
+  text-decoration: underline;
+}
+
+@media (max-width: 1080px) {
+  .help-wrapper {
+    grid-template-columns: 1fr;
+  }
+
+  .help-sidebar {
+    position: static;
+  }
+}
+
+@media (max-width: 640px) {
+  .help-section {
+    padding: 22px;
+  }
+
+  .help-card-grid,
+  .help-support-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,39 +1,372 @@
-import React from 'react';
+import React from "react";
+import { Link } from "react-router-dom";
+
+type Workflow = {
+  id: string;
+  title: string;
+  steps: string[];
+  outcome: string;
+};
+
+type FaqItem = {
+  question: string;
+  answer: string;
+};
+
+type QuickAction = {
+  title: string;
+  body: string;
+  link: string;
+};
+
+const quickActions: QuickAction[] = [
+  {
+    title: "Configure Accounts",
+    body: "Create PAYGW, GST and Super clearing accounts under Settings → Financial Accounts.",
+    link: "/settings",
+  },
+  {
+    title: "Run Compliance Wizard",
+    body: "Capture withholding rates, GST apportioning and payment cadence in the guided Wizard.",
+    link: "/wizard",
+  },
+  {
+    title: "Review Obligations",
+    body: "Track cash on hand, remittances due and alerts on the Dashboard timeline.",
+    link: "/",
+  },
+  {
+    title: "Prepare BAS",
+    body: "Generate statement-ready figures and validate declarations in the BAS workspace.",
+    link: "/bas",
+  },
+];
+
+const workflows: Workflow[] = [
+  {
+    id: "paygw-cycle",
+    title: "PAYGW Cycle",
+    steps: [
+      "Enter or sync payroll runs — the system calculates withheld tax by employee.",
+      "Review the holding account balance and approve the weekly transfer to the PAYGW buffer.",
+      "Schedule the ATO remittance before the due date; the ledger posts the payment automatically.",
+    ],
+    outcome: "Directors have visibility of withheld funds and an auditable payment trail for each period.",
+  },
+  {
+    id: "gst-lodgement",
+    title: "GST Lodgement",
+    steps: [
+      "Import sales and purchase activity from your accounting platform or upload a CSV.",
+      "Categorise exceptions flagged by the reconciliation engine to finalise net GST owed.",
+      "Use the BAS workspace to confirm G1, G2, G3 and 1A/1B boxes, then submit or export to the ATO portal.",
+    ],
+    outcome: "Ensures GST collected is fully reconciled before BAS lodgement, reducing manual adjustments.",
+  },
+  {
+    id: "super-monitoring",
+    title: "Superannuation Monitoring",
+    steps: [
+      "Map each payroll category to its corresponding super fund and clearing house reference.",
+      "Track super accruals in the Dashboard obligations panel and schedule clearing house payments.",
+      "Upload remittance confirmations so the audit trail records compliance for each quarter.",
+    ],
+    outcome: "Protects directors from Superannuation Guarantee Charge exposure through timely contributions.",
+  },
+];
+
+const faqs: FaqItem[] = [
+  {
+    question: "How do I invite my accountant or bookkeeper?",
+    answer:
+      "Go to Settings → Team Access and send an invitation. Guests receive read-only access unless you grant lodging permissions.",
+  },
+  {
+    question: "What file formats can I import for transaction evidence?",
+    answer:
+      "CSV, XLSX and the ATO-standard SAF-T JSON files are accepted. Each upload is validated and versioned for audit history.",
+  },
+  {
+    question: "Can APGMS submit BAS statements automatically?",
+    answer:
+      "Yes, when the integration with ATO Online Services is connected under Integrations. Otherwise, export the BAS PDF/XML and lodge manually.",
+  },
+  {
+    question: "Where can I see the evidence of payments sent to the ATO?",
+    answer:
+      "The Audit page stores evidence packs including bank remittance files, approval history and supporting documents for each period.",
+  },
+];
+
+const glossary = [
+  {
+    term: "PAYGW",
+    definition:
+      "Pay As You Go Withholding — tax withheld from employee wages that must be remitted to the ATO by the due date for your cycle.",
+  },
+  {
+    term: "GST Apportioning",
+    definition:
+      "The process of splitting GST collected versus GST paid to calculate the net amount owed (1A) or refundable (1B).",
+  },
+  {
+    term: "BAS",
+    definition:
+      "Business Activity Statement filed monthly or quarterly outlining GST, PAYGW and other tax obligations.",
+  },
+  {
+    term: "Evidence Pack",
+    definition:
+      "A compiled set of supporting documents (bank exports, reconciliations, approvals) that demonstrate compliance for auditors and directors.",
+  },
+];
+
+const complianceDeadlines = [
+  { category: "PAYGW (Small Withholders)", cadence: "Monthly", deadline: "21st of following month" },
+  { category: "PAYGW (Large Withholders)", cadence: "Twice weekly", deadline: "Due within 3 business days" },
+  { category: "GST/BAS - Quarterly", cadence: "Quarterly", deadline: "28th of month after quarter" },
+  { category: "Super Guarantee", cadence: "Quarterly", deadline: "28th day after quarter end" },
+];
+
+const supportLinks = [
+  {
+    label: "ATO PAYG Withholding guide",
+    url: "https://www.ato.gov.au/business/payg-withholding/",
+  },
+  {
+    label: "ATO GST information",
+    url: "https://www.ato.gov.au/business/gst/",
+  },
+  {
+    label: "ATO BAS portal",
+    url: "https://www.ato.gov.au/business/business-activity-statements-(bas)/",
+  },
+  {
+    label: "ATO Super for employers",
+    url: "https://www.ato.gov.au/business/super-for-employers/",
+  },
+  {
+    label: "ATO Online services",
+    url: "https://www.ato.gov.au/General/Online-services/",
+  },
+];
 
 export default function Help() {
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Help & Guidance</h1>
-      <p className="text-sm text-muted-foreground">
-        Access support for PAYGW, GST, BAS and using this system.
-      </p>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Getting Started</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Set up your buffer accounts and payment schedule in <strong>Settings</strong>.</li>
-          <li>Use the <strong>Wizard</strong> to define PAYGW and GST split rules.</li>
-          <li>Review <strong>Dashboard</strong> for current obligations and payment alerts.</li>
-          <li>Go to <strong>BAS</strong> to lodge your Business Activity Statement each quarter.</li>
-        </ul>
-      </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">ATO Compliance</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Use one-way tax accounts to prevent accidental use of withheld/collected funds.</li>
-          <li>Audit trail with timestamped actions supports legal protection and evidence.</li>
-          <li>Helps avoid wind-up notices, director penalties, and late lodgment fines.</li>
-        </ul>
-      </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Support Links</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/payg-withholding/">ATO PAYGW Guide</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/gst/">ATO GST Information</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/business-activity-statements-(bas)/">ATO BAS Portal</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/super-for-employers/">ATO Super Obligations</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/General/Online-services/">ATO Online Services</a></li>
-        </ul>
-      </div>
+    <div className="help-wrapper">
+      <aside className="help-sidebar" aria-label="Help navigation">
+        <div className="help-sidebar-header">
+          <h1>Help Centre</h1>
+          <p>Your guide to PAYGW, GST and BAS compliance in APGMS.</p>
+        </div>
+        <nav>
+          <ul>
+            <li><a href="#overview">Overview</a></li>
+            <li><a href="#quick-start">Quick start</a></li>
+            <li><a href="#workflows">Key workflows</a></li>
+            <li><a href="#compliance">Compliance calendar</a></li>
+            <li><a href="#troubleshooting">Troubleshooting</a></li>
+            <li><a href="#faq">FAQs</a></li>
+            <li><a href="#glossary">Glossary</a></li>
+            <li><a href="#support">Support & resources</a></li>
+          </ul>
+        </nav>
+        <div className="help-sidebar-card">
+          <h2>Need assistance fast?</h2>
+          <p>Email <a href="mailto:support@apgms.example">support@apgms.example</a> or call 1300-000-APG.</p>
+          <p className="help-sidebar-note">Support hours: 8am – 6pm AEST (Mon-Fri)</p>
+        </div>
+      </aside>
+
+      <main className="help-main">
+        <section id="overview" className="help-section" aria-labelledby="help-overview-heading">
+          <div className="help-section-header">
+            <h2 id="help-overview-heading">Overview</h2>
+            <p>
+              APGMS centralises PAYGW, GST, BAS and Super workflows with compliance safeguards and
+              evidence logging. Use this help centre to navigate tasks, deadlines and integrations.
+            </p>
+          </div>
+
+          <div className="help-card-grid">
+            {quickActions.map((action) => (
+              <article className="help-card" key={action.title}>
+                <h3>{action.title}</h3>
+                <p>{action.body}</p>
+                <Link className="help-link" to={action.link}>Open section →</Link>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="quick-start" className="help-section" aria-labelledby="help-quick-start-heading">
+          <div className="help-section-header">
+            <h2 id="help-quick-start-heading">Quick start checklist</h2>
+            <p>Follow the checklist below to configure APGMS for a new entity within an hour.</p>
+          </div>
+          <ol className="help-checklist">
+            <li>
+              <span className="help-step-title">Company profile</span>
+              <p>Confirm ABN, withholding status and lodgement frequency in Settings → Organisation.</p>
+            </li>
+            <li>
+              <span className="help-step-title">Financial accounts</span>
+              <p>Connect your bank feeds and nominate segregated PAYGW, GST and super accounts.</p>
+            </li>
+            <li>
+              <span className="help-step-title">Compliance wizard</span>
+              <p>Capture payroll cycle, GST registration and buffer thresholds in the guided wizard.</p>
+            </li>
+            <li>
+              <span className="help-step-title">Automation rules</span>
+              <p>Set approval workflows for remittances and enable notifications for variances & overdue tasks.</p>
+            </li>
+            <li>
+              <span className="help-step-title">User access</span>
+              <p>Invite finance staff, advisors and auditors with appropriate permission levels.</p>
+            </li>
+          </ol>
+        </section>
+
+        <section id="workflows" className="help-section" aria-labelledby="help-workflows-heading">
+          <div className="help-section-header">
+            <h2 id="help-workflows-heading">Key workflows</h2>
+            <p>Standard operating procedures to keep PAYGW, GST and superannuation obligations on track.</p>
+          </div>
+
+          <div className="help-workflow-grid">
+            {workflows.map((workflow) => (
+              <article className="help-workflow" key={workflow.id}>
+                <h3>{workflow.title}</h3>
+                <ol>
+                  {workflow.steps.map((step) => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ol>
+                <p className="help-workflow-outcome"><strong>Outcome:</strong> {workflow.outcome}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="compliance" className="help-section" aria-labelledby="help-compliance-heading">
+          <div className="help-section-header">
+            <h2 id="help-compliance-heading">Compliance calendar</h2>
+            <p>Deadlines are based on standard ATO cycles. Adjust in Settings → Compliance if you have alternative schedules.</p>
+          </div>
+          <div className="help-table-wrapper">
+            <table className="help-table">
+              <thead>
+                <tr>
+                  <th scope="col">Obligation</th>
+                  <th scope="col">Cadence</th>
+                  <th scope="col">Due date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {complianceDeadlines.map((item) => (
+                  <tr key={item.category}>
+                    <td>{item.category}</td>
+                    <td>{item.cadence}</td>
+                    <td>{item.deadline}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+
+        <section id="troubleshooting" className="help-section" aria-labelledby="help-troubleshooting-heading">
+          <div className="help-section-header">
+            <h2 id="help-troubleshooting-heading">Troubleshooting & monitoring</h2>
+            <p>Use these checks before escalating an issue to support.</p>
+          </div>
+          <ul className="help-troubleshooting-list">
+            <li>
+              <strong>Data import failures:</strong> Confirm the CSV/XLSX column headers match the provided templates and retry. All imports are logged in Audit → Evidence.
+            </li>
+            <li>
+              <strong>Bank feed delays:</strong> Re-authenticate the feed under Integrations. APGMS queues the last 72 hours of transactions for replay.
+            </li>
+            <li>
+              <strong>Unexpected balance variances:</strong> Use the Reconciliation report (Dashboard → Variance tab) to pinpoint missing journals before lodging.
+            </li>
+            <li>
+              <strong>ATO outage:</strong> Queue your BAS or PAYGW submission. The task automatically retries when the ATO gateway is available.
+            </li>
+            <li>
+              <strong>Access issues:</strong> Check multi-factor tokens or reset them from Settings → Security if a device is lost.
+            </li>
+          </ul>
+        </section>
+
+        <section id="faq" className="help-section" aria-labelledby="help-faq-heading">
+          <div className="help-section-header">
+            <h2 id="help-faq-heading">Frequently asked questions</h2>
+            <p>Answers to the most common setup and compliance questions.</p>
+          </div>
+          <div className="help-faq-list">
+            {faqs.map((item) => (
+              <article className="help-faq" key={item.question}>
+                <h3>{item.question}</h3>
+                <p>{item.answer}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="glossary" className="help-section" aria-labelledby="help-glossary-heading">
+          <div className="help-section-header">
+            <h2 id="help-glossary-heading">Glossary</h2>
+            <p>Definitions for the abbreviations and terms used throughout APGMS.</p>
+          </div>
+          <dl className="help-glossary">
+            {glossary.map((entry) => (
+              <div className="help-glossary-item" key={entry.term}>
+                <dt>{entry.term}</dt>
+                <dd>{entry.definition}</dd>
+              </div>
+            ))}
+          </dl>
+        </section>
+
+        <section id="support" className="help-section" aria-labelledby="help-support-heading">
+          <div className="help-section-header">
+            <h2 id="help-support-heading">Support & resources</h2>
+            <p>Find the right channel for implementation, compliance queries or technical help.</p>
+          </div>
+          <div className="help-support-grid">
+            <article className="help-support-card">
+              <h3>Product support</h3>
+              <ul>
+                <li>Email: <a href="mailto:support@apgms.example">support@apgms.example</a></li>
+                <li>Phone: 1300-000-APG</li>
+                <li>Service Level: Response within 4 business hours</li>
+              </ul>
+            </article>
+            <article className="help-support-card">
+              <h3>Implementation services</h3>
+              <ul>
+                <li>Book a onboarding session under Settings → Training.</li>
+                <li>Request migration assistance via <a href="mailto:projects@apgms.example">projects@apgms.example</a>.</li>
+                <li>Access recorded webinars in the Training library.</li>
+              </ul>
+            </article>
+            <article className="help-support-card">
+              <h3>External references</h3>
+              <ul>
+                {supportLinks.map((link) => (
+                  <li key={link.url}>
+                    <a href={link.url} target="_blank" rel="noreferrer">
+                      {link.label}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          </div>
+        </section>
+      </main>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the simple Help page with a full help centre including quick-start guidance, workflows, compliance calendar, FAQs, glossary, and support resources
- add tailored styling for the help centre layout, navigation sidebar, cards, and responsive behaviour

## Testing
- npm run dev *(fails: backend entrypoint requires ./api module that is unavailable in this workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68e202cee9288327a3f6c40f13ddd6a0