### PR TITLE
Fix anomaly helper usage and expand state transitions

### DIFF
--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -2,14 +2,21 @@
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
-  }
+  const key = `${current}:${evt}`;
+  const transitions: Record<string, PeriodState> = {
+    "OPEN:CLOSE": "CLOSING",
+    "CLOSING:PASS": "READY_RPT",
+    "CLOSING:FAIL_DISCREPANCY": "BLOCKED_DISCREPANCY",
+    "CLOSING:FAIL_ANOMALY": "BLOCKED_ANOMALY",
+    "BLOCKED_DISCREPANCY:REMEDIATED": "CLOSING",
+    "BLOCKED_DISCREPANCY:MANUAL_OVERRIDE": "READY_RPT",
+    "BLOCKED_ANOMALY:REMEDIATED": "CLOSING",
+    "BLOCKED_ANOMALY:MANUAL_OVERRIDE": "READY_RPT",
+    "READY_RPT:RELEASE": "RELEASED",
+    "READY_RPT:RELEASED": "RELEASED",
+    "READY_RPT:REVOKE": "CLOSING",
+    "RELEASED:REVERSAL": "READY_RPT",
+    "RELEASED:FINALIZE": "FINALIZED",
+  };
+  return transitions[key] ?? current;
 }

--- a/tests/unit/anomaly.test.ts
+++ b/tests/unit/anomaly.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { isAnomalous, AnomalyVector } from "../../src/anomaly/deterministic";
+
+describe("isAnomalous", () => {
+  const baseline: AnomalyVector = {
+    variance_ratio: 0.1,
+    dup_rate: 0.01,
+    gap_minutes: 15,
+    delta_vs_baseline: 0.05,
+  };
+
+  it("returns false when metrics are within default tolerances", () => {
+    assert.equal(isAnomalous(baseline), false);
+  });
+
+  it("flags anomalies when any dimension exceeds the default threshold", () => {
+    const spike: AnomalyVector = { ...baseline, variance_ratio: 0.5 };
+    assert.equal(isAnomalous(spike), true);
+  });
+
+  it("uses caller-provided thresholds before flagging", () => {
+    const overrides = { variance_ratio: 0.6 };
+    const spike: AnomalyVector = { ...baseline, variance_ratio: 0.55 };
+    assert.equal(isAnomalous(spike, overrides), false);
+    assert.equal(isAnomalous(spike, { variance_ratio: 0.5 }), true);
+  });
+});

--- a/tests/unit/stateMachine.test.ts
+++ b/tests/unit/stateMachine.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { nextState, PeriodState } from "../../src/recon/stateMachine";
+
+describe("nextState", () => {
+  it("follows the happy path from open to released", () => {
+    let state: PeriodState = "OPEN";
+    state = nextState(state, "CLOSE");
+    assert.equal(state, "CLOSING");
+    state = nextState(state, "PASS");
+    assert.equal(state, "READY_RPT");
+    state = nextState(state, "RELEASE");
+    assert.equal(state, "RELEASED");
+    state = nextState(state, "FINALIZE");
+    assert.equal(state, "FINALIZED");
+  });
+
+  it("routes failure events into their respective blocked states", () => {
+    assert.equal(nextState("CLOSING", "FAIL_DISCREPANCY"), "BLOCKED_DISCREPANCY");
+    assert.equal(nextState("CLOSING", "FAIL_ANOMALY"), "BLOCKED_ANOMALY");
+  });
+
+  it("allows remediation and overrides to resume closing", () => {
+    assert.equal(nextState("BLOCKED_DISCREPANCY", "REMEDIATED"), "CLOSING");
+    assert.equal(nextState("BLOCKED_ANOMALY", "MANUAL_OVERRIDE"), "READY_RPT");
+  });
+
+  it("ignores unknown events", () => {
+    assert.equal(nextState("READY_RPT", "UNKNOWN"), "READY_RPT");
+  });
+});


### PR DESCRIPTION
## Summary
- call the shared anomaly helper in the RPT issuer to enforce patent tolerances
- expand the period state machine with remediation and override transitions
- add node:test coverage around anomaly thresholds and nextState outcomes

## Testing
- npx tsx --test tests/unit/anomaly.test.ts tests/unit/stateMachine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e22d375cf88327b1040f427e3c36bf