### PR TITLE
chore: set payments service default port to 3001

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ Run the Development Server
 
 npm start
 
-The app will start on http://localhost:3000
+The app will start on http://localhost:3000.
+
+### Payments service
+
+From `apps/services/payments`, run `pnpm dev` (or `npm run dev`) to launch the
+payments service locally. It listens on http://localhost:3001 by default, or on
+the port provided through the `PORT` environment variable.
 
 Build for Production
 

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -11,8 +11,8 @@ import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
 
-// Port (defaults to 3000)
-const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+// Port (defaults to 3001)
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3001;
 
 // Prefer DATABASE_URL; else compose from PG* vars
 const connectionString =


### PR DESCRIPTION
## Summary
- update the payments service to listen on port 3001 by default while keeping the PORT override
- document how to run the payments service locally and note the expected port in the README

## Testing
- npm run dev *(fails: existing repo is missing ./api module)*
- (in apps/services/payments) npm run dev *(fails: local dependencies such as express are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e204eedbac8327bd2496481a32c683