### PR TITLE
Add compliance data context and tests for Dashboard and BAS

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,20 +9,30 @@
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
-    "devDependencies": {
-        "@types/express": "^5.0.3",
-        "@types/node": "^24.6.2",
-        "ts-node": "^10.9.2",
-        "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
-    },
+    "packageManager": "pnpm@9.12.2",
     "dependencies": {
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "pg": "^8.16.3",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^6.26.0",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
+    },
+    "devDependencies": {
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.6.1",
+        "@types/express": "^5.0.3",
+        "@types/node": "^24.6.2",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "jsdom": "^25.0.0",
+        "ts-node": "^10.9.2",
+        "tsx": "^4.20.6",
+        "typescript": "^5.9.3",
+        "vitest": "^2.1.3"
     }
 }

--- a/src/context/ComplianceContext.tsx
+++ b/src/context/ComplianceContext.tsx
@@ -1,0 +1,293 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+
+export interface ComplianceSelection {
+  abn: string;
+  taxType: string;
+  periodId: string;
+}
+
+export interface BalanceResponse {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  balance_cents?: number;
+  has_release?: boolean;
+  [key: string]: unknown;
+}
+
+export interface LedgerEntry {
+  id: number | string;
+  amount_cents: number;
+  balance_after_cents?: number;
+  created_at?: string;
+  [key: string]: unknown;
+}
+
+export interface LedgerResponse {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  rows: LedgerEntry[];
+  [key: string]: unknown;
+}
+
+export interface EvidencePayload {
+  period_id?: string;
+  amount_cents?: number;
+  tax_type?: string;
+  expiry_ts?: string;
+  created_at?: string;
+  [key: string]: unknown;
+}
+
+export interface EvidenceResponse {
+  rpt_payload?: EvidencePayload | null;
+  rpt_signature?: string | null;
+  owa_ledger_deltas?: Array<{ created_at?: string | null } & Record<string, unknown>> | null;
+  bas_labels?: Record<string, string | null> | null;
+  bank_receipt_hash?: string | null;
+  anomaly_thresholds?: Record<string, unknown> | null;
+  discrepancy_log?: unknown[] | null;
+  [key: string]: unknown;
+}
+
+export interface ComplianceSummary {
+  lodgmentsUpToDate: boolean;
+  paymentsUpToDate: boolean;
+  overallCompliance: number;
+  lastBAS: string;
+  nextDue: string;
+  outstandingLodgments: string[];
+  outstandingAmounts: string[];
+  outstandingPaymentCents: number;
+  totalDepositedCents: number;
+  totalReleasedCents: number;
+  requiredPaymentCents: number;
+}
+
+export interface ComplianceSnapshot {
+  status: "idle" | "loading" | "success" | "error";
+  error: string | null;
+  summary: ComplianceSummary | null;
+  raw: {
+    balance?: BalanceResponse;
+    ledger?: LedgerResponse;
+    evidence?: EvidenceResponse;
+  };
+}
+
+export interface ComplianceClient {
+  balance(selection: ComplianceSelection): Promise<BalanceResponse>;
+  ledger(selection: ComplianceSelection): Promise<LedgerResponse>;
+  evidence(selection: ComplianceSelection): Promise<EvidenceResponse>;
+}
+
+export interface ComplianceProviderProps {
+  children: React.ReactNode;
+  client?: ComplianceClient;
+  initialSelection?: ComplianceSelection;
+}
+
+interface ComplianceContextValue {
+  selection: ComplianceSelection;
+  setSelection: (update: Partial<ComplianceSelection>) => void;
+  refresh: () => Promise<void>;
+  snapshot: ComplianceSnapshot;
+}
+
+const ComplianceContext = createContext<ComplianceContextValue | undefined>(undefined);
+
+const DEFAULT_SELECTION: ComplianceSelection = {
+  abn: "12345678901",
+  taxType: "GST",
+  periodId: "2025-09",
+};
+
+function formatDate(value?: string | null): string {
+  if (!value) {
+    return "N/A";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString("en-AU", {
+    day: "2-digit",
+    month: "short",
+    year: "numeric",
+  });
+}
+
+function centsToCurrency(cents: number, currency: string = "AUD"): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  }).format(cents / 100);
+}
+
+export function normalizeCompliance(
+  balance: BalanceResponse,
+  ledger: LedgerResponse,
+  evidence: EvidenceResponse,
+  selection: ComplianceSelection,
+): ComplianceSummary {
+  const rows = Array.isArray(ledger?.rows) ? ledger.rows : [];
+  const totalDepositedCents = rows.reduce((acc, row) => {
+    const amount = Number(row.amount_cents ?? 0);
+    return amount > 0 ? acc + amount : acc;
+  }, 0);
+  const totalReleasedCents = rows.reduce((acc, row) => {
+    const amount = Number(row.amount_cents ?? 0);
+    return amount < 0 ? acc + Math.abs(amount) : acc;
+  }, 0);
+
+  const requiredPaymentCents = Number(evidence?.rpt_payload?.amount_cents ?? 0);
+  const outstandingPaymentCents = Math.max(requiredPaymentCents - totalReleasedCents, 0);
+
+  const lodgmentsUpToDate = Boolean(evidence?.rpt_payload && evidence?.rpt_signature);
+  const paymentsUpToDate = outstandingPaymentCents === 0 || Boolean(balance?.has_release);
+
+  const coverageRatio = requiredPaymentCents > 0
+    ? Math.min(totalDepositedCents / requiredPaymentCents, 1)
+    : 1;
+
+  const paymentScore = paymentsUpToDate ? 50 : Math.round(50 * coverageRatio);
+  const lodgingScore = lodgmentsUpToDate ? 50 : 10;
+  const overallCompliance = Math.max(0, Math.min(100, paymentScore + lodgingScore));
+
+  const lastLedgerEntry = rows.length > 0 ? rows[rows.length - 1] : null;
+  const deltas = Array.isArray(evidence?.owa_ledger_deltas)
+    ? (evidence?.owa_ledger_deltas as Array<{ created_at?: string | null }>)
+    : [];
+  const lastDelta = deltas.length > 0 ? deltas[deltas.length - 1] : null;
+  const lastBASDate = lastLedgerEntry?.created_at
+    || evidence?.rpt_payload?.created_at
+    || (lastDelta?.created_at ?? null);
+
+  const nextDueDate = evidence?.rpt_payload?.expiry_ts ?? null;
+
+  const outstandingAmounts = outstandingPaymentCents > 0
+    ? [
+        `${centsToCurrency(outstandingPaymentCents)} ${
+          evidence?.rpt_payload?.tax_type || selection.taxType
+        }`,
+      ]
+    : [];
+
+  const outstandingLodgments = lodgmentsUpToDate ? [] : [selection.periodId];
+
+  return {
+    lodgmentsUpToDate,
+    paymentsUpToDate,
+    overallCompliance,
+    lastBAS: formatDate(lastBASDate),
+    nextDue: formatDate(nextDueDate),
+    outstandingLodgments,
+    outstandingAmounts,
+    outstandingPaymentCents,
+    totalDepositedCents,
+    totalReleasedCents,
+    requiredPaymentCents,
+  };
+}
+
+async function fetchJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  const text = await res.text();
+  let data: any = null;
+  try {
+    data = text ? JSON.parse(text) : null;
+  } catch (error) {
+    throw new Error(`Failed to parse response from ${url}`);
+  }
+  if (!res.ok) {
+    const message = data?.error || data?.detail || text || `Request failed with ${res.status}`;
+    throw new Error(String(message));
+  }
+  return data as T;
+}
+
+const defaultClient: ComplianceClient = {
+  async balance(selection) {
+    const params = new URLSearchParams(selection as Record<string, string>);
+    return fetchJson<BalanceResponse>(`/api/balance?${params.toString()}`);
+  },
+  async ledger(selection) {
+    const params = new URLSearchParams(selection as Record<string, string>);
+    return fetchJson<LedgerResponse>(`/api/ledger?${params.toString()}`);
+  },
+  async evidence(selection) {
+    const params = new URLSearchParams(selection as Record<string, string>);
+    return fetchJson<EvidenceResponse>(`/api/evidence?${params.toString()}`);
+  },
+};
+
+export function ComplianceProvider({
+  children,
+  client = defaultClient,
+  initialSelection = DEFAULT_SELECTION,
+}: ComplianceProviderProps) {
+  const [selection, setSelectionState] = useState<ComplianceSelection>(initialSelection);
+  const [snapshot, setSnapshot] = useState<ComplianceSnapshot>({
+    status: "idle",
+    error: null,
+    summary: null,
+    raw: {},
+  });
+
+  const load = useCallback(
+    async (current: ComplianceSelection) => {
+      setSnapshot((prev) => ({ ...prev, status: "loading", error: null }));
+      try {
+        const [balance, ledger, evidence] = await Promise.all([
+          client.balance(current),
+          client.ledger(current),
+          client.evidence(current),
+        ]);
+        const summary = normalizeCompliance(balance, ledger, evidence, current);
+        setSnapshot({
+          status: "success",
+          error: null,
+          summary,
+          raw: { balance, ledger, evidence },
+        });
+      } catch (error: any) {
+        setSnapshot({
+          status: "error",
+          error: error?.message ?? "Failed to load compliance data",
+          summary: null,
+          raw: {},
+        });
+      }
+    },
+    [client],
+  );
+
+  useEffect(() => {
+    load(selection);
+  }, [selection, load]);
+
+  const setSelection = useCallback((update: Partial<ComplianceSelection>) => {
+    setSelectionState((prev) => ({ ...prev, ...update }));
+  }, []);
+
+  const refresh = useCallback(() => load(selection), [load, selection]);
+
+  const value = useMemo<ComplianceContextValue>(() => ({
+    selection,
+    setSelection,
+    refresh,
+    snapshot,
+  }), [selection, setSelection, refresh, snapshot]);
+
+  return <ComplianceContext.Provider value={value}>{children}</ComplianceContext.Provider>;
+}
+
+export function useCompliance(): ComplianceContextValue {
+  const ctx = useContext(ComplianceContext);
+  if (!ctx) {
+    throw new Error("useCompliance must be used within a ComplianceProvider");
+  }
+  return ctx;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,13 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { ComplianceProvider } from "./context/ComplianceContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
-root.render(<App />);
+root.render(
+  <React.StrictMode>
+    <ComplianceProvider>
+      <App />
+    </ComplianceProvider>
+  </React.StrictMode>
+);

--- a/src/pages/BAS.tsx
+++ b/src/pages/BAS.tsx
@@ -1,18 +1,49 @@
 import React from 'react';
+import { useCompliance } from '../context/ComplianceContext';
 
 export default function BAS() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65, // percentage from 0 to 100
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const { snapshot, refresh } = useCompliance();
+  const { status, summary, error } = snapshot;
+
+  if (status === 'loading' && !summary) {
+    return (
+      <div className="main-card">
+        <p className="text-sm text-gray-600">Loading BAS compliance data…</p>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="main-card space-y-4">
+        <div className="bg-red-100 border border-red-200 text-red-700 p-4 rounded-lg">
+          <p className="font-semibold">Unable to load BAS overview.</p>
+          <p className="text-sm mt-1">{error}</p>
+          <button
+            type="button"
+            onClick={refresh}
+            className="mt-3 inline-flex items-center rounded bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  const complianceStatus = summary;
 
   return (
     <div className="main-card">
+      {status === 'loading' && (
+        <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-700">
+          Refreshing BAS metrics…
+        </div>
+      )}
       <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
       <p className="text-sm text-muted-foreground mb-4">
         Lodge your BAS on time and accurately. Below is a summary of your current obligations.

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,20 +1,51 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useCompliance } from '../context/ComplianceContext';
 
 export default function Dashboard() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65,
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const { snapshot, refresh } = useCompliance();
+  const { status, summary, error } = snapshot;
+
+  if (status === 'loading' && !summary) {
+    return (
+      <div className="main-card">
+        <p className="text-sm text-gray-600">Loading compliance data…</p>
+      </div>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <div className="main-card space-y-4">
+        <div className="bg-red-100 border border-red-200 text-red-700 p-4 rounded-lg">
+          <p className="font-semibold">We couldn't load your compliance overview.</p>
+          <p className="text-sm mt-1">{error}</p>
+          <button
+            type="button"
+            onClick={refresh}
+            className="mt-3 inline-flex items-center rounded bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+          >
+            Try again
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!summary) {
+    return null;
+  }
+
+  const complianceStatus = summary;
 
   return (
     <div className="main-card">
+      {status === 'loading' && (
+        <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-3 text-xs text-blue-700">
+          Refreshing compliance data…
+        </div>
+      )}
       <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
         <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
         <p className="text-sm opacity-90">

--- a/src/pages/__tests__/CompliancePages.test.tsx
+++ b/src/pages/__tests__/CompliancePages.test.tsx
@@ -1,0 +1,133 @@
+import React from "react";
+import { describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { act, render, screen } from "@testing-library/react";
+import Dashboard from "../Dashboard";
+import BAS from "../BAS";
+import {
+  ComplianceClient,
+  ComplianceProvider,
+  ComplianceSelection,
+  BalanceResponse,
+  LedgerResponse,
+  EvidenceResponse,
+} from "../../context/ComplianceContext";
+
+const selection: ComplianceSelection = {
+  abn: "12345678901",
+  taxType: "GST",
+  periodId: "2025-09",
+};
+
+function renderWithClient(ui: React.ReactNode, client: ComplianceClient) {
+  return render(
+    <ComplianceProvider client={client} initialSelection={selection}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </ComplianceProvider>
+  );
+}
+
+function buildSuccessfulFixtures() {
+  const balance: BalanceResponse = {
+    abn: selection.abn,
+    taxType: selection.taxType,
+    periodId: selection.periodId,
+    balance_cents: 0,
+    has_release: true,
+  };
+
+  const ledger: LedgerResponse = {
+    abn: selection.abn,
+    taxType: selection.taxType,
+    periodId: selection.periodId,
+    rows: [
+      { id: 1, amount_cents: 50000, created_at: "2025-05-01T00:00:00Z" },
+      { id: 2, amount_cents: 73456, created_at: "2025-05-15T00:00:00Z" },
+      { id: 3, amount_cents: -123456, created_at: "2025-05-28T00:00:00Z" },
+    ],
+  };
+
+  const evidence: EvidenceResponse = {
+    rpt_payload: {
+      period_id: selection.periodId,
+      amount_cents: 123456,
+      tax_type: selection.taxType,
+      expiry_ts: "2025-07-28T00:00:00Z",
+      created_at: "2025-05-28T00:00:00Z",
+    },
+    rpt_signature: "signature",
+  };
+
+  return { balance, ledger, evidence };
+}
+
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("Compliance-enabled pages", () => {
+  it("shows a loading state while fetching compliance data", async () => {
+    const fixtures = buildSuccessfulFixtures();
+    const balance = createDeferred<BalanceResponse>();
+    const ledger = createDeferred<LedgerResponse>();
+    const evidence = createDeferred<EvidenceResponse>();
+
+    const client: ComplianceClient = {
+      balance: () => balance.promise,
+      ledger: () => ledger.promise,
+      evidence: () => evidence.promise,
+    };
+
+    renderWithClient(<Dashboard />, client);
+
+    expect(screen.getByText(/loading compliance data/i)).toBeInTheDocument();
+
+    await act(async () => {
+      balance.resolve(fixtures.balance);
+      ledger.resolve(fixtures.ledger);
+      evidence.resolve(fixtures.evidence);
+    });
+
+    expect(await screen.findByText(/Up to date ✅/)).toBeInTheDocument();
+  });
+
+  it("renders compliance insights once the API calls succeed", async () => {
+    const fixtures = buildSuccessfulFixtures();
+    const client: ComplianceClient = {
+      balance: vi.fn().mockResolvedValue(fixtures.balance),
+      ledger: vi.fn().mockResolvedValue(fixtures.ledger),
+      evidence: vi.fn().mockResolvedValue(fixtures.evidence),
+    };
+
+    renderWithClient(<Dashboard />, client);
+
+    expect(await screen.findByText(/Up to date ✅/)).toBeInTheDocument();
+    expect(screen.getByText(/All paid ✅/)).toBeInTheDocument();
+    expect(screen.getByText(/Compliance Score/i)).toBeInTheDocument();
+    expect(screen.getByText(/Next BAS due by/i)).toBeInTheDocument();
+  });
+
+  it("surfaces API failures on the BAS page", async () => {
+    const client: ComplianceClient = {
+      balance: vi.fn().mockRejectedValue(new Error("boom")),
+      ledger: vi.fn().mockResolvedValue({
+        abn: selection.abn,
+        taxType: selection.taxType,
+        periodId: selection.periodId,
+        rows: [],
+      }),
+      evidence: vi.fn().mockResolvedValue({}),
+    };
+
+    renderWithClient(<BAS />, client);
+
+    expect(await screen.findByText(/Unable to load BAS overview/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    setupFiles: "./vitest.setup.ts",
+    globals: true,
+  },
+});

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
## Summary
- add a shared compliance context that fetches balance, ledger, and evidence data and normalises it for consumers
- update the Dashboard and BAS pages to use the shared context with loading and error UI states
- configure Vitest and add component tests that cover loading, success, and failure scenarios with mocked API clients

## Testing
- pnpm exec vitest run *(fails: unable to download pnpm 9.12.2 in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e207bdd21883279afed31bbac9583d