### PR TITLE
feat: add configurable payments client base url

### DIFF
--- a/.env.development.local
+++ b/.env.development.local
@@ -1,0 +1,2 @@
+REACT_APP_PAYMENTS_BASE_URL=http://localhost:3000
+VITE_PAYMENTS_BASE_URL=http://localhost:3000

--- a/src/api/paymentsClient.ts
+++ b/src/api/paymentsClient.ts
@@ -1,0 +1,17 @@
+const fromEnv = () =>
+  (import.meta as any)?.env?.VITE_PAYMENTS_BASE_URL ??
+  (typeof process !== "undefined" ? process.env.REACT_APP_PAYMENTS_BASE_URL : undefined);
+
+const BASE = (fromEnv() as string) || "http://localhost:3000";
+
+async function doJson(path: string, init?: RequestInit) {
+  const r = await fetch(`${BASE}${path}`, { ...init, headers: { "content-type": "application/json", ...(init?.headers || {}) } });
+  if (!r.ok) throw new Error(`payments ${path} failed: ${r.status}`);
+  return r.json();
+}
+
+export const paymentsApi = {
+  deposit: (body: any) => doJson("/deposit", { method: "POST", body: JSON.stringify(body) }),
+  balance: (abn: string) => doJson(`/balance/${abn}`),
+  release: (body: any) => doJson("/release", { method: "POST", body: JSON.stringify(body) }), // keep if used
+};


### PR DESCRIPTION
## Summary
- add a shared payments client that reads Vite or CRA environment variables before falling back to localhost:3000
- document default payments base URL overrides in the development env example

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e219f4ca3c83279cb84ad2d6f45805