### PR TITLE
Persist PayTo and settlement integrations

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,15 @@
+import { Router } from "express";
+import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "../routes/reconcile";
+import { router as paytoRouter } from "../routes/payto";
+import { router as settlementRouter } from "../routes/settlement";
+
+export const api = Router();
+
+api.post("/close-issue", closeAndIssue);
+api.post("/pay", payAto);
+api.post("/payto/sweep", paytoSweep);
+api.post("/settlement/webhook", settlementWebhook);
+api.get("/evidence", evidence);
+
+api.use("/payto", paytoRouter);
+api.use("/settlement", settlementRouter);

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,8 @@
+import { Pool } from "pg";
+
+let pool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!pool) pool = new Pool();
+  return pool;
+}

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,47 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+import { getPool } from "../db/pool";
+import crypto from "crypto";
+
+export type PayToMandate = {
+  id: string; abn: string; payid: string; creditorName: string;
+  maxAmountCents: number; status: "ACTIVE"|"CANCELLED"; createdAt: string;
+};
+
+export const payto = {
+  async createMandate(abn: string, payid: string, creditorName: string, maxAmountCents: number): Promise<PayToMandate> {
+    const id = crypto.randomUUID();
+    const q = await getPool().query(
+      `insert into payto_mandates (id, abn, payid, creditor_name, max_amount_cents, status, created_at)
+       values ($1,$2,$3,$4,$5,'ACTIVE',now())
+       returning id, abn, payid, creditor_name as "creditorName", max_amount_cents as "maxAmountCents", status, created_at as "createdAt"`,
+      [id, abn, payid, creditorName, maxAmountCents]
+    );
+    return q.rows[0];
+  },
+  async cancelMandate(id: string): Promise<void> {
+    await getPool().query(`update payto_mandates set status='CANCELLED' where id=$1`, [id]);
+  },
+  async sweep(mandateId: string, amountCents: number, ref: string) {
+    const c = await getPool().connect();
+    try {
+      await c.query("BEGIN");
+      const m = await c.query(`select abn, status, max_amount_cents from payto_mandates where id=$1 for update`, [mandateId]);
+      if (!m.rowCount) throw new Error("mandate not found");
+      if (m.rows[0].status !== "ACTIVE") throw new Error("mandate not active");
+      if (amountCents > Number(m.rows[0].max_amount_cents)) throw new Error("amount exceeds mandate limit");
+
+      await c.query(
+        `insert into payto_sweeps (mandate_id, abn, amount_cents, reference, created_at) values ($1,$2,$3,$4,now())`,
+        [mandateId, m.rows[0].abn, amountCents, ref]
+      );
+
+      await c.query(
+        `insert into ledger (abn, direction, amount_cents, source, meta)
+         values ($1,'credit',$2,'payto_sweep',$3)`,
+        [m.rows[0].abn, amountCents, { mandateId, ref }]
+      );
+
+      await c.query("COMMIT");
+      return { ok: true };
+    } catch (e:any) { await c.query("ROLLBACK"); throw e; } finally { c.release(); }
+  },
+};

--- a/src/routes/payto.ts
+++ b/src/routes/payto.ts
@@ -1,0 +1,18 @@
+import { Router } from "express";
+import { payto } from "../payto/adapter";
+export const router = Router();
+
+router.post("/mandates", async (req, res) => {
+  const { abn, payid, creditorName, maxAmountCents } = req.body ?? {};
+  if (!abn || !payid || !creditorName || maxAmountCents == null) return res.status(400).json({ error: "missing fields" });
+  res.json(await payto.createMandate(abn, payid, creditorName, Number(maxAmountCents)));
+});
+router.post("/mandates/:id/cancel", async (req, res) => {
+  await payto.cancelMandate(req.params.id);
+  res.json({ ok: true });
+});
+router.post("/mandates/:id/sweep", async (req, res) => {
+  const { amountCents, ref } = req.body ?? {};
+  if (amountCents == null) return res.status(400).json({ error: "amountCents required" });
+  res.json(await payto.sweep(req.params.id, Number(amountCents), String(ref || "")));
+});

--- a/src/routes/settlement.ts
+++ b/src/routes/settlement.ts
@@ -1,0 +1,34 @@
+import { Router } from "express";
+import { getPool } from "../db/pool";
+export const router = Router();
+
+router.post("/webhook", async (req, res) => {
+  const { abn, period_id, settlementRef, paidAt, amountCents, channel } = req.body ?? {};
+  if (!abn || !period_id || !settlementRef || !paidAt || amountCents == null) {
+    return res.status(400).json({ error: "missing fields" });
+  }
+  const c = await getPool().connect();
+  try {
+    await c.query("BEGIN");
+    await c.query(
+      `insert into settlements (abn, period_id, settlement_ref, paid_at, amount_cents, channel, created_at)
+       values ($1,$2,$3,$4,$5,$6, now())`,
+      [abn, period_id, settlementRef, paidAt, amountCents, channel || null]
+    );
+    await c.query(
+      `update evidence_bundles
+         set details = jsonb_set(
+           coalesce(details,'{}'::jsonb),
+           '{settlement}',
+           to_jsonb($1::json)
+         )
+       where abn=$2 and period_id=$3
+       order by created_at desc
+       limit 1`,
+      [{ settlementRef, paidAt, amountCents, channel }, abn, period_id]
+    );
+    await c.query("COMMIT");
+    res.json({ ok: true });
+  } catch (e:any) { await c.query("ROLLBACK"); res.status(500).json({ error: e.message }); }
+  finally { c.release(); }
+});

--- a/src/utils/bankApi.ts
+++ b/src/utils/bankApi.ts
@@ -1,24 +1,23 @@
-export async function submitSTPReport(data: any): Promise<boolean> {
-  console.log("Submitting STP report to ATO:", data);
-  return true;
-}
+import { getPool } from "../db/pool";
+import crypto from "crypto";
 
-export async function signTransaction(amount: number, account: string): Promise<string> {
-  return `SIGNED-${amount}-${account}-${Date.now()}`;
-}
-
-export async function transferToOneWayAccount(amount: number, from: string, to: string): Promise<boolean> {
-  const signature = await signTransaction(amount, to);
-  console.log(`Transfer $${amount} from ${from} to ${to} [${signature}]`);
-  return true;
-}
-
-export async function verifyFunds(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
-}
-
-export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
-}
+export const bankApi = {
+  async eft(abn: string, amountCents: number, reference?: string) {
+    const id = crypto.randomUUID();
+    await getPool().query(
+      `insert into bank_transfers (id, abn, amount_cents, channel, reference, status, created_at)
+       values ($1,$2,$3,'EFT',$4,'PENDING', now())`,
+      [id, abn, amountCents, reference || null]
+    );
+    return { id, abn, amountCents, channel: "EFT", reference, status: "PENDING" };
+  },
+  async bpay(abn: string, amountCents: number, reference?: string) {
+    const id = crypto.randomUUID();
+    await getPool().query(
+      `insert into bank_transfers (id, abn, amount_cents, channel, reference, status, created_at)
+       values ($1,$2,$3,'BPAY',$4,'PENDING', now())`,
+      [id, abn, amountCents, reference || null]
+    );
+    return { id, abn, amountCents, channel: "BPAY", reference, status: "PENDING" };
+  }
+};


### PR DESCRIPTION
## Summary
- implement a persistent PayTo adapter with mandate management and sweep recording APIs
- persist EFT and BPAY initiation records and expose PayTo and settlement routes through the API router
- add a settlement webhook that stores settlement metadata and decorates the latest evidence bundle

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e22bac6a5c8327946ff617537d40c7