### PR TITLE
Simplify app context to fetch balance from API

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,27 +1,23 @@
-import React, { createContext, useState } from "react";
-import { mockPayroll, mockSales, mockBasHistory } from "../utils/mockData";
-import { BASHistory } from "../types/tax";
+import { createContext, useContext, useEffect, useState, type ReactNode } from "react";
+import { getBalance } from "../api/client";
 
-export const AppContext = createContext<any>(null);
+type AppState = {
+  abn: string;
+  balance?: number;
+};
 
-export function AppProvider({ children }: { children: React.ReactNode }) {
-  const [vaultBalance, setVaultBalance] = useState(10000);
-  const [businessBalance, setBusinessBalance] = useState(50000);
-  const [payroll, setPayroll] = useState(mockPayroll);
-  const [sales, setSales] = useState(mockSales);
-  const [basHistory, setBasHistory] = useState<BASHistory[]>(mockBasHistory);
-  const [auditLog, setAuditLog] = useState<any[]>([]);
+const Ctx = createContext<AppState>({ abn: "11122233344" });
 
-  return (
-    <AppContext.Provider value={{
-      vaultBalance, setVaultBalance,
-      businessBalance, setBusinessBalance,
-      payroll, setPayroll,
-      sales, setSales,
-      basHistory, setBasHistory,
-      auditLog, setAuditLog,
-    }}>
-      {children}
-    </AppContext.Provider>
-  );
+export function AppProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AppState>({ abn: "11122233344" });
+
+  useEffect(() => {
+    getBalance(state.abn)
+      .then((b) => setState((s) => ({ ...s, balance: b.balance })))
+      .catch(() => void 0);
+  }, [state.abn]);
+
+  return <Ctx.Provider value={state}>{children}</Ctx.Provider>;
 }
+
+export const useApp = () => useContext(Ctx);


### PR DESCRIPTION
## Summary
- replace the app context implementation with a minimal state containing the ABN and API-provided balance
- load the latest balance from the API when the ABN changes and expose it via the context hook

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2114efc94832784a51a4880d9a9b2