### PR TITLE
Align payments defaults with service port

### DIFF
--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -11,8 +11,8 @@ import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
 
-// Port (defaults to 3000)
-const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
+// Port (defaults to 3001 to avoid clashing with Next.js dev server)
+const PORT = process.env.PORT ? Number(process.env.PORT) : 3001;
 
 // Prefer DATABASE_URL; else compose from PG* vars
 const connectionString =

--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -4,10 +4,11 @@ export type DepositArgs = Common & { amountCents: number };   // > 0
 export type ReleaseArgs = Common & { amountCents: number };   // < 0
 
 // Prefer NEXT_PUBLIC_ (browser-safe), then server-only, then default
-const BASE =
+const rawBase =
   process.env.NEXT_PUBLIC_PAYMENTS_BASE_URL ||
   process.env.PAYMENTS_BASE_URL ||
   "http://localhost:3001";
+const BASE = rawBase.replace(/\/$/, "");
 
 async function handle(res: Response) {
   const text = await res.text();


### PR DESCRIPTION
## Summary
- default the payments service to port 3001 so it matches the shared client expectations
- normalise the payments client base URL so environment overrides work with or without a trailing slash

## Testing
- npx tsx tmp-smoke.ts

------
https://chatgpt.com/codex/tasks/task_e_68e218ff70c4832799f270fc50fe63e4