### PR TITLE
Update evidence bundle summary fields

### DIFF
--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,21 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+export type Evidence = {
+  expC: number;
+  actC: number;
+  delta: number;
+  toleranceBps: number;
+  anomalyHash: string;
+  ledgerHead: string;
+};
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+export function summarize(ev: Evidence) {
+  const pct = ev.expC === 0 ? 0 : (ev.delta / ev.expC) * 100;
+  return {
+    expected: ev.expC / 100,
+    actual: ev.actC / 100,
+    delta: ev.delta / 100,
+    deltaPct: Number(pct.toFixed(3)),
+    tolerancePct: ev.toleranceBps / 100,
+    anomalyHash: ev.anomalyHash,
+    ledgerHead: ev.ledgerHead,
   };
-  return bundle;
 }


### PR DESCRIPTION
## Summary
- replace the evidence bundle module with a simple evidence type definition
- add a summarize helper that normalizes cents to dollars and basis points to percents

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2112158208327a33624d91e06676a