### PR TITLE
Refine BAS state machine transitions and add coverage

### DIFF
--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -1,15 +1,67 @@
-﻿export type PeriodState = "OPEN"|"CLOSING"|"READY_RPT"|"BLOCKED_DISCREPANCY"|"BLOCKED_ANOMALY"|"RELEASED"|"FINALIZED";
-export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
+export const PeriodStates = {
+  OPEN: "OPEN",
+  CLOSING: "CLOSING",
+  READY_RPT: "READY_RPT",
+  BLOCKED_DISCREPANCY: "BLOCKED_DISCREPANCY",
+  BLOCKED_ANOMALY: "BLOCKED_ANOMALY",
+  RELEASED: "RELEASED",
+  FINALIZED: "FINALIZED",
+} as const;
 
-export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
+export type PeriodState = typeof PeriodStates[keyof typeof PeriodStates];
+
+export const PeriodEvents = {
+  CLOSE: "CLOSE",
+  PASS: "PASS",
+  FAIL_DISCREPANCY: "FAIL_DISCREPANCY",
+  FAIL_ANOMALY: "FAIL_ANOMALY",
+  RESOLVE_DISCREPANCY: "RESOLVE_DISCREPANCY",
+  RESOLVE_ANOMALY: "RESOLVE_ANOMALY",
+  RELEASE: "RELEASE",
+  FINALIZE: "FINALIZE",
+} as const;
+
+export type PeriodEvent = typeof PeriodEvents[keyof typeof PeriodEvents];
+
+export interface Thresholds {
+  epsilon_cents: number;
+  variance_ratio: number;
+  dup_rate: number;
+  gap_minutes: number;
+}
+
+type TransitionMap = {
+  [S in PeriodState]: Partial<Record<PeriodEvent, PeriodState>>;
+};
+
+export const periodTransitionMap = {
+  [PeriodStates.OPEN]: {
+    [PeriodEvents.CLOSE]: PeriodStates.CLOSING,
+  },
+  [PeriodStates.CLOSING]: {
+    [PeriodEvents.PASS]: PeriodStates.READY_RPT,
+    [PeriodEvents.FAIL_DISCREPANCY]: PeriodStates.BLOCKED_DISCREPANCY,
+    [PeriodEvents.FAIL_ANOMALY]: PeriodStates.BLOCKED_ANOMALY,
+  },
+  [PeriodStates.BLOCKED_DISCREPANCY]: {
+    [PeriodEvents.RESOLVE_DISCREPANCY]: PeriodStates.CLOSING,
+  },
+  [PeriodStates.BLOCKED_ANOMALY]: {
+    [PeriodEvents.RESOLVE_ANOMALY]: PeriodStates.CLOSING,
+  },
+  [PeriodStates.READY_RPT]: {
+    [PeriodEvents.RELEASE]: PeriodStates.RELEASED,
+  },
+  [PeriodStates.RELEASED]: {
+    [PeriodEvents.FINALIZE]: PeriodStates.FINALIZED,
+  },
+  [PeriodStates.FINALIZED]: {},
+} satisfies TransitionMap;
+
+export function nextState(current: PeriodState, evt: PeriodEvent): PeriodState {
+  const next = periodTransitionMap[current]?.[evt];
+  if (!next) {
+    throw new Error(`Invalid transition: ${current} -> ${evt}`);
   }
+  return next;
 }

--- a/tests/stateMachine.test.ts
+++ b/tests/stateMachine.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  nextState,
+  PeriodEvents,
+  PeriodStates,
+  PeriodState,
+  PeriodEvent,
+} from "../src/recon/stateMachine";
+
+test("BAS gate happy path transitions", () => {
+  let state: PeriodState = PeriodStates.OPEN;
+  state = nextState(state, PeriodEvents.CLOSE);
+  assert.equal(state, PeriodStates.CLOSING);
+
+  state = nextState(state, PeriodEvents.PASS);
+  assert.equal(state, PeriodStates.READY_RPT);
+
+  state = nextState(state, PeriodEvents.RELEASE);
+  assert.equal(state, PeriodStates.RELEASED);
+
+  state = nextState(state, PeriodEvents.FINALIZE);
+  assert.equal(state, PeriodStates.FINALIZED);
+});
+
+test("blocked discrepancy must be resolved before continuing", () => {
+  let state: PeriodState = PeriodStates.CLOSING;
+  state = nextState(state, PeriodEvents.FAIL_DISCREPANCY);
+  assert.equal(state, PeriodStates.BLOCKED_DISCREPANCY);
+
+  state = nextState(state, PeriodEvents.RESOLVE_DISCREPANCY);
+  assert.equal(state, PeriodStates.CLOSING);
+});
+
+test("blocked anomaly requires resolution", () => {
+  let state: PeriodState = PeriodStates.CLOSING;
+  state = nextState(state, PeriodEvents.FAIL_ANOMALY);
+  assert.equal(state, PeriodStates.BLOCKED_ANOMALY);
+
+  state = nextState(state, PeriodEvents.RESOLVE_ANOMALY);
+  assert.equal(state, PeriodStates.CLOSING);
+});
+
+test("invalid transitions throw", () => {
+  assert.throws(() => nextState(PeriodStates.OPEN, PeriodEvents.PASS));
+  assert.throws(() => nextState(PeriodStates.FINALIZED, PeriodEvents.CLOSE));
+  assert.throws(() => nextState(PeriodStates.CLOSING, "UNKNOWN" as PeriodEvent));
+});


### PR DESCRIPTION
## Summary
- replace the malformed state/event template with a proper template literal
- expose reusable BAS period state and event constants with a transition map
- enforce valid transitions, add unblock paths, and cover the flow with node:test cases

## Testing
- npx tsx tests/stateMachine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e21e609428832784b940dfd1f97260