### PR TITLE
Add OWA balance card to dashboard overview

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,17 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useApp } from '../context/AppContext';
+
+function OwaBalanceCard() {
+  const { balance } = useApp();
+  return (
+    <div className="card">
+      <h3>OWA Balance</h3>
+      <p>{balance !== undefined ? `$${balance.toFixed(2)}` : '—'}</p>
+    </div>
+  );
+}
 
 export default function Dashboard() {
   const complianceStatus = {
@@ -43,6 +54,8 @@ export default function Dashboard() {
           </p>
           <Link to="/audit" className="text-blue-600 text-sm underline">View Audit</Link>
         </div>
+
+        <OwaBalanceCard />
 
         <div className="bg-white p-4 rounded-xl shadow text-center">
           <h2 className="text-lg font-semibold mb-2">Compliance Score</h2>


### PR DESCRIPTION
## Summary
- import the application context and add an OWA balance card component to the dashboard
- render the new balance card within the dashboard grid so the balance is visible alongside other metrics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e21157b99c83278b330e6dc75b02af