### PR TITLE
Add Vitest test script and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "vitest run"
     },
     "version": "0.1.0",
     "name": "apgms",
@@ -13,9 +14,13 @@
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
+        "@types/supertest": "^2.0.16",
+        "supertest": "^7.0.0",
         "ts-node": "^10.9.2",
+        "ts-node-dev": "^2.0.0",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^2.0.0"
     },
     "dependencies": {
         "csv-parse": "^6.1.0",


### PR DESCRIPTION
## Summary
- add vitest, supertest, and supporting typings to devDependencies
- configure npm test script to run Vitest

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2117083d08327b0611c6910ff60e1