### PR TITLE
Implement closing workflow and evidence bundling improvements

### DIFF
--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,307 @@
-﻿import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
+import { merkleRootHex, sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+type Queryable = Pool | PoolClient;
+
+export interface DiscrepancyEntry {
+  code: string;
+  message: string;
+  expected?: number | string | null;
+  actual?: number | string | null;
+  delta?: number;
+}
+
+interface LedgerUpdate {
+  id: number;
+  prev_hash: string;
+  hash_after: string;
+  balance_after_cents?: number;
+}
+
+export interface LedgerRowWithProof {
+  id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string | null;
+  prev_hash: string | null;
+  hash_after: string | null;
+  created_at: Date | string;
+  computed_prev_hash: string;
+  computed_hash_after: string;
+  computed_balance_after_cents: number;
+}
+
+export interface LedgerArtifacts {
+  rows: LedgerRowWithProof[];
+  creditedTotal: number;
+  netBalance: number;
+  merkleRoot: string;
+  runningHash: string;
+  tailReceipt: string | null;
+  updates: LedgerUpdate[];
+  issues: DiscrepancyEntry[];
+}
+
+const DEFAULT_THRESHOLDS: Record<string, number> = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+function canonicalize(value: any): any {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object" && !(value instanceof Date)) {
+    const out: Record<string, any> = {};
+    for (const key of Object.keys(value).sort()) {
+      out[key] = canonicalize(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function canonicalJson(value: any): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function normalizeThresholds(...sources: Array<Record<string, any> | null | undefined>) {
+  const merged: Record<string, number> = { ...DEFAULT_THRESHOLDS };
+  for (const src of sources) {
+    if (!src) continue;
+    for (const [key, raw] of Object.entries(src)) {
+      const num = typeof raw === "number" ? raw : Number(raw);
+      if (Number.isFinite(num)) merged[key] = num;
+    }
+  }
+  return merged;
+}
+
+export async function computeLedgerArtifacts(db: Queryable, abn: string, taxType: string, periodId: string): Promise<LedgerArtifacts> {
+  const { rows } = await db.query(
+    "select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+    [abn, taxType, periodId]
+  );
+
+  const proofRows: LedgerRowWithProof[] = [];
+  const issues: DiscrepancyEntry[] = [];
+  const updateMap = new Map<number, LedgerUpdate>();
+  const recordUpdate = (id: number, prev_hash: string, hash_after: string) => {
+    const existing = updateMap.get(id) || { id, prev_hash, hash_after };
+    existing.prev_hash = prev_hash;
+    existing.hash_after = hash_after;
+    updateMap.set(id, existing);
+    return existing;
   };
-  return bundle;
+
+  let creditedTotal = 0;
+  let netBalance = 0;
+  let runningBalance = 0;
+  let prevHash = "";
+  const leaves: string[] = [];
+
+  for (const raw of rows as any[]) {
+    const id = Number(raw.id);
+    const amount = Number(raw.amount_cents ?? 0);
+    if (amount > 0) creditedTotal += amount;
+    netBalance += amount;
+    const expectedBalance = runningBalance + amount;
+    const storedBalance = raw.balance_after_cents != null ? Number(raw.balance_after_cents) : expectedBalance;
+    runningBalance = storedBalance;
+
+    if (raw.balance_after_cents == null || storedBalance !== expectedBalance) {
+      issues.push({
+        code: "LEDGER_BALANCE_MISMATCH",
+        message: `Ledger row ${id} balance mismatch`,
+        expected: expectedBalance,
+        actual: raw.balance_after_cents == null ? null : storedBalance,
+        delta: storedBalance - expectedBalance,
+      });
+      const entry = recordUpdate(id, prevHash, "");
+      entry.balance_after_cents = expectedBalance;
+    }
+
+    const receipt = raw.bank_receipt_hash ? String(raw.bank_receipt_hash) : "";
+    if (!receipt) {
+      issues.push({
+        code: "LEDGER_RECEIPT_MISSING",
+        message: `Ledger row ${id} missing bank_receipt_hash`,
+        expected: null,
+        actual: null,
+      });
+    }
+
+    const computedPrevHash = prevHash;
+    const computedHashAfter = sha256Hex(prevHash + receipt + String(runningBalance));
+    if ((raw.prev_hash || "") !== computedPrevHash || (raw.hash_after || "") !== computedHashAfter) {
+      issues.push({
+        code: "LEDGER_HASH_MISMATCH",
+        message: `Ledger row ${id} hash mismatch`,
+        expected: computedHashAfter,
+        actual: raw.hash_after || null,
+      });
+      const entry = recordUpdate(id, computedPrevHash, computedHashAfter);
+      if (entry.balance_after_cents === undefined) entry.balance_after_cents = runningBalance;
+    }
+
+    const canonicalLeaf = JSON.stringify({
+      amount_cents: amount,
+      balance_after_cents: runningBalance,
+      bank_receipt_hash: receipt,
+    });
+    leaves.push(canonicalLeaf);
+
+    proofRows.push({
+      id,
+      amount_cents: amount,
+      balance_after_cents: storedBalance,
+      bank_receipt_hash: receipt || null,
+      prev_hash: raw.prev_hash || null,
+      hash_after: raw.hash_after || null,
+      created_at: raw.created_at,
+      computed_prev_hash: computedPrevHash,
+      computed_hash_after: computedHashAfter,
+      computed_balance_after_cents: runningBalance,
+    });
+
+    prevHash = computedHashAfter;
+  }
+
+  const merkleRoot = merkleRootHex(leaves);
+  const runningHash = rows.length ? prevHash : sha256Hex("");
+  const tailReceipt = rows.length ? rows[rows.length - 1].bank_receipt_hash || null : null;
+
+  const updates = Array.from(updateMap.values()).map((u) => ({
+    id: u.id,
+    prev_hash: u.prev_hash,
+    hash_after: u.hash_after || sha256Hex((u.prev_hash || "") + String(u.balance_after_cents ?? 0)),
+    balance_after_cents: u.balance_after_cents,
+  }));
+
+  return { rows: proofRows, creditedTotal, netBalance, merkleRoot, runningHash, tailReceipt, updates, issues };
+}
+
+export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
+  const periodRes = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
+  if (periodRes.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+  const period = periodRes.rows[0];
+
+  const ledger = await computeLedgerArtifacts(pool, abn, taxType, periodId);
+  const rptRes = await pool.query(
+    "select payload, signature, payload_c14n, payload_sha256, created_at from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  const rptRow = rptRes.rows[0] || null;
+
+  let rptPayload: any = null;
+  let rptPayloadC14n: string | null = null;
+  let rptPayloadSha256: string | null = null;
+  if (rptRow) {
+    rptPayload = typeof rptRow.payload === "string" ? JSON.parse(rptRow.payload) : rptRow.payload;
+    rptPayloadC14n = rptRow.payload_c14n || canonicalJson(rptPayload);
+    rptPayloadSha256 = rptRow.payload_sha256 || sha256Hex(rptPayloadC14n);
+  }
+
+  const thresholds = normalizeThresholds(period.thresholds);
+  const accrued = Number(period.accrued_cents ?? 0);
+  const credited = Number(period.credited_to_owa_cents ?? ledger.creditedTotal);
+  const finalLiability = Number(period.final_liability_cents ?? ledger.creditedTotal);
+
+  const basLabels = {
+    W1: taxType === "PAYGW" ? accrued : null,
+    W2: taxType === "PAYGW" ? Math.max(0, accrued - finalLiability) : null,
+    "1A": taxType === "GST" ? finalLiability : finalLiability,
+    "1B": taxType === "GST" ? Math.max(0, credited - finalLiability) : null,
+  };
+
+  const discrepancyLog: DiscrepancyEntry[] = [...ledger.issues];
+  if (credited !== ledger.creditedTotal) {
+    discrepancyLog.push({
+      code: "PERIOD_CREDIT_MISMATCH",
+      message: "Period credited_to_owa_cents differs from ledger credits",
+      expected: ledger.creditedTotal,
+      actual: credited,
+      delta: credited - ledger.creditedTotal,
+    });
+  }
+  if ((period.merkle_root || "") !== ledger.merkleRoot) {
+    discrepancyLog.push({
+      code: "MERKLE_MISMATCH",
+      message: "Stored period merkle_root differs from computed ledger root",
+      expected: ledger.merkleRoot,
+      actual: period.merkle_root || null,
+    });
+  }
+  if ((period.running_balance_hash || "") !== ledger.runningHash) {
+    discrepancyLog.push({
+      code: "RUNNING_BALANCE_HASH_MISMATCH",
+      message: "Stored running_balance_hash differs from ledger tail hash",
+      expected: ledger.runningHash,
+      actual: period.running_balance_hash || null,
+    });
+  }
+  if (rptPayloadSha256 && rptRow?.payload_sha256 && rptRow.payload_sha256 !== rptPayloadSha256) {
+    discrepancyLog.push({
+      code: "RPT_PAYLOAD_SHA_MISMATCH",
+      message: "Stored payload_sha256 differs from recomputed hash",
+      expected: rptPayloadSha256,
+      actual: rptRow.payload_sha256,
+    });
+  }
+
+  const meta = { generated_at: new Date().toISOString(), abn, taxType, periodId };
+  const periodSummary = {
+    state: period.state,
+    accrued_cents: accrued,
+    credited_to_owa_cents: credited,
+    final_liability_cents: finalLiability,
+    merkle_root: ledger.merkleRoot,
+    running_balance_hash: ledger.runningHash,
+    anomaly_vector: period.anomaly_vector || {},
+    thresholds,
+  };
+
+  const rpt = rptRow
+    ? {
+        payload: rptPayload,
+        signature: rptRow.signature,
+        created_at: rptRow.created_at,
+        payload_c14n: rptPayloadC14n,
+        payload_sha256: rptPayloadSha256,
+      }
+    : null;
+
+  const owaLedger = ledger.rows.map((row) => ({
+    id: row.id,
+    amount_cents: row.amount_cents,
+    balance_after_cents: row.balance_after_cents,
+    bank_receipt_hash: row.bank_receipt_hash,
+    prev_hash: row.prev_hash,
+    hash_after: row.hash_after,
+    computed_prev_hash: row.computed_prev_hash,
+    computed_hash_after: row.computed_hash_after,
+    computed_balance_after_cents: row.computed_balance_after_cents,
+    created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+  }));
+
+  return {
+    meta,
+    period: periodSummary,
+    rpt,
+    owa_ledger: owaLedger,
+    bas_labels: basLabels,
+    verification: {
+      ledger_merkle_root: ledger.merkleRoot,
+      ledger_tail_hash: ledger.runningHash,
+      last_bank_receipt_hash: ledger.tailReceipt,
+      rpt_payload_sha256: rptPayloadSha256,
+    },
+    discrepancy_log: discrepancyLog,
+  };
 }

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -1,15 +1,37 @@
-﻿export type PeriodState = "OPEN"|"CLOSING"|"READY_RPT"|"BLOCKED_DISCREPANCY"|"BLOCKED_ANOMALY"|"RELEASED"|"FINALIZED";
-export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
+export type PeriodState =
+  | "OPEN"
+  | "CLOSING"
+  | "READY_RPT"
+  | "BLOCKED_DISCREPANCY"
+  | "BLOCKED_ANOMALY"
+  | "RELEASED"
+  | "FINALIZED";
+
+export interface Thresholds {
+  epsilon_cents: number;
+  variance_ratio: number;
+  dup_rate: number;
+  gap_minutes: number;
+}
+
+const transitions: Record<string, PeriodState> = {
+  "OPEN:CLOSE": "CLOSING",
+  "CLOSING:PASS": "READY_RPT",
+  "CLOSING:FAIL_DISCREPANCY": "BLOCKED_DISCREPANCY",
+  "CLOSING:FAIL_ANOMALY": "BLOCKED_ANOMALY",
+  "BLOCKED_DISCREPANCY:RESET": "CLOSING",
+  "BLOCKED_DISCREPANCY:OVERRIDE": "READY_RPT",
+  "BLOCKED_ANOMALY:RESET": "CLOSING",
+  "BLOCKED_ANOMALY:OVERRIDE": "READY_RPT",
+  "READY_RPT:RELEASE": "RELEASED",
+  "READY_RPT:RESET": "CLOSING",
+  "READY_RPT:BLOCK_DISCREPANCY": "BLOCKED_DISCREPANCY",
+  "READY_RPT:BLOCK_ANOMALY": "BLOCKED_ANOMALY",
+  "RELEASED:FINALIZE": "FINALIZED",
+  "RELEASED:REOPEN": "CLOSING",
+};
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
-  }
+  const key = `${current}:${evt.toUpperCase()}`;
+  return transitions[key] ?? current;
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,116 @@
-﻿import { issueRPT } from "../rpt/issuer";
-import { buildEvidenceBundle } from "../evidence/bundle";
+import { issueRPT } from "../rpt/issuer";
+import { buildEvidenceBundle, computeLedgerArtifacts, normalizeThresholds } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+export async function closeAndIssue(req: any, res: any) {
+  const { abn, taxType, periodId, thresholds } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+  const normalizedTaxType = String(taxType).toUpperCase();
+  if (normalizedTaxType !== "GST" && normalizedTaxType !== "PAYGW") {
+    return res.status(400).json({ error: "INVALID_TAX_TYPE" });
+  }
+
+  const client = await pool.connect();
+  let finalThresholds: Record<string, number> = normalizeThresholds(thresholds);
   try {
-    const rpt = await issueRPT(abn, taxType, periodId, thr);
+    await client.query("BEGIN");
+    const periodRes = await client.query(
+      "select * from periods where abn=$1 and tax_type=$2 and period_id=$3 for update",
+      [abn, normalizedTaxType, periodId]
+    );
+    if (periodRes.rowCount === 0) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+    const period = periodRes.rows[0];
+
+    const ledger = await computeLedgerArtifacts(client, abn, normalizedTaxType, periodId);
+
+    for (const update of ledger.updates) {
+      const sets = ["prev_hash=$1", "hash_after=$2"];
+      const values: any[] = [update.prev_hash, update.hash_after];
+      let nextIdx = 3;
+      if (update.balance_after_cents !== undefined) {
+        sets.push(`balance_after_cents=$${nextIdx}`);
+        values.push(update.balance_after_cents);
+        nextIdx += 1;
+      }
+      values.push(update.id);
+      const sql = `update owa_ledger set ${sets.join(", ")} where id=$${nextIdx}`;
+      await client.query(sql, values);
+    }
+
+    const credited = ledger.creditedTotal;
+    const finalLiability = credited;
+    finalThresholds = normalizeThresholds(period.thresholds, thresholds);
+
+    await client.query(
+      "update periods set state=$1, credited_to_owa_cents=$2, final_liability_cents=$3, merkle_root=$4, running_balance_hash=$5, thresholds=$6 where id=$7",
+      [
+        "CLOSING",
+        credited,
+        finalLiability,
+        ledger.merkleRoot,
+        ledger.runningHash,
+        finalThresholds,
+        period.id,
+      ]
+    );
+
+    await client.query("COMMIT");
+  } catch (err: any) {
+    await client.query("ROLLBACK");
+    if (err?.message === "PERIOD_NOT_FOUND") {
+      return res.status(404).json({ error: "PERIOD_NOT_FOUND" });
+    }
+    return res.status(400).json({ error: err.message });
+  } finally {
+    client.release();
+  }
+
+  try {
+    const rpt = await issueRPT(abn, normalizedTaxType as "PAYGW" | "GST", periodId, finalThresholds);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
   const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }


### PR DESCRIPTION
## Summary
- finalize the close-and-issue flow by normalizing thresholds, updating ledger hashes, and persisting period state before issuing an RPT
- generate ledger proofs and verified evidence bundles with BAS labels, discrepancy logs, and canonical payload hashes
- repair the reconciliation state machine to enumerate lifecycle transitions from OPEN through FINALIZED

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e21299c180832780a10896e4b81500