### PR TITLE
feat: centralize postgres pools with metrics

### DIFF
--- a/apps/services/payments/src/db/pool.ts
+++ b/apps/services/payments/src/db/pool.ts
@@ -1,0 +1,61 @@
+import type { PoolConfig } from "pg";
+import { Pool } from "pg";
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  `postgres://${process.env.PGUSER || "apgms"}:${encodeURIComponent(process.env.PGPASSWORD || "")}` +
+    `@${process.env.PGHOST || "127.0.0.1"}:${process.env.PGPORT || "5432"}/${process.env.PGDATABASE || "apgms"}`;
+
+const config: PoolConfig = { connectionString };
+
+export const pool = new Pool(config);
+
+const metrics = {
+  connects: 0,
+  acquires: 0,
+  releases: 0,
+  removes: 0,
+  errors: 0,
+};
+
+function logPoolState(event: string) {
+  console.log(
+    `[payments:db:pool] ${event} total=${pool.totalCount} idle=${pool.idleCount} waiting=${pool.waitingCount} ` +
+      `connects=${metrics.connects} acquires=${metrics.acquires} releases=${metrics.releases} removes=${metrics.removes} errors=${metrics.errors}`
+  );
+}
+
+pool.on("connect", () => {
+  metrics.connects += 1;
+  logPoolState("connect");
+});
+
+pool.on("acquire", () => {
+  metrics.acquires += 1;
+  logPoolState("acquire");
+});
+
+pool.on("release", () => {
+  metrics.releases += 1;
+  logPoolState("release");
+});
+
+pool.on("remove", () => {
+  metrics.removes += 1;
+  logPoolState("remove");
+});
+
+pool.on("error", (error) => {
+  metrics.errors += 1;
+  console.error(`[payments:db:pool] error: ${error.message}`);
+  logPoolState("error");
+});
+
+export function getPoolMetrics() {
+  return {
+    ...metrics,
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
+  };
+}

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -3,7 +3,6 @@ import 'dotenv/config';
 import './loadEnv.js'; // ensures .env.local is loaded when running with tsx
 
 import express from 'express';
-import pg from 'pg'; const { Pool } = pg;
 
 import { rptGate } from './middleware/rptGate.js';
 import { payAtoRelease } from './routes/payAto.js';
@@ -14,14 +13,8 @@ import { ledger } from './routes/ledger';
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 
-// Prefer DATABASE_URL; else compose from PG* vars
-const connectionString =
-  process.env.DATABASE_URL ??
-  `postgres://${process.env.PGUSER || 'apgms'}:${encodeURIComponent(process.env.PGPASSWORD || '')}` +
-  `@${process.env.PGHOST || '127.0.0.1'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'apgms'}`;
-
 // Export pool for other modules
-export const pool = new Pool({ connectionString });
+export { pool, getPoolMetrics } from './db/pool';
 
 const app = express();
 app.use(express.json());

--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -1,11 +1,10 @@
 // apps/services/payments/src/middleware/rptGate.ts
 import { Request, Response, NextFunction } from "express";
-import pg from "pg"; const { Pool } = pg;
 import { sha256Hex } from "../utils/crypto";
 import { selectKms } from "../kms/kmsProvider";
+import { pool } from "../db/pool";
 
 const kms = selectKms();
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 export async function rptGate(req: Request, res: Response, next: NextFunction) {
   try {

--- a/apps/services/payments/test/owa_constraints.test.ts
+++ b/apps/services/payments/test/owa_constraints.test.ts
@@ -1,5 +1,4 @@
-import { Pool } from "pg";
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+import { pool } from "../src/db/pool";
 
 test("OWA deposit-only constraint", async () => {
   const c = await pool.connect();

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,6 +1,5 @@
 ﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
 
 export async function appendAudit(actor: string, action: string, payload: any) {
   const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,57 @@
+import type { PoolConfig } from "pg";
+import { Pool } from "pg";
+
+const connectionString = process.env.DATABASE_URL;
+const config: PoolConfig = connectionString ? { connectionString } : {};
+
+export const pool = new Pool(config);
+
+const metrics = {
+  connects: 0,
+  acquires: 0,
+  releases: 0,
+  removes: 0,
+  errors: 0,
+};
+
+function logPoolState(event: string) {
+  console.log(
+    `[db:pool] ${event} total=${pool.totalCount} idle=${pool.idleCount} waiting=${pool.waitingCount} ` +
+      `connects=${metrics.connects} acquires=${metrics.acquires} releases=${metrics.releases} removes=${metrics.removes} errors=${metrics.errors}`
+  );
+}
+
+pool.on("connect", () => {
+  metrics.connects += 1;
+  logPoolState("connect");
+});
+
+pool.on("acquire", () => {
+  metrics.acquires += 1;
+  logPoolState("acquire");
+});
+
+pool.on("release", () => {
+  metrics.releases += 1;
+  logPoolState("release");
+});
+
+pool.on("remove", () => {
+  metrics.removes += 1;
+  logPoolState("remove");
+});
+
+pool.on("error", (error) => {
+  metrics.errors += 1;
+  console.error(`[db:pool] error: ${error.message}`);
+  logPoolState("error");
+});
+
+export function getPoolMetrics() {
+  return {
+    ...metrics,
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
+  };
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,5 +1,4 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+﻿import { pool } from "../db/pool";
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,5 +1,4 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+﻿import { pool } from "../db/pool";
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
   return async (req:any, res:any, next:any) => {

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,8 +1,7 @@
-﻿import { Pool } from "pg";
+﻿import { pool } from "../db/pool";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -3,8 +3,7 @@ import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,8 +1,7 @@
-﻿import { Pool } from "pg";
+﻿import { pool } from "../db/pool";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {


### PR DESCRIPTION
## Summary
- add shared PostgreSQL pool helpers for the monolith and payments service with lifecycle logging/metrics
- update all modules and tests to import the shared pools instead of instantiating new `Pool` objects
- re-export the payments pool utilities for downstream callers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e207c022b883278199ed0c8ec227c4