### PR TITLE
Align SQL adapters with patent schema and document validation

### DIFF
--- a/docs/patent_manual_validation.md
+++ b/docs/patent_manual_validation.md
@@ -1,0 +1,108 @@
+# APGMS Patent Core Validation Plan
+
+The following `psql` session exercises the RPT issuance, payment release, idempotency replay, and evidence export
+paths against the schema shipped in `migrations/002_apgms_patent_core.sql` together with the legacy period tables.
+
+> **Prerequisites**
+>
+> * Apply migrations `001_apgms_core.sql`, `002_apgms_patent_core.sql`, and `002_patent_extensions.sql`.
+> * Set `RPT_ED25519_SECRET_BASE64` and `ATO_PRN` environment variables for the API process.
+> * Start the API so the middleware and adapters can be invoked during manual verification.
+
+## 1. Seed a period and ledger credit
+
+```sql
+-- Open a period and credit the OWA ledger with 100.00 (10000 cents)
+INSERT INTO periods(abn,tax_type,period_id,state,final_liability_cents,credited_to_owa_cents)
+VALUES ('12345678901','GST','2025-09','CLOSING',10000,10000)
+ON CONFLICT (abn,tax_type,period_id) DO UPDATE
+SET state='CLOSING', final_liability_cents=10000, credited_to_owa_cents=10000;
+
+SELECT owa_append('12345678901','GST','2025-09', 10000, 'seed:credit');
+```
+
+## 2. Issue an RPT token
+
+```bash
+curl -X POST http://localhost:3000/api/close-issue \
+  -H 'Content-Type: application/json' \
+  -d '{
+        "abn":"12345678901",
+        "taxType":"GST",
+        "periodId":"2025-09",
+        "thresholds":{"epsilon_cents":50}
+      }'
+```
+
+Expected: HTTP 200 with payload + signature. Verify storage:
+
+```sql
+SELECT abn, tax_type, period_id, payload_sha256, signature
+FROM rpt_tokens
+WHERE abn='12345678901' AND tax_type='GST' AND period_id='2025-09'
+ORDER BY id DESC LIMIT 1;
+```
+
+## 3. Release the payment (idempotent)
+
+```bash
+curl -X POST http://localhost:3000/api/pay \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: demo-release-001' \
+  -d '{
+        "abn":"12345678901",
+        "taxType":"GST",
+        "periodId":"2025-09",
+        "rail":"EFT"
+      }'
+```
+
+Expected JSON fields: `transfer_uuid`, `bank_receipt_hash`, `balance_after_cents`, `audit_hash`, `status:"DONE"`.
+
+Replay with the same idempotency key:
+
+```bash
+curl -X POST http://localhost:3000/api/pay \
+  -H 'Content-Type: application/json' \
+  -H 'Idempotency-Key: demo-release-001' \
+  -d '{
+        "abn":"12345678901",
+        "taxType":"GST",
+        "periodId":"2025-09",
+        "rail":"EFT"
+      }'
+```
+
+Expected: HTTP 200 `{ "idempotent": true, "status": "DONE", "response_hash": "..." }` from middleware.
+
+Database verification:
+
+```sql
+SELECT balance_after_cents, bank_receipt_hash, hash_after
+FROM owa_ledger
+WHERE abn='12345678901' AND tax_type='GST' AND period_id='2025-09'
+ORDER BY id DESC LIMIT 1;
+
+SELECT last_status, response_hash
+FROM idempotency_keys
+WHERE key='demo-release-001';
+
+SELECT category, message, hash_prev, hash_this
+FROM audit_log
+ORDER BY id DESC LIMIT 1;
+```
+
+## 4. Export evidence bundle
+
+```bash
+curl "http://localhost:3000/api/evidence?abn=12345678901&taxType=GST&periodId=2025-09"
+```
+
+Expected JSON contains:
+
+* `rpt.payload`, `rpt.signature`, `rpt.payload_sha256`.
+* `owa_ledger_deltas` entries including the release debit with the hash chain intact.
+* `bank_receipt_hash` echoing the synthetic bank receipt.
+
+This plan can be recorded alongside application logs to demonstrate the reconciler, release adapter, idempotency
+middleware, and evidence exporter all operate against the patent schema using fully parameterised SQL.

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,15 +1,36 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
+import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
-export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
-  const prevHash = rows[0]?.terminal_hash || "";
-  const payloadHash = sha256Hex(JSON.stringify(payload));
-  const terminalHash = sha256Hex(prevHash + payloadHash);
-  await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
-    [actor, action, payloadHash, prevHash, terminalHash]
+type Queryable = Pick<Pool, "query"> | PoolClient;
+
+/**
+ * Append an audit entry using the schema defined in 002_apgms_patent_core.sql.
+ *
+ * When a PoolClient is supplied the insert participates in the caller's
+ * transaction which lets callers update business tables and the audit log
+ * atomically.
+ */
+export async function appendAudit(
+  category: string,
+  message: unknown,
+  client?: PoolClient
+): Promise<string> {
+  const runner: Queryable = client ?? pool;
+  const messageText = typeof message === "string" ? message : JSON.stringify(message);
+
+  const { rows } = await runner.query(
+    "SELECT hash_this FROM audit_log ORDER BY id DESC LIMIT 1"
   );
-  return terminalHash;
+  const hashPrev = rows[0]?.hash_this ?? "";
+  const payloadHash = sha256Hex(messageText);
+  const hashThis = sha256Hex(hashPrev + payloadHash);
+
+  const inserted = await runner.query(
+    "INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ($1,$2,$3,$4) RETURNING hash_this",
+    [category, messageText, hashPrev || null, hashThis]
+  );
+
+  return inserted.rows[0].hash_this as string;
 }

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,46 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
+  const period = await pool.query(
+    `SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents, thresholds
+       FROM periods
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+    [abn, taxType, periodId]
+  );
+
+  const rpt = await pool.query(
+    `SELECT payload, payload_c14n, payload_sha256, signature, created_at
+       FROM rpt_tokens
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC LIMIT 1`,
+    [abn, taxType, periodId]
+  );
+
+  const ledger = await pool.query(
+    `SELECT created_at AS ts, amount_cents, balance_after_cents, hash_after, bank_receipt_hash
+       FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id`,
+    [abn, taxType, periodId]
+  );
+
+  const deltas = ledger.rows;
+  const tail = deltas[deltas.length - 1];
+
+  return {
+    meta: {
+      generated_at: new Date().toISOString(),
+      abn,
+      taxType,
+      periodId
+    },
+    period: period.rows[0] || null,
+    rpt: rpt.rows[0] || null,
     owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    bank_receipt_hash: tail?.bank_receipt_hash ?? null,
+    bas_labels: { W1: null, W2: null, "1A": null, "1B": null },
+    discrepancy_log: []
   };
-  return bundle;
 }

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,29 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
 const pool = new Pool();
+
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
+
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query(
+        "INSERT INTO idempotency_keys(key,last_status) VALUES ($1,$2)",
+        [key, "INIT"]
+      );
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+      const existing = await pool.query(
+        "SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1",
+        [key]
+      );
+      return res.status(200).json({
+        idempotent: true,
+        status: existing.rows[0]?.last_status || "DONE",
+        response_hash: existing.rows[0]?.response_hash || null
+      });
     }
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,42 +1,127 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    `SELECT abn, rail, reference, label, account_bsb, account_number
+       FROM remittance_destinations
+      WHERE abn=$1 AND rail=$2 AND reference=$3`,
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
   return rows[0];
 }
 
+interface ReleaseResult {
+  transfer_uuid: string;
+  bank_receipt_hash: string;
+  balance_after_cents: number;
+  audit_hash: string;
+  status: "DONE" | "DUPLICATE" | "ERROR";
+}
+
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
-  const transfer_uuid = uuidv4();
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY",
+  reference: string
+): Promise<ReleaseResult> {
+  const transferUuid = uuidv4();
+  const client = await pool.connect();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
-  } catch {
-    return { transfer_uuid, status: "DUPLICATE" };
+    await client.query("BEGIN");
+
+    const insertedKey = await client.query(
+      `INSERT INTO idempotency_keys(key,last_status)
+         VALUES ($1,$2)
+         ON CONFLICT (key) DO NOTHING
+         RETURNING key`,
+      [transferUuid, "INIT"]
+    );
+
+    if (insertedKey.rowCount === 0) {
+      const existing = await client.query(
+        "SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1",
+        [transferUuid]
+      );
+      await client.query("ROLLBACK");
+      return {
+        transfer_uuid: transferUuid,
+        bank_receipt_hash: "",
+        balance_after_cents: 0,
+        audit_hash: existing.rows[0]?.response_hash ?? "",
+        status: (existing.rows[0]?.last_status as "DONE" | "DUPLICATE" | undefined) ?? "DUPLICATE"
+      };
+    }
+
+    const bankReceiptHash = `bank:${transferUuid.slice(0, 12)}`;
+
+    const { rows: last } = await client.query(
+      `SELECT balance_after_cents, hash_after
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const prevBal = Number(last[0]?.balance_after_cents ?? 0);
+    const prevHash = last[0]?.hash_after ?? "";
+    const newBal = prevBal - amountCents;
+    const hashAfter = sha256Hex(prevHash + bankReceiptHash + String(newBal));
+
+    const ledgerInsert = await client.query(
+      `INSERT INTO owa_ledger
+         (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       RETURNING balance_after_cents`,
+      [
+        abn,
+        taxType,
+        periodId,
+        transferUuid,
+        -amountCents,
+        newBal,
+        bankReceiptHash,
+        prevHash,
+        hashAfter
+      ]
+    );
+
+    const auditHash = await appendAudit(
+      "rails.release",
+      { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash: bankReceiptHash },
+      client
+    );
+
+    await client.query(
+      "UPDATE idempotency_keys SET last_status=$1, response_hash=$2 WHERE key=$3",
+      ["DONE", auditHash, transferUuid]
+    );
+
+    await client.query("COMMIT");
+
+    return {
+      transfer_uuid: transferUuid,
+      bank_receipt_hash: bankReceiptHash,
+      balance_after_cents: Number(ledgerInsert.rows[0].balance_after_cents),
+      audit_hash: auditHash,
+      status: "DONE"
+    };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    await client.query(
+      "UPDATE idempotency_keys SET last_status=$1 WHERE key=$2",
+      ["ERROR", transferUuid]
+    );
+    throw err;
+  } finally {
+    client.release();
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
-
-  const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
-  const prevHash = rows[0]?.hash_after ?? "";
-  const newBal = prevBal - amountCents;
-  const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
-
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
-  );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,21 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    `SELECT payload FROM rpt_tokens
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC LIMIT 1`,
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "UPDATE periods SET state='RELEASED' WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,79 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-  if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
-  const row = p.rows[0];
+const pool = new Pool();
+const secretKeyB64 = process.env.RPT_ED25519_SECRET_BASE64 || "";
+
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>
+) {
+  const period = await pool.query(
+    `SELECT id, abn, tax_type, period_id, state, final_liability_cents,
+            credited_to_owa_cents, merkle_root, running_balance_hash, anomaly_vector
+       FROM periods
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+    [abn, taxType, periodId]
+  );
+  if (period.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+  const row = period.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+  const anomalyVector = row.anomaly_vector || {};
+  if (exceeds(anomalyVector, thresholds)) {
+    await pool.query(
+      "UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1",
+      [row.id]
+    );
     throw new Error("BLOCKED_ANOMALY");
   }
+
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query(
+      "UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1",
+      [row.id]
+    );
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
+  if (!secretKeyB64) throw new Error("NO_RPT_SECRET");
+  const secretKey = new Uint8Array(Buffer.from(secretKeyB64, "base64"));
+
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: anomalyVector,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID()
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+
+  const payloadCanonical = JSON.stringify(payload);
+  const payloadSha256 = crypto.createHash("sha256").update(payloadCanonical).digest("hex");
+  const signature = signRpt(payload, secretKey);
+
+  await pool.query(
+    `INSERT INTO rpt_tokens
+      (abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256)
+      VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+    [abn, taxType, periodId, payload, signature, payloadCanonical, payloadSha256]
+  );
+
+  await pool.query(
+    "UPDATE periods SET state='READY_RPT' WHERE id=$1",
+    [row.id]
+  );
+
+  return { payload, signature, payload_sha256: payloadSha256 };
 }


### PR DESCRIPTION
## Summary
- update the reconcile route, RPT issuer, rails adapter, idempotency middleware, and evidence bundle to use fully parameterised SQL aligned with the patent schema
- compute canonical RPT payload hashes, perform release/audit writes atomically, and expose richer evidence payloads
- add a manual psql validation plan covering issuance, payment release, idempotency replay, and evidence export

## Testing
- npx tsc --noEmit *(fails: pre-existing syntax error in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e218fce1a0832788fbb9f14bd3b0d2