### PR TITLE
Add deterministic anomaly threshold helper for RPT issuance

### DIFF
--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -1,4 +1,12 @@
-﻿export interface AnomalyVector {
+/**
+ * Deterministic anomaly vectors encode proportional or time based deviations.
+ * Threshold inputs are expected to be expressed as:
+ *   - variance_ratio: unit-less ratio (e.g. 0.25 == 25% spread vs baseline)
+ *   - dup_rate: unit-less ratio of duplicates observed (0.01 == 1%)
+ *   - gap_minutes: whole minutes between successive lodgements
+ *   - delta_vs_baseline: absolute ratio difference vs historical baseline
+ */
+export interface AnomalyVector {
   variance_ratio: number;
   dup_rate: number;
   gap_minutes: number;
@@ -12,11 +20,25 @@ export interface Thresholds {
   delta_vs_baseline?: number;
 }
 
-export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
+const DEFAULT_THRESHOLDS: Required<Thresholds> = {
+  variance_ratio: 0.25,
+  dup_rate: 0.05,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.1,
+};
+
+export type AnomalyVectorLike = Partial<AnomalyVector>;
+
+export function exceeds(v: AnomalyVectorLike, thr: Thresholds = {}): boolean {
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...thr };
   return (
-    v.variance_ratio > (thr.variance_ratio ?? 0.25) ||
-    v.dup_rate > (thr.dup_rate ?? 0.05) ||
-    v.gap_minutes > (thr.gap_minutes ?? 60) ||
-    Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
+    (v.variance_ratio ?? 0) > thresholds.variance_ratio ||
+    (v.dup_rate ?? 0) > thresholds.dup_rate ||
+    (v.gap_minutes ?? 0) > thresholds.gap_minutes ||
+    Math.abs(v.delta_vs_baseline ?? 0) > thresholds.delta_vs_baseline
   );
+}
+
+export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
+  return exceeds(v, thr);
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,60 @@
-﻿import { Pool } from "pg";
 import crypto from "crypto";
+import { Pool } from "pg";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
+import { exceeds, Thresholds, AnomalyVectorLike } from "../anomaly/deterministic";
+
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+type Queryable = Pick<Pool, "query">;
+export type IssueThresholds = Thresholds & { epsilon_cents?: number };
+
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: IssueThresholds,
+  db: Queryable = pool
+) {
+  const p = await db.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
-  const v = row.anomaly_vector || {};
+  const v = (row.anomaly_vector || {}) as AnomalyVectorLike;
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await db.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
+
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await db.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await db.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4::jsonb,$5)",
+    [abn, taxType, periodId, JSON.stringify(payload), signature]
+  );
+  await db.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }

--- a/tests/unit/issuer.test.ts
+++ b/tests/unit/issuer.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+process.env.RPT_ED25519_SECRET_BASE64 = Buffer.alloc(64).toString("base64");
+process.env.ATO_PRN = "TEST-PRN";
+
+const issuerModulePromise = import("../../src/rpt/issuer");
+type IssueModule = typeof import("../../src/rpt/issuer");
+type IssueThresholds = IssueModule["IssueThresholds"];
+
+interface QueryCall { text: string; params?: unknown[]; }
+interface QueryResponse { rowCount: number; rows: any[]; }
+
+type QueryResult = QueryResponse | Promise<QueryResponse> | void;
+
+type QueryStub = (text: string, params?: unknown[]) => QueryResult;
+
+class StubDb {
+  public calls: QueryCall[] = [];
+  private responders: QueryStub[];
+
+  constructor(responders: QueryStub[]) {
+    this.responders = [...responders];
+  }
+
+  async query(text: string, params?: unknown[]) {
+    this.calls.push({ text, params });
+    const responder = this.responders.shift();
+    if (!responder) {
+      throw new Error("Unexpected query: " + text);
+    }
+    const result = responder(text, params);
+    return await Promise.resolve(result as QueryResponse);
+  }
+}
+
+const baseRow = {
+  id: 42,
+  abn: "12345678901",
+  period_id: "2025-09",
+  tax_type: "GST" as const,
+  state: "CLOSING",
+  anomaly_vector: { variance_ratio: 0.05, dup_rate: 0.001, gap_minutes: 10, delta_vs_baseline: 0.01 },
+  final_liability_cents: 1000,
+  credited_to_owa_cents: 1000,
+  merkle_root: "abc",
+  running_balance_hash: "def",
+};
+
+const thresholds: IssueThresholds = {
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+  epsilon_cents: 0,
+};
+
+test("issueRPT returns payload when anomaly checks pass", async () => {
+  const { issueRPT } = await issuerModulePromise;
+  const db = new StubDb([
+    () => ({ rowCount: 1, rows: [baseRow] }),
+    () => ({ rowCount: 1, rows: [] }),
+    () => ({ rowCount: 1, rows: [] }),
+  ]);
+
+  const result = await issueRPT(baseRow.abn, baseRow.tax_type, baseRow.period_id, thresholds, db as any);
+
+  assert.equal(db.calls.length, 3);
+  assert.match(db.calls[1].text, /insert into rpt_tokens/);
+  assert.equal(result.payload.amount_cents, baseRow.final_liability_cents);
+  assert.equal(result.payload.thresholds, thresholds);
+  assert.ok(typeof result.signature === "string" && result.signature.length > 0);
+});
+
+test("issueRPT blocks when anomaly exceeds thresholds", async () => {
+  const { issueRPT } = await issuerModulePromise;
+  const db = new StubDb([
+    () => ({
+      rowCount: 1,
+      rows: [{ ...baseRow, anomaly_vector: { ...baseRow.anomaly_vector, variance_ratio: 0.9 } }],
+    }),
+    () => ({ rowCount: 1, rows: [] }),
+  ]);
+
+  await assert.rejects(
+    () => issueRPT(baseRow.abn, baseRow.tax_type, baseRow.period_id, thresholds, db as any),
+    /BLOCKED_ANOMALY/
+  );
+
+  assert.equal(db.calls.length, 2);
+  assert.match(db.calls[1].text, /BLOCKED_ANOMALY/);
+});


### PR DESCRIPTION
## Summary
- add documentation and an `exceeds` helper for deterministic anomaly thresholds
- update the RPT issuer to reuse the helper and accept injectable queryables
- cover the pass and block flows with unit tests

## Testing
- npx tsx tests/unit/issuer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e21e5ea59c8327b71b7632f0bc0647