### PR TITLE
Add Express app factory for tests

### DIFF
--- a/tests/helpers/appFactory.ts
+++ b/tests/helpers/appFactory.ts
@@ -1,0 +1,16 @@
+import express from "express";
+import cors from "cors";
+import helmet from "helmet";
+import morgan from "morgan";
+import { api } from "../../src/api";
+
+export default async function appFactory() {
+  const app = express();
+  app.use(helmet());
+  app.use(cors());
+  app.use(express.json());
+  app.use(morgan("tiny"));
+  app.use("/api", api);
+  app.get("/healthz", (_req, res) => res.json({ ok: true }));
+  return app;
+}


### PR DESCRIPTION
## Summary
- add a reusable Express app factory helper for tests
- mount common middleware and the /api router on the generated app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e21129d46483279b10120a6e99f97c