### PR TITLE
Enhance evidence bundle and settlement ingestion

### DIFF
--- a/docs/evidence-bundle-schema.md
+++ b/docs/evidence-bundle-schema.md
@@ -1,0 +1,70 @@
+# Evidence bundle schema
+
+This document describes the JSON artifact produced by `buildEvidenceBundle` and returned by `GET /api/evidence`.  It is intended for auditors, downstream services, and data-retention tooling that need a stable contract.
+
+## Schema summary
+
+The canonical JSON Schema lives at [`schema/json/evidence_bundle.schema.json`](../schema/json/evidence_bundle.schema.json).  High-level fields:
+
+| Field | Description |
+| ----- | ----------- |
+| `meta` | Generation metadata (`generated_at`, `abn`, `taxType`, `periodId`). |
+| `period` | Period level state and financial tallies, including the anomaly vector captured at reconciliation time. |
+| `rpt` | Latest reconciliation pass token payload, canonical form, digest, and signature. |
+| `bas_labels` | BAS label amounts keyed by label code (W1/W2/1A/1B plus any extensions recorded by reconciliation). |
+| `anomaly_thresholds` | Thresholds used by the reconciliation engine when testing anomaly vectors. |
+| `owa_ledger_deltas` | Ordered movements applied to GST and net settlement ledgers during reconciliation. |
+| `discrepancy_log` | Chronological human-readable discrepancy entries emitted by reconciliation controls. |
+
+All currency values are expressed in integer cents.  The schema enforces ISO 8601 timestamps for temporal fields.
+
+## Source tables
+
+`buildEvidenceBundle` hydrates the evidence payload directly from the reconciliation tables.  The SQL fragments below document the exact lookups:
+
+```sql
+-- Period metadata
+SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents,
+       merkle_root, running_balance_hash, anomaly_vector, thresholds
+  FROM periods
+ WHERE abn=$1 AND tax_type=$2 AND period_id=$3;
+
+-- Reconciliation RPT artefact
+SELECT payload, payload_c14n, payload_sha256, signature, created_at
+  FROM rpt_tokens
+ WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+ ORDER BY created_at DESC
+ LIMIT 1;
+
+-- BAS label rollup
+SELECT label_code, amount_cents
+  FROM recon_bas_labels
+ WHERE abn=$1 AND tax_type=$2 AND period_id=$3;
+
+-- Thresholds and anomaly vector snapshot captured by reconciliation
+SELECT thresholds, anomaly_vector
+  FROM recon_anomaly_matrix
+ WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+ ORDER BY recorded_at DESC
+ LIMIT 1;
+
+-- Ledger movements produced by settlement ingestion
+SELECT txn_id, component, amount_cents, balance_after_cents, settled_at, source
+  FROM recon_ledger_deltas
+ WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+ ORDER BY settled_at ASC, id ASC;
+
+-- Detected discrepancies and remediation notes
+SELECT discrepancy_type, observed_cents, expected_cents, explanation, detected_at
+  FROM recon_discrepancies
+ WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+ ORDER BY detected_at ASC, id ASC;
+```
+
+The ledger rows referenced above are populated by the settlement ingestion webhook (see below).  Discrepancy entries are expected to be appended by reconciliation workers when human intervention is required.
+
+## Contract guarantees
+
+* `meta.generated_at` is populated at render time and should not be interpreted as the reconciliation timestamp.
+* The `bas_labels` object always contains the standard GST labels (`W1`, `W2`, `1A`, `1B`).  Additional labels may appear for extended reporting.
+* Missing data from any reconciliation table results in an empty/default structure rather than a server error, ensuring the endpoint remains available even when optional subsystems lag behind.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "node --test --import tsx tests/node/evidence-bundle.test.ts tests/node/settlement-webhook.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/schema/json/evidence_bundle.schema.json
+++ b/schema/json/evidence_bundle.schema.json
@@ -1,0 +1,125 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "EvidenceBundle",
+  "type": "object",
+  "required": [
+    "meta",
+    "period",
+    "rpt",
+    "bas_labels",
+    "anomaly_thresholds",
+    "owa_ledger_deltas",
+    "discrepancy_log"
+  ],
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["generated_at", "abn", "taxType", "periodId"],
+      "properties": {
+        "generated_at": { "type": "string", "format": "date-time" },
+        "abn": { "type": "string" },
+        "taxType": { "type": "string", "enum": ["GST", "PAYGW"] },
+        "periodId": { "type": "string", "pattern": "^\\d{4}-\\d{2}$" }
+      },
+      "additionalProperties": false
+    },
+    "period": {
+      "type": "object",
+      "required": [
+        "state",
+        "accrued_cents",
+        "credited_to_owa_cents",
+        "final_liability_cents",
+        "merkle_root",
+        "running_balance_hash",
+        "anomaly_vector"
+      ],
+      "properties": {
+        "state": {
+          "type": "string",
+          "enum": [
+            "OPEN",
+            "CLOSING",
+            "READY_RPT",
+            "RELEASED",
+            "BLOCKED_ANOMALY",
+            "BLOCKED_DISCREPANCY",
+            "FINALIZED"
+          ]
+        },
+        "accrued_cents": { "type": "integer" },
+        "credited_to_owa_cents": { "type": "integer" },
+        "final_liability_cents": { "type": "integer" },
+        "merkle_root": { "type": ["string", "null"] },
+        "running_balance_hash": { "type": ["string", "null"] },
+        "anomaly_vector": { "type": "object" },
+        "thresholds": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "rpt": {
+      "type": ["object", "null"],
+      "required": ["payload", "payload_c14n", "payload_sha256", "signature", "created_at"],
+      "properties": {
+        "payload": { "type": "object" },
+        "payload_c14n": { "type": ["string", "null"] },
+        "payload_sha256": { "type": ["string", "null"] },
+        "signature": { "type": "string" },
+        "created_at": { "type": "string", "format": "date-time" }
+      },
+      "additionalProperties": false
+    },
+    "bas_labels": {
+      "type": "object",
+      "properties": {
+        "W1": { "type": ["integer", "null"] },
+        "W2": { "type": ["integer", "null"] },
+        "1A": { "type": ["integer", "null"] },
+        "1B": { "type": ["integer", "null"] }
+      },
+      "additionalProperties": true
+    },
+    "anomaly_thresholds": {
+      "type": "object"
+    },
+    "owa_ledger_deltas": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "txn_id",
+          "component",
+          "amount_cents",
+          "balance_after_cents",
+          "settled_at",
+          "source"
+        ],
+        "properties": {
+          "txn_id": { "type": "string" },
+          "component": { "type": "string" },
+          "amount_cents": { "type": "integer" },
+          "balance_after_cents": { "type": "integer" },
+          "settled_at": { "type": "string", "format": "date-time" },
+          "source": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "discrepancy_log": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["discrepancy_type", "detected_at"],
+        "properties": {
+          "discrepancy_type": { "type": "string" },
+          "observed_cents": { "type": ["integer", "null"] },
+          "expected_cents": { "type": ["integer", "null"] },
+          "explanation": { "type": ["string", "null"] },
+          "detected_at": { "type": "string", "format": "date-time" }
+        },
+        "additionalProperties": true
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,250 @@
-﻿import { Pool } from "pg";
+import { Pool, QueryResult } from "pg";
+
+type Queryable = Pick<Pool, "query">;
+
 const pool = new Pool();
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+const PERIOD_SQL = `
+  SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents,
+         merkle_root, running_balance_hash, anomaly_vector, thresholds
+    FROM periods
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+`;
+
+const RPT_SQL = `
+  SELECT payload, payload_c14n, payload_sha256, signature, created_at
+    FROM rpt_tokens
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+   ORDER BY created_at DESC
+   LIMIT 1
+`;
+
+const BAS_SQL = `
+  SELECT label_code, amount_cents
+    FROM recon_bas_labels
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+`;
+
+const ANOMALY_SQL = `
+  SELECT thresholds, anomaly_vector
+    FROM recon_anomaly_matrix
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+   ORDER BY recorded_at DESC
+   LIMIT 1
+`;
+
+const LEDGER_SQL = `
+  SELECT txn_id, component, amount_cents, balance_after_cents, settled_at, source
+    FROM recon_ledger_deltas
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+   ORDER BY settled_at ASC, id ASC
+`;
+
+const DISCREPANCY_SQL = `
+  SELECT discrepancy_type, observed_cents, expected_cents, explanation, detected_at
+    FROM recon_discrepancies
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+   ORDER BY detected_at ASC, id ASC
+`;
+
+function isUndefinedTable(error: unknown) {
+  return typeof error === "object" && error !== null && (error as { code?: string }).code === "42P01";
+}
+
+async function safeQuery<T>(db: Queryable, sql: string, params: any[]): Promise<QueryResult<T>> {
+  try {
+    return await db.query<T>(sql, params);
+  } catch (error) {
+    if (isUndefinedTable(error)) {
+      return { rows: [] } as QueryResult<T>;
+    }
+    throw error;
+  }
+}
+
+function toRecord(value: unknown): Record<string, any> {
+  if (value === null || value === undefined) return {};
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return {};
+    }
+  }
+  if (typeof value === "object") return value as Record<string, any>;
+  return {};
+}
+
+type BasRow = { label_code: string; amount_cents: number | string | null };
+
+type LedgerRow = {
+  txn_id: string;
+  component: string;
+  amount_cents: number | string;
+  balance_after_cents: number | string;
+  settled_at: Date | string;
+  source: string | null;
+};
+
+type DiscrepancyRow = {
+  discrepancy_type: string;
+  observed_cents: number | string | null;
+  expected_cents: number | string | null;
+  explanation: string | null;
+  detected_at: Date | string;
+};
+
+type PeriodRow = {
+  state: string;
+  accrued_cents: number | string | null;
+  credited_to_owa_cents: number | string | null;
+  final_liability_cents: number | string | null;
+  merkle_root: string | null;
+  running_balance_hash: string | null;
+  anomaly_vector: unknown;
+  thresholds: unknown;
+};
+
+type RptRow = {
+  payload: any;
+  payload_c14n: string | null;
+  payload_sha256: string | null;
+  signature: string;
+  created_at: Date | string;
+};
+
+type AnomalyRow = {
+  thresholds: unknown;
+  anomaly_vector: unknown;
+};
+
+export type EvidenceBundle = {
+  meta: {
+    generated_at: string;
+    abn: string;
+    taxType: string;
+    periodId: string;
   };
-  return bundle;
+  period: {
+    state: string;
+    accrued_cents: number;
+    credited_to_owa_cents: number;
+    final_liability_cents: number;
+    merkle_root: string | null;
+    running_balance_hash: string | null;
+    anomaly_vector: Record<string, any>;
+    thresholds: Record<string, any>;
+  };
+  rpt: {
+    payload: any;
+    payload_c14n: string | null;
+    payload_sha256: string | null;
+    signature: string;
+    created_at: string;
+  } | null;
+  bas_labels: Record<string, number | null>;
+  anomaly_thresholds: Record<string, any>;
+  owa_ledger_deltas: Array<{
+    txn_id: string;
+    component: string;
+    amount_cents: number;
+    balance_after_cents: number;
+    settled_at: string;
+    source: string;
+  }>;
+  discrepancy_log: Array<{
+    discrepancy_type: string;
+    observed_cents: number | null;
+    expected_cents: number | null;
+    explanation: string | null;
+    detected_at: string;
+  }>;
+};
+
+export async function buildEvidenceBundle(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  db: Queryable = pool
+): Promise<EvidenceBundle> {
+  const { rows: periodRows } = await safeQuery<PeriodRow>(db, PERIOD_SQL, [abn, taxType, periodId]);
+  const periodRow = periodRows[0];
+  if (!periodRow) {
+    throw new Error("PERIOD_NOT_FOUND");
+  }
+
+  const { rows: rptRows } = await safeQuery<RptRow>(db, RPT_SQL, [abn, taxType, periodId]);
+  const rptRow = rptRows[0] ?? null;
+
+  const { rows: basRows } = await safeQuery<BasRow>(db, BAS_SQL, [abn, taxType, periodId]);
+  const { rows: anomalyRows } = await safeQuery<AnomalyRow>(db, ANOMALY_SQL, [abn, taxType, periodId]);
+  const anomalyRow = anomalyRows[0];
+
+  const { rows: ledgerRows } = await safeQuery<LedgerRow>(db, LEDGER_SQL, [abn, taxType, periodId]);
+  const { rows: discrepancyRows } = await safeQuery<DiscrepancyRow>(db, DISCREPANCY_SQL, [abn, taxType, periodId]);
+
+  const basLabels: Record<string, number | null> = { W1: null, W2: null, "1A": null, "1B": null };
+  for (const row of basRows) {
+    const amount = row.amount_cents === null ? null : Number(row.amount_cents);
+    basLabels[row.label_code] = Number.isFinite(amount) ? amount : null;
+  }
+
+  const anomalyThresholds = {
+    ...toRecord(periodRow.thresholds),
+    ...toRecord(anomalyRow?.thresholds)
+  };
+
+  const anomalyVector = {
+    ...toRecord(periodRow.anomaly_vector),
+    ...toRecord(anomalyRow?.anomaly_vector)
+  };
+
+  const ledgerDeltas = ledgerRows.map((row) => ({
+    txn_id: row.txn_id,
+    component: row.component,
+    amount_cents: Number(row.amount_cents),
+    balance_after_cents: Number(row.balance_after_cents),
+    settled_at: new Date(row.settled_at).toISOString(),
+    source: row.source ?? "SETTLEMENT_WEBHOOK"
+  }));
+
+  const discrepancyLog = discrepancyRows.map((row) => ({
+    discrepancy_type: row.discrepancy_type,
+    observed_cents: row.observed_cents === null ? null : Number(row.observed_cents),
+    expected_cents: row.expected_cents === null ? null : Number(row.expected_cents),
+    explanation: row.explanation ?? null,
+    detected_at: new Date(row.detected_at).toISOString()
+  }));
+
+  return {
+    meta: {
+      generated_at: new Date().toISOString(),
+      abn,
+      taxType,
+      periodId
+    },
+    period: {
+      state: periodRow.state,
+      accrued_cents: Number(periodRow.accrued_cents ?? 0),
+      credited_to_owa_cents: Number(periodRow.credited_to_owa_cents ?? 0),
+      final_liability_cents: Number(periodRow.final_liability_cents ?? 0),
+      merkle_root: periodRow.merkle_root ?? null,
+      running_balance_hash: periodRow.running_balance_hash ?? null,
+      anomaly_vector: anomalyVector,
+      thresholds: toRecord(periodRow.thresholds)
+    },
+    rpt: rptRow
+      ? {
+          payload: rptRow.payload,
+          payload_c14n: rptRow.payload_c14n ?? null,
+          payload_sha256: rptRow.payload_sha256 ?? null,
+          signature: rptRow.signature,
+          created_at: new Date(rptRow.created_at).toISOString()
+        }
+      : null,
+    bas_labels: basLabels,
+    anomaly_thresholds: anomalyThresholds,
+    owa_ledger_deltas: ledgerDeltas,
+    discrepancy_log: discrepancyLog
+  };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -3,8 +3,148 @@ import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import { Pool, QueryResult } from "pg";
 const pool = new Pool();
+
+type Queryable = Pick<Pool, "query">;
+
+type SettlementRow = {
+  txn_id: string;
+  gst_cents: number;
+  net_cents: number;
+  settlement_ts: string;
+};
+
+const CHECK_LEDGER_SQL = `
+  SELECT id
+    FROM recon_ledger_deltas
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+     AND txn_id=$4 AND component=$5 AND amount_cents=$6
+   LIMIT 1
+`;
+
+const LAST_BALANCE_SQL = `
+  SELECT balance_after_cents
+    FROM recon_ledger_deltas
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND component=$4
+   ORDER BY settled_at DESC, id DESC
+   LIMIT 1
+`;
+
+const INSERT_LEDGER_SQL = `
+  INSERT INTO recon_ledger_deltas(
+    abn,tax_type,period_id,txn_id,component,amount_cents,balance_after_cents,settled_at,source
+  ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+  RETURNING id
+`;
+
+const FIND_ORIGINAL_SQL = `
+  SELECT txn_id
+    FROM recon_ledger_deltas
+   WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+     AND txn_id=$4 AND component=$5 AND amount_cents > 0
+   ORDER BY settled_at ASC, id ASC
+   LIMIT 1
+`;
+
+const UPSERT_REVERSAL_SQL = `
+  INSERT INTO recon_txn_reversals(
+    abn,tax_type,period_id,original_txn_id,reversal_txn_id,recorded_at
+  ) VALUES ($1,$2,$3,$4,$5,$6)
+  ON CONFLICT (abn,tax_type,period_id,reversal_txn_id)
+  DO UPDATE SET original_txn_id=EXCLUDED.original_txn_id, recorded_at=EXCLUDED.recorded_at
+`;
+
+function isUndefinedTable(error: unknown) {
+  return typeof error === "object" && error !== null && (error as { code?: string }).code === "42P01";
+}
+
+async function safeExec<T>(db: Queryable, sql: string, params: any[]): Promise<QueryResult<T>> {
+  try {
+    return await db.query<T>(sql, params);
+  } catch (error) {
+    if (isUndefinedTable(error)) {
+      return { rows: [], rowCount: 0 } as QueryResult<T>;
+    }
+    throw error;
+  }
+}
+
+async function postLedgerComponent(
+  db: Queryable,
+  abn: string,
+  taxType: string,
+  periodId: string,
+  row: SettlementRow,
+  component: "GST" | "NET",
+  amount: number
+) {
+  if (!Number.isFinite(amount) || amount === 0) return;
+
+  const existing = await safeExec<{ id: number }>(db, CHECK_LEDGER_SQL, [
+    abn,
+    taxType,
+    periodId,
+    row.txn_id,
+    component,
+    amount
+  ]);
+  if (existing.rowCount && existing.rowCount > 0) {
+    return;
+  }
+
+  const prevBalance = await safeExec<{ balance_after_cents: number | string }>(
+    db,
+    LAST_BALANCE_SQL,
+    [abn, taxType, periodId, component]
+  );
+  const prev = prevBalance.rows[0]?.balance_after_cents ?? 0;
+  const newBalance = Number(prev) + amount;
+
+  await safeExec(db, INSERT_LEDGER_SQL, [
+    abn,
+    taxType,
+    periodId,
+    row.txn_id,
+    component,
+    amount,
+    newBalance,
+    new Date(row.settlement_ts).toISOString(),
+    "SETTLEMENT_WEBHOOK"
+  ]);
+
+  if (amount < 0) {
+    const original = await safeExec<{ txn_id: string }>(db, FIND_ORIGINAL_SQL, [
+      abn,
+      taxType,
+      periodId,
+      row.txn_id,
+      component
+    ]);
+    const originalTxn = original.rows[0]?.txn_id ?? row.txn_id;
+    await safeExec(db, UPSERT_REVERSAL_SQL, [
+      abn,
+      taxType,
+      periodId,
+      originalTxn,
+      row.txn_id,
+      new Date(row.settlement_ts).toISOString()
+    ]);
+  }
+}
+
+export async function ingestSettlementRows(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  rows: SettlementRow[],
+  db: Queryable = pool
+) {
+  for (const row of rows) {
+    await postLedgerComponent(db, abn, taxType, periodId, row, "GST", Number(row.gst_cents));
+    await postLedgerComponent(db, abn, taxType, periodId, row, "NET", Number(row.net_cents));
+  }
+}
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;
@@ -40,10 +180,18 @@ export async function paytoSweep(req:any, res:any) {
 }
 
 export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
-  const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
-  return res.json({ ingested: rows.length });
+  const { abn, taxType, periodId, csv } = req.body || {};
+  if (!abn || !taxType || !periodId || typeof csv !== "string") {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+
+  const rows = parseSettlementCSV(csv);
+  try {
+    await ingestSettlementRows(abn, taxType, periodId, rows, pool);
+    return res.json({ ingested: rows.length });
+  } catch (e:any) {
+    return res.status(500).json({ error: "SETTLEMENT_INGEST_FAILED", detail: String(e?.message || e) });
+  }
 }
 
 export async function evidence(req:any, res:any) {

--- a/tests/fixtures/evidence/bundle.expected.json
+++ b/tests/fixtures/evidence/bundle.expected.json
@@ -1,0 +1,80 @@
+{
+  "meta": {
+    "generated_at": "<<timestamp>>",
+    "abn": "12345678901",
+    "taxType": "GST",
+    "periodId": "2025-09"
+  },
+  "period": {
+    "state": "READY_RPT",
+    "accrued_cents": 150000,
+    "credited_to_owa_cents": 125000,
+    "final_liability_cents": 120000,
+    "merkle_root": "merkle-root",
+    "running_balance_hash": "balance-hash",
+    "anomaly_vector": {
+      "gap_minutes": 7,
+      "dup_rate": 0,
+      "variance_ratio": 0.12
+    },
+    "thresholds": {
+      "epsilon_cents": 50
+    }
+  },
+  "rpt": {
+    "payload": {
+      "amount_cents": 120000,
+      "reference": "REF123"
+    },
+    "payload_c14n": "{\"amount_cents\":120000}",
+    "payload_sha256": "hash123",
+    "signature": "sig",
+    "created_at": "2025-10-05T00:00:00.000Z"
+  },
+  "bas_labels": {
+    "W1": 200000,
+    "W2": 50000,
+    "1A": 18000,
+    "1B": 12000
+  },
+  "anomaly_thresholds": {
+    "epsilon_cents": 50,
+    "variance_ratio": 0.2,
+    "dup_rate": 0.01
+  },
+  "owa_ledger_deltas": [
+    {
+      "txn_id": "TXN-1",
+      "component": "GST",
+      "amount_cents": 1000,
+      "balance_after_cents": 1000,
+      "settled_at": "2025-09-30T10:00:00.000Z",
+      "source": "SETTLEMENT_WEBHOOK"
+    },
+    {
+      "txn_id": "TXN-1",
+      "component": "NET",
+      "amount_cents": 9000,
+      "balance_after_cents": 9000,
+      "settled_at": "2025-09-30T10:00:00.000Z",
+      "source": "SETTLEMENT_WEBHOOK"
+    },
+    {
+      "txn_id": "TXN-2",
+      "component": "GST",
+      "amount_cents": -1000,
+      "balance_after_cents": 0,
+      "settled_at": "2025-10-01T11:00:00.000Z",
+      "source": "SETTLEMENT_WEBHOOK"
+    }
+  ],
+  "discrepancy_log": [
+    {
+      "discrepancy_type": "UNMATCHED_SETTLEMENT",
+      "observed_cents": 1000,
+      "expected_cents": 0,
+      "explanation": "Manual investigation required",
+      "detected_at": "2025-10-01T12:00:00.000Z"
+    }
+  ]
+}

--- a/tests/node/evidence-bundle.test.ts
+++ b/tests/node/evidence-bundle.test.ts
@@ -1,0 +1,234 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { buildEvidenceBundle } from "../../src/evidence/bundle";
+import expected from "../fixtures/evidence/bundle.expected.json";
+
+type QueryResult<T> = { rows: T[]; rowCount: number };
+
+type PeriodRow = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  state: string;
+  accrued_cents: number;
+  credited_to_owa_cents: number;
+  final_liability_cents: number;
+  merkle_root: string | null;
+  running_balance_hash: string | null;
+  anomaly_vector: Record<string, unknown>;
+  thresholds: Record<string, unknown>;
+};
+
+type RptRow = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  payload: any;
+  payload_c14n: string | null;
+  payload_sha256: string | null;
+  signature: string;
+  created_at: string;
+};
+
+type BasRow = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  label_code: string;
+  amount_cents: number;
+};
+
+type AnomalyRow = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  thresholds: Record<string, unknown>;
+  anomaly_vector: Record<string, unknown>;
+};
+
+type LedgerRow = {
+  id: number;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  txn_id: string;
+  component: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  settled_at: string;
+  source: string | null;
+};
+
+type DiscrepancyRow = {
+  id: number;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  discrepancy_type: string;
+  observed_cents: number;
+  expected_cents: number;
+  explanation: string;
+  detected_at: string;
+};
+
+class FakeDb {
+  periods: PeriodRow[] = [];
+  rpt: RptRow[] = [];
+  bas: BasRow[] = [];
+  anomaly: AnomalyRow[] = [];
+  ledger: LedgerRow[] = [];
+  discrepancies: DiscrepancyRow[] = [];
+
+  async query<T>(sql: string, params: any[]): Promise<QueryResult<T>> {
+    const normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+    if (normalized.includes("from periods")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.periods.filter(
+        (p) => p.abn === abn && p.taxType === taxType && p.periodId === periodId
+      ) as unknown as T[];
+      return { rows, rowCount: rows.length };
+    }
+    if (normalized.includes("from rpt_tokens")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rpt
+        .filter((r) => r.abn === abn && r.taxType === taxType && r.periodId === periodId)
+        .sort((a, b) => a.created_at.localeCompare(b.created_at) * -1) as unknown as T[];
+      return { rows: rows.slice(0, 1), rowCount: rows.length ? 1 : 0 };
+    }
+    if (normalized.includes("from recon_bas_labels")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.bas.filter(
+        (b) => b.abn === abn && b.taxType === taxType && b.periodId === periodId
+      ) as unknown as T[];
+      return { rows, rowCount: rows.length };
+    }
+    if (normalized.includes("from recon_anomaly_matrix")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.anomaly
+        .filter((a) => a.abn === abn && a.taxType === taxType && a.periodId === periodId)
+        .sort((a, b) => 0) as unknown as T[];
+      return { rows: rows.slice(0, 1), rowCount: rows.length ? 1 : 0 };
+    }
+    if (normalized.includes("from recon_ledger_deltas")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.ledger
+        .filter((l) => l.abn === abn && l.taxType === taxType && l.periodId === periodId)
+        .sort((a, b) => {
+          const ts = a.settled_at.localeCompare(b.settled_at);
+          if (ts !== 0) return ts;
+          return a.id - b.id;
+        }) as unknown as T[];
+      return { rows, rowCount: rows.length };
+    }
+    if (normalized.includes("from recon_discrepancies")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.discrepancies
+        .filter((d) => d.abn === abn && d.taxType === taxType && d.periodId === periodId)
+        .sort((a, b) => {
+          const ts = a.detected_at.localeCompare(b.detected_at);
+          if (ts !== 0) return ts;
+          return a.id - b.id;
+        }) as unknown as T[];
+      return { rows, rowCount: rows.length };
+    }
+    throw new Error(`Unhandled SQL: ${sql}`);
+  }
+}
+
+async function buildFixtureDb() {
+  const db = new FakeDb();
+  db.periods.push({
+    abn: "12345678901",
+    taxType: "GST",
+    periodId: "2025-09",
+    state: "READY_RPT",
+    accrued_cents: 150000,
+    credited_to_owa_cents: 125000,
+    final_liability_cents: 120000,
+    merkle_root: "merkle-root",
+    running_balance_hash: "balance-hash",
+    anomaly_vector: { gap_minutes: 5, dup_rate: 0 },
+    thresholds: { epsilon_cents: 50 }
+  });
+  db.rpt.push({
+    abn: "12345678901",
+    taxType: "GST",
+    periodId: "2025-09",
+    payload: { amount_cents: 120000, reference: "REF123" },
+    payload_c14n: "{\"amount_cents\":120000}",
+    payload_sha256: "hash123",
+    signature: "sig",
+    created_at: "2025-10-05T00:00:00.000Z"
+  });
+  db.bas.push(
+    { abn: "12345678901", taxType: "GST", periodId: "2025-09", label_code: "W1", amount_cents: 200000 },
+    { abn: "12345678901", taxType: "GST", periodId: "2025-09", label_code: "W2", amount_cents: 50000 },
+    { abn: "12345678901", taxType: "GST", periodId: "2025-09", label_code: "1A", amount_cents: 18000 },
+    { abn: "12345678901", taxType: "GST", periodId: "2025-09", label_code: "1B", amount_cents: 12000 }
+  );
+  db.anomaly.push({
+    abn: "12345678901",
+    taxType: "GST",
+    periodId: "2025-09",
+    thresholds: { variance_ratio: 0.2, dup_rate: 0.01 },
+    anomaly_vector: { gap_minutes: 7, variance_ratio: 0.12 }
+  });
+  db.ledger.push(
+    {
+      id: 1,
+      abn: "12345678901",
+      taxType: "GST",
+      periodId: "2025-09",
+      txn_id: "TXN-1",
+      component: "GST",
+      amount_cents: 1000,
+      balance_after_cents: 1000,
+      settled_at: "2025-09-30T10:00:00.000Z",
+      source: "SETTLEMENT_WEBHOOK"
+    },
+    {
+      id: 2,
+      abn: "12345678901",
+      taxType: "GST",
+      periodId: "2025-09",
+      txn_id: "TXN-1",
+      component: "NET",
+      amount_cents: 9000,
+      balance_after_cents: 9000,
+      settled_at: "2025-09-30T10:00:00.000Z",
+      source: "SETTLEMENT_WEBHOOK"
+    },
+    {
+      id: 3,
+      abn: "12345678901",
+      taxType: "GST",
+      periodId: "2025-09",
+      txn_id: "TXN-2",
+      component: "GST",
+      amount_cents: -1000,
+      balance_after_cents: 0,
+      settled_at: "2025-10-01T11:00:00.000Z",
+      source: "SETTLEMENT_WEBHOOK"
+    }
+  );
+  db.discrepancies.push({
+    id: 1,
+    abn: "12345678901",
+    taxType: "GST",
+    periodId: "2025-09",
+    discrepancy_type: "UNMATCHED_SETTLEMENT",
+    observed_cents: 1000,
+    expected_cents: 0,
+    explanation: "Manual investigation required",
+    detected_at: "2025-10-01T12:00:00.000Z"
+  });
+  return db;
+}
+
+test("buildEvidenceBundle hydrates reconciliation artefacts", async () => {
+  const db = await buildFixtureDb();
+  const bundle = await buildEvidenceBundle("12345678901", "GST", "2025-09", db);
+  const normalised = JSON.parse(JSON.stringify(bundle));
+  normalised.meta.generated_at = "<<timestamp>>";
+  assert.deepEqual(normalised, expected);
+});

--- a/tests/node/settlement-webhook.test.ts
+++ b/tests/node/settlement-webhook.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ingestSettlementRows } from "../../src/routes/reconcile";
+
+type LedgerEntry = {
+  id: number;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  txn_id: string;
+  component: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  settled_at: string;
+  source: string;
+};
+
+type ReversalEntry = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  original_txn_id: string;
+  reversal_txn_id: string;
+  recorded_at: string;
+};
+
+class FakeSettlementDb {
+  ledger: LedgerEntry[] = [];
+  reversals: ReversalEntry[] = [];
+  nextId = 1;
+
+  async query(sql: string, params: any[]) {
+    const normalized = sql.replace(/\s+/g, " ").trim().toLowerCase();
+    if (normalized.startsWith("select id from recon_ledger_deltas")) {
+      const [abn, taxType, periodId, txnId, component, amount] = params;
+      const match = this.ledger
+        .filter((row) =>
+          row.abn === abn &&
+          row.taxType === taxType &&
+          row.periodId === periodId &&
+          row.txn_id === txnId &&
+          row.component === component &&
+          row.amount_cents === Number(amount)
+        )
+        .sort((a, b) => b.settled_at.localeCompare(a.settled_at) || b.id - a.id)[0];
+      if (!match) {
+        return { rows: [], rowCount: 0 };
+      }
+      return {
+        rows: [{ id: match.id }],
+        rowCount: 1
+      };
+    }
+    if (normalized.startsWith("select balance_after_cents from recon_ledger_deltas")) {
+      const [abn, taxType, periodId, component] = params;
+      const match = this.ledger
+        .filter((row) =>
+          row.abn === abn &&
+          row.taxType === taxType &&
+          row.periodId === periodId &&
+          row.component === component
+        )
+        .sort((a, b) => b.settled_at.localeCompare(a.settled_at) || b.id - a.id)[0];
+      if (!match) {
+        return { rows: [], rowCount: 0 };
+      }
+      return {
+        rows: [{ balance_after_cents: match.balance_after_cents }],
+        rowCount: 1
+      };
+    }
+    if (normalized.startsWith("insert into recon_ledger_deltas")) {
+      const [abn, taxType, periodId, txnId, component, amount, balanceAfter, settledAt, source] = params;
+      const entry: LedgerEntry = {
+        id: this.nextId++,
+        abn,
+        taxType,
+        periodId,
+        txn_id: txnId,
+        component,
+        amount_cents: Number(amount),
+        balance_after_cents: Number(balanceAfter),
+        settled_at: new Date(settledAt).toISOString(),
+        source
+      };
+      this.ledger.push(entry);
+      return { rows: [{ id: entry.id }], rowCount: 1 };
+    }
+    if (normalized.startsWith("select txn_id from recon_ledger_deltas")) {
+      const [abn, taxType, periodId, txnId, component] = params;
+      const match = this.ledger
+        .filter((row) =>
+          row.abn === abn &&
+          row.taxType === taxType &&
+          row.periodId === periodId &&
+          row.txn_id === txnId &&
+          row.component === component &&
+          row.amount_cents > 0
+        )
+        .sort((a, b) => a.settled_at.localeCompare(b.settled_at) || a.id - b.id)[0];
+      if (!match) {
+        return { rows: [], rowCount: 0 };
+      }
+      return { rows: [{ txn_id: match.txn_id }], rowCount: 1 };
+    }
+    if (normalized.startsWith("insert into recon_txn_reversals")) {
+      const [abn, taxType, periodId, originalTxn, reversalTxn, recordedAt] = params;
+      const existingIndex = this.reversals.findIndex(
+        (r) =>
+          r.abn === abn &&
+          r.taxType === taxType &&
+          r.periodId === periodId &&
+          r.reversal_txn_id === reversalTxn
+      );
+      const entry: ReversalEntry = {
+        abn,
+        taxType,
+        periodId,
+        original_txn_id: originalTxn,
+        reversal_txn_id: reversalTxn,
+        recorded_at: new Date(recordedAt).toISOString()
+      };
+      if (existingIndex >= 0) {
+        this.reversals[existingIndex] = entry;
+      } else {
+        this.reversals.push(entry);
+      }
+      return { rows: [], rowCount: 1 };
+    }
+    throw new Error(`Unhandled SQL: ${sql}`);
+  }
+}
+
+test("ingestSettlementRows posts components and records reversals", async () => {
+  const db = new FakeSettlementDb();
+  const rows = [
+    {
+      txn_id: "TXN-1",
+      gst_cents: 1000,
+      net_cents: 9000,
+      settlement_ts: "2025-09-30T10:00:00Z"
+    },
+    {
+      txn_id: "TXN-2",
+      gst_cents: 500,
+      net_cents: 4500,
+      settlement_ts: "2025-09-30T11:00:00Z"
+    },
+    {
+      txn_id: "TXN-1",
+      gst_cents: -1000,
+      net_cents: -9000,
+      settlement_ts: "2025-10-01T09:00:00Z"
+    }
+  ];
+
+  await ingestSettlementRows("12345678901", "GST", "2025-09", rows, db as any);
+
+  assert.equal(db.ledger.length, 6);
+  const gstLedger = db.ledger.filter((e) => e.component === "GST");
+  assert.deepEqual(
+    gstLedger.map((e) => [e.txn_id, e.amount_cents, e.balance_after_cents]),
+    [
+      ["TXN-1", 1000, 1000],
+      ["TXN-2", 500, 1500],
+      ["TXN-1", -1000, 500]
+    ]
+  );
+  const netLedger = db.ledger.filter((e) => e.component === "NET");
+  assert.deepEqual(
+    netLedger.map((e) => [e.txn_id, e.amount_cents, e.balance_after_cents]),
+    [
+      ["TXN-1", 9000, 9000],
+      ["TXN-2", 4500, 13500],
+      ["TXN-1", -9000, 4500]
+    ]
+  );
+  assert.equal(db.reversals.length, 1);
+  assert.equal(db.reversals[0].original_txn_id, "TXN-1");
+  assert.equal(db.reversals[0].reversal_txn_id, "TXN-1");
+
+  await ingestSettlementRows("12345678901", "GST", "2025-09", rows, db as any);
+  assert.equal(db.ledger.length, 6, "idempotent ingest should not duplicate rows");
+});


### PR DESCRIPTION
## Summary
- document the evidence bundle contract and publish a JSON schema for downstream consumers
- hydrate evidence bundles from reconciliation tables, including BAS labels, anomaly thresholds, ledger deltas, and discrepancy logs
- flesh out settlement ingestion to post GST/NET components and track reversals, with fixture-backed tests exercising both workflows

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e207ba0d688327a9cd0442b837fb75