### PR TITLE
Use shared pg pool and consolidate deposit route

### DIFF
--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -1,6 +1,7 @@
 // src/api/payments.ts
 import express from "express";
 import { Payments } from "../../libs/paymentsClient"; // adjust if your libs path differs
+import { router as depositRouter } from "../routes/deposit";
 
 export const paymentsApi = express.Router();
 
@@ -33,21 +34,7 @@ paymentsApi.get("/ledger", async (req, res) => {
 });
 
 // POST /api/deposit
-paymentsApi.post("/deposit", async (req, res) => {
-  try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
-    if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
-      return res.status(400).json({ error: "Missing fields" });
-    }
-    if (amountCents <= 0) {
-      return res.status(400).json({ error: "Deposit must be positive" });
-    }
-    const data = await Payments.deposit({ abn, taxType, periodId, amountCents });
-    res.json(data);
-  } catch (err: any) {
-    res.status(400).json({ error: err?.message || "Deposit failed" });
-  }
-});
+paymentsApi.use("/deposit", depositRouter);
 
 // POST /api/release  (calls payAto)
 paymentsApi.post("/release", async (req, res) => {

--- a/src/api/payments/index.ts
+++ b/src/api/payments/index.ts
@@ -5,9 +5,9 @@ import { Router } from "express";
 // We import the handlers directly so your main app can proxy them at /api/*
 import { balance } from "../../../apps/services/payments/src/routes/balance.js";
 import { ledger } from "../../../apps/services/payments/src/routes/ledger.js";
-import { deposit } from "../../../apps/services/payments/src/routes/deposit.js";
 import { rptGate } from "../../../apps/services/payments/src/middleware/rptGate.js";
 import { payAtoRelease } from "../../../apps/services/payments/src/routes/payAto.js";
+import { router as depositRouter } from "../../routes/deposit";
 
 export const paymentsApi = Router();
 
@@ -16,5 +16,5 @@ paymentsApi.get("/balance", balance);
 paymentsApi.get("/ledger", ledger);
 
 // write
-paymentsApi.post("/deposit", deposit);
+paymentsApi.use("/deposit", depositRouter);
 paymentsApi.post("/release", rptGate, payAtoRelease);

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,6 +1,7 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { sha256Hex } from "../crypto/merkle";
+import { getPool } from "../db/pool";
+
+const pool = getPool();
 
 export async function appendAudit(actor: string, action: string, payload: any) {
   const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,13 @@
+import { Pool } from "pg";
+let _pool: Pool | null = null;
+export function getPool(): Pool {
+  if (_pool) return _pool;
+  _pool = new Pool({
+    connectionString: process.env.DATABASE_URL || "postgres://apgms:apgms@127.0.0.1:5432/apgms",
+    max: Number(process.env.PG_POOL_MAX || 10),
+    idleTimeoutMillis: 30000,
+    statement_timeout: 30000,
+    application_name: "apgms-api",
+  });
+  return _pool;
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,5 +1,6 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+
+const pool = getPool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,8 +1,9 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  const pool = getPool();
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
@@ -10,7 +11,7 @@ export function idempotency() {
       return next();
     } catch {
       const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+      return res.status(200).json({ idempotent: true, status: r.rows[0]?.last_status || "DONE" });
     }
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,8 +1,9 @@
-﻿import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+
+const pool = getPool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,54 +1,25 @@
-﻿import { Request, Response } from "express";
-import { pool } from "../index.js";
-import { randomUUID } from "node:crypto";
+import { Router } from "express";
+import { getPool } from "../db/pool";
 
-export async function deposit(req: Request, res: Response) {
+export const router = Router();
+
+router.post("/", async (req, res) => {
+  const { abn, amount, source, idempotencyKey, period_id } = req.body ?? {};
+  if (!abn || amount == null || !idempotencyKey) return res.status(400).json({ error: "abn, amount, idempotencyKey required" });
+  const cents = Math.round(Number(amount) * 100);
+  const c = await getPool().connect();
   try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
-    if (!abn || !taxType || !periodId) {
-      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
-    }
-    const amt = Number(amountCents);
-    if (!Number.isFinite(amt) || amt <= 0) {
-      return res.status(400).json({ error: "amountCents must be positive for a deposit" });
-    }
-
-    const client = await pool.connect();
-    try {
-      await client.query("BEGIN");
-
-      const { rows: last } = await client.query(
-        `SELECT balance_after_cents FROM owa_ledger
-         WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-         ORDER BY id DESC LIMIT 1`,
-        [abn, taxType, periodId]
-      );
-      const prevBal = last[0]?.balance_after_cents ?? 0;
-      const newBal = prevBal + amt;
-
-      const { rows: ins } = await client.query(
-        `INSERT INTO owa_ledger
-           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,now())
-         RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
-      );
-
-      await client.query("COMMIT");
-      return res.json({
-        ok: true,
-        ledger_id: ins[0].id,
-        transfer_uuid: ins[0].transfer_uuid,
-        balance_after_cents: ins[0].balance_after_cents
-      });
-
-    } catch (e:any) {
-      await client.query("ROLLBACK");
-      return res.status(500).json({ error: "Deposit failed", detail: String(e.message || e) });
-    } finally {
-      client.release();
-    }
-  } catch (e:any) {
-    return res.status(500).json({ error: "Deposit error", detail: String(e.message || e) });
-  }
-}
+    await c.query("BEGIN");
+    const idem = await c.query(`select id from idempotency where key=$1 for update`, [idempotencyKey]);
+    if (idem.rowCount) { await c.query("ROLLBACK"); return res.json({ ok:true, idempotent:true }); }
+    await c.query(
+      `insert into ledger (abn, period_id, direction, amount_cents, source, meta)
+       values ($1,$2,'credit',$3,$4,$5)`,
+      [abn, period_id ?? null, cents, source || "deposit", { idempotencyKey }]
+    );
+    await c.query(`insert into idempotency (key, seen_at) values ($1, now())`, [idempotencyKey]);
+    await c.query("COMMIT");
+    res.json({ ok: true });
+  } catch (e:any) { await c.query("ROLLBACK"); res.status(500).json({ error: e.message }); }
+  finally { c.release(); }
+});

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,53 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
 
-export async function closeAndIssue(req:any, res:any) {
+const pool = getPool();
+
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
   const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
   const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,8 +1,9 @@
-﻿import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+
+const pool = getPool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {


### PR DESCRIPTION
## Summary
- add a shared pg pool helper in src/db/pool.ts and update database callers to use it
- replace the deposit route with an idempotent ledger writer and reuse it across API routers
- ensure only a single /api/deposit handler remains mounted

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22b71af208327b9066a76c6379da0