### PR TITLE
Fix SQL parameterization and add reconciliation integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx --test tests/integration/api.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const api = Router();

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,14 +1,14 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { sha256Hex } from "../crypto/merkle";
+import { getPool } from "../db/pool";
+const pool = getPool();
 
 export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
+  const { rows } = await pool.query("SELECT terminal_hash FROM audit_log ORDER BY seq DESC LIMIT 1");
   const prevHash = rows[0]?.terminal_hash || "";
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "INSERT INTO audit_log (actor, action, payload_hash, prev_hash, terminal_hash) VALUES ($1, $2, $3, $4, $5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,23 @@
+import { Pool } from "pg";
+
+export interface QueryResult<T = any> {
+  rows: T[];
+  rowCount: number;
+}
+
+export interface DatabasePool {
+  query<T = any>(text: string, params?: any[]): Promise<QueryResult<T>>;
+}
+
+let sharedPool: DatabasePool | null = null;
+
+export function getPool(): DatabasePool {
+  if (!sharedPool) {
+    sharedPool = new Pool();
+  }
+  return sharedPool;
+}
+
+export function setPool(custom: DatabasePool) {
+  sharedPool = custom;
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,10 +1,25 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+const pool = getPool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (
+    await pool.query(
+      "SELECT thresholds FROM periods WHERE abn = $1 AND tax_type = $2 AND period_id = $3",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      "SELECT payload, signature FROM rpt_tokens WHERE abn = $1 AND tax_type = $2 AND period_id = $3 ORDER BY id DESC LIMIT 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "SELECT created_at AS ts, amount_cents, hash_after, bank_receipt_hash FROM owa_ledger WHERE abn = $1 AND tax_type = $2 AND period_id = $3 ORDER BY id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,30 +9,40 @@ import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
 
-const app = express();
-app.use(express.json({ limit: "2mb" }));
+export function createApp() {
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
 
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+  // (optional) quick request logger
+  app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
 
-// Simple health check
-app.get("/health", (_req, res) => res.json({ ok: true }));
+  // Simple health check
+  app.get("/health", (_req, res) => res.json({ ok: true }));
 
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+  // Existing explicit endpoints
+  app.post("/api/pay", idempotency(), payAto);
+  app.post("/api/close-issue", closeAndIssue);
+  app.post("/api/payto/sweep", paytoSweep);
+  app.post("/api/settlement/webhook", settlementWebhook);
+  app.get("/api/evidence", evidence);
 
-// ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
+  // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
+  app.use("/api", paymentsApi);
 
-// Existing API router(s) after
-app.use("/api", api);
+  // Existing API router(s) after
+  app.use("/api", api);
 
-// 404 fallback (must be last)
-app.use((_req, res) => res.status(404).send("Not found"));
+  // 404 fallback (must be last)
+  app.use((_req, res) => res.status(404).send("Not found"));
 
-const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+  return app;
+}
+
+const app = createApp();
+
+if (process.env.NODE_ENV !== "test") {
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => console.log("APGMS server listening on", port));
+}
+
+export default app;

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,15 +1,21 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+const pool = getPool();
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
   return async (req:any, res:any, next:any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query(
+        "INSERT INTO idempotency_keys (key, last_status) VALUES ($1, $2)",
+        [key, "INIT"]
+      );
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
+      const r = await pool.query(
+        "SELECT last_status, response_hash FROM idempotency_keys WHERE key = $1",
+        [key]
+      );
       return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
   };

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,13 +1,13 @@
-﻿import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+const pool = getPool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "SELECT id, abn, label, rail, reference, account_bsb, account_number FROM remittance_destinations WHERE abn = $1 AND rail = $2 AND reference = $3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,32 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query(
+      "INSERT INTO idempotency_keys (key, last_status) VALUES ($1, $2)",
+      [transfer_uuid, "INIT"]
+    );
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    "SELECT balance_after_cents, hash_after FROM owa_ledger WHERE abn = $1 AND tax_type = $2 AND period_id = $3 ORDER BY id DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "INSERT INTO owa_ledger (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query(
+    "UPDATE idempotency_keys SET last_status = $2 WHERE key = $1",
+    [transfer_uuid, "DONE"]
+  );
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -3,8 +3,8 @@ import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+const pool = getPool();
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "SELECT payload FROM rpt_tokens WHERE abn = $1 AND tax_type = $2 AND period_id = $3 ORDER BY id DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "UPDATE periods SET state = $4 WHERE abn = $1 AND tax_type = $2 AND period_id = $3",
+      [abn, taxType, periodId, "RELEASED"]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/tests/integration/api.test.ts
+++ b/tests/integration/api.test.ts
@@ -1,0 +1,98 @@
+import "./setupEnv.ts";
+import { test, before, beforeEach, after } from "node:test";
+import assert from "node:assert/strict";
+import { once } from "node:events";
+import { AddressInfo } from "node:net";
+import { getPool } from "../../src/db/pool.ts";
+
+const pool = getPool();
+let baseUrl = "";
+let server: import("http").Server;
+
+before(async () => {
+  const { createApp } = await import("../../src/index.ts");
+  const app = createApp();
+  server = app.listen(0);
+  await once(server, "listening");
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+});
+
+after(async () => {
+  if (!server) return;
+  await new Promise<void>((resolve, reject) => {
+    server.close(err => (err ? reject(err) : resolve()));
+  });
+});
+
+const abn = "53004085616";
+const taxType = "GST";
+const periodId = "2024Q4";
+const thresholds = { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+
+beforeEach(async () => {
+  await pool.query("TRUNCATE audit_log, idempotency_keys, owa_ledger, rpt_tokens, remittance_destinations, periods RESTART IDENTITY");
+  await pool.query(
+    "INSERT INTO periods (abn, tax_type, period_id, state, accrued_cents, credited_to_owa_cents, final_liability_cents, merkle_root, running_balance_hash, anomaly_vector, thresholds) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)",
+    [
+      abn,
+      taxType,
+      periodId,
+      "CLOSING",
+      125000,
+      125000,
+      125000,
+      "merkle-root",
+      "running-hash",
+      {},
+      thresholds
+    ]
+  );
+  await pool.query(
+    "INSERT INTO remittance_destinations (abn, label, rail, reference, account_bsb, account_number) VALUES ($1,$2,$3,$4,$5,$6)",
+    [abn, "Primary", "EFT", process.env.ATO_PRN, "123-456", "987654"]
+  );
+});
+
+test("reconcile endpoints succeed against seeded database", async () => {
+  const closeRes = await fetch(`${baseUrl}/api/close-issue`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ abn, taxType, periodId, thresholds })
+  });
+  assert.equal(closeRes.status, 200);
+  const closeBody = await closeRes.json();
+  assert.equal(closeBody.payload.entity_id, abn);
+  assert.equal(closeBody.payload.amount_cents, 125000);
+  assert.ok(closeBody.signature, "expected RPT signature");
+
+  const payRes = await fetch(`${baseUrl}/api/pay`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": "idem-pay-1"
+    },
+    body: JSON.stringify({ abn, taxType, periodId, rail: "EFT" })
+  });
+  assert.equal(payRes.status, 200);
+  const payBody = await payRes.json();
+  assert.ok(payBody.transfer_uuid, "expected transfer UUID");
+  assert.ok(payBody.bank_receipt_hash, "expected bank receipt hash");
+
+  const csvPayload = "txn_id,gst_cents,net_cents,settlement_ts\n1,100,900,2024-01-01T00:00:00Z";
+  const settlementRes = await fetch(`${baseUrl}/api/settlement/webhook`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ csv: csvPayload })
+  });
+  assert.equal(settlementRes.status, 200);
+  const settlementBody = await settlementRes.json();
+  assert.equal(settlementBody.ingested, 1);
+
+  const evidenceRes = await fetch(`${baseUrl}/api/evidence?abn=${encodeURIComponent(abn)}&taxType=${taxType}&periodId=${periodId}`);
+  assert.equal(evidenceRes.status, 200);
+  const evidenceBody = await evidenceRes.json();
+  assert.ok(Array.isArray(evidenceBody.owa_ledger_deltas));
+  assert.equal(evidenceBody.rpt_payload.entity_id, abn);
+  assert.equal(evidenceBody.bank_receipt_hash, payBody.bank_receipt_hash);
+});

--- a/tests/integration/setupEnv.ts
+++ b/tests/integration/setupEnv.ts
@@ -1,0 +1,334 @@
+import nacl from "tweetnacl";
+import { setPool } from "../../src/db/pool.ts";
+
+process.env.NODE_ENV = "test";
+process.env.ATO_PRN = process.env.ATO_PRN || "TEST-ATO-PRN";
+
+if (!process.env.RPT_ED25519_SECRET_BASE64) {
+  const keyPair = nacl.sign.keyPair();
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString("base64");
+}
+
+class FakePool {
+  constructor() {
+    this.periods = [];
+    this.remittance = [];
+    this.rptTokens = [];
+    this.idempotency = new Map();
+    this.owaLedger = [];
+    this.auditLog = [];
+    this.sequences = {
+      periods: 0,
+      remittance: 0,
+      rptTokens: 0,
+      owaLedger: 0,
+      audit: 0
+    };
+  }
+
+  async query(text, params = []) {
+    const normalized = text.replace(/\s+/g, " ").trim();
+    const upper = normalized.toUpperCase();
+
+    if (upper.startsWith("TRUNCATE")) {
+      this.handleTruncate(normalized);
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (upper.startsWith("INSERT INTO PERIODS")) {
+      this.insertPeriod(params);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (upper.startsWith("INSERT INTO REMITTANCE_DESTINATIONS")) {
+      this.insertRemittance(params);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (upper.startsWith("INSERT INTO IDEMPOTENCY_KEYS")) {
+      this.insertIdempotency(params);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (upper.startsWith("UPDATE IDEMPOTENCY_KEYS")) {
+      const [key, status] = params;
+      const row = this.idempotency.get(key);
+      if (row) {
+        row.last_status = status;
+        row.response_hash = row.response_hash ?? null;
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (upper.startsWith("SELECT LAST_STATUS")) {
+      const [key] = params;
+      const row = this.idempotency.get(key);
+      if (!row) return { rows: [], rowCount: 0 };
+      return { rows: [{ last_status: row.last_status, response_hash: row.response_hash ?? null }], rowCount: 1 };
+    }
+
+    if (upper.startsWith("SELECT ID, ABN, TAX_TYPE, PERIOD_ID")) {
+      const [abn, taxType, periodId] = params;
+      const row = this.periods.find(p => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      if (!row) return { rows: [], rowCount: 0 };
+      return {
+        rows: [{
+          id: row.id,
+          abn: row.abn,
+          tax_type: row.tax_type,
+          period_id: row.period_id,
+          state: row.state,
+          anomaly_vector: row.anomaly_vector,
+          final_liability_cents: row.final_liability_cents,
+          credited_to_owa_cents: row.credited_to_owa_cents,
+          merkle_root: row.merkle_root,
+          running_balance_hash: row.running_balance_hash
+        }],
+        rowCount: 1
+      };
+    }
+
+    if (upper.startsWith("SELECT THRESHOLDS FROM PERIODS")) {
+      const [abn, taxType, periodId] = params;
+      const row = this.periods.find(p => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      if (!row) return { rows: [], rowCount: 0 };
+      return { rows: [{ thresholds: row.thresholds }], rowCount: 1 };
+    }
+
+    if (upper.startsWith("UPDATE PERIODS SET STATE = $2 WHERE ID = $1")) {
+      const [id, state] = params;
+      const row = this.periods.find(p => p.id === id);
+      if (row) {
+        row.state = state;
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (upper.startsWith("UPDATE PERIODS SET STATE = $4")) {
+      const [abn, taxType, periodId, state] = params;
+      const row = this.periods.find(p => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      if (row) {
+        row.state = state;
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (upper.startsWith("INSERT INTO RPT_TOKENS")) {
+      this.insertRptToken(params);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (upper.startsWith("SELECT PAYLOAD FROM RPT_TOKENS")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rptTokens
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(r => ({ payload: r.payload }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (upper.startsWith("SELECT PAYLOAD, SIGNATURE FROM RPT_TOKENS")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rptTokens
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(r => ({ payload: r.payload, signature: r.signature }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (upper.startsWith("SELECT ID, ABN, LABEL")) {
+      const [abn, rail, reference] = params;
+      const rows = this.remittance
+        .filter(r => r.abn === abn && r.rail === rail && r.reference === reference)
+        .map(r => ({
+          id: r.id,
+          abn: r.abn,
+          label: r.label,
+          rail: r.rail,
+          reference: r.reference,
+          account_bsb: r.account_bsb,
+          account_number: r.account_number
+        }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (upper.startsWith("SELECT BALANCE_AFTER_CENTS")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(r => ({ balance_after_cents: r.balance_after_cents, hash_after: r.hash_after }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (upper.startsWith("INSERT INTO OWA_LEDGER")) {
+      this.insertOwaLedger(params);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (upper.startsWith("SELECT CREATED_AT AS TS")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => a.id - b.id)
+        .map(r => ({ ts: r.created_at, amount_cents: r.amount_cents, hash_after: r.hash_after, bank_receipt_hash: r.bank_receipt_hash }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (upper.startsWith("SELECT TERMINAL_HASH FROM AUDIT_LOG")) {
+      const rows = this.auditLog
+        .slice()
+        .sort((a, b) => b.seq - a.seq)
+        .slice(0, 1)
+        .map(r => ({ terminal_hash: r.terminal_hash }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (upper.startsWith("INSERT INTO AUDIT_LOG")) {
+      this.insertAuditLog(params);
+      return { rows: [], rowCount: 1 };
+    }
+
+    throw new Error(`Unsupported query in FakePool: ${normalized}`);
+  }
+
+  handleTruncate(query) {
+    const body = query
+      .replace(/TRUNCATE/i, "")
+      .replace(/RESTART IDENTITY/gi, "")
+      .replace(/CASCADE/gi, "")
+      .trim();
+    const tables = body.split(",").map(t => t.trim()).filter(Boolean);
+    for (const table of tables) {
+      const key = table.toLowerCase();
+      switch (key) {
+        case "periods":
+          this.periods = [];
+          this.sequences.periods = 0;
+          break;
+        case "remittance_destinations":
+          this.remittance = [];
+          this.sequences.remittance = 0;
+          break;
+        case "rpt_tokens":
+          this.rptTokens = [];
+          this.sequences.rptTokens = 0;
+          break;
+        case "idempotency_keys":
+          this.idempotency.clear();
+          break;
+        case "owa_ledger":
+          this.owaLedger = [];
+          this.sequences.owaLedger = 0;
+          break;
+        case "audit_log":
+          this.auditLog = [];
+          this.sequences.audit = 0;
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  insertPeriod(params) {
+    const [abn, taxType, periodId, state, accrued, credited, final, merkle, running, anomaly, thresholds] = params;
+    this.sequences.periods += 1;
+    this.periods.push({
+      id: this.sequences.periods,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      state,
+      accrued_cents: Number(accrued),
+      credited_to_owa_cents: Number(credited),
+      final_liability_cents: Number(final),
+      merkle_root: merkle,
+      running_balance_hash: running,
+      anomaly_vector: anomaly,
+      thresholds
+    });
+  }
+
+  insertRemittance(params) {
+    const [abn, label, rail, reference, account_bsb, account_number] = params;
+    this.sequences.remittance += 1;
+    this.remittance.push({
+      id: this.sequences.remittance,
+      abn,
+      label,
+      rail,
+      reference,
+      account_bsb: account_bsb ?? null,
+      account_number: account_number ?? null
+    });
+  }
+
+  insertIdempotency(params) {
+    const [key, status] = params;
+    if (this.idempotency.has(key)) {
+      throw new Error("duplicate key value violates unique constraint idempotency_keys_pkey");
+    }
+    this.idempotency.set(key, {
+      key,
+      last_status: status,
+      response_hash: null,
+      created_at: new Date().toISOString()
+    });
+  }
+
+  insertRptToken(params) {
+    const [abn, taxType, periodId, payload, signature] = params;
+    this.sequences.rptTokens += 1;
+    this.rptTokens.push({
+      id: this.sequences.rptTokens,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      payload,
+      signature,
+      created_at: new Date().toISOString()
+    });
+  }
+
+  insertOwaLedger(params) {
+    const [abn, taxType, periodId, transfer_uuid, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after] = params;
+    this.sequences.owaLedger += 1;
+    this.owaLedger.push({
+      id: this.sequences.owaLedger,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      transfer_uuid,
+      amount_cents: Number(amount_cents),
+      balance_after_cents: Number(balance_after_cents),
+      bank_receipt_hash,
+      prev_hash,
+      hash_after,
+      created_at: new Date().toISOString()
+    });
+  }
+
+  insertAuditLog(params) {
+    const [actor, action, payload_hash, prev_hash, terminal_hash] = params;
+    this.sequences.audit += 1;
+    this.auditLog.push({
+      seq: this.sequences.audit,
+      ts: new Date().toISOString(),
+      actor,
+      action,
+      payload_hash,
+      prev_hash,
+      terminal_hash
+    });
+  }
+}
+
+export const fakePool = new FakePool();
+setPool(fakePool);


### PR DESCRIPTION
## Summary
- replace unsafe SQL snippets in reconciliation, rails, audit, evidence, and idempotency flows with parameterized queries and explicit column lists
- share a configurable pg pool helper and wire the express bootstrap so tests can spin up the app without binding a port by default
- add a fake in-memory pool plus an integration test that seeds data and exercises /api/close-issue, /api/pay, /api/settlement/webhook, and /api/evidence

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e207b6833c83279184e358f697e592