### PR TITLE
Implement close/pay flow with service tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,18 +4,22 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "vitest run"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.0.0",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "pg-mem": "^3.0.5",
+        "supertest": "^7.0.0",
+        "vitest": "^2.1.3"
     },
     "dependencies": {
         "csv-parse": "^6.1.0",

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -3,12 +3,12 @@ import { Pool } from "pg";
 const pool = new Pool();
 
 export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
+  const { rows } = await pool.query("SELECT terminal_hash FROM audit_log ORDER BY seq DESC LIMIT 1");
   const prevHash = rows[0]?.terminal_hash || "";
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "INSERT INTO audit_log(actor,action,payload_hash,prev_hash,terminal_hash) VALUES ($1,$2,$3,$4,$5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -2,9 +2,29 @@
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (
+    await pool.query(
+      "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      `SELECT * FROM rpt_tokens
+         WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+         ORDER BY id DESC LIMIT 1`,
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      `SELECT created_at as ts, amount_cents, hash_after, bank_receipt_hash
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    )
+  ).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
 
-const app = express();
+export const app = express();
 app.use(express.json({ limit: "2mb" }));
 
 // (optional) quick request logger
@@ -34,5 +34,7 @@ app.use("/api", api);
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));
 
-const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+if (process.env.NODE_ENV !== "test") {
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => console.log("APGMS server listening on", port));
+}

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,35 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+import { sha256Hex } from "../crypto/merkle";
 const pool = new Pool();
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
-      return next();
+      await pool.query("INSERT INTO idempotency_keys(key,last_status) VALUES ($1,$2)", [key, "INIT"]);
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+      const r = await pool.query(
+        "SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1",
+        [key]
+      );
+      const row = r.rows[0];
+      return res.status(200).json({
+        idempotent: true,
+        status: row?.last_status || "DONE",
+        response_hash: row?.response_hash || null,
+      });
     }
+
+    res.locals.idempotencyKey = key;
+    res.locals.completeIdempotency = async (status: string, body: any) => {
+      const hash = sha256Hex(JSON.stringify(body ?? null));
+      await pool.query(
+        "UPDATE idempotency_keys SET last_status=$1, response_hash=$2 WHERE key=$3",
+        [status, hash, key]
+      );
+      return hash;
+    };
+    return next();
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "SELECT * FROM remittance_destinations WHERE abn=$1 AND rail=$2 AND reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,36 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("INSERT INTO idempotency_keys(key,last_status) VALUES ($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    `SELECT balance_after_cents, hash_after FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC LIMIT 1`,
     [abn, taxType, periodId]);
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
-  );
+    await pool.query(
+      `INSERT INTO owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)`,
+      [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
+    );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
+  const response = { transfer_uuid, bank_receipt_hash, hash_after: hashAfter, balance_after_cents: newBal };
+  await pool.query(
+    "UPDATE idempotency_keys SET last_status=$1, response_hash=$2 WHERE key=$3",
+    [
+      "DONE",
+      sha256Hex(JSON.stringify({ transfer_uuid, bank_receipt_hash })),
+      transfer_uuid,
+    ]
+  );
+  return response;
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -3,32 +3,176 @@ import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
+import { merkleRootHex, sha256Hex } from "../crypto/merkle";
 import { Pool } from "pg";
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr = thresholds ? { ...DEFAULT_THRESHOLDS, ...thresholds } : { ...DEFAULT_THRESHOLDS };
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const { rows: periodRows } = await client.query(
+      `SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3 FOR UPDATE`,
+      [abn, taxType, periodId]
+    );
+    if (periodRows.length === 0) {
+      await client.query("ROLLBACK");
+      return res.status(404).json({ error: "PERIOD_NOT_FOUND" });
+    }
+
+    const period = periodRows[0];
+    if (period.state !== "OPEN" && period.state !== "CLOSING") {
+      await client.query("ROLLBACK");
+      return res.status(409).json({ error: "BAD_STATE", state: period.state });
+    }
+
+    const { rows: ledgerRows } = await client.query(
+      `SELECT id, transfer_uuid, amount_cents, balance_after_cents, bank_receipt_hash, hash_after
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    );
+
+    let creditedToOwa = 0;
+    let runningHash = "";
+    const leaves: string[] = [];
+    for (const row of ledgerRows) {
+      const amount = Number(row.amount_cents || 0);
+      if (amount > 0) creditedToOwa += amount;
+      const balance = Number(row.balance_after_cents || 0);
+      const receiptHash = row.bank_receipt_hash || "";
+      const computedHash = sha256Hex(runningHash + receiptHash + String(balance));
+      runningHash = row.hash_after && row.hash_after.length ? row.hash_after : computedHash;
+      leaves.push(
+        JSON.stringify({
+          transfer_uuid: row.transfer_uuid,
+          amount_cents: amount,
+          balance_after_cents: balance,
+          bank_receipt_hash: receiptHash,
+          hash_after: runningHash,
+        })
+      );
+    }
+    const existingCredits = Number(period.credited_to_owa_cents || 0);
+    if (leaves.length === 0) {
+      creditedToOwa = creditedToOwa || existingCredits;
+      runningHash = sha256Hex("");
+    }
+    const finalLiability = creditedToOwa || Number(period.final_liability_cents || existingCredits);
+    const merkleRoot = merkleRootHex(leaves);
+
+    await client.query(
+      `UPDATE periods
+          SET state=$4,
+              credited_to_owa_cents=$5,
+              final_liability_cents=$6,
+              merkle_root=$7,
+              running_balance_hash=$8,
+              thresholds=$9::jsonb
+        WHERE id=$1`,
+      [
+        period.id,
+        "CLOSING",
+        creditedToOwa,
+        finalLiability,
+        merkleRoot,
+        runningHash,
+        JSON.stringify(thr),
+      ]
+    );
+
+    await client.query("COMMIT");
+  } catch (e: any) {
+    await client.query("ROLLBACK");
+    return res.status(400).json({ error: e.message });
+  } finally {
+    client.release();
+  }
+
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
-  const payload = pr.rows[0].payload;
+  const rpt = await pool.query(
+    `SELECT payload FROM rpt_tokens
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC LIMIT 1`,
+    [abn, taxType, periodId]
+  );
+  if (rpt.rowCount === 0) {
+    if (res.locals?.completeIdempotency) {
+      await res.locals.completeIdempotency("ERROR", { error: "NO_RPT" });
+    }
+    return res.status(400).json({ error: "NO_RPT" });
+  }
+  const payload = rpt.rows[0].payload;
+
   try {
-    await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-    return res.json(r);
-  } catch (e:any) {
+    const destination = await resolveDestination(abn, rail, payload.reference);
+    const releaseResult = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      destination.reference
+    );
+    const release: any = releaseResult;
+    if (release.status === "DUPLICATE") {
+      if (res.locals?.completeIdempotency) {
+        await res.locals.completeIdempotency("ERROR", { error: "DUPLICATE_TRANSFER" });
+      }
+      return res.status(409).json({ error: "DUPLICATE_TRANSFER" });
+    }
+
+    const latestHash = release.hash_after ?? null;
+    const latestBalance = Number(release.balance_after_cents ?? 0);
+
+    await pool.query(
+      `UPDATE periods
+          SET state=$4,
+              running_balance_hash=$5
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId, "RELEASED", latestHash]
+    );
+
+    const response = {
+      transfer_uuid: release.transfer_uuid,
+      bank_receipt_hash: release.bank_receipt_hash,
+      new_balance: latestBalance,
+      destination: {
+        rail: destination.rail,
+        reference: destination.reference,
+      },
+    };
+
+    if (res.locals?.completeIdempotency) {
+      await res.locals.completeIdempotency("DONE", response);
+    }
+    return res.json(response);
+  } catch (e: any) {
+    if (res.locals?.completeIdempotency) {
+      await res.locals.completeIdempotency("ERROR", { error: e.message });
+    }
     return res.status(400).json({ error: e.message });
   }
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -6,19 +6,22 @@ const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +33,10 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "INSERT INTO rpt_tokens(abn,tax_type,period_id,payload,signature) VALUES ($1,$2,$3,$4::jsonb,$5)",
+    [abn, taxType, periodId, JSON.stringify(payload), signature]
+  );
+  await pool.query("UPDATE periods SET state='READY_RPT' WHERE id=$1", [row.id]);
   return { payload, signature };
 }

--- a/tests/service/close-pay-evidence.test.ts
+++ b/tests/service/close-pay-evidence.test.ts
@@ -1,0 +1,228 @@
+import { beforeAll, afterAll, expect, test } from "vitest";
+import { newDb } from "pg-mem";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import supertest from "supertest";
+import nacl from "tweetnacl";
+import type { Pool } from "pg";
+import * as pg from "pg";
+
+import { sha256Hex, merkleRootHex } from "../../src/crypto/merkle";
+
+const ABN = "12345678901";
+const TAX_TYPE = "GST";
+const PERIOD_ID = "2025-09";
+const RAIL = "EFT";
+const PRN = "1234567890";
+
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+type LedgerSeed = {
+  transfer_uuid: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string;
+};
+
+const ledgerSeed: LedgerSeed[] = [
+  {
+    transfer_uuid: "11111111-1111-1111-1111-111111111111",
+    amount_cents: 45000,
+    balance_after_cents: 45000,
+    bank_receipt_hash: "rcpt:credit-1",
+  },
+  {
+    transfer_uuid: "22222222-2222-2222-2222-222222222222",
+    amount_cents: 30000,
+    balance_after_cents: 75000,
+    bank_receipt_hash: "rcpt:credit-2",
+  },
+];
+
+function computeLedgerArtifacts(entries: LedgerSeed[]) {
+  let runningHash = "";
+  let credited = 0;
+  const leaves: string[] = [];
+  for (const entry of entries) {
+    if (entry.amount_cents > 0) {
+      credited += entry.amount_cents;
+    }
+    const balance = entry.balance_after_cents;
+    const computed = sha256Hex(runningHash + entry.bank_receipt_hash + String(balance));
+    runningHash = computed;
+    leaves.push(
+      JSON.stringify({
+        transfer_uuid: entry.transfer_uuid,
+        amount_cents: entry.amount_cents,
+        balance_after_cents: balance,
+        bank_receipt_hash: entry.bank_receipt_hash,
+        hash_after: runningHash,
+      })
+    );
+  }
+  const merkleRoot = merkleRootHex(leaves);
+  return {
+    credited,
+    runningHash: runningHash || sha256Hex(""),
+    merkleRoot,
+  };
+}
+
+const seededArtifacts = computeLedgerArtifacts(ledgerSeed);
+
+let pool: Pool;
+let request: supertest.SuperTest<supertest.Test>;
+
+beforeAll(async () => {
+  process.env.NODE_ENV = "test";
+  process.env.ATO_PRN = PRN;
+  const seed = new Uint8Array(32).fill(7);
+  const keyPair = nacl.sign.keyPair.fromSeed(seed);
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString("base64");
+
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  const adapter = db.adapters.createPg();
+  (pg as any).Pool = adapter.Pool;
+  (pg as any).Client = adapter.Client;
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const migrationSql = readFileSync(
+    path.resolve(__dirname, "../../migrations/001_apgms_core.sql"),
+    "utf8"
+  );
+  db.public.none(migrationSql);
+
+  pool = new (pg as any).Pool();
+
+  await pool.query(
+    `INSERT INTO periods(abn,tax_type,period_id,state,basis,accrued_cents,credited_to_owa_cents,final_liability_cents,anomaly_vector,thresholds)
+     VALUES ($1,$2,$3,'OPEN','ACCRUAL',0,0,0,$4::jsonb,$5::jsonb)`,
+    [
+      ABN,
+      TAX_TYPE,
+      PERIOD_ID,
+      JSON.stringify({
+        dup_rate: 0,
+        variance_ratio: 0.1,
+        gap_minutes: 10,
+        delta_vs_baseline: 0.05,
+      }),
+      JSON.stringify({}),
+    ]
+  );
+
+  for (const entry of ledgerSeed) {
+    await pool.query(
+      `INSERT INTO owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,now())`,
+      [
+        ABN,
+        TAX_TYPE,
+        PERIOD_ID,
+        entry.transfer_uuid,
+        entry.amount_cents,
+        entry.balance_after_cents,
+        entry.bank_receipt_hash,
+      ]
+    );
+  }
+
+  await pool.query(
+    `INSERT INTO remittance_destinations(abn,label,rail,reference,account_bsb,account_number)
+     VALUES ($1,$2,$3,$4,$5,$6)`,
+    [ABN, "Primary ATO EFT", RAIL, PRN, "123-456", "987654321"]
+  );
+
+  const { app } = await import("../../src/index");
+  request = supertest(app);
+});
+
+afterAll(async () => {
+  await pool?.end();
+});
+
+test("close-issue, pay, and evidence flow updates persistence and payloads", async () => {
+  const closeRes = await request.post("/api/close-issue").send({
+    abn: ABN,
+    taxType: TAX_TYPE,
+    periodId: PERIOD_ID,
+  });
+  expect(closeRes.status).toBe(200);
+  expect(closeRes.body).toHaveProperty("signature");
+  expect(closeRes.body.payload.amount_cents).toBe(seededArtifacts.credited);
+  expect(closeRes.body.payload.merkle_root).toBe(seededArtifacts.merkleRoot);
+
+  const { rows: periodAfterCloseRows } = await pool.query(
+    `SELECT state, final_liability_cents, credited_to_owa_cents, merkle_root, running_balance_hash, thresholds
+       FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+    [ABN, TAX_TYPE, PERIOD_ID]
+  );
+  const periodAfterClose = periodAfterCloseRows[0];
+  expect(periodAfterClose.state).toBe("READY_RPT");
+  expect(Number(periodAfterClose.final_liability_cents)).toBe(seededArtifacts.credited);
+  expect(Number(periodAfterClose.credited_to_owa_cents)).toBe(seededArtifacts.credited);
+  expect(periodAfterClose.merkle_root).toBe(seededArtifacts.merkleRoot);
+  expect(periodAfterClose.running_balance_hash).toBe(seededArtifacts.runningHash);
+  expect(periodAfterClose.thresholds).toMatchObject(DEFAULT_THRESHOLDS);
+
+  const payKey = "pay-key-1";
+  const payRes = await request
+    .post("/api/pay")
+    .set("Idempotency-Key", payKey)
+    .send({ abn: ABN, taxType: TAX_TYPE, periodId: PERIOD_ID, rail: RAIL });
+  expect(payRes.status).toBe(200);
+  expect(payRes.body.destination).toEqual({ rail: RAIL, reference: PRN });
+  expect(payRes.body.new_balance).toBe(0);
+
+  const { rows: periodAfterPayRows } = await pool.query(
+    `SELECT state, running_balance_hash FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+    [ABN, TAX_TYPE, PERIOD_ID]
+  );
+  const periodAfterPay = periodAfterPayRows[0];
+  expect(periodAfterPay.state).toBe("RELEASED");
+  const expectedReleaseHash = sha256Hex(
+    periodAfterClose.running_balance_hash + payRes.body.bank_receipt_hash + String(payRes.body.new_balance)
+  );
+  expect(periodAfterPay.running_balance_hash).toBe(expectedReleaseHash);
+
+  const { rows: latestLedgerRows } = await pool.query(
+    `SELECT amount_cents, balance_after_cents, bank_receipt_hash FROM owa_ledger
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+       ORDER BY id DESC LIMIT 1`,
+    [ABN, TAX_TYPE, PERIOD_ID]
+  );
+  const latestLedger = latestLedgerRows[0];
+  expect(Number(latestLedger.amount_cents)).toBe(-seededArtifacts.credited);
+  expect(Number(latestLedger.balance_after_cents)).toBe(0);
+  expect(latestLedger.bank_receipt_hash).toBe(payRes.body.bank_receipt_hash);
+
+  const responseHash = sha256Hex(JSON.stringify(payRes.body));
+  const { rows: idempotencyRows } = await pool.query(
+    `SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1`,
+    [payKey]
+  );
+  expect(idempotencyRows[0]).toEqual({ last_status: "DONE", response_hash: responseHash });
+
+  const duplicateRes = await request
+    .post("/api/pay")
+    .set("Idempotency-Key", payKey)
+    .send({ abn: ABN, taxType: TAX_TYPE, periodId: PERIOD_ID, rail: RAIL });
+  expect(duplicateRes.status).toBe(200);
+  expect(duplicateRes.body).toEqual({ idempotent: true, status: "DONE", response_hash: responseHash });
+
+  const evidenceRes = await request
+    .get("/api/evidence")
+    .query({ abn: ABN, taxType: TAX_TYPE, periodId: PERIOD_ID });
+  expect(evidenceRes.status).toBe(200);
+  expect(evidenceRes.body.rpt_payload.merkle_root).toBe(seededArtifacts.merkleRoot);
+  expect(evidenceRes.body.bank_receipt_hash).toBe(payRes.body.bank_receipt_hash);
+  expect(evidenceRes.body.owa_ledger_deltas).toHaveLength(ledgerSeed.length + 1);
+  expect(evidenceRes.body.owa_ledger_deltas.at(-1)?.amount_cents).toBe(String(-seededArtifacts.credited));
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    reporters: "default",
+    pool: "threads",
+    testTimeout: 30000,
+  },
+});


### PR DESCRIPTION
## Summary
- compute closing ledger artifacts before issuing RPTs and update SQL usage to parameterised queries
- ensure pay release honours allow-listed destinations, persists response hashes, and exports the Express app for testing
- add Vitest-based integration coverage for /api/close-issue, /api/pay, and /api/evidence with supporting config and deps

## Testing
- pnpm test *(fails: unable to download pnpm 9.0.0 due to restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68e22d366ab0832784b41fded31abe33