### PR TITLE
Integrate payments service checks for BAS remittance

### DIFF
--- a/src/components/BasLodgment.tsx
+++ b/src/components/BasLodgment.tsx
@@ -1,35 +1,62 @@
 import React, { useContext, useState } from 'react';
 import { AppContext } from '../context/AppContext';
-import { verifyFunds, initiateTransfer, submitSTPReport } from '../utils/bankApi';
+import { verifyFunds, initiateTransfer, submitSTPReport, RemittanceFailureReason } from '../utils/bankApi';
 import { calculatePenalties } from '../utils/penalties';
 
 export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gstDue: number }) {
-  const { basHistory, setBasHistory, auditLog, setAuditLog } = useContext(AppContext);
+  const { setBasHistory, setAuditLog, setDiscrepancyAlerts } = useContext(AppContext);
   const [isProcessing, setIsProcessing] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [trackedDiscrepancies, setTrackedDiscrepancies] = useState<string[]>([]);
+
+  const totalDue = paygwDue + gstDue;
+
+  function recordDiscrepancy(reason: RemittanceFailureReason, message: string) {
+    const entry = {
+      timestamp: Date.now(),
+      action: `BAS Lodgment blocked (${reason})`,
+      user: "Admin",
+      reason,
+      detail: message,
+    };
+    setAuditLog((prev: any[]) => [...prev, entry]);
+    setDiscrepancyAlerts((prev: string[]) => (prev.includes(message) ? prev : [...prev, message]));
+    setTrackedDiscrepancies((prev) => (prev.includes(message) ? prev : [...prev, message]));
+    setBasHistory((prev: any[]) => [
+      {
+        period: new Date(),
+        paygwPaid: 0,
+        gstPaid: 0,
+        status: "Late",
+        daysLate: 7,
+        penalties: calculatePenalties(7, totalDue)
+      },
+      ...prev
+    ]);
+  }
 
   async function handleLodgment() {
     setIsProcessing(true);
+    setErrorMessage(null);
     try {
-      const fundsOk = await verifyFunds(paygwDue, gstDue);
-      if (!fundsOk) {
-        setBasHistory([
-          {
-            period: new Date(),
-            paygwPaid: 0,
-            gstPaid: 0,
-            status: "Late",
-            daysLate: 7,
-            penalties: calculatePenalties(7, paygwDue + gstDue)
-          },
-          ...basHistory
-        ]);
-        setAuditLog([...auditLog, { timestamp: Date.now(), action: `BAS Lodgment failed: insufficient funds`, user: "Admin" }]);
-        setIsProcessing(false);
+      const fundsCheck = await verifyFunds(paygwDue, gstDue);
+      if (!fundsCheck.ok) {
+        const reason = fundsCheck.reason ?? "anomaly";
+        const message = fundsCheck.message ?? "Payments service rejected the request.";
+        recordDiscrepancy(reason, message);
+        setErrorMessage(message);
         return;
       }
       await submitSTPReport({ paygw: paygwDue, gst: gstDue, period: new Date() });
-      await initiateTransfer(paygwDue, gstDue);
-      setBasHistory([
+      const transferResult = await initiateTransfer(paygwDue, gstDue);
+      if (!transferResult.ok) {
+        const reason = transferResult.reason ?? "anomaly";
+        const message = transferResult.message ?? "Payments service rejected the release.";
+        recordDiscrepancy(reason, message);
+        setErrorMessage(message);
+        return;
+      }
+      setBasHistory((prev: any[]) => [
         {
           period: new Date(),
           paygwPaid: paygwDue,
@@ -38,9 +65,19 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
           daysLate: 0,
           penalties: 0
         },
-        ...basHistory
+        ...prev
       ]);
-      setAuditLog([...auditLog, { timestamp: Date.now(), action: `BAS Lodged: $${paygwDue + gstDue}`, user: "Admin" }]);
+      setAuditLog((prev: any[]) => [
+        ...prev,
+        { timestamp: Date.now(), action: `BAS Lodged: $${(paygwDue + gstDue).toFixed(2)}`, user: "Admin" }
+      ]);
+      setDiscrepancyAlerts((prev: string[]) => prev.filter(alert => !trackedDiscrepancies.includes(alert)));
+      setTrackedDiscrepancies([]);
+      setErrorMessage(null);
+    } catch (err: any) {
+      const message = err instanceof Error ? err.message : String(err);
+      recordDiscrepancy("anomaly", `Unexpected error: ${message}`);
+      setErrorMessage(`Unexpected error: ${message}`);
     } finally {
       setIsProcessing(false);
     }
@@ -52,6 +89,11 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
       <div>PAYGW: ${paygwDue.toFixed(2)}</div>
       <div>GST: ${gstDue.toFixed(2)}</div>
       <div className="total">Total: ${(paygwDue + gstDue).toFixed(2)}</div>
+      {errorMessage && (
+        <div className="alert" style={{ marginTop: 12, padding: 12, background: "#fff4f4", color: "#a30000", borderRadius: 8 }}>
+          {errorMessage}
+        </div>
+      )}
       <button onClick={handleLodgment} disabled={isProcessing}>
         {isProcessing ? "Processing..." : "Lodge BAS & Transfer Funds"}
       </button>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -11,6 +11,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [sales, setSales] = useState(mockSales);
   const [basHistory, setBasHistory] = useState<BASHistory[]>(mockBasHistory);
   const [auditLog, setAuditLog] = useState<any[]>([]);
+  const [discrepancyAlerts, setDiscrepancyAlerts] = useState<string[]>([]);
 
   return (
     <AppContext.Provider value={{
@@ -20,6 +21,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       sales, setSales,
       basHistory, setBasHistory,
       auditLog, setAuditLog,
+      discrepancyAlerts, setDiscrepancyAlerts,
     }}>
       {children}
     </AppContext.Provider>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,17 +1,20 @@
 // src/pages/Dashboard.tsx
-import React from 'react';
+import React, { useContext, useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { AppContext } from '../context/AppContext';
 
 export default function Dashboard() {
-  const complianceStatus = {
+  const { discrepancyAlerts } = useContext(AppContext);
+  const complianceStatus = useMemo(() => ({
     lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
+    paymentsUpToDate: !(discrepancyAlerts && discrepancyAlerts.length),
     overallCompliance: 65,
     lastBAS: '29 May 2025',
     nextDue: '28 July 2025',
     outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+    outstandingAmounts: discrepancyAlerts || []
+  }), [discrepancyAlerts]);
+  const hasOutstandingPayments = complianceStatus.outstandingAmounts.length > 0;
 
   return (
     <div className="main-card">
@@ -87,8 +90,10 @@ export default function Dashboard() {
         {complianceStatus.outstandingLodgments.length > 0 && (
           <p className="text-red-600">Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
         )}
-        {complianceStatus.outstandingAmounts.length > 0 && (
-          <p className="text-red-600">Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
+        {hasOutstandingPayments ? (
+          <p className="text-red-600">Outstanding Payments: {complianceStatus.outstandingAmounts.join('; ')}</p>
+        ) : (
+          <p className="text-green-600">Outstanding Payments: None</p>
         )}
       </div>
 

--- a/src/utils/bankApi.ts
+++ b/src/utils/bankApi.ts
@@ -1,3 +1,79 @@
+export type RemittanceFailureReason = "shortfall" | "anomaly";
+
+export type RemittanceResult = {
+  ok: boolean;
+  reason?: RemittanceFailureReason;
+  message?: string;
+  paygwBalance?: number;
+  gstBalance?: number;
+};
+
+type BalanceResponse = {
+  balance_cents: number;
+  has_release: boolean;
+};
+
+function resolvePaymentsBase(): string {
+  const raw = process.env.NEXT_PUBLIC_PAYMENTS_PROXY_BASE || "/api";
+  if (/^https?:/i.test(raw)) {
+    return raw.replace(/\/$/, "");
+  }
+  if (typeof window !== "undefined" && window.location) {
+    const prefix = raw.startsWith("/") ? raw : `/${raw}`;
+    return `${window.location.origin}${prefix}`.replace(/\/$/, "");
+  }
+  const fallback = process.env.PAYMENTS_BASE_URL || "http://localhost:3000";
+  const prefix = raw.startsWith("/") ? raw : `/${raw}`;
+  return `${fallback.replace(/\/$/, "")}${prefix}`.replace(/\/$/, "");
+}
+
+const PAYMENTS_API_BASE = resolvePaymentsBase();
+const DEMO_ABN = (process.env.NEXT_PUBLIC_DEMO_ABN || "12345678901").replace(/\s+/g, "");
+const DEFAULT_PERIOD_ID = process.env.NEXT_PUBLIC_DEMO_PERIOD_ID || new Date().toISOString().slice(0, 7);
+
+function formatDollars(cents: number): string {
+  return (cents / 100).toFixed(2);
+}
+
+async function fetchJson(input: RequestInfo | URL, init?: RequestInit) {
+  const response = await fetch(input, init);
+  const text = await response.text();
+  let json: any = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch (_err) {
+    json = null;
+  }
+  if (!response.ok) {
+    const message = json?.error || json?.detail || text || response.statusText;
+    throw new Error(message);
+  }
+  return json;
+}
+
+async function getBalance(taxType: "PAYGW" | "GST"): Promise<BalanceResponse> {
+  const query = new URLSearchParams({
+    abn: DEMO_ABN,
+    taxType,
+    periodId: DEFAULT_PERIOD_ID,
+  });
+  const url = `${PAYMENTS_API_BASE}/balance?${query.toString()}`;
+  const data = await fetchJson(url);
+  return {
+    balance_cents: Number(data?.balance_cents ?? 0),
+    has_release: Boolean(data?.has_release),
+  };
+}
+
+class RemittanceError extends Error {
+  reason: RemittanceFailureReason;
+
+  constructor(reason: RemittanceFailureReason, message: string) {
+    super(message);
+    this.reason = reason;
+  }
+}
+
 export async function submitSTPReport(data: any): Promise<boolean> {
   console.log("Submitting STP report to ATO:", data);
   return true;
@@ -13,12 +89,104 @@ export async function transferToOneWayAccount(amount: number, from: string, to: 
   return true;
 }
 
-export async function verifyFunds(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
+export async function verifyFunds(paygwDue: number, gstDue: number): Promise<RemittanceResult> {
+  try {
+    const [paygw, gst] = await Promise.all([
+      getBalance("PAYGW"),
+      getBalance("GST"),
+    ]);
+
+    const paygwDueCents = Math.round(paygwDue * 100);
+    const gstDueCents = Math.round(gstDue * 100);
+
+    const anomalyTypes: string[] = [];
+    if (paygw.has_release) anomalyTypes.push("PAYGW");
+    if (gst.has_release) anomalyTypes.push("GST");
+    if (anomalyTypes.length) {
+      const message = `${anomalyTypes.join(" & ")} period already released — investigate before re-lodging.`;
+      return {
+        ok: false,
+        reason: "anomaly",
+        message,
+        paygwBalance: paygw.balance_cents / 100,
+        gstBalance: gst.balance_cents / 100,
+      };
+    }
+
+    const shortfalls: { type: "PAYGW" | "GST"; due: number; held: number }[] = [];
+    if (paygwDueCents > paygw.balance_cents) {
+      shortfalls.push({ type: "PAYGW", due: paygwDueCents, held: paygw.balance_cents });
+    }
+    if (gstDueCents > gst.balance_cents) {
+      shortfalls.push({ type: "GST", due: gstDueCents, held: gst.balance_cents });
+    }
+
+    if (shortfalls.length) {
+      const details = shortfalls
+        .map((s) => {
+          const shortfall = s.due - s.held;
+          return `${s.type} shortfall $${formatDollars(shortfall)} (held $${formatDollars(s.held)} vs due $${formatDollars(s.due)})`;
+        })
+        .join("; ");
+      return {
+        ok: false,
+        reason: "shortfall",
+        message: details,
+        paygwBalance: paygw.balance_cents / 100,
+        gstBalance: gst.balance_cents / 100,
+      };
+    }
+
+    return {
+      ok: true,
+      message: "Sufficient funds reserved in OWA.",
+      paygwBalance: paygw.balance_cents / 100,
+      gstBalance: gst.balance_cents / 100,
+    };
+  } catch (error: any) {
+    const message = error instanceof Error ? error.message : String(error);
+    return {
+      ok: false,
+      reason: "anomaly",
+      message: `Payments service error: ${message}`,
+    };
+  }
 }
 
-export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
+async function releaseFunds(taxType: "PAYGW" | "GST", due: number) {
+  if (due <= 0) return;
+  const amountCents = -Math.round(due * 100);
+  const body = JSON.stringify({
+    abn: DEMO_ABN,
+    taxType,
+    periodId: DEFAULT_PERIOD_ID,
+    amountCents,
+  });
+  try {
+    await fetchJson(`${PAYMENTS_API_BASE}/release`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    });
+  } catch (error: any) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new RemittanceError("anomaly", message);
+  }
+}
+
+export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<RemittanceResult> {
+  try {
+    await releaseFunds("PAYGW", paygwDue);
+    await releaseFunds("GST", gstDue);
+    return {
+      ok: true,
+      message: "Release instructions accepted by payments service.",
+    };
+  } catch (error: any) {
+    if (error instanceof RemittanceError) {
+      return { ok: false, reason: error.reason, message: error.message };
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: "anomaly", message };
+  }
 }


### PR DESCRIPTION
## Summary
- hook BAS remittance checks into the payments service so balances and releases use live OWA data and carry failure reasons
- surface payment shortfall/anomaly errors in the BAS Lodgment UI while logging them for auditing and dashboard alerts
- persist discrepancy alerts in application context so the dashboard reflects outstanding payment issues

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e202a0598c8327922a2cd3c2c9eded