### PR TITLE
Refactor legacy API routes into reusable router

### DIFF
--- a/docs/smoke/api-gateway.md
+++ b/docs/smoke/api-gateway.md
@@ -1,0 +1,21 @@
+# API Gateway Smoke Plan
+
+This checklist exercises the Express gateway to make sure the legacy routes
+still load without runtime import failures after refactoring.
+
+1. `pnpm install` (first run only) and `pnpm dev` from the repository root.
+2. In another terminal run the following requests. Each command should respond
+   with a structured JSON error (400/422 is fine) rather than crashing, which
+   confirms the handler and its imports resolved correctly.
+
+   ```bash
+   curl -i http://localhost:3000/api/pay -X POST -H 'content-type: application/json' -d '{}'
+   curl -i http://localhost:3000/api/close-issue -X POST -H 'content-type: application/json' -d '{}'
+   curl -i http://localhost:3000/api/payto/sweep -X POST -H 'content-type: application/json' -d '{}'
+   curl -i http://localhost:3000/api/settlement/webhook -X POST -H 'content-type: application/json' -d '{"csv":""}'
+   curl -i "http://localhost:3000/api/evidence?abn=123&taxType=GST&periodId=2024-Q1"
+   ```
+3. Stop the dev server with `Ctrl+C`.
+
+If any command returns a 500 or stack trace, investigate the handler imports
+and ensure they are exported from `src/api/index.ts` and its dependencies.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,27 @@
+import express from "express";
+
+import { idempotency } from "../middleware/idempotency";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+  settlementWebhook,
+  evidence,
+} from "../routes/reconcile";
+
+/**
+ * Primary Express router for legacy gateway endpoints.
+ *
+ * These routes previously lived on the monolithic gateway server and are kept
+ * together so they can be mounted behind `/api` from the main app bootstrap.
+ */
+export const api = express.Router();
+
+// Legacy reconciliation + evidence endpoints
+api.post("/pay", idempotency(), payAto);
+api.post("/close-issue", closeAndIssue);
+api.post("/payto/sweep", paytoSweep);
+api.post("/settlement/webhook", settlementWebhook);
+api.get("/evidence", evidence);
+
+export default api;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,8 @@
 import express from "express";
 import dotenv from "dotenv";
 
-import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { api } from "./api";                  // consolidated legacy routes
 
 dotenv.config();
 
@@ -18,17 +16,10 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
-
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
 
-// Existing API router(s) after
+// Legacy gateway routes after the payments micro-frontend
 app.use("/api", api);
 
 // 404 fallback (must be last)


### PR DESCRIPTION
## Summary
- add `src/api/index.ts` to expose the legacy reconciliation/evidence routes through an Express router
- update the server bootstrap to mount the payments and legacy routers in order
- document a manual smoke checklist to ensure `/api/*` handlers load without import errors

## Testing
- npx tsc --noEmit *(fails: repo contains pre-existing type errors in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e218fc06948327a0efe463a3964c91