### PR TITLE
Enhance idempotency persistence and settlement anomaly triage

### DIFF
--- a/migrations/001_apgms_core.sql
+++ b/migrations/001_apgms_core.sql
@@ -68,6 +68,29 @@ create table if not exists remittance_destinations (
 create table if not exists idempotency_keys (
   key text primary key,
   created_at timestamptz default now(),
+  updated_at timestamptz default now(),
   last_status text,
-  response_hash text
+  request_hash text,
+  response_hash text,
+  response_body text,
+  response_is_json boolean default false,
+  status_code integer
 );
+
+create table if not exists settlement_exceptions (
+  id bigserial primary key,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  txn_id text not null,
+  bank_reference text not null,
+  reason text not null,
+  status text not null default 'OPEN',
+  raw_payload jsonb,
+  resolved_at timestamptz,
+  resolution_notes text,
+  unique (txn_id, bank_reference)
+);
+
+create index if not exists idx_settlement_exceptions_status on settlement_exceptions(status);
+create index if not exists idx_settlement_exceptions_txn on settlement_exceptions(txn_id);
+create index if not exists idx_settlement_exceptions_bank on settlement_exceptions(bank_reference);

--- a/migrations/003_idempotency_settlement_queue.sql
+++ b/migrations/003_idempotency_settlement_queue.sql
@@ -1,0 +1,28 @@
+-- 003_idempotency_settlement_queue.sql
+alter table idempotency_keys
+  add column if not exists updated_at timestamptz default now(),
+  add column if not exists request_hash text,
+  add column if not exists response_body text,
+  add column if not exists response_is_json boolean default false,
+  add column if not exists status_code integer;
+
+alter table idempotency_keys
+  add column if not exists response_hash text;
+
+create table if not exists settlement_exceptions (
+  id bigserial primary key,
+  created_at timestamptz default now(),
+  updated_at timestamptz default now(),
+  txn_id text not null,
+  bank_reference text not null,
+  reason text not null,
+  status text not null default 'OPEN',
+  raw_payload jsonb,
+  resolved_at timestamptz,
+  resolution_notes text,
+  unique (txn_id, bank_reference)
+);
+
+create index if not exists idx_settlement_exceptions_status on settlement_exceptions(status);
+create index if not exists idx_settlement_exceptions_txn on settlement_exceptions(txn_id);
+create index if not exists idx_settlement_exceptions_bank on settlement_exceptions(bank_reference);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence, listSettlementExceptions } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -23,6 +23,7 @@ app.post("/api/pay", idempotency(), payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
+app.get("/api/settlement/exceptions", listSettlementExceptions);
 app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,183 @@
-﻿import { Pool } from "pg";
+import type { NextFunction, Request, Response } from "express";
+import { createHash } from "crypto";
+import { Pool } from "pg";
+
+type IdempotencyRecord = {
+  key: string;
+  request_hash: string | null;
+  last_status: string | null;
+  response_hash: string | null;
+  response_body: string | null;
+  response_is_json: boolean | null;
+  status_code: number | null;
+};
+
 const pool = new Pool();
-/** Express middleware for idempotency via Idempotency-Key header */
+
+function stableBodyString(body: unknown): string {
+  if (body === undefined) return "";
+
+  const normalize = (value: any): any => {
+    if (value === null) return null;
+    if (Array.isArray(value)) return value.map((v) => normalize(v));
+    if (typeof value === "object") {
+      const sorted = Object.keys(value as Record<string, unknown>).sort();
+      const acc: Record<string, unknown> = {};
+      for (const key of sorted) acc[key] = normalize((value as Record<string, unknown>)[key]);
+      return acc;
+    }
+    return value;
+  };
+
+  try {
+    return JSON.stringify(normalize(body));
+  } catch {
+    return String(body);
+  }
+}
+
+function computeRequestHash(req: Request): string {
+  const bodyString = stableBodyString(req.body ?? null);
+  const basis = `${req.method}:${req.originalUrl}:${bodyString}`;
+  return createHash("sha256").update(basis).digest("hex");
+}
+
+function serializeBody(value: any, treatAsJson: boolean): { buffer: Buffer | null; isJson: boolean } {
+  if (value === undefined) return { buffer: null, isJson: treatAsJson };
+  if (Buffer.isBuffer(value)) return { buffer: value, isJson: treatAsJson };
+  if (typeof value === "string") return { buffer: Buffer.from(value), isJson: treatAsJson };
+
+  try {
+    const serialized = JSON.stringify(value);
+    const inferredJson = treatAsJson || (value !== null && typeof value === "object");
+    return { buffer: Buffer.from(serialized), isJson: inferredJson };
+  } catch {
+    return { buffer: Buffer.from(String(value ?? "")), isJson: false };
+  }
+}
+
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
+
+    const requestHash = computeRequestHash(req);
+
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      const insertResult = await pool.query(
+        `insert into idempotency_keys (key, request_hash, last_status, created_at, updated_at)
+         values ($1, $2, $3, now(), now())
+         on conflict (key) do nothing
+         returning key`,
+        [key, requestHash, "IN_PROGRESS"]
+      );
+
+      if (insertResult.rowCount === 0) {
+        const existingResult = await pool.query<IdempotencyRecord>(
+          `select key, request_hash, last_status, response_hash, response_body, response_is_json, status_code
+             from idempotency_keys
+            where key = $1`,
+          [key]
+        );
+        const existing = existingResult.rows[0];
+
+        if (existing?.request_hash && existing.request_hash !== requestHash) {
+          return res.status(409).json({ error: "IDEMPOTENCY_KEY_CONFLICT" });
+        }
+
+        const hasReplayableResponse =
+          existing?.last_status === "COMPLETED" || existing?.response_body != null || existing?.status_code != null;
+
+        if (existing && hasReplayableResponse) {
+          res.setHeader("Idempotent-Replay", "true");
+          const statusCode = existing.status_code ?? 200;
+          if (existing.response_is_json && existing.response_body != null) {
+            try {
+              return res.status(statusCode).json(JSON.parse(existing.response_body));
+            } catch {
+              return res.status(statusCode).send(existing.response_body);
+            }
+          }
+          if (existing.response_body != null) {
+            return res.status(statusCode).send(existing.response_body);
+          }
+          res.status(statusCode);
+          return res.send();
+        }
+
+        if (existing) {
+          res.setHeader("Idempotent-Replay", "pending");
+          return res.status(409).json({ error: "IDEMPOTENT_REQUEST_IN_PROGRESS" });
+        }
+      }
+
+      let responseBuffer: Buffer | null = null;
+      let responseIsJson = false;
+
+      const originalJson = res.json.bind(res);
+      res.json = (payload: any) => {
+        const { buffer, isJson } = serializeBody(payload, true);
+        responseBuffer = buffer;
+        responseIsJson = isJson;
+        return originalJson(payload);
+      };
+
+      const originalSend = res.send.bind(res);
+      res.send = (payload: any) => {
+        if (responseBuffer === null) {
+          const inferredJson =
+            (payload !== null && typeof payload === "object" && !Buffer.isBuffer(payload)) ||
+            ((res.get("Content-Type") || "").includes("application/json"));
+          const { buffer, isJson } = serializeBody(payload, inferredJson);
+          responseBuffer = buffer;
+          responseIsJson = isJson;
+        }
+        return originalSend(payload);
+      };
+
+      const originalEnd = res.end.bind(res);
+      res.end = (chunk?: any, encoding?: any, cb?: any) => {
+        if (responseBuffer === null && chunk !== undefined && chunk !== null) {
+          const inferredJson = (res.get("Content-Type") || "").includes("application/json");
+          const { buffer, isJson } = serializeBody(chunk, inferredJson);
+          responseBuffer = buffer;
+          responseIsJson = responseIsJson || isJson;
+        }
+        return originalEnd(chunk, encoding as any, cb as any);
+      };
+
+      res.on("finish", () => {
+        const statusCode = res.statusCode;
+        const lastStatus = statusCode >= 400 ? "FAILED" : "COMPLETED";
+        const responseBody = responseBuffer ? responseBuffer.toString("utf8") : "";
+        const responseHash = responseBody ? createHash("sha256").update(responseBody).digest("hex") : null;
+        void pool.query(
+          `update idempotency_keys
+              set last_status = $2,
+                  response_body = $3,
+                  response_hash = $4,
+                  response_is_json = $5,
+                  status_code = $6,
+                  updated_at = now()
+            where key = $1`,
+          [key, lastStatus, responseBody, responseHash, responseIsJson, statusCode]
+        );
+      });
+
+      res.on("error", (err) => {
+        console.error("idempotency middleware response error", err);
+        void pool.query(
+          `update idempotency_keys
+              set last_status = $2,
+                  updated_at = now()
+            where key = $1`,
+          [key, "FAILED"]
+        );
+      });
+
       return next();
-    } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+    } catch (err) {
+      return next(err);
     }
   };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,160 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import type { Request, Response } from "express";
+import { Pool } from "pg";
+
 import { buildEvidenceBundle } from "../evidence/bundle";
-import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import { issueRPT } from "../rpt/issuer";
+import { releasePayment, resolveDestination } from "../rails/adapter";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+type SettlementException = { id: number };
+
+async function enqueueSettlementException(
+  txnId: string,
+  bankReference: string,
+  reason: string,
+  payload: unknown
+): Promise<SettlementException> {
+  const existing = await pool.query<{ id: number }>(
+    `select id from settlement_exceptions where txn_id = $1 or bank_reference = $2 limit 1`,
+    [txnId, bankReference]
+  );
+
+  if (existing.rowCount > 0) {
+    const exceptionId = existing.rows[0].id;
+    await pool.query(
+      `update settlement_exceptions
+          set reason = $2,
+              raw_payload = $3,
+              status = 'OPEN',
+              updated_at = now(),
+              resolved_at = null,
+              resolution_notes = null,
+              txn_id = case when coalesce($4, '') <> '' then $4 else txn_id end,
+              bank_reference = case when coalesce($5, '') <> '' then $5 else bank_reference end
+        where id = $1`,
+      [exceptionId, reason, payload, txnId, bankReference]
+    );
+    return { id: exceptionId };
+  }
+
+  const inserted = await pool.query<SettlementException>(
+    `insert into settlement_exceptions (txn_id, bank_reference, reason, raw_payload)
+     values ($1, $2, $3, $4)
+     returning id`,
+    [txnId, bankReference, reason, payload]
+  );
+  return inserted.rows[0];
+}
+
+export async function closeAndIssue(req: Request, res: Response) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: Request, res: Response) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: Request, res: Response) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
+export async function settlementWebhook(req: Request, res: Response) {
+  const csvText = typeof req.body?.csv === "string" ? req.body.csv : "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
-  return res.json({ ingested: rows.length });
+
+  const seenTxn = new Set<string>();
+  const seenBankRef = new Set<string>();
+  const flagged: Array<{ txn_id: string; bank_reference: string; reason: string; exception_id: number }> = [];
+  let processedCount = 0;
+
+  for (const row of rows) {
+    const txnId = String(row.txn_id ?? "").trim();
+    const bankReference = String(row.bank_reference ?? "").trim();
+    let reason: string | null = null;
+
+    if (!txnId || !bankReference) {
+      reason = "MISSING_IDENTIFIERS";
+    } else if (seenTxn.has(txnId)) {
+      reason = "DUPLICATE_TXN_ID_IN_BATCH";
+    } else if (seenBankRef.has(bankReference)) {
+      reason = "DUPLICATE_BANK_REFERENCE_IN_BATCH";
+    } else {
+      const existing = await pool.query<{ txn_id: string; bank_reference: string; status: string }>(
+        `select txn_id, bank_reference, status
+           from settlement_exceptions
+          where txn_id = $1 or bank_reference = $2
+          order by created_at desc
+          limit 1`,
+        [txnId, bankReference]
+      );
+
+      if (existing.rowCount > 0) {
+        const match = existing.rows[0];
+        if (match.txn_id === txnId) {
+          reason = "DUPLICATE_TXN_ID_HISTORY";
+        } else if (match.bank_reference === bankReference) {
+          reason = "DUPLICATE_BANK_REFERENCE_HISTORY";
+        }
+      }
+    }
+
+    if (reason) {
+      const exception = await enqueueSettlementException(txnId, bankReference, reason, row);
+      flagged.push({ txn_id: txnId, bank_reference: bankReference, reason, exception_id: exception.id });
+      continue;
+    }
+
+    seenTxn.add(txnId);
+    seenBankRef.add(bankReference);
+    // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
+    processedCount += 1;
+  }
+
+  return res.json({ ingested: processedCount, flagged });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: Request, res: Response) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
+}
+
+export async function listSettlementExceptions(req: Request, res: Response) {
+  const statusFilter = typeof req.query.status === "string" ? req.query.status : null;
+  const result = await pool.query(
+    `select id, txn_id, bank_reference, reason, status, created_at, updated_at, resolved_at, resolution_notes, raw_payload
+       from settlement_exceptions
+      where ($1::text is null or status = $1)
+      order by created_at asc`,
+    [statusFilter]
+  );
+
+  return res.json({ exceptions: result.rows });
 }

--- a/src/settlement/splitParser.ts
+++ b/src/settlement/splitParser.ts
@@ -1,11 +1,19 @@
 ﻿import { parse } from "csv-parse/sync";
-/** Split-payment settlement ingestion (stub). CSV cols: txn_id,gst_cents,net_cents,settlement_ts */
+/**
+ * Split-payment settlement ingestion (stub).
+ * CSV expected columns: txn_id,gst_cents,net_cents,settlement_ts,bank_reference
+ */
 export function parseSettlementCSV(csvText: string) {
   const rows = parse(csvText, { columns: true, skip_empty_lines: true });
-  return rows.map((r:any) => ({
-    txn_id: String(r.txn_id),
-    gst_cents: Number(r.gst_cents),
-    net_cents: Number(r.net_cents),
-    settlement_ts: new Date(r.settlement_ts).toISOString()
-  }));
+  return rows.map((r: Record<string, unknown>) => {
+    const txnId = r.txn_id ?? r["TXN_ID"] ?? r["transaction_id"];
+    const bankRef = r.bank_reference ?? r["bank_ref"] ?? r["reference"] ?? r["BANK_REFERENCE"];
+    return {
+      txn_id: txnId != null ? String(txnId) : "",
+      bank_reference: bankRef != null ? String(bankRef) : "",
+      gst_cents: Number(r.gst_cents ?? r["gst"] ?? 0),
+      net_cents: Number(r.net_cents ?? r["net"] ?? 0),
+      settlement_ts: r.settlement_ts ? new Date(String(r.settlement_ts)).toISOString() : null
+    };
+  });
 }


### PR DESCRIPTION
## Summary
- persist request hashes and serialized responses for idempotent endpoints, replaying stored results on duplicates
- detect duplicate settlement rows, enqueue them for manual review, and expose the settlement exception queue via API
- add database migrations for the new idempotency columns and settlement_exceptions table

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e23223bba483278459836c6cdb6e9f