### PR TITLE
Align patent migrations with canonical ledger/audit schema

### DIFF
--- a/README_PATENT_ADD.md
+++ b/README_PATENT_ADD.md
@@ -1,8 +1,10 @@
 ﻿# APGMS Patent Gate-and-Token Additions
 
 ## Quick start
-1) Apply migration in Postgres:
+1) Apply migrations in Postgres (run in order):
+   psql -h 127.0.0.1 -U postgres -d postgres -f migrations/001_apgms_core.sql
    psql -h 127.0.0.1 -U postgres -d postgres -f migrations/002_apgms_patent_core.sql
+   psql -h 127.0.0.1 -U postgres -d postgres -f migrations/002_patent_extensions.sql
 
 2) Build and run the services:
    docker compose -f docker-compose.patent.yml build
@@ -33,3 +35,8 @@
 Notes:
 - Replace the HMAC secret with KMS in production.
 - Enforce SoD in your auth layer: role A issues RPT, role B calls egress.
+
+## Canonical schema summary
+- `owa_ledger` now exposes both the tax-ledger cent-based fields and the patent credit view via the generated `credit_amount` column alongside `amount_cents`, idempotency hashes (`prev_hash`/`hash_after`) and banking references (`bank_receipt_hash`, `source_ref`, `audit_hash`).
+- `audit_log` remains an append-only hash chain (`prev_hash` → `terminal_hash`) while also carrying optional categorical metadata (`category`, `message`) for patent service audit trails. Both patent services and legacy appenders use the same table.
+- `rpt_store` is a compatibility view over `rpt_tokens`, so the Python audit bundle code can continue querying `rpt_store` without diverging storage.

--- a/apply_app_upgrades.ps1
+++ b/apply_app_upgrades.ps1
@@ -64,17 +64,20 @@ create table if not exists periods (
 );
 
 create table if not exists owa_ledger (
-  id bigserial primary key,
-  abn text not null,
-  tax_type text not null,
-  period_id text not null,
+  id            bigserial primary key,
+  abn           text not null,
+  tax_type      text not null,
+  period_id     text not null,
   transfer_uuid uuid not null,
-  amount_cents bigint not null,
+  amount_cents  bigint not null,
+  credit_amount numeric(18,2) generated always as ((amount_cents::numeric) / 100.0) stored,
   balance_after_cents bigint not null,
-  bank_receipt_hash text,
-  prev_hash text,
-  hash_after text,
-  created_at timestamptz default now(),
+  bank_receipt_hash  text,
+  source_ref         text,
+  prev_hash          text,
+  hash_after         text,
+  audit_hash         text,
+  created_at         timestamptz default now(),
   unique (transfer_uuid)
 );
 
@@ -92,12 +95,14 @@ create table if not exists rpt_tokens (
 );
 
 create table if not exists audit_log (
-  seq bigserial primary key,
-  ts timestamptz default now(),
-  actor text not null,
-  action text not null,
-  payload_hash text not null,
-  prev_hash text,
+  seq           bigserial primary key,
+  created_at    timestamptz default now(),
+  actor         text,
+  action        text,
+  payload_hash  text,
+  category      text,
+  message       text,
+  prev_hash     text,
   terminal_hash text
 );
 

--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -18,7 +18,10 @@ def bundle(period_id: str):
     conn = db(); cur = conn.cursor()
     cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
     rpt = cur.fetchone()
-    cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
-    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []
+    cur.execute(
+        "SELECT created_at, category, message FROM audit_log WHERE message LIKE %s ORDER BY created_at",
+        (f'%\"period_id\":\"{period_id}\"%',)
+    )
+    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]} for r in cur.fetchall()]
     cur.close(); conn.close()
     return {"period_id": period_id, "rpt": rpt[0] if rpt else None, "audit": logs}

--- a/apps/services/bank-egress/main.py
+++ b/apps/services/bank-egress/main.py
@@ -30,7 +30,10 @@ def remit(req: EgressReq):
         raise HTTPException(409, "gate not in RPT-Issued")
     # Here you would call the real bank API via mTLS. For now, we just log.
     payload = json.dumps({"period_id": req.period_id, "action": "remit"})
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('egress',%s,NULL,NULL)", (payload,))
+    cur.execute(
+        "INSERT INTO audit_log(category,message,prev_hash,terminal_hash) VALUES ('egress',%s,NULL,NULL)",
+        (payload,)
+    )
     cur.execute("UPDATE bas_gate_states SET state='Remitted', updated_at=NOW() WHERE period_id=%s", (req.period_id,))
     conn.commit(); cur.close(); conn.close()
     return {"ok": True}

--- a/apps/services/bas-gate/main.py
+++ b/apps/services/bas-gate/main.py
@@ -31,12 +31,18 @@ def transition(req: TransitionReq):
     import libs.audit_chain.chain as ch
     h = ch.link(prev, payload)
     if row:
-        cur.execute("UPDATE bas_gate_states SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s WHERE period_id=%s",
-                    (req.target_state, req.reason_code, prev, h, req.period_id))
+        cur.execute(
+            "UPDATE bas_gate_states SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s WHERE period_id=%s",
+            (req.target_state, req.reason_code, prev, h, req.period_id)
+        )
     else:
-        cur.execute("INSERT INTO bas_gate_states(period_id,state,reason_code,hash_prev,hash_this) VALUES (%s,%s,%s,%s,%s)",
-                    (req.period_id, req.target_state, req.reason_code, prev, h))
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('bas_gate',%s,%s,%s)",
-                (payload, prev, h))
+        cur.execute(
+            "INSERT INTO bas_gate_states(period_id,state,reason_code,hash_prev,hash_this) VALUES (%s,%s,%s,%s,%s)",
+            (req.period_id, req.target_state, req.reason_code, prev, h)
+        )
+    cur.execute(
+        "INSERT INTO audit_log(category,message,prev_hash,terminal_hash) VALUES ('bas_gate',%s,%s,%s)",
+        (payload, prev, h)
+    )
     conn.commit(); cur.close(); conn.close()
     return {"ok": True, "hash": h}

--- a/migrations/001_apgms_core.sql
+++ b/migrations/001_apgms_core.sql
@@ -17,17 +17,20 @@ create table if not exists periods (
 );
 
 create table if not exists owa_ledger (
-  id bigserial primary key,
-  abn text not null,
-  tax_type text not null,
-  period_id text not null,
+  id            bigserial primary key,
+  abn           text not null,
+  tax_type      text not null,
+  period_id     text not null,
   transfer_uuid uuid not null,
-  amount_cents bigint not null,
+  amount_cents  bigint not null,
+  credit_amount numeric(18,2) generated always as ((amount_cents::numeric) / 100.0) stored,
   balance_after_cents bigint not null,
-  bank_receipt_hash text,
-  prev_hash text,
-  hash_after text,
-  created_at timestamptz default now(),
+  bank_receipt_hash  text,
+  source_ref         text,
+  prev_hash          text,
+  hash_after         text,
+  audit_hash         text,
+  created_at         timestamptz default now(),
   unique (transfer_uuid)
 );
 
@@ -45,12 +48,14 @@ create table if not exists rpt_tokens (
 );
 
 create table if not exists audit_log (
-  seq bigserial primary key,
-  ts timestamptz default now(),
-  actor text not null,
-  action text not null,
-  payload_hash text not null,
-  prev_hash text,
+  seq           bigserial primary key,
+  created_at    timestamptz default now(),
+  actor         text,
+  action        text,
+  payload_hash  text,
+  category      text,
+  message       text,
+  prev_hash     text,
   terminal_hash text
 );
 


### PR DESCRIPTION
## Summary
- harmonise owa_ledger and audit_log definitions across the base and patent migrations, including generated credit amounts and compatibility views
- update the patent FastAPI services to use the unified audit_log fields and document the required migration order
- sync helper scripts so regenerated assets emit the canonical schema

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e22d39aa3c8327b63f2dcdef57fb8c