### PR TITLE
Implement settlement reconciliation ledger handling

### DIFF
--- a/apps/services/payments/test/settlement_webhook.test.ts
+++ b/apps/services/payments/test/settlement_webhook.test.ts
@@ -1,0 +1,203 @@
+import { randomUUID } from "crypto";
+import { Pool } from "pg";
+
+const connectionString = process.env.DATABASE_URL;
+if (!connectionString) {
+  throw new Error("DATABASE_URL must be set for settlement tests");
+}
+
+const adminPool = new Pool({ connectionString });
+let settlementWebhook: (req: any, res: any) => Promise<any>;
+
+beforeAll(async () => {
+  ({ settlementWebhook } = await import("../../../../src/routes/reconcile"));
+  await adminPool.query(`
+    CREATE TABLE IF NOT EXISTS owa_ledger (
+      id BIGSERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      transfer_uuid UUID NOT NULL,
+      amount_cents BIGINT NOT NULL,
+      balance_after_cents BIGINT NOT NULL,
+      bank_receipt_hash TEXT,
+      prev_hash TEXT,
+      hash_after TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      UNIQUE (transfer_uuid)
+    )
+  `);
+  await adminPool.query(`
+    CREATE TABLE IF NOT EXISTS settlement_reversals (
+      id BIGSERIAL PRIMARY KEY,
+      txn_id TEXT NOT NULL,
+      component TEXT NOT NULL CHECK (component IN ('GST','NET')),
+      reversal_transfer_uuid UUID NOT NULL,
+      amount_cents BIGINT NOT NULL,
+      settlement_ts TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      UNIQUE (txn_id, component, reversal_transfer_uuid)
+    )
+  `);
+});
+
+afterAll(async () => {
+  await adminPool.end();
+});
+
+beforeEach(async () => {
+  await adminPool.query("TRUNCATE settlement_reversals RESTART IDENTITY CASCADE");
+  await adminPool.query("TRUNCATE owa_ledger RESTART IDENTITY CASCADE");
+});
+
+function createRes() {
+  return {
+    statusCode: 200,
+    body: undefined as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.body = payload;
+      return this;
+    },
+  };
+}
+
+async function seedPayable(params: { abn: string; taxType: string; periodId: string; depositCents: number; releaseCents: number; }) {
+  const { abn, taxType, periodId, depositCents, releaseCents } = params;
+  const depositUuid = randomUUID();
+  await adminPool.query(
+    `INSERT INTO owa_ledger
+       (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,now())`,
+    [abn, taxType, periodId, depositUuid, depositCents, depositCents]
+  );
+  const releaseUuid = randomUUID();
+  const balanceAfterRelease = depositCents + releaseCents;
+  await adminPool.query(
+    `INSERT INTO owa_ledger
+       (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,now())`,
+    [abn, taxType, periodId, releaseUuid, releaseCents, balanceAfterRelease]
+  );
+  return { releaseUuid, abn, taxType, periodId };
+}
+
+function buildCsv(txnId: string, gst: number, net: number, ts: string) {
+  return `txn_id,gst_cents,net_cents,settlement_ts\n${txnId},${gst},${net},${ts}\n`;
+}
+
+test("duplicate settlement rows are ignored after first ingest", async () => {
+  const { releaseUuid } = await seedPayable({
+    abn: "111111111",
+    taxType: "GST",
+    periodId: "2025-09",
+    depositCents: 200000,
+    releaseCents: -150000,
+  });
+
+  const csv = buildCsv(releaseUuid, 60000, 90000, "2025-10-06T00:00:00.000Z");
+  const firstRes = createRes();
+  await settlementWebhook({ body: { csv } }, firstRes);
+  expect(firstRes.statusCode).toBe(200);
+  expect(firstRes.body).toMatchObject({ ingested: 1, duplicates: 0 });
+
+  const mapRows = await adminPool.query(
+    `SELECT component, amount_cents FROM settlement_reversals WHERE txn_id=$1 ORDER BY component`,
+    [releaseUuid]
+  );
+  expect(mapRows.rows.map((r) => ({
+    component: r.component,
+    amount: Number(r.amount_cents),
+  }))).toEqual([
+    { component: "GST", amount: 60000 },
+    { component: "NET", amount: 90000 },
+  ]);
+
+  const secondRes = createRes();
+  await settlementWebhook({ body: { csv } }, secondRes);
+  expect(secondRes.statusCode).toBe(200);
+  expect(secondRes.body).toMatchObject({ ingested: 0, duplicates: 1 });
+
+  const afterRows = await adminPool.query(
+    `SELECT COUNT(*)::int AS count FROM settlement_reversals WHERE txn_id=$1`,
+    [releaseUuid]
+  );
+  expect(Number(afterRows.rows[0].count)).toBe(2);
+});
+
+test("negative settlement entries reverse prior splits", async () => {
+  const { releaseUuid } = await seedPayable({
+    abn: "222222222",
+    taxType: "GST",
+    periodId: "2025-09",
+    depositCents: 250000,
+    releaseCents: -150000,
+  });
+
+  const settleCsv = buildCsv(releaseUuid, 70000, 80000, "2025-10-07T00:00:00.000Z");
+  await settlementWebhook({ body: { csv: settleCsv } }, createRes());
+
+  const reversalCsv = buildCsv(releaseUuid, -20000, -30000, "2025-10-08T00:00:00.000Z");
+  const reversalRes = createRes();
+  await settlementWebhook({ body: { csv: reversalCsv } }, reversalRes);
+  expect(reversalRes.statusCode).toBe(200);
+  expect(reversalRes.body).toMatchObject({ ingested: 1, duplicates: 0 });
+
+  const totals = await adminPool.query(
+    `SELECT component, SUM(amount_cents)::bigint AS total FROM settlement_reversals WHERE txn_id=$1 GROUP BY component ORDER BY component`,
+    [releaseUuid]
+  );
+  expect(totals.rows.map((r) => ({ component: r.component, total: Number(r.total) }))).toEqual([
+    { component: "GST", total: 50000 },
+    { component: "NET", total: 50000 },
+  ]);
+});
+
+test("partial settlements accumulate until payable fully cleared", async () => {
+  const { releaseUuid } = await seedPayable({
+    abn: "333333333",
+    taxType: "GST",
+    periodId: "2025-09",
+    depositCents: 300000,
+    releaseCents: -180000,
+  });
+
+  const firstCsv = buildCsv(releaseUuid, 50000, 40000, "2025-10-09T00:00:00.000Z");
+  const firstRes = createRes();
+  await settlementWebhook({ body: { csv: firstCsv } }, firstRes);
+  expect(firstRes.statusCode).toBe(200);
+  expect(firstRes.body.ingested).toBe(1);
+
+  const middleSum = await adminPool.query(
+    `SELECT SUM(amount_cents)::bigint AS total FROM settlement_reversals WHERE txn_id=$1`,
+    [releaseUuid]
+  );
+  expect(Number(middleSum.rows[0].total)).toBe(90000);
+
+  const secondCsv = buildCsv(releaseUuid, 30000, 20000, "2025-10-10T00:00:00.000Z");
+  const secondRes = createRes();
+  await settlementWebhook({ body: { csv: secondCsv } }, secondRes);
+  expect(secondRes.statusCode).toBe(200);
+  expect(secondRes.body.ingested).toBe(1);
+
+  const finalCsv = buildCsv(releaseUuid, 0, 80000, "2025-10-11T00:00:00.000Z");
+  const finalRes = createRes();
+  await settlementWebhook({ body: { csv: finalCsv } }, finalRes);
+  expect(finalRes.statusCode).toBe(200);
+  expect(finalRes.body.ingested).toBe(1);
+
+  const finalSum = await adminPool.query(
+    `SELECT SUM(amount_cents)::bigint AS total FROM settlement_reversals WHERE txn_id=$1`,
+    [releaseUuid]
+  );
+  expect(Number(finalSum.rows[0].total)).toBe(180000);
+
+  const overCsv = buildCsv(releaseUuid, 1000, 0, "2025-10-12T00:00:00.000Z");
+  const overRes = createRes();
+  await settlementWebhook({ body: { csv: overCsv } }, overRes);
+  expect(overRes.statusCode).toBe(400);
+  expect(overRes.body.error).toContain("OVER_SETTLEMENT");
+});

--- a/docs/settlement_reconciliation.md
+++ b/docs/settlement_reconciliation.md
@@ -1,0 +1,45 @@
+# Settlement Reconciliation Flow
+
+This document explains how split-payment settlement files from the acquiring bank are reconciled into APGMS ledgers. It covers the webhook contract, validation steps, ledger side-effects, and how operators can trace a settlement end-to-end.
+
+## Inbound data contract
+
+The `/api/settlement/webhook` endpoint accepts a CSV payload via `req.body.csv`. Each record must provide the following columns:
+
+| Column | Description |
+| --- | --- |
+| `txn_id` | UUID of the originating payable (`owa_ledger.transfer_uuid`) released to the ATO |
+| `gst_cents` | GST component (positive for settlement, negative for reversal) |
+| `net_cents` | Net component (positive for settlement, negative for reversal) |
+| `settlement_ts` | ISO-8601 timestamp supplied by the bank |
+
+Rows are parsed and normalised to integers before processing; non-integer values are rejected so ledger math remains exact.【F:src/settlement/splitParser.ts†L3-L11】【F:src/routes/reconcile.ts†L45-L63】
+
+## Processing pipeline
+
+For every parsed row the webhook performs the following transactional workflow:
+
+1. **Payable verification** – lock and validate the originating payable in `owa_ledger`. The entry must exist and represent an outbound release (negative `amount_cents`).【F:src/routes/reconcile.ts†L65-L82】
+2. **Idempotency filter** – skip any component that already exists in `settlement_reversals` with the same (`txn_id`, `component`, `amount_cents`, `settlement_ts`). Entire rows without new work are counted as duplicates in the response.【F:src/routes/reconcile.ts†L84-L108】【F:src/routes/reconcile.ts†L132-L134】
+3. **Balance guardrails** – ensure the cumulative settled amount for `txn_id` never exceeds the absolute payable, nor drops below zero when processing reversals.【F:src/routes/reconcile.ts†L110-L122】
+4. **Ledger posting** – append GST and NET entries to `owa_ledger`, preserving running balance order and stamping the bank timestamp onto `created_at`.【F:src/routes/reconcile.ts†L124-L145】
+5. **Reversal map persistence** – write the new split entry into `settlement_reversals`, linking the original `txn_id` to the reversal `transfer_uuid` for traceability.【F:src/routes/reconcile.ts†L147-L156】
+
+The endpoint responds with counts of unique rows ingested and duplicate rows that were skipped.【F:src/routes/reconcile.ts†L136-L141】
+
+## Ledger impacts
+
+Every settlement inserts two entries (GST and NET) per row unless a component is zero or already recorded. Entries use fresh UUIDs but inherit the original `abn`, `tax_type`, and `period_id` from the payable so auditors can follow the balance trajectory. The helper table below records the mapping required to unwind or audit settlements later on.【F:schema/settlement_reversals.sql†L1-L11】
+
+```sql
+SELECT ol.transfer_uuid AS payable_txn,
+       sr.component,
+       sr.reversal_transfer_uuid,
+       sr.amount_cents,
+       sr.settlement_ts
+  FROM settlement_reversals sr
+  JOIN owa_ledger ol ON ol.transfer_uuid = sr.txn_id
+ ORDER BY sr.settlement_ts;
+```
+
+This query yields the full lineage from release to settlement splits, supporting duplicate detection, reversals, and partial settlement tracking for operations teams.【F:apps/services/payments/test/settlement_webhook.test.ts†L108-L178】

--- a/migrations/001_apgms_core.sql
+++ b/migrations/001_apgms_core.sql
@@ -33,6 +33,19 @@ create table if not exists owa_ledger (
 
 create index if not exists idx_owa_balance on owa_ledger(abn, tax_type, period_id, id);
 
+create table if not exists settlement_reversals (
+  id bigserial primary key,
+  txn_id text not null,
+  component text not null check (component in ('GST','NET')),
+  reversal_transfer_uuid uuid not null,
+  amount_cents bigint not null,
+  settlement_ts timestamptz not null,
+  created_at timestamptz default now(),
+  unique (txn_id, component, reversal_transfer_uuid)
+);
+
+create index if not exists idx_settlement_reversals_txn on settlement_reversals(txn_id);
+
 create table if not exists rpt_tokens (
   id bigserial primary key,
   abn text not null,

--- a/migrations/002_apgms_patent_core.sql
+++ b/migrations/002_apgms_patent_core.sql
@@ -22,6 +22,19 @@ CREATE TABLE IF NOT EXISTS owa_ledger (
   audit_hash CHAR(64)
 );
 
+CREATE TABLE IF NOT EXISTS settlement_reversals (
+  id BIGSERIAL PRIMARY KEY,
+  txn_id VARCHAR(64) NOT NULL,
+  component VARCHAR(10) NOT NULL CHECK (component IN ('GST','NET')),
+  reversal_transfer_uuid UUID NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  settlement_ts TIMESTAMP NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+  UNIQUE (txn_id, component, reversal_transfer_uuid)
+);
+
+CREATE INDEX IF NOT EXISTS settlement_reversals_txn_idx ON settlement_reversals (txn_id);
+
 CREATE TABLE IF NOT EXISTS audit_log (
   id BIGSERIAL PRIMARY KEY,
   event_time TIMESTAMP NOT NULL DEFAULT NOW(),

--- a/schema/settlement_reversals.sql
+++ b/schema/settlement_reversals.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS settlement_reversals (
+  id BIGSERIAL PRIMARY KEY,
+  txn_id TEXT NOT NULL,
+  component TEXT NOT NULL CHECK (component IN ('GST','NET')),
+  reversal_transfer_uuid UUID NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  settlement_ts TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (txn_id, component, reversal_transfer_uuid)
+);
+
+CREATE INDEX IF NOT EXISTS settlement_reversals_txn_idx ON settlement_reversals (txn_id);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -4,6 +4,7 @@ import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+import { randomUUID } from "crypto";
 const pool = new Pool();
 
 export async function closeAndIssue(req:any, res:any) {
@@ -42,11 +43,150 @@ export async function paytoSweep(req:any, res:any) {
 export async function settlementWebhook(req:any, res:any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
-  return res.json({ ingested: rows.length });
+  if (!rows.length) {
+    return res.json({ ingested: 0, duplicates: 0 });
+  }
+
+  const client = await pool.connect();
+  let ingested = 0;
+  let duplicates = 0;
+  try {
+    await client.query("BEGIN");
+
+    for (const row of rows) {
+      const txnId = row.txn_id;
+      const gst = ensureInteger(row.gst_cents, "gst_cents", txnId);
+      const net = ensureInteger(row.net_cents, "net_cents", txnId);
+      const settlementTs = new Date(row.settlement_ts);
+      if (Number.isNaN(settlementTs.getTime())) {
+        throw new Error(`INVALID_TS:${txnId}`);
+      }
+      const settlementIso = settlementTs.toISOString();
+
+      const payable = await client.query(
+        `SELECT abn, tax_type, period_id, amount_cents
+         FROM owa_ledger
+         WHERE transfer_uuid=$1
+         FOR UPDATE`,
+        [txnId]
+      );
+      if (payable.rowCount === 0) {
+        throw new Error(`UNKNOWN_TXN:${txnId}`);
+      }
+      const payableRow = payable.rows[0];
+      const payableAmount = Number(payableRow.amount_cents);
+      if (!Number.isFinite(payableAmount) || payableAmount >= 0) {
+        throw new Error(`NOT_PAYABLE:${txnId}`);
+      }
+
+      const components = [
+        { component: "GST", amount: gst },
+        { component: "NET", amount: net }
+      ];
+
+      const inserts: { component: string; amount: number }[] = [];
+      for (const part of components) {
+        if (part.amount === 0) continue;
+        const existing = await client.query(
+          `SELECT 1 FROM settlement_reversals
+            WHERE txn_id=$1 AND component=$2 AND amount_cents=$3 AND settlement_ts=$4`,
+          [txnId, part.component, part.amount, settlementIso]
+        );
+        if (existing.rowCount > 0) {
+          continue;
+        }
+        inserts.push(part);
+      }
+
+      if (inserts.length === 0) {
+        duplicates += 1;
+        continue;
+      }
+
+      const settledTotalRes = await client.query(
+        `SELECT COALESCE(SUM(amount_cents),0) AS total
+           FROM settlement_reversals
+          WHERE txn_id=$1`,
+        [txnId]
+      );
+      const settledSoFar = Number(settledTotalRes.rows[0].total) || 0;
+      const toSettle = inserts.reduce((sum, p) => sum + p.amount, 0);
+      const newTotal = settledSoFar + toSettle;
+      const payableAbs = Math.abs(payableAmount);
+      if (newTotal > payableAbs) {
+        throw new Error(`OVER_SETTLEMENT:${txnId}`);
+      }
+      if (newTotal < 0) {
+        throw new Error(`NEGATIVE_SETTLEMENT:${txnId}`);
+      }
+
+      for (const part of inserts) {
+        const { rows: balRows } = await client.query(
+          `SELECT balance_after_cents FROM owa_ledger
+             WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+             ORDER BY id DESC LIMIT 1`,
+          [payableRow.abn, payableRow.tax_type, payableRow.period_id]
+        );
+        const prevBal = Number(balRows[0]?.balance_after_cents || 0);
+        const newBal = prevBal + part.amount;
+        const reversalTransferUuid = randomUUID();
+
+        const inserted = await client.query(
+          `INSERT INTO owa_ledger
+             (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,$7)
+           RETURNING transfer_uuid`,
+          [
+            payableRow.abn,
+            payableRow.tax_type,
+            payableRow.period_id,
+            reversalTransferUuid,
+            part.amount,
+            newBal,
+            settlementIso
+          ]
+        );
+
+        await client.query(
+          `INSERT INTO settlement_reversals
+             (txn_id, component, reversal_transfer_uuid, amount_cents, settlement_ts)
+           VALUES ($1,$2,$3,$4,$5)
+           ON CONFLICT (txn_id, component, reversal_transfer_uuid) DO NOTHING`,
+          [
+            txnId,
+            part.component,
+            inserted.rows[0].transfer_uuid,
+            part.amount,
+            settlementIso
+          ]
+        );
+      }
+
+      ingested += 1;
+    }
+
+    await client.query("COMMIT");
+    return res.json({ ingested, duplicates });
+  } catch (e:any) {
+    await client.query("ROLLBACK");
+    return res.status(400).json({ error: e.message || String(e) });
+  } finally {
+    client.release();
+  }
 }
 
 export async function evidence(req:any, res:any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
+}
+
+function ensureInteger(value:number, field:string, txnId:string) {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    throw new Error(`INVALID_${field}:${txnId}`);
+  }
+  if (!Number.isInteger(num)) {
+    throw new Error(`NON_INTEGER_${field}:${txnId}`);
+  }
+  return num;
 }


### PR DESCRIPTION
## Summary
- add the settlement_reversals helper table to the core migrations and schema bundle
- implement the settlement webhook to validate payables, post GST/NET ledger entries, and persist reversal mappings
- cover duplicate, reversal, and partial settlement scenarios with integration-style tests and document the operator flow

## Testing
- not run (requires DATABASE_URL for Postgres)

------
https://chatgpt.com/codex/tasks/task_e_68e23224c5088327bdc1bd0519861888