### PR TITLE
Add settlement ingestion validation and compliance dashboards

### DIFF
--- a/migrations/003_settlement_ingest.sql
+++ b/migrations/003_settlement_ingest.sql
@@ -1,0 +1,24 @@
+-- 003_settlement_ingest.sql
+create table if not exists settlement_files (
+  id bigserial primary key,
+  file_id text,
+  schema_version text,
+  generated_at timestamptz,
+  received_at timestamptz not null default now(),
+  signer_key_id text,
+  signature_verified boolean,
+  hmac_key_id text,
+  hmac_verified boolean,
+  csv_sha256 text,
+  row_count integer,
+  status text not null,
+  error_code text,
+  error_detail jsonb,
+  raw_payload jsonb not null,
+  verification_artifacts jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_settlement_files_received_at on settlement_files(received_at desc);
+create index if not exists idx_settlement_files_status on settlement_files(status);
+create unique index if not exists uq_settlement_files_file_id_success on settlement_files(file_id) where status = 'ACCEPTED';

--- a/src/components/SettlementIngestionPanel.tsx
+++ b/src/components/SettlementIngestionPanel.tsx
@@ -1,0 +1,299 @@
+import React, { useEffect, useState } from "react";
+
+type SettlementStatus = "ACCEPTED" | "REJECTED";
+
+type SettlementSummary = {
+  id: number;
+  file_id: string | null;
+  schema_version: string | null;
+  generated_at: string | null;
+  received_at: string;
+  signer_key_id: string | null;
+  signature_verified: boolean | null;
+  hmac_key_id: string | null;
+  hmac_verified: boolean | null;
+  row_count: number | null;
+  status: SettlementStatus;
+  error_code: string | null;
+};
+
+type SettlementDetail = SettlementSummary & {
+  csv_sha256?: string | null;
+  error_detail?: any;
+  raw_payload?: any;
+  verification_artifacts?: any;
+};
+
+type Metrics = {
+  acceptedCount: number;
+  rejectedCount: number;
+  lastFileId: string | null;
+  lastStatus: SettlementStatus | null;
+  lastErrorCode: string | null;
+  lastReceivedAt: string | null;
+};
+
+function formatDate(value: string | null | undefined) {
+  if (!value) return "—";
+  try {
+    const dt = new Date(value);
+    if (Number.isNaN(dt.getTime())) return value;
+    return dt.toLocaleString();
+  } catch {
+    return value;
+  }
+}
+
+export function SettlementIngestionPanel() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [rows, setRows] = useState<SettlementSummary[]>([]);
+  const [selectedFileId, setSelectedFileId] = useState<string | null>(null);
+  const [detail, setDetail] = useState<SettlementDetail | null>(null);
+  const [metrics, setMetrics] = useState<Metrics | null>(null);
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  useEffect(() => {
+    if (!selectedFileId) {
+      setDetail(null);
+      return;
+    }
+    let cancelled = false;
+    async function loadDetail() {
+      setDetailError(null);
+      try {
+        const res = await fetch(`/api/settlement/files/${encodeURIComponent(selectedFileId)}`);
+        const text = await res.text();
+        let json: any = null;
+        try {
+          json = text ? JSON.parse(text) : null;
+        } catch {
+          json = null;
+        }
+        if (!res.ok) {
+          throw new Error(json?.error || json?.detail || res.statusText);
+        }
+        if (!cancelled) {
+          setDetail(json as SettlementDetail);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setDetail(null);
+          setDetailError(err?.message || "Failed to load file detail");
+        }
+      }
+    }
+    loadDetail();
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedFileId]);
+
+  async function refresh() {
+    setLoading(true);
+    setError(null);
+    try {
+      const [statusRes, metricsRes] = await Promise.all([
+        fetch("/api/settlement/files?limit=25"),
+        fetch("/api/settlement/metrics"),
+      ]);
+
+      if (!statusRes.ok) {
+        const payload = await statusRes.json().catch(() => ({}));
+        throw new Error(payload.error || payload.detail || statusRes.statusText);
+      }
+      const summary = (await statusRes.json()) as SettlementSummary[];
+      setRows(summary);
+      if (summary.length > 0) {
+        setSelectedFileId(summary[0].file_id || null);
+      } else {
+        setSelectedFileId(null);
+        setDetail(null);
+      }
+
+      if (metricsRes.ok) {
+        const metricsJson = (await metricsRes.json()) as Metrics;
+        setMetrics(metricsJson);
+      }
+    } catch (err: any) {
+      setError(err?.message || "Failed to load settlement ingestion status");
+      setRows([]);
+      setSelectedFileId(null);
+      setDetail(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="bg-white p-4 rounded-xl shadow space-y-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900">Settlement ingestion</h2>
+          <p className="text-sm text-gray-500">
+            Signed settlement CSVs received from your acquiring bank.
+          </p>
+        </div>
+        <button
+          onClick={refresh}
+          className="bg-[#00716b] text-white text-sm font-medium px-3 py-1.5 rounded-md shadow-sm hover:bg-[#00564f]"
+          disabled={loading}
+        >
+          {loading ? "Refreshing…" : "Refresh"}
+        </button>
+      </div>
+
+      {metrics && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-gray-500 uppercase tracking-wide text-xs">Accepted</p>
+            <p className="text-xl font-semibold text-[#00716b]">{metrics.acceptedCount}</p>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-gray-500 uppercase tracking-wide text-xs">Rejected</p>
+            <p className="text-xl font-semibold text-red-600">{metrics.rejectedCount}</p>
+          </div>
+          <div className="bg-gray-50 rounded-lg p-3">
+            <p className="text-gray-500 uppercase tracking-wide text-xs">Last event</p>
+            <p className="text-base font-medium text-gray-800">
+              {metrics.lastStatus ? `${metrics.lastStatus} • ${formatDate(metrics.lastReceivedAt)}` : "—"}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {error && <div className="text-sm text-red-600">{error}</div>}
+
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm border border-gray-200 rounded-lg">
+          <thead className="bg-gray-100 text-left">
+            <tr>
+              <th className="px-3 py-2 border-b">File</th>
+              <th className="px-3 py-2 border-b">Received</th>
+              <th className="px-3 py-2 border-b">Status</th>
+              <th className="px-3 py-2 border-b">Rows</th>
+              <th className="px-3 py-2 border-b">Signature</th>
+              <th className="px-3 py-2 border-b">HMAC</th>
+              <th className="px-3 py-2 border-b">Error</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr>
+                <td className="px-3 py-4 text-center text-gray-500" colSpan={7}>
+                  {loading ? "Loading settlement files…" : "No settlement files have been processed yet."}
+                </td>
+              </tr>
+            )}
+            {rows.map((row) => {
+              const isSelected = row.file_id && row.file_id === selectedFileId;
+              return (
+                <tr
+                  key={`${row.id}-${row.received_at}`}
+                  onClick={() => row.file_id && setSelectedFileId(row.file_id)}
+                  className={`border-t cursor-pointer hover:bg-gray-50 ${
+                    isSelected ? "bg-teal-50" : "bg-white"
+                  }`}
+                >
+                  <td className="px-3 py-2 font-mono text-xs">{row.file_id || "—"}</td>
+                  <td className="px-3 py-2">{formatDate(row.received_at)}</td>
+                  <td className="px-3 py-2">
+                    <span
+                      className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium ${
+                        row.status === "ACCEPTED" ? "bg-green-100 text-green-700" : "bg-red-100 text-red-700"
+                      }`}
+                    >
+                      {row.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">{row.row_count ?? "—"}</td>
+                  <td className="px-3 py-2">{row.signature_verified ? "✅" : "⚠️"}</td>
+                  <td className="px-3 py-2">{row.hmac_verified ? "✅" : "⚠️"}</td>
+                  <td className="px-3 py-2 text-red-600">{row.error_code || ""}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {detailError && <div className="text-sm text-red-600">{detailError}</div>}
+
+      {detail && (
+        <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm space-y-2">
+          <h3 className="font-semibold text-gray-800">File detail</h3>
+          <div className="grid gap-2 md:grid-cols-2">
+            <div>
+              <p className="text-xs text-gray-500 uppercase">File ID</p>
+              <p className="font-mono text-xs break-all">{detail.file_id}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Schema</p>
+              <p>{detail.schema_version || "—"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Generated at</p>
+              <p>{formatDate(detail.generated_at)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Received at</p>
+              <p>{formatDate(detail.received_at)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Signature key</p>
+              <p>{detail.signer_key_id || "—"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">HMAC key</p>
+              <p>{detail.hmac_key_id || "—"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">CSV SHA-256</p>
+              <p className="font-mono text-xs break-all">{detail.csv_sha256 || "—"}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Row count</p>
+              <p>{detail.row_count ?? "—"}</p>
+            </div>
+          </div>
+
+          {detail.error_code && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Error</p>
+              <p className="text-red-600">{detail.error_code}</p>
+              {detail.error_detail && (
+                <pre className="mt-1 text-xs bg-white border border-red-200 rounded p-2 overflow-x-auto">
+                  {JSON.stringify(detail.error_detail, null, 2)}
+                </pre>
+              )}
+            </div>
+          )}
+
+          {detail.verification_artifacts && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Verification artifacts</p>
+              <pre className="mt-1 text-xs bg-white border border-gray-200 rounded p-2 overflow-x-auto">
+                {JSON.stringify(detail.verification_artifacts, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {detail.raw_payload && (
+            <div>
+              <p className="text-xs text-gray-500 uppercase">Raw payload</p>
+              <pre className="mt-1 text-xs bg-white border border-gray-200 rounded p-2 overflow-x-auto">
+                {JSON.stringify(detail.raw_payload, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default SettlementIngestionPanel;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,16 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+  settlementWebhook,
+  evidence,
+  listSettlementFiles,
+  getSettlementFile,
+  settlementMetricsHandler,
+} from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -23,6 +32,9 @@ app.post("/api/pay", idempotency(), payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
+app.get("/api/settlement/files", listSettlementFiles);
+app.get("/api/settlement/files/:fileId", getSettlementFile);
+app.get("/api/settlement/metrics", settlementMetricsHandler);
 app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`

--- a/src/pages/Audit.tsx
+++ b/src/pages/Audit.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import SettlementIngestionPanel from "../components/SettlementIngestionPanel";
 
 export default function Audit() {
   const [logs] = useState([
@@ -12,7 +13,7 @@ export default function Audit() {
   ]);
 
   return (
-    <div className="p-6 space-y-4">
+    <div className="p-6 space-y-6">
       <h1 className="text-2xl font-bold">Compliance & Audit</h1>
       <p className="text-sm text-muted-foreground">
         Track every action in your PAYGW and GST account for compliance.
@@ -36,6 +37,7 @@ export default function Audit() {
         </table>
       </div>
       <button className="mt-4 bg-primary text-white p-2 rounded-md">Download Full Log</button>
+      <SettlementIngestionPanel />
     </div>
   );
 }

--- a/src/settlement/events.ts
+++ b/src/settlement/events.ts
@@ -1,0 +1,79 @@
+import { EventEmitter } from "events";
+
+export type SettlementAcceptedEvent = {
+  type: "settlement.accepted";
+  fileId: string;
+  rowCount: number;
+  generatedAt: string;
+  receivedAt: string;
+  signerKeyId: string;
+  hmacKeyId: string;
+};
+
+export type SettlementRejectedEvent = {
+  type: "settlement.rejected";
+  fileId?: string;
+  receivedAt: string;
+  errorCode: string;
+};
+
+type SettlementEvents = {
+  "settlement.accepted": (event: SettlementAcceptedEvent) => void;
+  "settlement.rejected": (event: SettlementRejectedEvent) => void;
+};
+
+class SettlementEventBus {
+  private emitter = new EventEmitter();
+
+  on<TEvent extends keyof SettlementEvents>(event: TEvent, handler: SettlementEvents[TEvent]) {
+    this.emitter.on(event, handler);
+  }
+
+  off<TEvent extends keyof SettlementEvents>(event: TEvent, handler: SettlementEvents[TEvent]) {
+    this.emitter.off(event, handler);
+  }
+
+  emit(event: SettlementAcceptedEvent | SettlementRejectedEvent) {
+    this.emitter.emit(event.type, event as any);
+  }
+}
+
+export const settlementEvents = new SettlementEventBus();
+
+export interface SettlementMetrics {
+  acceptedCount: number;
+  rejectedCount: number;
+  lastFileId: string | null;
+  lastStatus: "ACCEPTED" | "REJECTED" | null;
+  lastErrorCode: string | null;
+  lastReceivedAt: string | null;
+}
+
+const metrics: SettlementMetrics = {
+  acceptedCount: 0,
+  rejectedCount: 0,
+  lastFileId: null,
+  lastStatus: null,
+  lastErrorCode: null,
+  lastReceivedAt: null,
+};
+
+settlementEvents.on("settlement.accepted", (event) => {
+  metrics.acceptedCount += 1;
+  metrics.lastFileId = event.fileId;
+  metrics.lastStatus = "ACCEPTED";
+  metrics.lastErrorCode = null;
+  metrics.lastReceivedAt = event.receivedAt;
+});
+
+settlementEvents.on("settlement.rejected", (event) => {
+  metrics.rejectedCount += 1;
+  metrics.lastFileId = event.fileId ?? null;
+  metrics.lastStatus = "REJECTED";
+  metrics.lastErrorCode = event.errorCode;
+  metrics.lastReceivedAt = event.receivedAt;
+});
+
+export function getSettlementMetrics(): SettlementMetrics {
+  return { ...metrics };
+}

--- a/src/settlement/splitParser.ts
+++ b/src/settlement/splitParser.ts
@@ -1,11 +1,318 @@
-﻿import { parse } from "csv-parse/sync";
-/** Split-payment settlement ingestion (stub). CSV cols: txn_id,gst_cents,net_cents,settlement_ts */
-export function parseSettlementCSV(csvText: string) {
-  const rows = parse(csvText, { columns: true, skip_empty_lines: true });
-  return rows.map((r:any) => ({
-    txn_id: String(r.txn_id),
-    gst_cents: Number(r.gst_cents),
-    net_cents: Number(r.net_cents),
-    settlement_ts: new Date(r.settlement_ts).toISOString()
-  }));
+import { parse } from "csv-parse/sync";
+import { createHash, createHmac, timingSafeEqual } from "crypto";
+import nacl from "tweetnacl";
+
+export interface SettlementEnvelope {
+  file_id: string;
+  generated_at: string;
+  schema_version?: string;
+  signer_key_id?: string;
+  signature: string;
+  hmac_key_id?: string;
+  hmac: string;
+  csv: string;
+}
+
+export interface SettlementRow {
+  txn_id: string;
+  gst_cents: number;
+  net_cents: number;
+  settlement_ts: string;
+}
+
+export interface SettlementValidationOptions {
+  /** Allow callers to override signer key material (base64/base64url/hex) */
+  signerKeys?: Record<string, string>;
+  /** Allow callers to override HMAC secrets (base64/base64url/hex) */
+  hmacSecrets?: Record<string, string>;
+  /** Maximum acceptable skew (minutes) between `generated_at` and now */
+  maxClockSkewMinutes?: number;
+  /** Clock override for testing */
+  now?: () => Date;
+  /**
+   * Optional replay guard – should return true when the given file has already
+   * been seen (and therefore must be rejected).
+   */
+  hasSeen?: (fileId: string) => Promise<boolean> | boolean;
+}
+
+export interface SettlementValidationResult {
+  fileId: string;
+  schemaVersion: string;
+  generatedAt: string;
+  signerKeyId: string;
+  hmacKeyId: string;
+  csvHash: string;
+  canonicalMessage: string;
+  rows: SettlementRow[];
+  rawCsv: string;
+  signatureValid: boolean;
+  hmacValid: boolean;
+  timestampSkewMinutes: number;
+}
+
+export class SettlementValidationError extends Error {
+  constructor(public code: string, message: string, public details?: Record<string, any>) {
+    super(message);
+    this.name = "SettlementValidationError";
+  }
+}
+
+const DEFAULT_SCHEMA_VERSION = "2025-10";
+const DEFAULT_ALLOWED_SCHEMAS = new Set([DEFAULT_SCHEMA_VERSION]);
+const DEFAULT_MAX_SKEW_MINUTES = 15;
+
+function getSignerKeysFromEnv(): Record<string, string> {
+  const raw = process.env.SETTLEMENT_SIGNER_KEYS;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== "object" || parsed === null) {
+        throw new Error("Signer config must be an object");
+      }
+      return parsed;
+    } catch (err: any) {
+      throw new SettlementValidationError(
+        "SIGNER_CONFIG_INVALID",
+        `Unable to parse SETTLEMENT_SIGNER_KEYS: ${err.message}`
+      );
+    }
+  }
+
+  const single = process.env.SETTLEMENT_SIGNER_PUBLIC_KEY;
+  if (single) {
+    return { primary: single };
+  }
+
+  throw new SettlementValidationError(
+    "SIGNER_CONFIG_MISSING",
+    "No signer keys configured. Set SETTLEMENT_SIGNER_KEYS or SETTLEMENT_SIGNER_PUBLIC_KEY."
+  );
+}
+
+function getHmacSecretsFromEnv(): Record<string, string> {
+  const raw = process.env.SETTLEMENT_HMAC_SECRETS;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      if (typeof parsed !== "object" || parsed === null) {
+        throw new Error("HMAC config must be an object");
+      }
+      return parsed;
+    } catch (err: any) {
+      throw new SettlementValidationError(
+        "HMAC_CONFIG_INVALID",
+        `Unable to parse SETTLEMENT_HMAC_SECRETS: ${err.message}`
+      );
+    }
+  }
+
+  const single = process.env.SETTLEMENT_HMAC_SECRET;
+  if (single) {
+    return { primary: single };
+  }
+
+  throw new SettlementValidationError(
+    "HMAC_CONFIG_MISSING",
+    "No HMAC secrets configured. Set SETTLEMENT_HMAC_SECRETS or SETTLEMENT_HMAC_SECRET."
+  );
+}
+
+function decodeKey(material: string, label: string): Buffer {
+  const value = (material || "").trim();
+  if (!value) {
+    throw new SettlementValidationError("KEY_MISSING", `${label} is not configured`);
+  }
+  const encodings: BufferEncoding[] = ["base64url", "base64", "hex"];
+  for (const enc of encodings) {
+    try {
+      const buf = Buffer.from(value, enc);
+      if (buf.length > 0) {
+        return buf;
+      }
+    } catch {
+      // try next encoding
+    }
+  }
+  throw new SettlementValidationError(
+    "KEY_DECODE_FAILED",
+    `${label} must be base64url, base64, or hex encoded`
+  );
+}
+
+function toIsoString(date: Date): string {
+  return new Date(date.getTime()).toISOString();
+}
+
+function ensureEnvelope(payload: any): asserts payload is SettlementEnvelope {
+  if (!payload || typeof payload !== "object") {
+    throw new SettlementValidationError("PAYLOAD_TYPE", "Settlement payload must be an object");
+  }
+  const requiredFields: Array<keyof SettlementEnvelope> = [
+    "file_id",
+    "generated_at",
+    "signature",
+    "hmac",
+    "csv",
+  ];
+  for (const field of requiredFields) {
+    if (typeof payload[field] !== "string" || !payload[field]) {
+      throw new SettlementValidationError("PAYLOAD_FIELD", `Missing or invalid field: ${field}`);
+    }
+  }
+}
+
+function validateSchemaVersion(version: string): string {
+  if (!DEFAULT_ALLOWED_SCHEMAS.has(version)) {
+    throw new SettlementValidationError(
+      "SCHEMA_VERSION_UNSUPPORTED",
+      `Unsupported settlement schema: ${version}`,
+      { allowed: Array.from(DEFAULT_ALLOWED_SCHEMAS), received: version }
+    );
+  }
+  return version;
+}
+
+function validateTimestamp(generatedAt: Date, now: Date, maxSkewMinutes: number): number {
+  const deltaMinutes = Math.abs(now.getTime() - generatedAt.getTime()) / 60000;
+  if (deltaMinutes > maxSkewMinutes) {
+    throw new SettlementValidationError(
+      "TIMESTAMP_OUT_OF_RANGE",
+      "Settlement file timestamp outside allowable skew",
+      { generated_at: generatedAt.toISOString(), now: now.toISOString(), skew_minutes: deltaMinutes }
+    );
+  }
+  return deltaMinutes;
+}
+
+function canonicalizePayload(fileId: string, generatedAt: string, schemaVersion: string, csvHash: string) {
+  return JSON.stringify({ file_id: fileId, generated_at: generatedAt, schema_version: schemaVersion, csv_sha256: csvHash });
+}
+
+function validateSignature(message: string, signature: string, keyMaterial: string): void {
+  const signatureBuf = decodeKey(signature, "signature");
+  const publicKey = decodeKey(keyMaterial, "signer public key");
+  if (publicKey.length !== nacl.sign.publicKeyLength) {
+    throw new SettlementValidationError(
+      "SIGNER_KEY_LENGTH",
+      `Signer key must be ${nacl.sign.publicKeyLength} bytes`);
+  }
+  const ok = nacl.sign.detached.verify(
+    new TextEncoder().encode(message),
+    signatureBuf,
+    publicKey
+  );
+  if (!ok) {
+    throw new SettlementValidationError("SIGNATURE_INVALID", "Invalid settlement file signature");
+  }
+}
+
+function validateHmac(message: string, providedHmac: string, secretMaterial: string) {
+  const provided = decodeKey(providedHmac, "HMAC value");
+  const secret = decodeKey(secretMaterial, "HMAC secret");
+  const computed = createHmac("sha256", secret).update(message).digest();
+  if (provided.length !== computed.length || !timingSafeEqual(provided, computed)) {
+    throw new SettlementValidationError("HMAC_INVALID", "Settlement HMAC validation failed");
+  }
+}
+
+function normalizeRow(raw: any, index: number): SettlementRow {
+  if (!raw || typeof raw !== "object") {
+    throw new SettlementValidationError("ROW_TYPE", `Row ${index + 1} is not an object`);
+  }
+  const txn = String(raw.txn_id ?? "").trim();
+  const gst = Number(raw.gst_cents);
+  const net = Number(raw.net_cents);
+  const settlementTs = String(raw.settlement_ts ?? "").trim();
+  if (!txn) {
+    throw new SettlementValidationError("ROW_TXN_ID", `Row ${index + 1} missing txn_id`);
+  }
+  if (!Number.isFinite(gst) || !Number.isInteger(gst)) {
+    throw new SettlementValidationError("ROW_GST", `Row ${index + 1} has invalid gst_cents`);
+  }
+  if (!Number.isFinite(net) || !Number.isInteger(net)) {
+    throw new SettlementValidationError("ROW_NET", `Row ${index + 1} has invalid net_cents`);
+  }
+  const ts = Date.parse(settlementTs);
+  if (Number.isNaN(ts)) {
+    throw new SettlementValidationError("ROW_TS", `Row ${index + 1} has invalid settlement_ts`);
+  }
+  return {
+    txn_id: txn,
+    gst_cents: gst,
+    net_cents: net,
+    settlement_ts: new Date(ts).toISOString(),
+  };
+}
+
+export async function parseSettlementEnvelope(
+  payload: any,
+  options: SettlementValidationOptions = {}
+): Promise<SettlementValidationResult> {
+  ensureEnvelope(payload);
+  const signerKeys = options.signerKeys ?? getSignerKeysFromEnv();
+  const hmacSecrets = options.hmacSecrets ?? getHmacSecretsFromEnv();
+
+  const fileId = payload.file_id.trim();
+  const schemaVersion = validateSchemaVersion(payload.schema_version ?? DEFAULT_SCHEMA_VERSION);
+
+  const generatedAtDate = new Date(payload.generated_at);
+  if (Number.isNaN(generatedAtDate.getTime())) {
+    throw new SettlementValidationError("TIMESTAMP_INVALID", "generated_at is not a valid ISO timestamp");
+  }
+
+  const now = options.now?.() ?? new Date();
+  const skewMinutes = validateTimestamp(generatedAtDate, now, options.maxClockSkewMinutes ?? DEFAULT_MAX_SKEW_MINUTES);
+
+  if (options.hasSeen) {
+    const seen = await options.hasSeen(fileId);
+    if (seen) {
+      throw new SettlementValidationError("REPLAYED_FILE", "Settlement file already processed", { file_id: fileId });
+    }
+  }
+
+  const rawCsv = payload.csv;
+  const csvHash = createHash("sha256").update(rawCsv, "utf8").digest("base64url");
+  const canonicalMessage = canonicalizePayload(fileId, toIsoString(generatedAtDate), schemaVersion, csvHash);
+
+  const signerKeyId = payload.signer_key_id ?? "primary";
+  const signerKey = signerKeys[signerKeyId];
+  if (!signerKey) {
+    throw new SettlementValidationError("SIGNER_KEY_UNKNOWN", `Unknown signer key id: ${signerKeyId}`);
+  }
+  validateSignature(canonicalMessage, payload.signature, signerKey);
+
+  const hmacKeyId = payload.hmac_key_id ?? "primary";
+  const hmacSecret = hmacSecrets[hmacKeyId];
+  if (!hmacSecret) {
+    throw new SettlementValidationError("HMAC_KEY_UNKNOWN", `Unknown HMAC key id: ${hmacKeyId}`);
+  }
+  validateHmac(canonicalMessage, payload.hmac, hmacSecret);
+
+  let rawRows: any[];
+  try {
+    rawRows = parse(rawCsv, { columns: true, skip_empty_lines: true, trim: true });
+  } catch (err: any) {
+    throw new SettlementValidationError("CSV_PARSE", `Unable to parse settlement CSV: ${err.message}`);
+  }
+  if (!Array.isArray(rawRows) || rawRows.length === 0) {
+    throw new SettlementValidationError("CSV_EMPTY", "Settlement file contains no rows");
+  }
+
+  const rows = rawRows.map((row, idx) => normalizeRow(row, idx));
+
+  return {
+    fileId,
+    schemaVersion,
+    generatedAt: toIsoString(generatedAtDate),
+    signerKeyId,
+    hmacKeyId,
+    csvHash,
+    canonicalMessage,
+    rows,
+    rawCsv,
+    signatureValid: true,
+    hmacValid: true,
+    timestampSkewMinutes: skewMinutes,
+  };
 }


### PR DESCRIPTION
## Summary
- validate and parse settlement envelopes including signature, HMAC, timestamp and replay checks
- persist settlement payloads, emit ingestion events, and expose new status/metrics endpoints
- surface settlement ingestion status for compliance operators in the audit UI

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2321e2f388327b7bab589b759d182