### PR TITLE
Parameterize SQL queries and add regression tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx tests/sqlQueries.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -20,3 +20,7 @@ export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
     Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
   );
 }
+
+export function exceeds(v: AnomalyVector, thr: Thresholds = {}): boolean {
+  return isAnomalous(v, thr);
+}

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -8,7 +8,7 @@ export async function appendAudit(actor: string, action: string, payload: any) {
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values ($1,$2,$3,$4,$5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -2,9 +2,24 @@
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (
+    await pool.query(
+      "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -6,10 +6,16 @@ export function idempotency() {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query(
+        "insert into idempotency_keys(key,last_status) values($1,$2)",
+        [key, "INIT"]
+      );
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
+      const r = await pool.query(
+        "select last_status, response_hash from idempotency_keys where key=$1",
+        [key]
+      );
       return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
   };

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,32 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query(
+      "insert into idempotency_keys(key,last_status) values($1,$2)",
+      [transfer_uuid, "INIT"]
+    );
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query(
+    "update idempotency_keys set last_status=$1 where key=$2",
+    ["DONE", transfer_uuid]
+  );
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -6,19 +6,22 @@ const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +33,10 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }

--- a/tests/sqlQueries.test.ts
+++ b/tests/sqlQueries.test.ts
@@ -1,0 +1,417 @@
+import assert from "node:assert/strict";
+import { createRequire } from "module";
+import nacl from "tweetnacl";
+
+const require = createRequire(import.meta.url);
+
+type QueryResult = { rows: any[]; rowCount: number };
+
+type PeriodRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  final_liability_cents: number;
+  credited_to_owa_cents: number;
+  merkle_root: string;
+  running_balance_hash: string;
+  anomaly_vector: any;
+  thresholds: any;
+};
+
+type RptTokenRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  payload: any;
+  signature: string;
+  created_at: string;
+};
+
+type OwaLedgerRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  transfer_uuid: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string;
+  prev_hash: string;
+  hash_after: string;
+  created_at: string;
+};
+
+type RemittanceRow = {
+  id: number;
+  abn: string;
+  rail: string;
+  reference: string;
+};
+
+const store = {
+  periods: [] as PeriodRow[],
+  rpt_tokens: [] as RptTokenRow[],
+  owa_ledger: [] as OwaLedgerRow[],
+  remittance_destinations: [] as RemittanceRow[],
+  idempotency_keys: new Map<string, { last_status: string; response_hash?: string }>(),
+  audit_log: [] as { seq: number; actor: string; action: string; payload_hash: string; prev_hash: string; terminal_hash: string; created_at: string }[],
+};
+
+const sequences = {
+  periods: 1,
+  rpt_tokens: 1,
+  owa_ledger: 1,
+  remittance_destinations: 1,
+  audit_log: 1,
+};
+
+function normalize(sql: string): string {
+  return sql.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+class MemoryPool {
+  async query(text: string, params: any[] = []): Promise<QueryResult> {
+    const sql = normalize(text);
+    switch (sql) {
+      case "insert into periods (abn, tax_type, period_id, state, final_liability_cents, credited_to_owa_cents, merkle_root, running_balance_hash, anomaly_vector, thresholds) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10) returning id": {
+        const id = sequences.periods++;
+        const row: PeriodRow = {
+          id,
+          abn: params[0],
+          tax_type: params[1],
+          period_id: params[2],
+          state: params[3],
+          final_liability_cents: params[4],
+          credited_to_owa_cents: params[5],
+          merkle_root: params[6],
+          running_balance_hash: params[7],
+          anomaly_vector: params[8],
+          thresholds: params[9],
+        };
+        store.periods.push(row);
+        return { rows: [{ id }], rowCount: 1 };
+      }
+      case "select state from periods where abn=$1 and tax_type=$2 and period_id=$3": {
+        const rows = store.periods
+          .filter((p) => p.abn === params[0] && p.tax_type === params[1] && p.period_id === params[2])
+          .map((p) => ({ state: p.state }));
+        return { rows, rowCount: rows.length };
+      }
+      case "select * from periods where abn=$1 and tax_type=$2 and period_id=$3": {
+        const rows = store.periods.filter((p) => p.abn === params[0] && p.tax_type === params[1] && p.period_id === params[2]);
+        return { rows, rowCount: rows.length };
+      }
+      case "update periods set state='blocked_anomaly' where id=$1": {
+        const updated = store.periods.find((p) => p.id === params[0]);
+        if (updated) updated.state = "BLOCKED_ANOMALY";
+        return { rows: [], rowCount: updated ? 1 : 0 };
+      }
+      case "update periods set state='blocked_discrepancy' where id=$1": {
+        const updated = store.periods.find((p) => p.id === params[0]);
+        if (updated) updated.state = "BLOCKED_DISCREPANCY";
+        return { rows: [], rowCount: updated ? 1 : 0 };
+      }
+      case "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)": {
+        const id = sequences.rpt_tokens++;
+        const row: RptTokenRow = {
+          id,
+          abn: params[0],
+          tax_type: params[1],
+          period_id: params[2],
+          payload: params[3],
+          signature: params[4],
+          created_at: new Date().toISOString(),
+        };
+        store.rpt_tokens.push(row);
+        return { rows: [], rowCount: 1 };
+      }
+      case "update periods set state='ready_rpt' where id=$1": {
+        const updated = store.periods.find((p) => p.id === params[0]);
+        if (updated) updated.state = "READY_RPT";
+        return { rows: [], rowCount: updated ? 1 : 0 };
+      }
+      case "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1": {
+        const rows = store.rpt_tokens
+          .filter((r) => r.abn === params[0] && r.tax_type === params[1] && r.period_id === params[2])
+          .sort((a, b) => b.id - a.id)
+          .slice(0, 1);
+        return { rows, rowCount: rows.length };
+      }
+      case "update periods set state='released' where abn=$1 and tax_type=$2 and period_id=$3": {
+        const updated = store.periods.find(
+          (p) => p.abn === params[0] && p.tax_type === params[1] && p.period_id === params[2]
+        );
+        if (updated) updated.state = "RELEASED";
+        return { rows: [], rowCount: updated ? 1 : 0 };
+      }
+      case "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id": {
+        const rows = store.owa_ledger
+          .filter((o) => o.abn === params[0] && o.tax_type === params[1] && o.period_id === params[2])
+          .sort((a, b) => a.id - b.id)
+          .map((o) => ({
+            ts: o.created_at,
+            amount_cents: o.amount_cents,
+            hash_after: o.hash_after,
+            bank_receipt_hash: o.bank_receipt_hash,
+          }));
+        return { rows, rowCount: rows.length };
+      }
+      case "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1": {
+        const rows = store.owa_ledger
+          .filter((o) => o.abn === params[0] && o.tax_type === params[1] && o.period_id === params[2])
+          .sort((a, b) => b.id - a.id)
+          .slice(0, 1)
+          .map((o) => ({ balance_after_cents: o.balance_after_cents, hash_after: o.hash_after }));
+        return { rows, rowCount: rows.length };
+      }
+      case "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)": {
+        const id = sequences.owa_ledger++;
+        const row: OwaLedgerRow = {
+          id,
+          abn: params[0],
+          tax_type: params[1],
+          period_id: params[2],
+          transfer_uuid: params[3],
+          amount_cents: params[4],
+          balance_after_cents: params[5],
+          bank_receipt_hash: params[6],
+          prev_hash: params[7],
+          hash_after: params[8],
+          created_at: new Date().toISOString(),
+        };
+        store.owa_ledger.push(row);
+        return { rows: [], rowCount: 1 };
+      }
+      case "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3": {
+        const rows = store.remittance_destinations.filter(
+          (r) => r.abn === params[0] && r.rail === params[1] && r.reference === params[2]
+        );
+        return { rows, rowCount: rows.length };
+      }
+      case "insert into remittance_destinations(abn, rail, reference) values ($1,$2,$3)": {
+        const id = sequences.remittance_destinations++;
+        store.remittance_destinations.push({ id, abn: params[0], rail: params[1], reference: params[2] });
+        return { rows: [], rowCount: 1 };
+      }
+      case "insert into idempotency_keys(key,last_status) values($1,$2)": {
+        const key = params[0];
+        if (store.idempotency_keys.has(key)) {
+          const error = new Error("duplicate key value violates unique constraint idempotency_keys_pkey");
+          throw error;
+        }
+        store.idempotency_keys.set(key, { last_status: params[1] });
+        return { rows: [], rowCount: 1 };
+      }
+      case "select last_status, response_hash from idempotency_keys where key=$1": {
+        const row = store.idempotency_keys.get(params[0]);
+        return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+      }
+      case "update idempotency_keys set last_status=$1 where key=$2": {
+        const entry = store.idempotency_keys.get(params[1]);
+        if (entry) entry.last_status = params[0];
+        return { rows: [], rowCount: entry ? 1 : 0 };
+      }
+      case "select terminal_hash from audit_log order by seq desc limit 1": {
+        const rows = [...store.audit_log]
+          .sort((a, b) => b.seq - a.seq)
+          .slice(0, 1)
+          .map((a) => ({ terminal_hash: a.terminal_hash }));
+        return { rows, rowCount: rows.length };
+      }
+      case "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values ($1,$2,$3,$4,$5)": {
+        const seq = sequences.audit_log++;
+        store.audit_log.push({
+          seq,
+          actor: params[0],
+          action: params[1],
+          payload_hash: params[2],
+          prev_hash: params[3],
+          terminal_hash: params[4],
+          created_at: new Date().toISOString(),
+        });
+        return { rows: [], rowCount: 1 };
+      }
+      case "select count(*)::int as c from audit_log": {
+        return { rows: [{ c: store.audit_log.length }], rowCount: 1 };
+      }
+      default:
+        throw new Error(`Unhandled SQL: ${text}`);
+    }
+  }
+
+  async end(): Promise<void> {
+    // no-op for in-memory implementation
+  }
+}
+
+require.cache[require.resolve("pg")] = { exports: { Pool: MemoryPool } };
+
+const pool = new MemoryPool();
+
+const keyPair = nacl.sign.keyPair();
+process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString("base64");
+process.env.ATO_PRN = "ATOREF123";
+
+const thresholds = {
+  variance_ratio: 0.5,
+  dup_rate: 0.05,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+  epsilon_cents: 75,
+};
+
+async function insertPeriod(periodId: string, overrides: Partial<{ state: string; final_liability_cents: number; credited_to_owa_cents: number; anomaly_vector: any; thresholds: any; merkle_root: string; running_balance_hash: string; }>) {
+  const base = {
+    state: "CLOSING",
+    final_liability_cents: 1000,
+    credited_to_owa_cents: 1000,
+    anomaly_vector: { variance_ratio: 0, dup_rate: 0, gap_minutes: 0, delta_vs_baseline: 0 },
+    thresholds,
+    merkle_root: "merkle",
+    running_balance_hash: "hash",
+    ...overrides,
+  };
+  const result = await pool.query(
+    `insert into periods (abn, tax_type, period_id, state, final_liability_cents, credited_to_owa_cents, merkle_root, running_balance_hash, anomaly_vector, thresholds)
+     values ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+     returning id`,
+    [
+      "12345678901",
+      "GST",
+      periodId,
+      base.state,
+      base.final_liability_cents,
+      base.credited_to_owa_cents,
+      base.merkle_root,
+      base.running_balance_hash,
+      base.anomaly_vector,
+      base.thresholds,
+    ]
+  );
+  return result.rows[0].id as number;
+}
+
+async function expectState(periodId: string, state: string) {
+  const { rows } = await pool.query(
+    "select state from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    ["12345678901", "GST", periodId]
+  );
+  assert.equal(rows[0]?.state, state);
+}
+
+async function main() {
+  const [rptModule, reconcileModule, bundleModule, middlewareModule] = await Promise.all([
+    import("../src/rpt/issuer.ts"),
+    import("../src/routes/reconcile.ts"),
+    import("../src/evidence/bundle.ts"),
+    import("../src/middleware/idempotency.ts"),
+  ]);
+
+  const { issueRPT } = rptModule;
+  const { payAto } = reconcileModule;
+  const { buildEvidenceBundle } = bundleModule;
+  const { idempotency } = middlewareModule;
+
+  await insertPeriod("2025-07", {
+    anomaly_vector: { variance_ratio: 0.9, dup_rate: 0, gap_minutes: 0, delta_vs_baseline: 0 },
+  });
+
+  await assert.rejects(
+    issueRPT("12345678901", "GST", "2025-07", thresholds),
+    /BLOCKED_ANOMALY/
+  );
+  await expectState("2025-07", "BLOCKED_ANOMALY");
+
+  await insertPeriod("2025-08", {
+    final_liability_cents: 1000,
+    credited_to_owa_cents: 800,
+  });
+
+  await assert.rejects(
+    issueRPT("12345678901", "GST", "2025-08", thresholds),
+    /BLOCKED_DISCREPANCY/
+  );
+  await expectState("2025-08", "BLOCKED_DISCREPANCY");
+
+  await insertPeriod("2025-09", {});
+  const rpt = await issueRPT("12345678901", "GST", "2025-09", thresholds);
+  assert.ok(rpt.signature.length > 0);
+  await expectState("2025-09", "READY_RPT");
+
+  await pool.query(
+    "insert into remittance_destinations(abn, rail, reference) values ($1,$2,$3)",
+    ["12345678901", "EFT", process.env.ATO_PRN]
+  );
+
+  const res = {
+    statusCode: 200,
+    payload: undefined as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: any) {
+      this.payload = body;
+      return this;
+    },
+  };
+
+  await payAto({ body: { abn: "12345678901", taxType: "GST", periodId: "2025-09", rail: "EFT" } }, res);
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.payload.transfer_uuid);
+
+  await expectState("2025-09", "RELEASED");
+
+  const bundle = await buildEvidenceBundle("12345678901", "GST", "2025-09");
+  assert.equal(bundle.rpt_payload.period_id, "2025-09");
+  assert.ok(Array.isArray(bundle.owa_ledger_deltas));
+  assert.equal(bundle.owa_ledger_deltas.length, 1);
+
+  const { rows: auditRows } = await pool.query("select count(*)::int as c from audit_log");
+  assert.equal(auditRows[0].c, 1);
+
+  const middleware = idempotency();
+  let nextCalled = false;
+  await middleware(
+    { header: (key: string) => (key === "Idempotency-Key" ? "X-KEY" : undefined) },
+    {
+      status: () => ({ json: () => ({}) }),
+      json: () => ({}),
+    },
+    () => {
+      nextCalled = true;
+    }
+  );
+  assert.ok(nextCalled);
+
+  const res2 = {
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: any) {
+      this.body = body;
+      return this;
+    },
+  } as any;
+
+  await middleware(
+    { header: () => "X-KEY" },
+    res2,
+    () => {
+      throw new Error("should not reach next on duplicate key");
+    }
+  );
+  assert.equal(res2.body.status, "INIT");
+  assert.equal(res2.body.idempotent, true);
+
+  await pool.end();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- update reconciliation, RPT issuance, evidence, rails, idempotency, and audit modules to use parameterized SQL placeholders
- expose the deterministic anomaly `exceeds` helper to align with issuer usage
- add a regression test harness with an in-memory pg stub and package script to exercise each query path

## Testing
- npx tsx tests/sqlQueries.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e21e5dc7c483279105911a891f69af