### PR TITLE
Add persistent PayTo mandates with sweep routes

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { router as paytoRouter } from "../routes/payto";
+
+export const api = Router();
+
+api.use("/payto", paytoRouter);

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,10 @@
+import { Pool } from "pg";
+
+let pool: Pool | null = null;
+
+export const getPool = () => {
+  if (!pool) {
+    pool = new Pool();
+  }
+  return pool;
+};

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,69 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+import { getPool } from "../db/pool";
+import crypto from "crypto";
+
+export type PayToMandate = {
+  id: string;
+  abn: string;
+  payid: string;
+  creditorName: string;
+  maxAmountCents: number;
+  status: "ACTIVE" | "CANCELLED";
+  createdAt: string;
+};
+
+export const payto = {
+  async createMandate(abn: string, payid: string, creditorName: string, maxAmountCents: number): Promise<PayToMandate> {
+    const id = crypto.randomUUID();
+    const q = await getPool().query(
+      `insert into payto_mandates (id, abn, payid, creditor_name, max_amount_cents, status, created_at)
+       values ($1,$2,$3,$4,$5,'ACTIVE',now())
+       returning id, abn, payid, creditor_name as "creditorName", max_amount_cents as "maxAmountCents", status, created_at as "createdAt"`,
+      [id, abn, payid, creditorName, maxAmountCents]
+    );
+    return q.rows[0];
+  },
+
+  async cancelMandate(id: string): Promise<void> {
+    await getPool().query(`update payto_mandates set status='CANCELLED' where id=$1`, [id]);
+  },
+
+  async getMandate(id: string): Promise<PayToMandate | null> {
+    const q = await getPool().query(
+      `select id, abn, payid, creditor_name as "creditorName", max_amount_cents as "maxAmountCents", status, created_at as "createdAt"
+         from payto_mandates where id=$1`,
+      [id]
+    );
+    return q.rowCount ? q.rows[0] : null;
+  },
+
+  async sweep(mandateId: string, amountCents: number, ref: string) {
+    const c = await getPool().connect();
+    try {
+      await c.query("BEGIN");
+      const m = await c.query(`select abn, status, max_amount_cents from payto_mandates where id=$1 for update`, [mandateId]);
+      if (!m.rowCount) throw new Error("mandate not found");
+      if (m.rows[0].status !== "ACTIVE") throw new Error("mandate not active");
+      if (amountCents > Number(m.rows[0].max_amount_cents)) throw new Error("amount exceeds mandate limit");
+
+      await c.query(
+        `insert into payto_sweeps (mandate_id, abn, amount_cents, reference, created_at) values ($1,$2,$3,$4,now())`,
+        [mandateId, m.rows[0].abn, amountCents, ref]
+      );
+
+      // credit OWA ledger
+      await c.query(
+        `insert into ledger (abn, direction, amount_cents, source, meta)
+         values ($1,'credit',$2,'payto_sweep',$3)`,
+        [m.rows[0].abn, amountCents, { mandateId, ref }]
+      );
+
+      await c.query("COMMIT");
+      return { ok: true };
+    } catch (e: any) {
+      await c.query("ROLLBACK");
+      throw e;
+    } finally {
+      c.release();
+    }
+  },
+};

--- a/src/routes/payto.ts
+++ b/src/routes/payto.ts
@@ -1,0 +1,41 @@
+import { Router } from "express";
+import { payto } from "../payto/adapter";
+export const router = Router();
+
+router.post("/mandates", async (req, res) => {
+  try {
+    const { abn, payid, creditorName, maxAmountCents } = req.body ?? {};
+    if (!abn || !payid || !creditorName || maxAmountCents === undefined) {
+      return res.status(400).json({ error: "missing fields" });
+    }
+    const max = Number(maxAmountCents);
+    if (!Number.isFinite(max) || max <= 0) {
+      return res.status(400).json({ error: "invalid maxAmountCents" });
+    }
+    res.json(await payto.createMandate(abn, payid, creditorName, max));
+  } catch (e: any) {
+    res.status(400).json({ error: e?.message || "failed to create mandate" });
+  }
+});
+
+router.post("/mandates/:id/cancel", async (req, res) => {
+  try {
+    await payto.cancelMandate(req.params.id);
+    res.json({ ok: true });
+  } catch (e: any) {
+    res.status(400).json({ error: e?.message || "failed to cancel" });
+  }
+});
+
+router.post("/mandates/:id/sweep", async (req, res) => {
+  try {
+    const { amountCents, ref } = req.body ?? {};
+    const amount = Number(amountCents);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return res.status(400).json({ error: "invalid amountCents" });
+    }
+    res.json(await payto.sweep(req.params.id, amount, String(ref || "")));
+  } catch (e: any) {
+    res.status(400).json({ error: e?.message || "failed to sweep" });
+  }
+});


### PR DESCRIPTION
## Summary
- implement a persistent PayTo adapter that records mandates and sweeps in Postgres and credits the ledger
- add an Express router that exposes mandate create/cancel/sweep endpoints under /api/payto
- share a Postgres pool helper and update the existing PayTo sweep endpoint to use the new mandate-aware adapter

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e219fca7bc83278f75bdc64f928d01