### PR TITLE
Add canonical evidence bundle aggregation and tests

### DIFF
--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,564 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { Pool, PoolClient } from "pg";
+import { sha256Hex } from "../crypto/merkle";
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+export interface EvidenceBundleOptions {
+  pool?: QueryablePool;
+  now?: Date;
+}
+
+type QueryablePool = Pick<Pool, "connect"> & { query: Pool["query"] };
+
+type JsonRecord = Record<string, unknown>;
+
+export interface BasLabelEvidence {
+  ledger_total_cents: number | null;
+  source_total_cents: number | null;
+  variance_cents: number | null;
+  final_value_cents: number | null;
+  override: {
+    value_cents: number;
+    operator: string;
+    reason: string;
+    applied_at: string | null;
+  } | null;
+}
+
+export type ReconDiscrepancyEntry = {
+  type: "recon";
+  bas_label: string;
+  status: string;
+  source_total_cents: number | null;
+  ledger_total_cents: number | null;
+  variance_cents: number | null;
+  noted_at: string | null;
+  note: string | null;
+};
+
+export type OverrideDiscrepancyEntry = {
+  type: "override";
+  bas_label: string;
+  override_value_cents: number;
+  reason: string;
+  operator: string;
+  applied_at: string | null;
+};
+
+export type DiscrepancyEntry = ReconDiscrepancyEntry | OverrideDiscrepancyEntry;
+
+export interface EvidenceBundle {
+  meta: {
+    generated_at: string;
+    abn: string;
+    taxType: string;
+    periodId: string;
+    payload_sha256: string;
   };
-  return bundle;
+  period: {
+    state: string;
+    accrued_cents: number;
+    credited_to_owa_cents: number;
+    final_liability_cents: number;
+    merkle_root: string | null;
+    running_balance_hash: string | null;
+    anomaly_vector: JsonRecord;
+    thresholds: JsonRecord;
+  };
+  rpt: {
+    id: number;
+    payload: JsonRecord;
+    signature: string;
+    created_at: string;
+    payload_c14n: string | null;
+    payload_sha256: string | null;
+  } | null;
+  owa_ledger: Array<{
+    id: number;
+    amount_cents: number;
+    balance_after_cents: number;
+    bank_receipt_hash: string | null;
+    prev_hash: string | null;
+    hash_after: string | null;
+    created_at: string;
+  }>;
+  bas_labels: Record<string, BasLabelEvidence>;
+  discrepancy_log: DiscrepancyEntry[];
+  canonical_json: string;
+}
+
+const DEFAULT_LABELS = ["W1", "W2", "1A", "1B"];
+const defaultPool = new Pool();
+
+type BaseEvidenceBundle = {
+  meta: {
+    generated_at: string;
+    abn: string;
+    taxType: string;
+    periodId: string;
+  };
+} & Omit<EvidenceBundle, "meta" | "canonical_json">;
+
+export async function buildEvidenceBundle(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  options: EvidenceBundleOptions = {}
+): Promise<EvidenceBundle> {
+  const pool = options.pool ?? defaultPool;
+  const now = options.now ?? new Date();
+  const client = await pool.connect();
+  try {
+    const periodRes = await client.query(
+      "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
+    if (!periodRes.rowCount) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+    const periodRow = periodRes.rows[0];
+
+    const rptRes = await client.query(
+      `SELECT id, payload, payload_c14n, payload_sha256, signature, created_at
+         FROM rpt_tokens
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const rptRow = rptRes.rows[0] ?? null;
+
+    const ledgerRes = await client.query(
+      `SELECT id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    );
+    const ledger = ledgerRes.rows.map(row => ({
+      id: Number(row.id),
+      amount_cents: Number(row.amount_cents),
+      balance_after_cents: Number(row.balance_after_cents),
+      bank_receipt_hash: row.bank_receipt_hash ?? null,
+      prev_hash: row.prev_hash ?? null,
+      hash_after: row.hash_after ?? null,
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    }));
+
+    const ledgerSummaries = await fetchLedgerSummaries(client, abn, taxType, periodId);
+    const reconRows = await fetchReconRows(client, abn, taxType, periodId);
+    const overrides = await fetchOverrides(client, abn, taxType, periodId);
+
+    const { basLabels, discrepancyLog } = buildBasEvidence(ledgerSummaries, reconRows, overrides);
+
+    const baseBundle: BaseEvidenceBundle = {
+      meta: {
+        generated_at: now.toISOString(),
+        abn,
+        taxType,
+        periodId,
+      },
+      period: {
+        state: periodRow.state,
+        accrued_cents: Number(periodRow.accrued_cents ?? 0),
+        credited_to_owa_cents: Number(periodRow.credited_to_owa_cents ?? 0),
+        final_liability_cents: Number(periodRow.final_liability_cents ?? 0),
+        merkle_root: periodRow.merkle_root ?? null,
+        running_balance_hash: periodRow.running_balance_hash ?? null,
+        anomaly_vector: (periodRow.anomaly_vector as JsonRecord) ?? {},
+        thresholds: (periodRow.thresholds as JsonRecord) ?? {},
+      },
+      rpt: rptRow
+        ? {
+            id: Number(rptRow.id),
+            payload: rptRow.payload as JsonRecord,
+            signature: String(rptRow.signature),
+            created_at: rptRow.created_at instanceof Date ? rptRow.created_at.toISOString() : rptRow.created_at,
+            payload_c14n: rptRow.payload_c14n ?? null,
+            payload_sha256: rptRow.payload_sha256 ?? null,
+          }
+        : null,
+      owa_ledger: ledger,
+      bas_labels: basLabels,
+      discrepancy_log: discrepancyLog,
+    };
+
+    const canonical = canonicalJson(baseBundle);
+    const payloadHash = sha256Hex(canonical);
+
+    const finalBundle: EvidenceBundle = {
+      ...baseBundle,
+      meta: {
+        ...baseBundle.meta,
+        payload_sha256: payloadHash,
+      },
+      canonical_json: canonical,
+    };
+
+    await persistBundle(
+      client,
+      { abn, taxType, periodId },
+      periodRow,
+      rptRow,
+      overrides,
+      canonical,
+      payloadHash,
+      finalBundle
+    );
+
+    return finalBundle;
+  } finally {
+    client.release();
+  }
+}
+
+function buildBasEvidence(
+  ledgerSummaries: Map<string, number>,
+  reconRows: ReconRow[],
+  overrides: OverrideRow[]
+): { basLabels: Record<string, BasLabelEvidence>; discrepancyLog: Array<JsonRecord> } {
+  const labelOrder = new Map<string, number>();
+  DEFAULT_LABELS.forEach((label, idx) => labelOrder.set(label, idx));
+  const labels = new Set<string>(DEFAULT_LABELS);
+  for (const key of ledgerSummaries.keys()) labels.add(key);
+  for (const row of reconRows) labels.add(row.bas_label);
+  for (const row of overrides) labels.add(row.bas_label);
+  const ordered = Array.from(labels).sort((a, b) => {
+    const ia = labelOrder.get(a);
+    const ib = labelOrder.get(b);
+    if (ia != null && ib != null) return ia - ib;
+    if (ia != null) return -1;
+    if (ib != null) return 1;
+    return a.localeCompare(b);
+  });
+
+  const basLabels: Record<string, BasLabelEvidence> = {};
+  for (const label of ordered) {
+    const ledgerTotal = ledgerSummaries.has(label) ? ledgerSummaries.get(label)! : null;
+    const reconForLabel = reconRows.filter(r => r.bas_label === label);
+    const latestRecon = reconForLabel.length ? reconForLabel[reconForLabel.length - 1] : null;
+    const overridesForLabel = overrides.filter(o => o.bas_label === label);
+    const latestOverride = overridesForLabel.length ? overridesForLabel[overridesForLabel.length - 1] : null;
+
+    const sourceTotal = latestRecon?.source_total_cents ?? null;
+    const reconLedger = latestRecon?.ledger_total_cents ?? ledgerTotal;
+    let variance = latestRecon?.variance_cents ?? null;
+    if (variance == null && sourceTotal != null && reconLedger != null) {
+      variance = sourceTotal - reconLedger;
+    }
+
+    const finalValue = latestOverride
+      ? latestOverride.override_value_cents
+      : reconLedger ?? ledgerTotal ?? null;
+
+    basLabels[label] = {
+      ledger_total_cents: ledgerTotal,
+      source_total_cents: sourceTotal,
+      variance_cents: variance,
+      final_value_cents: finalValue,
+      override: latestOverride
+        ? {
+            value_cents: latestOverride.override_value_cents,
+            operator: latestOverride.operator_name,
+            reason: latestOverride.reason,
+            applied_at: latestOverride.applied_at ?? null,
+          }
+        : null,
+    };
+  }
+
+  const discrepancyLog: DiscrepancyEntry[] = [];
+  for (const row of reconRows) {
+    discrepancyLog.push({
+      type: "recon",
+      bas_label: row.bas_label,
+      status: row.status,
+      source_total_cents: row.source_total_cents,
+      ledger_total_cents: row.ledger_total_cents,
+      variance_cents: row.variance_cents,
+      noted_at: row.noted_at,
+      note: row.note ?? null,
+    });
+  }
+  for (const row of overrides) {
+    discrepancyLog.push({
+      type: "override",
+      bas_label: row.bas_label,
+      override_value_cents: row.override_value_cents,
+      reason: row.reason,
+      operator: row.operator_name,
+      applied_at: row.applied_at,
+    });
+  }
+  discrepancyLog.sort((a, b) => {
+    const ta = a.type === "recon" ? a.noted_at : a.applied_at;
+    const tb = b.type === "recon" ? b.noted_at : b.applied_at;
+    return String(ta ?? "").localeCompare(String(tb ?? ""));
+  });
+
+  return { basLabels, discrepancyLog };
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(sortKeysDeep(value));
+}
+
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>);
+    entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of entries) {
+      out[k] = sortKeysDeep(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+async function fetchLedgerSummaries(
+  client: PoolClient,
+  abn: string,
+  taxType: string,
+  periodId: string
+): Promise<Map<string, number>> {
+  if (!(await tableExists(client, "bas_ledger_movements"))) return new Map();
+  const res = await client.query(
+    `SELECT bas_label, SUM(amount_cents)::bigint AS ledger_total_cents
+       FROM bas_ledger_movements
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      GROUP BY bas_label`,
+    [abn, taxType, periodId]
+  );
+  const out = new Map<string, number>();
+  for (const row of res.rows) {
+    out.set(row.bas_label, Number(row.ledger_total_cents));
+  }
+  return out;
+}
+
+type ReconRow = {
+  bas_label: string;
+  source_total_cents: number | null;
+  ledger_total_cents: number | null;
+  variance_cents: number | null;
+  status: string;
+  noted_at: string | null;
+  note: string | null;
+};
+
+async function fetchReconRows(
+  client: PoolClient,
+  abn: string,
+  taxType: string,
+  periodId: string
+): Promise<ReconRow[]> {
+  if (!(await tableExists(client, "bas_recon_results"))) return [];
+  const res = await client.query(
+    `SELECT bas_label,
+            source_total_cents::bigint AS source_total_cents,
+            ledger_total_cents::bigint AS ledger_total_cents,
+            variance_cents::bigint AS variance_cents,
+            status,
+            noted_at,
+            note
+       FROM bas_recon_results
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY noted_at ASC, bas_label ASC`,
+    [abn, taxType, periodId]
+  );
+  return res.rows.map(row => ({
+    bas_label: row.bas_label,
+    source_total_cents: row.source_total_cents == null ? null : Number(row.source_total_cents),
+    ledger_total_cents: row.ledger_total_cents == null ? null : Number(row.ledger_total_cents),
+    variance_cents: row.variance_cents == null ? null : Number(row.variance_cents),
+    status: row.status,
+    noted_at: row.noted_at instanceof Date ? row.noted_at.toISOString() : row.noted_at,
+    note: row.note ?? null,
+  }));
+}
+
+type OverrideRow = {
+  bas_label: string;
+  override_value_cents: number;
+  reason: string;
+  operator_name: string;
+  applied_at: string | null;
+};
+
+async function fetchOverrides(
+  client: PoolClient,
+  abn: string,
+  taxType: string,
+  periodId: string
+): Promise<OverrideRow[]> {
+  if (!(await tableExists(client, "bas_operator_overrides"))) return [];
+  const res = await client.query(
+    `SELECT bas_label,
+            override_value_cents::bigint AS override_value_cents,
+            reason,
+            operator_name,
+            applied_at
+       FROM bas_operator_overrides
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY applied_at ASC, bas_label ASC`,
+    [abn, taxType, periodId]
+  );
+  return res.rows.map(row => ({
+    bas_label: row.bas_label,
+    override_value_cents: Number(row.override_value_cents),
+    reason: row.reason,
+    operator_name: row.operator_name,
+    applied_at: row.applied_at instanceof Date ? row.applied_at.toISOString() : row.applied_at,
+  }));
+}
+
+async function persistBundle(
+  client: PoolClient,
+  params: { abn: string; taxType: string; periodId: string },
+  periodRow: any,
+  rptRow: any,
+  overrides: OverrideRow[],
+  canonical: string,
+  payloadHash: string,
+  bundle: EvidenceBundle
+) {
+  if (!(await tableExists(client, "evidence_blobs"))) {
+    // nothing to persist
+  } else {
+    const hashBuf = Buffer.from(payloadHash, "hex");
+    const contentBuf = Buffer.from(canonical, "utf8");
+    await client.query(
+      `INSERT INTO evidence_blobs (payload_sha256, content)
+       VALUES ($1, $2)
+       ON CONFLICT (payload_sha256) DO NOTHING`,
+      [hashBuf, contentBuf]
+    );
+  }
+
+  if (await tableExists(client, "evidence_bundles")) {
+    try {
+      const columns = await getTableColumns(client, "evidence_bundles");
+      const insertColumns = ["abn", "tax_type", "period_id", "payload_sha256"];
+      const placeholders = ["$1", "$2", "$3", "$4"];
+      const values: any[] = [params.abn, params.taxType, params.periodId, Buffer.from(payloadHash, "hex")];
+      const updates = ["payload_sha256 = EXCLUDED.payload_sha256"];
+      let idx = 5;
+
+      if (columns.has("rpt_id") && rptRow?.id != null) {
+        insertColumns.push("rpt_id");
+        placeholders.push(`$${idx}`);
+        values.push(Number(rptRow.id));
+        updates.push("rpt_id = EXCLUDED.rpt_id");
+        idx++;
+      }
+      if (columns.has("rpt_payload_json") && rptRow?.payload) {
+        insertColumns.push("rpt_payload_json");
+        placeholders.push(`$${idx}::jsonb`);
+        values.push(JSON.stringify(rptRow.payload));
+        updates.push("rpt_payload_json = EXCLUDED.rpt_payload_json");
+        idx++;
+      }
+      if (columns.has("rpt_sig_ed25519") && rptRow?.signature) {
+        const sigBuf = decodeBase64Safe(String(rptRow.signature));
+        insertColumns.push("rpt_sig_ed25519");
+        placeholders.push(`$${idx}`);
+        values.push(sigBuf);
+        updates.push("rpt_sig_ed25519 = EXCLUDED.rpt_sig_ed25519");
+        idx++;
+      } else if (columns.has("rpt_signature") && rptRow?.signature) {
+        insertColumns.push("rpt_signature");
+        placeholders.push(`$${idx}`);
+        values.push(String(rptRow.signature));
+        updates.push("rpt_signature = EXCLUDED.rpt_signature");
+        idx++;
+      }
+      if (columns.has("rpt_payload_sha256") && rptRow?.payload_sha256) {
+        insertColumns.push("rpt_payload_sha256");
+        placeholders.push(`$${idx}`);
+        values.push(decodeHexSafe(String(rptRow.payload_sha256)));
+        updates.push("rpt_payload_sha256 = EXCLUDED.rpt_payload_sha256");
+        idx++;
+      }
+      if (columns.has("anomaly_vector")) {
+        insertColumns.push("anomaly_vector");
+        placeholders.push(`$${idx}::jsonb`);
+        values.push(JSON.stringify(periodRow?.anomaly_vector ?? {}));
+        updates.push("anomaly_vector = EXCLUDED.anomaly_vector");
+        idx++;
+      }
+      if (columns.has("thresholds")) {
+        insertColumns.push("thresholds");
+        placeholders.push(`$${idx}::jsonb`);
+        values.push(JSON.stringify(periodRow?.thresholds ?? {}));
+        updates.push("thresholds = EXCLUDED.thresholds");
+        idx++;
+      }
+      if (columns.has("operator_overrides")) {
+        insertColumns.push("operator_overrides");
+        placeholders.push(`$${idx}::jsonb`);
+        values.push(JSON.stringify(overrides));
+        updates.push("operator_overrides = EXCLUDED.operator_overrides");
+        idx++;
+      }
+      if (columns.has("bas_labels")) {
+        insertColumns.push("bas_labels");
+        placeholders.push(`$${idx}::jsonb`);
+        values.push(JSON.stringify(bundle.bas_labels));
+        updates.push("bas_labels = EXCLUDED.bas_labels");
+        idx++;
+      }
+      if (columns.has("discrepancy_log")) {
+        insertColumns.push("discrepancy_log");
+        placeholders.push(`$${idx}::jsonb`);
+        values.push(JSON.stringify(bundle.discrepancy_log));
+        updates.push("discrepancy_log = EXCLUDED.discrepancy_log");
+        idx++;
+      }
+
+      const sql = `INSERT INTO evidence_bundles (${insertColumns.join(", ")})
+        VALUES (${placeholders.join(", ")})
+        ON CONFLICT (abn, tax_type, period_id) DO UPDATE SET ${updates.join(", ")}`;
+      await client.query(sql, values);
+    } catch {
+      // Best effort persistence; swallow to avoid breaking bundle generation if schema differs.
+    }
+  }
+}
+
+async function tableExists(client: PoolClient, table: string): Promise<boolean> {
+  const res = await client.query<{ exists: boolean }>(
+    "SELECT to_regclass($1) IS NOT NULL AS exists",
+    [table]
+  );
+  return Boolean(res.rows[0]?.exists);
+}
+
+async function getTableColumns(client: PoolClient, table: string): Promise<Set<string>> {
+  const res = await client.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = $1`,
+    [table]
+  );
+  return new Set(res.rows.map(row => row.column_name));
+}
+
+function decodeBase64Safe(input: string): Buffer {
+  try {
+    return Buffer.from(input, "base64url");
+  } catch {
+    try {
+      return Buffer.from(input, "base64");
+    } catch {
+      return Buffer.from(input, "utf8");
+    }
+  }
+}
+
+function decodeHexSafe(input: string): Buffer {
+  try {
+    return Buffer.from(input.replace(/^0x/, ""), "hex");
+  } catch {
+    return Buffer.from(input, "utf8");
+  }
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -48,5 +48,7 @@ export async function settlementWebhook(req:any, res:any) {
 
 export async function evidence(req:any, res:any) {
   const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+  const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+  res.setHeader("x-payload-sha256", bundle.meta.payload_sha256);
+  res.type("application/json").send(bundle.canonical_json);
 }

--- a/tests/evidence/bundle.test.ts
+++ b/tests/evidence/bundle.test.ts
@@ -1,0 +1,498 @@
+import assert from "node:assert/strict";
+import { buildEvidenceBundle, canonicalJson, DiscrepancyEntry } from "../../src/evidence/bundle";
+import { sha256Hex } from "../../src/crypto/merkle";
+
+type PeriodRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  accrued_cents: number;
+  credited_to_owa_cents: number;
+  final_liability_cents: number;
+  merkle_root: string;
+  running_balance_hash: string;
+  anomaly_vector: Record<string, unknown>;
+  thresholds: Record<string, unknown>;
+};
+
+type RptRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  payload: Record<string, unknown>;
+  payload_c14n: string;
+  payload_sha256: string;
+  signature: string;
+  created_at: Date;
+};
+
+type LedgerRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string | null;
+  prev_hash: string | null;
+  hash_after: string | null;
+  created_at: Date;
+};
+
+type BasLedgerMovement = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  bas_label: string;
+  amount_cents: number;
+};
+
+type ReconRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  bas_label: string;
+  source_total_cents: number;
+  ledger_total_cents: number;
+  variance_cents: number;
+  status: string;
+  noted_at: Date;
+  note: string;
+};
+
+type OverrideRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  bas_label: string;
+  override_value_cents: number;
+  reason: string;
+  operator_name: string;
+  applied_at: Date;
+};
+
+type EvidenceBlobRow = {
+  payload_sha256: Buffer;
+  content: Buffer;
+};
+
+type EvidenceBundleRow = Record<string, any>;
+
+type FakeData = {
+  tables: Set<string>;
+  columns: Record<string, string[]>;
+  periods: PeriodRow[];
+  rpt_tokens: RptRow[];
+  owa_ledger: LedgerRow[];
+  bas_ledger_movements: BasLedgerMovement[];
+  bas_recon_results: ReconRow[];
+  bas_operator_overrides: OverrideRow[];
+  evidence_blobs: EvidenceBlobRow[];
+  evidence_bundles: EvidenceBundleRow[];
+};
+
+type QueryResult<T = any> = { rows: T[]; rowCount: number };
+
+class FakeClient {
+  constructor(private readonly data: FakeData) {}
+
+  async query<T = any>(text: string, params: any[] = []): Promise<QueryResult<T>> {
+    const normalized = text.replace(/\s+/g, " ").trim();
+
+    if (normalized.startsWith("SELECT to_regclass")) {
+      const name = params[0];
+      return { rows: [{ exists: this.data.tables.has(name) }] as T[], rowCount: 1 };
+    }
+
+    if (normalized.startsWith("SELECT column_name FROM information_schema.columns")) {
+      const table = params[0];
+      const cols = this.data.columns[table] || [];
+      return { rows: cols.map(column_name => ({ column_name })) as T[], rowCount: cols.length };
+    }
+
+    if (normalized.startsWith("SELECT * FROM periods")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.data.periods.filter(p => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      return { rows: rows as unknown as T[], rowCount: rows.length };
+    }
+
+    if (normalized.startsWith("SELECT id, payload, payload_c14n")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.data.rpt_tokens
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(row => ({
+          id: row.id,
+          payload: row.payload,
+          payload_c14n: row.payload_c14n,
+          payload_sha256: row.payload_sha256,
+          signature: row.signature,
+          created_at: row.created_at,
+        }));
+      return { rows: rows as unknown as T[], rowCount: rows.length };
+    }
+
+    if (normalized.startsWith("SELECT id, amount_cents")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.data.owa_ledger
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => a.id - b.id)
+        .map(row => ({
+          id: row.id,
+          amount_cents: row.amount_cents,
+          balance_after_cents: row.balance_after_cents,
+          bank_receipt_hash: row.bank_receipt_hash,
+          prev_hash: row.prev_hash,
+          hash_after: row.hash_after,
+          created_at: row.created_at,
+        }));
+      return { rows: rows as unknown as T[], rowCount: rows.length };
+    }
+
+    if (normalized.startsWith("SELECT bas_label, SUM")) {
+      const [abn, taxType, periodId] = params;
+      const sums = new Map<string, number>();
+      for (const row of this.data.bas_ledger_movements) {
+        if (row.abn === abn && row.tax_type === taxType && row.period_id === periodId) {
+          sums.set(row.bas_label, (sums.get(row.bas_label) ?? 0) + row.amount_cents);
+        }
+      }
+      const rows = Array.from(sums.entries()).map(([bas_label, ledger_total_cents]) => ({
+        bas_label,
+        ledger_total_cents,
+      }));
+      return { rows: rows as unknown as T[], rowCount: rows.length };
+    }
+
+    if (normalized.startsWith("SELECT bas_label, source_total_cents")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.data.bas_recon_results
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => a.noted_at.getTime() - b.noted_at.getTime() || a.bas_label.localeCompare(b.bas_label))
+        .map(row => ({
+          bas_label: row.bas_label,
+          source_total_cents: row.source_total_cents,
+          ledger_total_cents: row.ledger_total_cents,
+          variance_cents: row.variance_cents,
+          status: row.status,
+          noted_at: row.noted_at,
+          note: row.note,
+        }));
+      return { rows: rows as unknown as T[], rowCount: rows.length };
+    }
+
+    if (normalized.startsWith("SELECT bas_label, override_value_cents")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.data.bas_operator_overrides
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => a.applied_at.getTime() - b.applied_at.getTime() || a.bas_label.localeCompare(b.bas_label))
+        .map(row => ({
+          bas_label: row.bas_label,
+          override_value_cents: row.override_value_cents,
+          reason: row.reason,
+          operator_name: row.operator_name,
+          applied_at: row.applied_at,
+        }));
+      return { rows: rows as unknown as T[], rowCount: rows.length };
+    }
+
+    if (normalized.startsWith("INSERT INTO evidence_blobs")) {
+      const [payloadSha, content] = params as [Buffer, Buffer];
+      const key = payloadSha.toString("hex");
+      const existing = this.data.evidence_blobs.find(row => row.payload_sha256.toString("hex") === key);
+      if (!existing) {
+        this.data.evidence_blobs.push({ payload_sha256: payloadSha, content } as EvidenceBlobRow);
+      }
+      return { rows: [] as T[], rowCount: 0 };
+    }
+
+    if (normalized.startsWith("INSERT INTO evidence_bundles")) {
+      const columnMatch = normalized.match(/INSERT INTO evidence_bundles \(([^)]+)\)/);
+      const valuesMatch = normalized.match(/VALUES \(([^)]+)\)/);
+      if (!columnMatch || !valuesMatch) throw new Error(`Unable to parse INSERT: ${normalized}`);
+      const columns = columnMatch[1].split(",").map(c => c.trim());
+      const row: Record<string, any> = {};
+      columns.forEach((col, idx) => {
+        row[col] = params[idx];
+      });
+      const existingIndex = this.data.evidence_bundles.findIndex(
+        r => r.abn === row.abn && r.tax_type === row.tax_type && r.period_id === row.period_id
+      );
+      if (existingIndex >= 0) {
+        this.data.evidence_bundles[existingIndex] = { ...this.data.evidence_bundles[existingIndex], ...row };
+      } else {
+        this.data.evidence_bundles.push(row);
+      }
+      return { rows: [] as T[], rowCount: 0 };
+    }
+
+    throw new Error(`Unsupported query: ${normalized}`);
+  }
+
+  release(): void {
+    // no-op for fake client
+  }
+}
+
+class FakePool {
+  constructor(private readonly data: FakeData) {}
+
+  async connect(): Promise<FakeClient> {
+    return new FakeClient(this.data);
+  }
+
+  async query<T = any>(text: string, params?: any[]): Promise<QueryResult<T>> {
+    const client = await this.connect();
+    try {
+      return await client.query<T>(text, params);
+    } finally {
+      client.release();
+    }
+  }
+}
+
+const abn = "12345678901";
+const taxType = "GST";
+const periodId = "2025-09";
+
+const periodRow: PeriodRow = {
+  abn,
+  tax_type: taxType,
+  period_id: periodId,
+  state: "RELEASED",
+  accrued_cents: 150000,
+  credited_to_owa_cents: 150000,
+  final_liability_cents: 150000,
+  merkle_root: "demo_merkle_root",
+  running_balance_hash: "demo_running_hash",
+  anomaly_vector: { variance_ratio: 0.1 },
+  thresholds: { variance_ratio: 0.2 },
+};
+
+const rptPayload = {
+  entity_id: abn,
+  period_id: periodId,
+  tax_type: taxType,
+  amount_cents: 150000,
+  merkle_root: periodRow.merkle_root,
+};
+
+const rptRow: RptRow = {
+  id: 42,
+  abn,
+  tax_type: taxType,
+  period_id: periodId,
+  payload: rptPayload,
+  payload_c14n: canonicalJson(rptPayload),
+  payload_sha256: sha256Hex(canonicalJson(rptPayload)),
+  signature: "signature-demo",
+  created_at: new Date("2025-10-04T23:50:00Z"),
+};
+
+const ledgerRows: LedgerRow[] = [
+  {
+    id: 1,
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    amount_cents: 60000,
+    balance_after_cents: 60000,
+    bank_receipt_hash: "rcpt:a",
+    prev_hash: null,
+    hash_after: "hash1",
+    created_at: new Date("2025-10-04T20:00:00Z"),
+  },
+  {
+    id: 2,
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    amount_cents: 90000,
+    balance_after_cents: 150000,
+    bank_receipt_hash: "rcpt:b",
+    prev_hash: "hash1",
+    hash_after: "hash2",
+    created_at: new Date("2025-10-04T21:00:00Z"),
+  },
+];
+
+const movementRows: BasLedgerMovement[] = [
+  { abn, tax_type: taxType, period_id: periodId, bas_label: "W1", amount_cents: 120000 },
+  { abn, tax_type: taxType, period_id: periodId, bas_label: "W1", amount_cents: 5000 },
+  { abn, tax_type: taxType, period_id: periodId, bas_label: "W2", amount_cents: 20000 },
+  { abn, tax_type: taxType, period_id: periodId, bas_label: "1A", amount_cents: 10000 },
+  { abn, tax_type: taxType, period_id: periodId, bas_label: "1B", amount_cents: 5000 },
+];
+
+const reconRows: ReconRow[] = [
+  {
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    bas_label: "W1",
+    source_total_cents: 130000,
+    ledger_total_cents: 125000,
+    variance_cents: 5000,
+    status: "MISMATCH",
+    noted_at: new Date("2025-10-04T21:05:00Z"),
+    note: "Payroll variance",
+  },
+  {
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    bas_label: "1A",
+    source_total_cents: 10000,
+    ledger_total_cents: 10000,
+    variance_cents: 0,
+    status: "MATCH",
+    noted_at: new Date("2025-10-04T21:10:00Z"),
+    note: "GST sales aligned",
+  },
+];
+
+const overrideRows: OverrideRow[] = [
+  {
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    bas_label: "W2",
+    override_value_cents: 23000,
+    reason: "ATO guidance",
+    operator_name: "cfo@example.com",
+    applied_at: new Date("2025-10-04T22:00:00Z"),
+  },
+];
+
+const fakeData: FakeData = {
+  tables: new Set([
+    "periods",
+    "rpt_tokens",
+    "owa_ledger",
+    "bas_ledger_movements",
+    "bas_recon_results",
+    "bas_operator_overrides",
+    "evidence_blobs",
+    "evidence_bundles",
+  ]),
+  columns: {
+    evidence_bundles: [
+      "abn",
+      "tax_type",
+      "period_id",
+      "payload_sha256",
+      "rpt_id",
+      "rpt_payload_json",
+      "rpt_signature",
+      "rpt_payload_sha256",
+      "anomaly_vector",
+      "thresholds",
+      "operator_overrides",
+      "bas_labels",
+      "discrepancy_log",
+    ],
+  },
+  periods: [periodRow],
+  rpt_tokens: [rptRow],
+  owa_ledger: ledgerRows,
+  bas_ledger_movements: movementRows,
+  bas_recon_results: reconRows,
+  bas_operator_overrides: overrideRows,
+  evidence_blobs: [],
+  evidence_bundles: [],
+};
+
+const pool = new FakePool(fakeData);
+
+async function run() {
+  const fixedNow = new Date("2025-10-05T00:00:00Z");
+
+  const bundle = await buildEvidenceBundle(abn, taxType, periodId, { pool: pool as any, now: fixedNow });
+
+  assert.equal(bundle.meta.abn, abn);
+  assert.equal(bundle.meta.taxType, taxType);
+  assert.equal(bundle.meta.periodId, periodId);
+  assert.equal(bundle.meta.generated_at, fixedNow.toISOString());
+  assert.deepEqual(bundle.period, {
+    state: periodRow.state,
+    accrued_cents: periodRow.accrued_cents,
+    credited_to_owa_cents: periodRow.credited_to_owa_cents,
+    final_liability_cents: periodRow.final_liability_cents,
+    merkle_root: periodRow.merkle_root,
+    running_balance_hash: periodRow.running_balance_hash,
+    anomaly_vector: periodRow.anomaly_vector,
+    thresholds: periodRow.thresholds,
+  });
+
+  const canonical = bundle.canonical_json;
+  assert.equal(bundle.meta.payload_sha256, sha256Hex(canonical));
+  assert.equal(bundle.canonical_json, canonical);
+
+  assert.deepEqual(bundle.rpt?.payload, rptPayload);
+  assert.equal(bundle.rpt?.id, 42);
+  assert.equal(bundle.owa_ledger.length, ledgerRows.length);
+
+  const basW1 = bundle.bas_labels["W1"];
+  assert.deepEqual(basW1, {
+    ledger_total_cents: 125000,
+    source_total_cents: 130000,
+    variance_cents: 5000,
+    final_value_cents: 125000,
+    override: null,
+  });
+
+  const basW2 = bundle.bas_labels["W2"];
+  assert.deepEqual(basW2, {
+    ledger_total_cents: 20000,
+    source_total_cents: null,
+    variance_cents: null,
+    final_value_cents: 23000,
+    override: {
+      value_cents: 23000,
+      operator: "cfo@example.com",
+      reason: "ATO guidance",
+      applied_at: overrideRows[0].applied_at.toISOString(),
+    },
+  });
+
+  const discrepancyLog = bundle.discrepancy_log as DiscrepancyEntry[];
+  assert.equal(discrepancyLog.length, 3);
+  assert.equal(discrepancyLog[0].type, "recon");
+  assert.equal(discrepancyLog[1].type, "recon");
+  assert.equal(discrepancyLog[2].type, "override");
+
+  assert.equal(fakeData.evidence_blobs.length, 1);
+  const storedBlob = fakeData.evidence_blobs[0];
+  assert.equal(storedBlob.payload_sha256.toString("hex"), bundle.meta.payload_sha256);
+  assert.equal(storedBlob.content.toString("utf8"), canonical);
+
+  assert.equal(fakeData.evidence_bundles.length, 1);
+  const storedBundle = fakeData.evidence_bundles[0];
+  assert.equal(storedBundle.payload_sha256.toString("hex"), bundle.meta.payload_sha256);
+  assert.equal(storedBundle.abn, abn);
+  assert.equal(storedBundle.tax_type, taxType);
+  assert.equal(storedBundle.period_id, periodId);
+  assert.equal(storedBundle.rpt_id, rptRow.id);
+  assert.equal(storedBundle.rpt_signature, rptRow.signature);
+  assert.deepEqual(JSON.parse(storedBundle.rpt_payload_json), rptRow.payload);
+  assert.equal(storedBundle.rpt_payload_sha256.toString("hex"), rptRow.payload_sha256);
+  assert.deepEqual(JSON.parse(storedBundle.bas_labels), bundle.bas_labels);
+  assert.deepEqual(JSON.parse(storedBundle.discrepancy_log), bundle.discrepancy_log);
+  assert.deepEqual(JSON.parse(storedBundle.operator_overrides), overrideRows.map(o => ({
+    bas_label: o.bas_label,
+    override_value_cents: o.override_value_cents,
+    reason: o.reason,
+    operator_name: o.operator_name,
+    applied_at: o.applied_at.toISOString(),
+  })));
+
+  console.log("evidence bundle test: ok");
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- build the evidence bundle from ledger movements, recon deltas, and operator overrides while computing canonical JSON and payload hashes
- persist the generated bundle into the evidence tables and expose the canonical payload hash to consumers
- add an integration-style unit test that seeds fake ledger/RPT data and asserts bundle contents and stored hashes

## Testing
- npx tsx tests/evidence/bundle.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e21e63d8c88327b76f34d9f91b0b01