### PR TITLE
Integrate secure banking client and settle split payments

### DIFF
--- a/docs/external-bank-api.md
+++ b/docs/external-bank-api.md
@@ -1,0 +1,49 @@
+# External Banking & PayTo Integration
+
+This service talks to the bank's PSD2 / NPP sandbox so deployments must provision
+credentials and callback endpoints before going live.
+
+## API base URLs
+
+| Purpose | Env var | Notes |
+| --- | --- | --- |
+| Core secure banking API (STP, balances, tax disbursement) | `BANK_API_BASE_URL` | HTTPS base URL for the bank's REST gateway. Defaults to the AusPayNet PayTo sandbox placeholder. |
+| PayTo API base (mandates, debits) | `PAYTO_API_BASE_URL` | Optional – falls back to `BANK_API_BASE_URL` if omitted. |
+
+## Client credentials
+
+| Env var | Required | Description |
+| --- | --- | --- |
+| `BANK_API_CLIENT_ID` | ✅ | OAuth2 client id issued by the bank. |
+| `BANK_API_CLIENT_SECRET` | ✅ | OAuth2 client secret. |
+| `BANK_API_DEFAULT_DEBIT_ACCOUNT` | ✅ | Account number / alias used when debiting BAS funds. |
+| `BANK_API_ACCOUNT_<ALIAS>` | ⚙️ | Map friendly aliases (e.g. `BANK_API_ACCOUNT_BUSINESSREVENUEACC`) to real account identifiers. Used by the UI helpers when moving money between one-way accounts. |
+| `BANK_TLS_CA` | ⚙️ | Absolute path to the bank CA bundle (PEM). |
+| `BANK_TLS_CERT` | ⚙️ | Absolute path to the client certificate for mTLS. |
+| `BANK_TLS_KEY` | ⚙️ | Absolute path to the private key for mTLS. |
+| `PAYTO_CLIENT_ID` / `PAYTO_CLIENT_SECRET` | ✅ (if PayTo lives on a separate tenant) | Overrides the bank client id/secret for PayTo-specific endpoints when required. |
+| `PAYTO_SCOPE` | ⚙️ | Optional OAuth scope to request when exchanging PayTo credentials. |
+
+All credentials are loaded at process start; store them in your secrets manager and inject via the runtime environment.
+
+## Callbacks and webhooks
+
+* **Settlement webhook** – expose `/api/settlement/webhook` publicly. The bank posts split-payment CSV payloads with the following JSON body:
+  ```json
+  {
+    "abn": "12345678901",
+    "taxType": "GST",
+    "periodId": "2025-09",
+    "csv": "txn_id,gst_cents,net_cents,settlement_ts\n..."
+  }
+  ```
+  Protect the endpoint with the bank's signing secret or mutual TLS (configure via the TLS env vars above).
+* **PayTo status** – the PayTo mandate lifecycle is polled via the secure client; no inbound webhook is required yet, but the bank may optionally call `/api/settlement/webhook` to indicate mandate reversals alongside settlement reversals.
+
+## Stored artefacts
+
+* `bank_transaction_signatures` – immutable log of signatures returned by the bank for STP submissions, one-way sweeps, and BAS payments. This table backs audit/evidence workflows.
+* `split_settlement_receipts` – idempotency state for split payments received via the webhook.
+* `settlement_discrepancies` – findings injected into evidence bundles (see `/api/evidence`).
+
+Rotate OAuth tokens according to bank policy – the client performs the `client_credentials` grant automatically and caches the token for the published `expires_in` window.

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -5,6 +5,10 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
   const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
   const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const discrepancies = (await pool.query(
+    "select created_at as ts, txn_id, severity, message, observed from settlement_discrepancies where abn= and tax_type= and period_id= order by id",
+    [abn, taxType, periodId]
+  )).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
@@ -13,7 +17,13 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: discrepancies.map((d:any) => ({
+      timestamp: d.ts,
+      txn_id: d.txn_id,
+      severity: d.severity,
+      message: d.message,
+      observed: d.observed ?? {}
+    }))
   };
   return bundle;
 }

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,99 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+import { BankApiError, bankClient } from "../utils/secureBankClient";
+
+export type PayToMandateStatus = "PENDING" | "ACTIVE" | "SUSPENDED" | "CANCELLED";
+
+export interface PayToMandate {
+  mandateId: string;
+  status: PayToMandateStatus;
+  capCents: number;
+  reference: string;
+  debtorAbn: string;
+  createdAt: string;
+  updatedAt: string;
+  bankReference?: string;
+}
+
+export interface PayToCreateMandateResult {
+  status: "OK";
+  mandate: PayToMandate;
+}
+
+export interface PayToDebitParams {
+  abn: string;
+  mandateId: string;
+  amountCents: number;
+  reference: string;
+}
+
+export interface PayToDebitResult {
+  status: "OK" | "INSUFFICIENT_FUNDS" | "BANK_ERROR";
+  bank_ref?: string;
+  code?: string;
+  message?: string;
+}
+
+function mapMandate(payload: any): PayToMandate {
+  return {
+    mandateId: payload?.mandate_id ?? payload?.id,
+    status: (payload?.status || "PENDING") as PayToMandateStatus,
+    capCents: Number(payload?.cap_cents ?? payload?.capCents ?? 0),
+    reference: payload?.reference ?? payload?.customer_reference ?? "",
+    debtorAbn: payload?.abn ?? payload?.debtor_abn ?? "",
+    createdAt: payload?.created_at ?? new Date().toISOString(),
+    updatedAt: payload?.updated_at ?? payload?.created_at ?? new Date().toISOString(),
+    bankReference: payload?.bank_reference ?? payload?.npp_reference,
+  };
+}
+
+const insufficientCodes = new Set([
+  "INSUFFICIENT_FUNDS",
+  "PAYMENT_REFUSED_INSUFFICIENT_FUNDS",
+  "RTP_0500",
+]);
+
+export async function createMandate(abn: string, capCents: number, reference: string): Promise<PayToCreateMandateResult> {
+  if (!abn) throw new Error("ABN is required to create a PayTo mandate");
+  if (!Number.isFinite(capCents) || capCents <= 0) throw new Error("capCents must be a positive integer");
+  if (!reference) throw new Error("reference is required");
+
+  const payload = await bankClient.createPayToMandate({ abn, capCents, reference });
+  const mandate = mapMandate(payload);
+  if (!mandate.mandateId) {
+    throw new Error("Bank API did not return a mandate identifier");
+  }
+  return { status: "OK", mandate };
+}
+
+export async function debit(params: PayToDebitParams): Promise<PayToDebitResult> {
+  const { abn, mandateId, amountCents, reference } = params;
+  if (!mandateId) throw new Error("mandateId is required for PayTo debit");
+  if (!Number.isFinite(amountCents) || amountCents <= 0) {
+    throw new Error("amountCents must be a positive integer");
+  }
+  try {
+    const payload = await bankClient.debitPayToMandate({
+      mandateId,
+      amountCents,
+      debtorAbn: abn,
+      reference,
+    });
+    const bankRef = payload?.bank_reference ?? payload?.receipt_id ?? reference;
+    return { status: "OK", bank_ref: bankRef };
+  } catch (err: any) {
+    if (err instanceof BankApiError) {
+      const code = err.code || err.details?.code || err.details?.reason;
+      const bankRef = err.details?.bank_reference ?? err.details?.receipt_id;
+      if (code && insufficientCodes.has(String(code))) {
+        return { status: "INSUFFICIENT_FUNDS", bank_ref: bankRef, code, message: err.message };
+      }
+      return { status: "BANK_ERROR", bank_ref: bankRef, code, message: err.message };
+    }
+    throw err;
+  }
+}
+
+export async function cancelMandate(mandateId: string) {
+  if (!mandateId) throw new Error("mandateId is required to cancel a PayTo mandate");
+  await bankClient.cancelPayToMandate(mandateId);
+  return { status: "OK" };
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,341 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
-import { debit as paytoDebit } from "../payto/adapter";
+import { debit as paytoDebit, PayToDebitParams } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { Pool, PoolClient } from "pg";
+import { v5 as uuidv5 } from "uuid";
 
-export async function closeAndIssue(req:any, res:any) {
+const pool = new Pool();
+const PAYTO_NAMESPACE = uuidv5("apgms-payto-ledger", uuidv5.URL);
+
+const transferUuid = (txnId: string, kind: "deposit" | "reversal") =>
+  uuidv5(`${txnId}:${kind}`, PAYTO_NAMESPACE);
+
+type Severity = "INFO" | "WARN" | "ERROR";
+
+type SettlementSummary = {
+  ingested: number;
+  posted: number;
+  reversals: number;
+  duplicates: number;
+  discrepancies: number;
+};
+
+let ensureSettlementTablesPromise: Promise<void> | null = null;
+
+async function ensureSettlementTables() {
+  if (!ensureSettlementTablesPromise) {
+    ensureSettlementTablesPromise = (async () => {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS split_settlement_receipts (
+          id BIGSERIAL PRIMARY KEY,
+          abn TEXT NOT NULL,
+          tax_type TEXT NOT NULL,
+          period_id TEXT NOT NULL,
+          txn_id TEXT NOT NULL,
+          gst_cents BIGINT NOT NULL,
+          net_cents BIGINT NOT NULL,
+          settlement_ts TIMESTAMPTZ NOT NULL,
+          ledger_row_id BIGINT,
+          reversed BOOLEAN NOT NULL DEFAULT false,
+          reversal_gst_cents BIGINT,
+          reversal_net_cents BIGINT,
+          reversal_settlement_ts TIMESTAMPTZ,
+          reversal_ledger_row_id BIGINT,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+          UNIQUE (abn, tax_type, period_id, txn_id)
+        )
+      `);
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS settlement_discrepancies (
+          id BIGSERIAL PRIMARY KEY,
+          abn TEXT NOT NULL,
+          tax_type TEXT NOT NULL,
+          period_id TEXT NOT NULL,
+          txn_id TEXT,
+          severity TEXT NOT NULL,
+          message TEXT NOT NULL,
+          observed JSONB NOT NULL DEFAULT '{}'::jsonb,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+      `);
+      await pool.query(
+        `CREATE INDEX IF NOT EXISTS ix_settlement_discrepancies_period ON settlement_discrepancies(abn, tax_type, period_id)`
+      );
+    })();
+  }
+  return ensureSettlementTablesPromise;
+}
+
+async function recordDiscrepancy(
+  client: PoolClient,
+  summary: SettlementSummary,
+  abn: string,
+  taxType: string,
+  periodId: string,
+  txnId: string | null,
+  severity: Severity,
+  message: string,
+  observed: any
+) {
+  summary.discrepancies += 1;
+  await client.query(
+    `INSERT INTO settlement_discrepancies(abn,tax_type,period_id,txn_id,severity,message,observed)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+    [abn, taxType, periodId, txnId, severity, message, observed ?? {}]
+  );
+}
+
+function coerceCents(value: any, label: string): number {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    throw new Error(`${label} must be numeric`);
+  }
+  return Math.trunc(num);
+}
+
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds ||
+    { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: any, res: any) {
+  const { abn, taxType, periodId, rail } = req.body;
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
-  const { abn, amount_cents, reference } = req.body;
-  const r = await paytoDebit(abn, amount_cents, reference);
-  return res.json(r);
+export async function paytoSweep(req: any, res: any) {
+  try {
+    const params: PayToDebitParams = {
+      abn: req.body?.abn,
+      mandateId: req.body?.mandateId,
+      amountCents: coerceCents(req.body?.amount_cents, "amount_cents"),
+      reference: req.body?.reference,
+    };
+    const r = await paytoDebit(params);
+    return res.json(r);
+  } catch (e: any) {
+    return res.status(400).json({ error: e.message });
+  }
 }
 
-export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
+export async function settlementWebhook(req: any, res: any) {
+  const { abn, taxType, periodId, csv } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+  }
+  const csvText = typeof csv === "string" ? csv : "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
-  return res.json({ ingested: rows.length });
+  const summary: SettlementSummary = { ingested: rows.length, posted: 0, reversals: 0, duplicates: 0, discrepancies: 0 };
+  await ensureSettlementTables();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const last = await client.query(
+      `SELECT balance_after_cents FROM owa_ledger
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+       ORDER BY id DESC LIMIT 1 FOR UPDATE`,
+      [abn, taxType, periodId]
+    );
+    let balance = Number(last.rows[0]?.balance_after_cents ?? 0);
+
+    for (const row of rows) {
+      const txnId = String(row.txn_id || "").trim();
+      if (!txnId) {
+        await recordDiscrepancy(client, summary, abn, taxType, periodId, null, "ERROR", "Row missing txn_id", row);
+        continue;
+      }
+      let gstCents: number;
+      let netCents: number;
+      try {
+        gstCents = coerceCents(row.gst_cents, "gst_cents");
+        netCents = coerceCents(row.net_cents, "net_cents");
+      } catch (e: any) {
+        await recordDiscrepancy(client, summary, abn, taxType, periodId, txnId, "ERROR", e.message, row);
+        continue;
+      }
+
+      const existing = await client.query(
+        `SELECT * FROM split_settlement_receipts
+         WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND txn_id=$4
+         FOR UPDATE`,
+        [abn, taxType, periodId, txnId]
+      );
+      const receipt = existing.rows[0];
+
+      if (gstCents >= 0) {
+        if (receipt && receipt.ledger_row_id && !receipt.reversed) {
+          summary.duplicates += 1;
+          await recordDiscrepancy(
+            client,
+            summary,
+            abn,
+            taxType,
+            periodId,
+            txnId,
+            "WARN",
+            "Duplicate settlement row ignored",
+            { incoming_gst_cents: gstCents, ledger_row_id: receipt.ledger_row_id }
+          );
+          continue;
+        }
+
+        const upsert = await client.query(
+          `INSERT INTO split_settlement_receipts
+             (abn,tax_type,period_id,txn_id,gst_cents,net_cents,settlement_ts,reversed)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,false)
+           ON CONFLICT (abn,tax_type,period_id,txn_id)
+           DO UPDATE SET
+             gst_cents = EXCLUDED.gst_cents,
+             net_cents = EXCLUDED.net_cents,
+             settlement_ts = EXCLUDED.settlement_ts,
+             reversed = false,
+             reversal_gst_cents = NULL,
+             reversal_net_cents = NULL,
+             reversal_settlement_ts = NULL,
+             reversal_ledger_row_id = NULL
+           RETURNING id, ledger_row_id`,
+          [abn, taxType, periodId, txnId, gstCents, netCents, row.settlement_ts]
+        );
+        const receiptId = upsert.rows[0].id;
+
+        const uuid = transferUuid(txnId, "deposit");
+        const insertLedger = await client.query(
+          `INSERT INTO owa_ledger
+             (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_id,created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+           ON CONFLICT (transfer_uuid) DO NOTHING
+           RETURNING id,balance_after_cents`,
+          [abn, taxType, periodId, uuid, gstCents, balance + gstCents, txnId, row.settlement_ts]
+        );
+
+        if (insertLedger.rowCount === 0) {
+          const existingLedger = await client.query(
+            `SELECT id,balance_after_cents FROM owa_ledger WHERE transfer_uuid=$1`,
+            [uuid]
+          );
+          if (existingLedger.rowCount === 0) {
+            await recordDiscrepancy(
+              client,
+              summary,
+              abn,
+              taxType,
+              periodId,
+              txnId,
+              "ERROR",
+              "Failed to persist settlement in owa_ledger",
+              { gst_cents: gstCents }
+            );
+            continue;
+          }
+          summary.duplicates += 1;
+          balance = Number(existingLedger.rows[0].balance_after_cents);
+        } else {
+          balance = Number(insertLedger.rows[0].balance_after_cents);
+          summary.posted += 1;
+          await client.query(
+            `UPDATE split_settlement_receipts SET ledger_row_id=$1 WHERE id=$2`,
+            [insertLedger.rows[0].id, receiptId]
+          );
+        }
+      } else {
+        if (!receipt || !receipt.ledger_row_id) {
+          await recordDiscrepancy(
+            client,
+            summary,
+            abn,
+            taxType,
+            periodId,
+            txnId,
+            "ERROR",
+            "Reversal received before original settlement",
+            { reversal_gst_cents: gstCents }
+          );
+          continue;
+        }
+        if (receipt.reversed) {
+          summary.duplicates += 1;
+          await recordDiscrepancy(
+            client,
+            summary,
+            abn,
+            taxType,
+            periodId,
+            txnId,
+            "INFO",
+            "Ignoring duplicate reversal notification",
+            { reversal_gst_cents: gstCents }
+          );
+          continue;
+        }
+        const reversalAmount = Math.abs(gstCents);
+        const uuid = transferUuid(txnId, "reversal");
+        const insertLedger = await client.query(
+          `INSERT INTO owa_ledger
+             (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_id,created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+           RETURNING id,balance_after_cents`,
+          [abn, taxType, periodId, uuid, reversalAmount, balance + gstCents, `${txnId}:REVERSAL`, row.settlement_ts]
+        );
+        balance = Number(insertLedger.rows[0].balance_after_cents);
+        summary.reversals += 1;
+        await client.query(
+          `UPDATE split_settlement_receipts
+             SET reversed=true,
+                 reversal_gst_cents=$1,
+                 reversal_net_cents=$2,
+                 reversal_settlement_ts=$3,
+                 reversal_ledger_row_id=$4
+           WHERE id=$5`,
+          [reversalAmount, Math.abs(netCents), row.settlement_ts, insertLedger.rows[0].id, receipt.id]
+        );
+        await recordDiscrepancy(
+          client,
+          summary,
+          abn,
+          taxType,
+          periodId,
+          txnId,
+          "WARN",
+          "Settlement reversal applied",
+          { reversal_gst_cents: reversalAmount, resulting_balance_cents: balance }
+        );
+      }
+    }
+
+    await client.query("COMMIT");
+    return res.json(summary);
+  } catch (e: any) {
+    await client.query("ROLLBACK");
+    return res.status(500).json({ error: e.message || String(e) });
+  } finally {
+    client.release();
+  }
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/src/utils/bankApi.ts
+++ b/src/utils/bankApi.ts
@@ -1,24 +1,51 @@
+import { bankClient, dollarsToCents } from "./secureBankClient";
+
+function ensureFinite(value: number, label: string) {
+  if (!Number.isFinite(value)) {
+    throw new Error(`${label} must be a finite number`);
+  }
+}
+
 export async function submitSTPReport(data: any): Promise<boolean> {
-  console.log("Submitting STP report to ATO:", data);
+  await bankClient.submitStpReport(data);
   return true;
 }
 
-export async function signTransaction(amount: number, account: string): Promise<string> {
-  return `SIGNED-${amount}-${account}-${Date.now()}`;
+export async function signTransaction(amount: number, accountAlias: string): Promise<string> {
+  ensureFinite(amount, "amount");
+  return bankClient.createStandaloneSignature(amount, accountAlias, "UI_MANUAL");
 }
 
-export async function transferToOneWayAccount(amount: number, from: string, to: string): Promise<boolean> {
-  const signature = await signTransaction(amount, to);
-  console.log(`Transfer $${amount} from ${from} to ${to} [${signature}]`);
+export async function transferToOneWayAccount(amount: number, fromAlias: string, toAlias: string): Promise<boolean> {
+  ensureFinite(amount, "amount");
+  const cents = dollarsToCents(amount);
+  await bankClient.transfer({
+    amountCents: cents,
+    debitAccountAlias: fromAlias,
+    creditAccountAlias: toAlias,
+    purpose: "OWA_SWEEP",
+    narrative: `OWA:${toAlias}`,
+  });
   return true;
 }
 
 export async function verifyFunds(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
+  ensureFinite(paygwDue, "paygwDue");
+  ensureFinite(gstDue, "gstDue");
+  const requiredCents = dollarsToCents(paygwDue + gstDue);
+  return bankClient.verifyAvailableFunds(requiredCents);
 }
 
 export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
+  ensureFinite(paygwDue, "paygwDue");
+  ensureFinite(gstDue, "gstDue");
+  const paygwCents = dollarsToCents(paygwDue);
+  const gstCents = dollarsToCents(gstDue);
+  await bankClient.transferTaxAmounts({
+    paygwCents,
+    gstCents,
+    reference: `BAS-${new Date().toISOString().slice(0, 10)}`,
+    debitAccountAlias: "__default__",
+  });
   return true;
 }

--- a/src/utils/secureBankClient.ts
+++ b/src/utils/secureBankClient.ts
@@ -1,0 +1,424 @@
+import { Agent, Dispatcher } from "undici";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { Pool } from "pg";
+import { randomUUID } from "node:crypto";
+
+export class BankApiError extends Error {
+  public readonly statusCode: number;
+  public readonly code?: string;
+  public readonly details?: any;
+
+  constructor(statusCode: number, message: string, code?: string, details?: any) {
+    super(message);
+    this.name = "BankApiError";
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+type SignatureMetadata = {
+  type: string;
+  context: string;
+  amount_cents: number;
+  debit_account: string;
+  credit_account?: string | null;
+  reference?: string | null;
+  bank_reference?: string | null;
+};
+
+type SecureBankClientOptions = {
+  baseUrl: string;
+  clientId: string;
+  clientSecret: string;
+  defaultDebitAccount?: string;
+  dispatcher?: Dispatcher;
+  scope?: string;
+  pool?: Pool;
+  paytoBaseUrl?: string;
+  paytoClientId?: string;
+  paytoClientSecret?: string;
+  paytoScope?: string;
+};
+
+type TransferArgs = {
+  amountCents: number;
+  debitAccountAlias: string;
+  creditAccountAlias: string;
+  purpose: string;
+  narrative?: string;
+  requestedAt?: string;
+};
+
+type TaxTransferArgs = {
+  paygwCents: number;
+  gstCents: number;
+  reference: string;
+  debitAccountAlias: string;
+};
+
+type PayToMandateArgs = {
+  abn: string;
+  capCents: number;
+  reference: string;
+};
+
+type PayToDebitArgs = {
+  mandateId: string;
+  amountCents: number;
+  debtorAbn: string;
+  reference: string;
+};
+
+type AccountAliasResolver = (alias: string) => string;
+
+const defaultScope = "payments payto";
+
+function dollarsToCents(amount: number) {
+  return Math.round(amount * 100);
+}
+
+export class SecureBankClient {
+  private readonly baseUrl: string;
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly dispatcher?: Dispatcher;
+  private readonly scope: string;
+  private readonly paytoBaseUrl?: string;
+  private readonly paytoClientId?: string;
+  private readonly paytoClientSecret?: string;
+  private readonly paytoScope: string;
+  private readonly pool: Pool;
+  private readonly resolveAlias: AccountAliasResolver;
+  private token?: { value: string; expiresAt: number };
+  private paytoToken?: { value: string; expiresAt: number };
+  private ensureSignatureTablePromise?: Promise<void>;
+
+  constructor(options: SecureBankClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, "");
+    this.clientId = options.clientId;
+    this.clientSecret = options.clientSecret;
+    this.dispatcher = options.dispatcher;
+    this.scope = options.scope || defaultScope;
+    this.paytoBaseUrl = options.paytoBaseUrl?.replace(/\/$/, "");
+    this.paytoClientId = options.paytoClientId;
+    this.paytoClientSecret = options.paytoClientSecret;
+    this.paytoScope = options.paytoScope || this.scope;
+    this.pool = options.pool || new Pool();
+
+    const envAliases = Object.entries(process.env)
+      .filter(([key]) => key.startsWith("BANK_API_ACCOUNT_"))
+      .reduce((acc, [key, value]) => {
+        if (!value) return acc;
+        const alias = key.replace("BANK_API_ACCOUNT_", "");
+        acc[alias] = value;
+        return acc;
+      }, {} as Record<string, string>);
+
+    this.resolveAlias = (alias: string) => {
+      if (!alias) {
+        throw new Error("Account alias must be provided");
+      }
+      if (alias.startsWith("acct_")) {
+        return alias;
+      }
+      if (alias === "__default__") {
+        const mapped = options.defaultDebitAccount;
+        if (!mapped) throw new Error("No default debit account configured for bank client");
+        return mapped;
+      }
+      const envKey = alias
+        .replace(/[^a-zA-Z0-9]/g, "_")
+        .toUpperCase();
+      const direct = envAliases[envKey];
+      if (direct) return direct;
+      const prefixed = envAliases[`ACCOUNT_${envKey}`];
+      if (prefixed) return prefixed;
+      const envVar = `BANK_API_ACCOUNT_${envKey}`;
+      const fallback = process.env[envVar];
+      if (fallback) return fallback;
+      throw new Error(`Missing BANK_API_ACCOUNT mapping for alias '${alias}'. Expected env ${envVar}`);
+    };
+  }
+
+  private async ensureSignatureTable() {
+    if (!this.ensureSignatureTablePromise) {
+      this.ensureSignatureTablePromise = this.pool.query(`
+        CREATE TABLE IF NOT EXISTS bank_transaction_signatures (
+          signature TEXT PRIMARY KEY,
+          metadata  JSONB NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+        )
+      `).then(() => undefined);
+    }
+    return this.ensureSignatureTablePromise;
+  }
+
+  private async persistSignature(signature: string, metadata: SignatureMetadata) {
+    await this.ensureSignatureTable();
+    await this.pool.query(
+      `INSERT INTO bank_transaction_signatures(signature, metadata)
+       VALUES ($1,$2)
+       ON CONFLICT (signature) DO UPDATE SET metadata = EXCLUDED.metadata`,
+      [signature, metadata]
+    );
+  }
+
+  private async getAccessToken(context: "bank" | "payto" = "bank"): Promise<string> {
+    const now = Date.now();
+    const isPayTo = context === "payto" && this.paytoClientId && this.paytoClientSecret;
+    const tokenCache = isPayTo ? this.paytoToken : this.token;
+    if (tokenCache && tokenCache.expiresAt - 30_000 > now) {
+      return tokenCache.value;
+    }
+    const clientId = isPayTo ? this.paytoClientId! : this.clientId;
+    const clientSecret = isPayTo ? this.paytoClientSecret! : this.clientSecret;
+    if (!clientId || !clientSecret) {
+      throw new Error("Bank API credentials (client id/secret) are not configured");
+    }
+    const scope = isPayTo ? this.paytoScope : this.scope;
+    const base = isPayTo && this.paytoBaseUrl ? this.paytoBaseUrl : this.baseUrl;
+    const auth = Buffer.from(`${clientId}:${clientSecret}`).toString("base64");
+    const body = new URLSearchParams({ grant_type: "client_credentials", scope });
+    const res = await fetch(`${base}/oauth/token`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        authorization: `Basic ${auth}`,
+      },
+      body,
+      dispatcher: this.dispatcher,
+    });
+    const data = await this.parseResponse(res);
+    if (!data?.access_token) {
+      throw new Error("Bank API did not return an access token");
+    }
+    const expiresIn = Number(data.expires_in ?? 300);
+    const cache = { value: data.access_token, expiresAt: now + expiresIn * 1000 };
+    if (isPayTo) {
+      this.paytoToken = cache;
+    } else {
+      this.token = cache;
+    }
+    return data.access_token;
+  }
+
+  private async parseResponse(res: Response) {
+    const text = await res.text();
+    if (!text) return res.ok ? null : undefined;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  private async request<T = any>(
+    method: string,
+    path: string,
+    body?: any,
+    idempotencyKey?: string,
+    context: "bank" | "payto" = "bank"
+  ): Promise<T> {
+    const token = await this.getAccessToken(context);
+    const headers: Record<string, string> = {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+    };
+    let payload: string | undefined;
+    if (body !== undefined) {
+      headers["content-type"] = "application/json";
+      payload = JSON.stringify(body);
+    }
+    if (idempotencyKey) {
+      headers["idempotency-key"] = idempotencyKey;
+    }
+    const base = context === "payto" && this.paytoBaseUrl ? this.paytoBaseUrl : this.baseUrl;
+    const url = path.startsWith("http") ? path : `${base}${path}`;
+    const res = await fetch(url, {
+      method,
+      headers,
+      body: payload,
+      dispatcher: this.dispatcher,
+    });
+    const parsed = await this.parseResponse(res);
+    if (!res.ok) {
+      const message = typeof parsed === "string" ? parsed : parsed?.message || parsed?.error || `HTTP ${res.status}`;
+      const code = typeof parsed === "object" && parsed ? parsed.code || parsed.error_code : undefined;
+      throw new BankApiError(res.status, message, code, parsed);
+    }
+    return parsed as T;
+  }
+
+  private mapAlias(alias: string, fallbackDefault = false): string {
+    if (fallbackDefault && !alias) {
+      return this.resolveAlias("__default__");
+    }
+    return this.resolveAlias(alias || "__default__");
+  }
+
+  async submitStpReport(payload: any) {
+    await this.request("POST", "/reports/stp", payload, randomUUID());
+  }
+
+  async createStandaloneSignature(amountDollars: number, creditAlias: string, context = "manual") {
+    const amountCents = dollarsToCents(amountDollars);
+    const creditAccount = this.mapAlias(creditAlias);
+    const debitAccount = this.mapAlias("__default__", true);
+    const result = await this.request<{ signature: string; bank_reference?: string }>(
+      "POST",
+      "/payments/signatures",
+      {
+        amount_cents: amountCents,
+        debit_account: debitAccount,
+        credit_account: creditAccount,
+        context,
+      },
+      randomUUID()
+    );
+    const signature = result.signature;
+    await this.persistSignature(signature, {
+      type: "SIGNATURE",
+      context,
+      amount_cents: amountCents,
+      debit_account: debitAccount,
+      credit_account: creditAccount,
+      reference: null,
+      bank_reference: result.bank_reference ?? null,
+    });
+    return signature;
+  }
+
+  async transfer(args: TransferArgs) {
+    const debitAccount = this.mapAlias(args.debitAccountAlias, true);
+    const creditAccount = this.mapAlias(args.creditAccountAlias);
+    const res = await this.request<{ bank_reference: string; signature: string }>(
+      "POST",
+      "/payments/transfers",
+      {
+        amount_cents: args.amountCents,
+        debit_account: debitAccount,
+        credit_account: creditAccount,
+        purpose: args.purpose,
+        narrative: args.narrative,
+        requested_at: args.requestedAt || new Date().toISOString(),
+      },
+      randomUUID()
+    );
+    await this.persistSignature(res.signature, {
+      type: "TRANSFER",
+      context: args.purpose,
+      amount_cents: args.amountCents,
+      debit_account: debitAccount,
+      credit_account: creditAccount,
+      reference: args.narrative ?? null,
+      bank_reference: res.bank_reference,
+    });
+    return res;
+  }
+
+  async verifyAvailableFunds(requiredCents: number) {
+    const debitAccount = this.mapAlias("__default__", true);
+    const res = await this.request<{ available_cents: number }>(
+      "GET",
+      `/accounts/${encodeURIComponent(debitAccount)}/balance`
+    );
+    return Number(res.available_cents) >= requiredCents;
+  }
+
+  async transferTaxAmounts(args: TaxTransferArgs) {
+    const debitAccount = this.mapAlias(args.debitAccountAlias, true);
+    const res = await this.request<{ signature: string; bank_reference: string }>(
+      "POST",
+      "/payments/tax",
+      {
+        debit_account: debitAccount,
+        paygw_cents: args.paygwCents,
+        gst_cents: args.gstCents,
+        reference: args.reference,
+      },
+      randomUUID()
+    );
+    await this.persistSignature(res.signature, {
+      type: "TAX_TRANSFER",
+      context: "ATO_SETTLEMENT",
+      amount_cents: args.paygwCents + args.gstCents,
+      debit_account: debitAccount,
+      credit_account: null,
+      reference: args.reference,
+      bank_reference: res.bank_reference,
+    });
+    return res;
+  }
+
+  async createPayToMandate(args: PayToMandateArgs) {
+    return this.request<any>(
+      "POST",
+      "/payto/mandates",
+      {
+        abn: args.abn,
+        cap_cents: args.capCents,
+        reference: args.reference,
+      },
+      randomUUID(),
+      "payto"
+    );
+  }
+
+  async debitPayToMandate(args: PayToDebitArgs) {
+    return this.request<any>(
+      "POST",
+      `/payto/mandates/${encodeURIComponent(args.mandateId)}/debit`,
+      {
+        amount_cents: args.amountCents,
+        debtor_abn: args.debtorAbn,
+        reference: args.reference,
+      },
+      randomUUID(),
+      "payto"
+    );
+  }
+
+  async cancelPayToMandate(mandateId: string) {
+    return this.request<any>(
+      "POST",
+      `/payto/mandates/${encodeURIComponent(mandateId)}/cancel`,
+      {},
+      randomUUID(),
+      "payto"
+    );
+  }
+}
+
+function buildDispatcher(): Dispatcher | undefined {
+  const caPath = process.env.BANK_TLS_CA;
+  const certPath = process.env.BANK_TLS_CERT;
+  const keyPath = process.env.BANK_TLS_KEY;
+  if (!caPath && !certPath && !keyPath) {
+    return undefined;
+  }
+  return new Agent({
+    connect: {
+      ca: caPath ? readFileSync(resolve(caPath)) : undefined,
+      cert: certPath ? readFileSync(resolve(certPath)) : undefined,
+      key: keyPath ? readFileSync(resolve(keyPath)) : undefined,
+    },
+  });
+}
+
+const dispatcher = buildDispatcher();
+
+export const bankClient = new SecureBankClient({
+  baseUrl: process.env.BANK_API_BASE_URL || "https://sandbox.bank.example.com", // default sandbox
+  clientId: process.env.BANK_API_CLIENT_ID || "",
+  clientSecret: process.env.BANK_API_CLIENT_SECRET || "",
+  defaultDebitAccount: process.env.BANK_API_DEFAULT_DEBIT_ACCOUNT,
+  dispatcher,
+  paytoBaseUrl: process.env.PAYTO_API_BASE_URL,
+  paytoClientId: process.env.PAYTO_CLIENT_ID,
+  paytoClientSecret: process.env.PAYTO_CLIENT_SECRET,
+  paytoScope: process.env.PAYTO_SCOPE,
+});
+
+export { dollarsToCents };


### PR DESCRIPTION
## Summary
- replace the mocked bank API helpers with a shared secure banking client that persists transaction signatures and supports OAuth/mTLS
- flesh out the PayTo adapter so mandate creation, debits, and cancellations call the banking platform and surface insufficient-funds errors
- extend the settlement webhook to ingest split-payment CSVs into owa_ledger, track reversals/discrepancies, and expose the findings inside evidence bundles
- document the external banking API credentials, webhook requirements, and new persistence tables for deployment teams

## Testing
- npm run lint
- npx tsc --noEmit *(fails: pre-existing syntax error in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e22d3ce0348327862cd50bbe44219b