### PR TITLE
Fix RPT anomaly check import and add deterministic tests

### DIFF
--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,7 +1,7 @@
 ﻿import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
+import { isAnomalous } from "../anomaly/deterministic";
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
@@ -12,7 +12,7 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
+  if (isAnomalous(v, thresholds)) {
     await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }

--- a/tests/anomaly/deterministic.test.ts
+++ b/tests/anomaly/deterministic.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isAnomalous, AnomalyVector, Thresholds } from "../../src/anomaly/deterministic";
+
+describe("isAnomalous", () => {
+  const baseVector: AnomalyVector = {
+    variance_ratio: 0.1,
+    dup_rate: 0.02,
+    gap_minutes: 10,
+    delta_vs_baseline: 0.02,
+  };
+
+  it("returns false when metrics are within defaults", () => {
+    const result = isAnomalous(baseVector);
+    assert.equal(result, false);
+  });
+
+  it("returns true when a metric exceeds provided thresholds", () => {
+    const thresholds: Thresholds = { variance_ratio: 0.05 };
+    const result = isAnomalous({ ...baseVector, variance_ratio: 0.5 }, thresholds);
+    assert.equal(result, true);
+  });
+});


### PR DESCRIPTION
## Summary
- update the RPT issuer to call the deterministic anomaly helper that is actually exported
- add node:test coverage to ensure anomaly vectors both pass and trigger blocks under threshold changes

## Testing
- npx tsx --test tests/anomaly/deterministic.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e218fe59148327b5d0d42d9c9ebad9