### PR TITLE
Fix RPT issuance SQL and add coverage for RPT tokens

### DIFF
--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -20,3 +20,22 @@ export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
     Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
   );
 }
+
+export function exceeds(
+  v: Partial<AnomalyVector> | null | undefined,
+  thr: Thresholds = {}
+): boolean {
+  if (!v) return false;
+
+  const varianceRatio = v.variance_ratio ?? 0;
+  const dupRate = v.dup_rate ?? 0;
+  const gapMinutes = v.gap_minutes ?? 0;
+  const deltaVsBaseline = v.delta_vs_baseline ?? 0;
+
+  return (
+    varianceRatio > (thr.variance_ratio ?? 0.25) ||
+    dupRate > (thr.dup_rate ?? 0.05) ||
+    gapMinutes > (thr.gap_minutes ?? 60) ||
+    Math.abs(deltaVsBaseline) > (thr.delta_vs_baseline ?? 0.1)
+  );
+}

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -5,20 +5,28 @@ import { exceeds } from "../anomaly/deterministic";
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>
+) {
+  const p = await pool.query(
+    "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
-  const v = row.anomaly_vector || {};
+  const v = (row.anomaly_vector as Record<string, number>) || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +38,11 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  const payloadJson = JSON.stringify(payload);
+  await pool.query(
+    "INSERT INTO rpt_tokens(abn, tax_type, period_id, payload, signature, status) VALUES ($1,$2,$3,$4::jsonb,$5,$6)",
+    [abn, taxType, periodId, payloadJson, signature, "ISSUED"]
+  );
+  await pool.query("UPDATE periods SET state='READY_RPT' WHERE id=$1", [row.id]);
   return { payload, signature };
 }

--- a/tests/rpt/issuer.test.ts
+++ b/tests/rpt/issuer.test.ts
@@ -1,0 +1,98 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+process.env.RPT_ED25519_SECRET_BASE64 = Buffer.alloc(64).toString("base64");
+
+class MockPool {
+  private responses: Array<{ rowCount: number; rows: any[]; command?: string }> = [];
+  public queries: Array<{ text: string; params?: any[] }> = [];
+
+  queue(response: { rowCount: number; rows: any[]; command?: string }) {
+    this.responses.push(response);
+  }
+
+  async query(text: string, params?: any[]) {
+    this.queries.push({ text, params });
+    const next = this.responses.shift();
+    if (!next) {
+      throw new Error(`No response queued for query: ${text}`);
+    }
+    return next;
+  }
+}
+
+const mockPool = new MockPool();
+mockPool.queue({
+  rowCount: 1,
+  rows: [
+    {
+      id: 42,
+      abn: "12345678901",
+      tax_type: "GST",
+      period_id: "2024-09",
+      state: "CLOSING",
+      anomaly_vector: { variance_ratio: 0.01, dup_rate: 0, gap_minutes: 0, delta_vs_baseline: 0 },
+      final_liability_cents: 1000,
+      credited_to_owa_cents: 1000,
+      merkle_root: "abc",
+      running_balance_hash: "def",
+    },
+  ],
+});
+mockPool.queue({ rowCount: 1, rows: [], command: "INSERT" });
+mockPool.queue({ rowCount: 1, rows: [], command: "UPDATE" });
+
+type IssueRPT = typeof import("../../src/rpt/issuer").issueRPT;
+let issueRPT: IssueRPT;
+
+test.before(async () => {
+  const pgModule = await import("pg");
+  const pgAny = pgModule as any;
+  const Mock = class {
+    constructor() {
+      return mockPool;
+    }
+  };
+  pgAny.Pool = Mock;
+  if (pgAny.default) {
+    pgAny.default.Pool = Mock;
+  }
+
+  ({ issueRPT } = await import("../../src/rpt/issuer"));
+});
+
+test("issueRPT persists token and marks period ready", async () => {
+  const thresholds = {
+    variance_ratio: 0.5,
+    dup_rate: 0.5,
+    gap_minutes: 120,
+    delta_vs_baseline: 0.5,
+    epsilon_cents: 10,
+  };
+
+  const result = await issueRPT("12345678901", "GST", "2024-09", thresholds);
+
+  assert.equal(result.payload.entity_id, "12345678901");
+  assert.equal(result.payload.period_id, "2024-09");
+  assert.equal(result.payload.tax_type, "GST");
+  assert.equal(typeof result.signature, "string");
+  assert.ok(result.signature.length > 0, "signature should not be empty");
+
+  const insertCall = mockPool.queries.find((q) =>
+    q.text.toLowerCase().startsWith("insert into rpt_tokens")
+  );
+  assert.ok(insertCall, "insert into rpt_tokens should be executed");
+  assert.deepEqual(insertCall?.params?.slice(0, 3), ["12345678901", "GST", "2024-09"]);
+  assert.equal(typeof insertCall?.params?.[3], "string", "payload stored as canonical JSON string");
+  assert.equal(insertCall?.params?.[5], "ISSUED");
+  assert.ok(
+    insertCall?.text.includes("$4::jsonb"),
+    "payload should be stored via jsonb parameter placeholder"
+  );
+
+  const updateCall = mockPool.queries.find((q) =>
+    q.text.toLowerCase().startsWith("update periods set state='ready_rpt'")
+  );
+  assert.ok(updateCall, "period state transition should be executed");
+  assert.deepEqual(updateCall?.params, [42]);
+});


### PR DESCRIPTION
## Summary
- add an `exceeds` helper that mirrors the anomaly threshold logic
- parameterize the `issueRPT` queries to persist payload/signature/status and scope the state update by id
- cover the issuance flow with a node:test that seeds a period row and asserts the insert/update interactions

## Testing
- npx tsx --test tests/rpt/issuer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e207b77d2c8327bd74d1be1ac9e76f