### PR TITLE
Add evidence API route

### DIFF
--- a/src/routes/evidence.ts
+++ b/src/routes/evidence.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+import { getPool } from "../db/pool";
+
+export const router = Router();
+
+// GET /api/evidence/:abn/:pid
+router.get("/:abn/:pid", async (req, res) => {
+  const { abn, pid } = req.params;
+  const q = await getPool().query(
+    `select abn, period_id, rpt_token, delta_cents, tolerance_bps, details, created_at
+       from evidence_bundles
+      where abn = $1 and period_id = $2
+      order by created_at desc
+      limit 1`,
+    [abn, pid]
+  );
+  if (!q.rowCount) return res.status(404).json({ error: "not found" });
+  res.json(q.rows[0]);
+});


### PR DESCRIPTION
## Summary
- add an evidence router that looks up the most recent evidence bundle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2110348088327bac53a4efe2552e9