### PR TITLE
Add aggregated API router

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+
+import { paymentsApi } from "./payments";
+
+const api = Router();
+
+// Ensure payments routes are registered before any other subrouters that may shadow them.
+api.use(paymentsApi);
+
+export { api, paymentsApi };
+export default api;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,7 @@ import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
-import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import api from "./api"; // Aggregated API router(s)
 
 dotenv.config();
 
@@ -25,10 +24,7 @@ app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
 
-// ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
-
-// Existing API router(s) after
+// Mount aggregated API router(s)
 app.use("/api", api);
 
 // 404 fallback (must be last)


### PR DESCRIPTION
## Summary
- add an Express router at `src/api/index.ts` that aggregates the existing payments routes
- simplify `src/index.ts` to import and mount the aggregated API router

## Testing
- npm run dev
- curl -sSf http://127.0.0.1:3000/health


------
https://chatgpt.com/codex/tasks/task_e_68e207b3de508327b8c73c451ecedd44