### PR TITLE
Implement deterministic pre-close and recon pipeline

### DIFF
--- a/apps/services/bas-gate/main.py
+++ b/apps/services/bas-gate/main.py
@@ -5,10 +5,18 @@ import os, psycopg2, json, time
 
 app = FastAPI(title="bas-gate")
 
+class ReconMeta(BaseModel):
+    passed: bool
+    reason_code: str | None = None
+    anomaly_vector: dict[str, float] | None = None
+    thresholds: dict[str, float] | None = None
+
+
 class TransitionReq(BaseModel):
     period_id: str
     target_state: str
     reason_code: str | None = None
+    recon: ReconMeta | None = None
 
 def db():
     return psycopg2.connect(
@@ -23,20 +31,46 @@ def db():
 def transition(req: TransitionReq):
     if req.target_state not in {"Open","Pending-Close","Reconciling","RPT-Issued","Remitted","Blocked"}:
         raise HTTPException(400, "invalid state")
+    target_state = req.target_state
+    reason_code = req.reason_code
+    if req.recon:
+        if not req.recon.passed:
+            target_state = "Blocked"
+            reason_code = req.recon.reason_code or reason_code
+        elif target_state == "Blocked":
+            target_state = "Reconciling"
     conn = db(); cur = conn.cursor()
     cur.execute("SELECT hash_this FROM bas_gate_states WHERE period_id=%s", (req.period_id,))
     row = cur.fetchone()
     prev = row[0] if row else None
-    payload = json.dumps({"period_id": req.period_id, "state": req.target_state, "ts": int(time.time())}, separators=(",",":"))
+    payload = {
+        "period_id": req.period_id,
+        "state": target_state,
+        "ts": int(time.time()),
+    }
+    if req.recon:
+        payload["recon"] = {
+            "passed": req.recon.passed,
+            "reason_code": req.recon.reason_code,
+            "anomaly_vector": req.recon.anomaly_vector,
+            "thresholds": req.recon.thresholds,
+        }
+    payload_json = json.dumps(payload, separators=(",",":"))
     import libs.audit_chain.chain as ch
-    h = ch.link(prev, payload)
+    h = ch.link(prev, payload_json)
     if row:
-        cur.execute("UPDATE bas_gate_states SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s WHERE period_id=%s",
-                    (req.target_state, req.reason_code, prev, h, req.period_id))
+        cur.execute(
+            "UPDATE bas_gate_states SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s WHERE period_id=%s",
+            (target_state, reason_code, prev, h, req.period_id),
+        )
     else:
-        cur.execute("INSERT INTO bas_gate_states(period_id,state,reason_code,hash_prev,hash_this) VALUES (%s,%s,%s,%s,%s)",
-                    (req.period_id, req.target_state, req.reason_code, prev, h))
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('bas_gate',%s,%s,%s)",
-                (payload, prev, h))
+        cur.execute(
+            "INSERT INTO bas_gate_states(period_id,state,reason_code,hash_prev,hash_this) VALUES (%s,%s,%s,%s,%s)",
+            (req.period_id, target_state, reason_code, prev, h),
+        )
+    cur.execute(
+        "INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('bas_gate',%s,%s,%s)",
+        (payload_json, prev, h),
+    )
     conn.commit(); cur.close(); conn.close()
     return {"ok": True, "hash": h}

--- a/apps/services/event-normalizer/app/main.py
+++ b/apps/services/event-normalizer/app/main.py
@@ -1,10 +1,25 @@
-﻿from fastapi import FastAPI, Response
+from fastapi import FastAPI, HTTPException, Response
 from fastapi.responses import PlainTextResponse
 from typing import Optional
 from prometheus_client import REGISTRY, Gauge, generate_latest, CONTENT_TYPE_LATEST
+import os
+import psycopg2
+
+from .processors import summarise_period
 
 APP_NAME = "event-normalizer"
 app = FastAPI(title=APP_NAME)
+
+
+def db():
+    return psycopg2.connect(
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
+    )
+
 
 def _get_or_make_results_gauge() -> Gauge:
     name = "normalizer_tax_results_total"
@@ -22,20 +37,47 @@ def _get_or_make_results_gauge() -> Gauge:
         existing = getattr(REGISTRY, "_names_to_collectors", {})
         return existing[name]  # type: ignore[return-value]
 
+
 NORMALIZER_TAX_RESULTS: Gauge = _get_or_make_results_gauge()
+
 
 def record_result(outcome: str, count: int = 1) -> None:
     NORMALIZER_TAX_RESULTS.labels(outcome=outcome).inc(count)
+
 
 @app.get("/", response_class=PlainTextResponse)
 def root() -> str:
     return f"{APP_NAME} up"
 
+
 @app.get("/readyz", response_class=PlainTextResponse)
 def readyz() -> str:
     return "ok"
+
 
 @app.get("/metrics")
 def metrics() -> Response:
     payload = generate_latest(REGISTRY)
     return Response(payload, media_type=CONTENT_TYPE_LATEST)
+
+
+@app.get("/periods/{abn}/{tax_type}/{period_id}")
+def period_summary(abn: str, tax_type: str, period_id: str):
+    conn = db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT accrued_cents FROM periods WHERE abn=%s AND tax_type=%s AND period_id=%s",
+            (abn, tax_type, period_id),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="period_not_found")
+        baseline = int(row[0] or 0)
+        summary = summarise_period(conn, abn, tax_type, period_id, baseline)
+        summary["baseline_cents"] = baseline
+        record_result("summary", 1)
+        return summary
+    finally:
+        cur.close()
+        conn.close()

--- a/apps/services/event-normalizer/app/processors/__init__.py
+++ b/apps/services/event-normalizer/app/processors/__init__.py
@@ -1,0 +1,10 @@
+"""Utility helpers for producing normalized ledger events."""
+
+from .ledger import NormalizedEvent, load_ledger_events, compute_anomaly_vector, summarise_period
+
+__all__ = [
+    "NormalizedEvent",
+    "load_ledger_events",
+    "compute_anomaly_vector",
+    "summarise_period",
+]

--- a/apps/services/event-normalizer/app/processors/ledger.py
+++ b/apps/services/event-normalizer/app/processors/ledger.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Any, Dict, List, Sequence
+
+from psycopg2.extensions import connection as PgConnection
+
+
+@dataclass
+class NormalizedEvent:
+    """Normalized representation of a single ledger mutation."""
+
+    event_id: str
+    abn: str
+    tax_type: str
+    period_id: str
+    amount_cents: int
+    occurred_at: datetime
+    source: str = "ledger"
+    metadata: Dict[str, Any] | None = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = asdict(self)
+        payload["occurred_at"] = self.occurred_at.isoformat()
+        payload["metadata"] = self.metadata or {}
+        return payload
+
+
+def load_ledger_events(
+    conn: PgConnection,
+    abn: str,
+    tax_type: str,
+    period_id: str,
+) -> List[NormalizedEvent]:
+    """Load and normalize OWA ledger rows for a given period."""
+
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            SELECT id, amount_cents, balance_after_cents, bank_receipt_hash,
+                   hash_after, created_at
+              FROM owa_ledger
+             WHERE abn=%s AND tax_type=%s AND period_id=%s
+             ORDER BY created_at ASC, id ASC
+            """,
+            (abn, tax_type, period_id),
+        )
+        rows = cur.fetchall()
+    finally:
+        cur.close()
+
+    events: List[NormalizedEvent] = []
+    for row in rows:
+        row_id, amount_cents, balance_after, receipt_hash, hash_after, created_at = row
+        event_id = receipt_hash or f"ledger:{period_id}:{row_id}"
+        metadata: Dict[str, Any] = {
+            "balance_after_cents": int(balance_after),
+            "hash_after": hash_after,
+        }
+        if receipt_hash:
+            metadata["bank_receipt_hash"] = receipt_hash
+        events.append(
+            NormalizedEvent(
+                event_id=event_id,
+                abn=abn,
+                tax_type=tax_type,
+                period_id=period_id,
+                amount_cents=int(amount_cents),
+                occurred_at=created_at,
+                metadata=metadata,
+            )
+        )
+    return events
+
+
+def compute_anomaly_vector(
+    events: Sequence[NormalizedEvent],
+    baseline_cents: int | None,
+) -> Dict[str, float]:
+    """Compute deterministic anomaly heuristics over normalized events."""
+
+    credits = [float(evt.amount_cents) for evt in events if evt.amount_cents > 0]
+    variance_ratio = 0.0
+    if credits:
+        mean = sum(credits) / len(credits)
+        if mean:
+            variance = sum((amt - mean) ** 2 for amt in credits) / len(credits)
+            variance_ratio = math.sqrt(variance) / mean if mean else 0.0
+        else:
+            variance_ratio = 0.0
+
+    total_events = len(events)
+    seen_counts: Dict[str, int] = {}
+    for evt in events:
+        seen_counts[evt.event_id] = seen_counts.get(evt.event_id, 0) + 1
+    duplicate_events = sum(count - 1 for count in seen_counts.values() if count > 1)
+    dup_rate = (duplicate_events / total_events) if total_events else 0.0
+
+    timestamps = [evt.occurred_at for evt in events]
+    timestamps.sort()
+    gap_minutes = 0.0
+    if len(timestamps) > 1:
+        gap_minutes = max(
+            (t2 - t1).total_seconds() / 60.0
+            for t1, t2 in zip(timestamps, timestamps[1:])
+        )
+
+    total_credits = sum(credits)
+    baseline = float(baseline_cents or 0)
+    denom = baseline if baseline else (total_credits if total_credits else 1.0)
+    delta_vs_baseline = (total_credits - baseline) / denom if denom else 0.0
+
+    return {
+        "variance_ratio": float(variance_ratio),
+        "dup_rate": float(dup_rate),
+        "gap_minutes": float(gap_minutes),
+        "delta_vs_baseline": float(delta_vs_baseline),
+    }
+
+
+def summarise_period(
+    conn: PgConnection,
+    abn: str,
+    tax_type: str,
+    period_id: str,
+    baseline_cents: int | None,
+) -> Dict[str, Any]:
+    events = load_ledger_events(conn, abn, tax_type, period_id)
+    vector = compute_anomaly_vector(events, baseline_cents)
+    total_credits = sum(int(evt.amount_cents) for evt in events if evt.amount_cents > 0)
+    return {
+        "events": [evt.as_dict() for evt in events],
+        "counts": {
+            "total_events": len(events),
+            "credit_events": sum(1 for evt in events if evt.amount_cents > 0),
+            "total_credit_cents": total_credits,
+        },
+        "anomaly_vector": vector,
+    }

--- a/apps/services/event-normalizer/pyproject.toml
+++ b/apps/services/event-normalizer/pyproject.toml
@@ -13,6 +13,7 @@ pydantic = "^2.9.2"
 nats-py = "^2.11.0"
 orjson = "^3.10.7"
 prometheus-client = "^0.21.0"
+psycopg2-binary = "^2.9.9"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/apps/services/recon/main.py
+++ b/apps/services/recon/main.py
@@ -1,25 +1,190 @@
-﻿# apps/services/recon/main.py
-from fastapi import FastAPI
+# apps/services/recon/main.py
+from __future__ import annotations
+
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import os, psycopg2, json, math
+from typing import Any, Dict
+import os
+import psycopg2
+import json
+import httpx
 
 app = FastAPI(title="recon")
 
-class ReconReq(BaseModel):
-    period_id: str
-    paygw_total: float
-    gst_total: float
-    owa_paygw: float
-    owa_gst: float
-    anomaly_score: float
-    tolerance: float = 0.01
 
-@app.post("/recon/run")
-def run(req: ReconReq):
-    pay_ok = math.isclose(req.paygw_total, req.owa_paygw, abs_tol=req.tolerance)
-    gst_ok = math.isclose(req.gst_total, req.owa_gst, abs_tol=req.tolerance)
-    anomaly_ok = req.anomaly_score < 0.8
-    if pay_ok and gst_ok and anomaly_ok:
-        return {"pass": True, "reason_code": None, "controls": ["BAS-GATE","RPT"], "next_state": "RPT-Issued"}
-    reason = "shortfall" if (not pay_ok or not gst_ok) else "anomaly_breach"
-    return {"pass": False, "reason_code": reason, "controls": ["BLOCK"], "next_state": "Blocked"}
+DEFAULT_THRESHOLDS: Dict[str, float] = {
+    "variance_ratio": 0.25,
+    "dup_rate": 0.01,
+    "gap_minutes": 60.0,
+    "delta_vs_baseline": 0.2,
+}
+
+EVENT_NORMALIZER_URL = os.getenv("NORMALIZER_URL", "http://event-normalizer:8001")
+
+
+def db():
+    return psycopg2.connect(
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
+    )
+
+
+def ensure_tables() -> None:
+    conn = db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS recon_runs (
+                id SERIAL PRIMARY KEY,
+                abn TEXT NOT NULL,
+                tax_type TEXT NOT NULL,
+                period_id TEXT NOT NULL,
+                passed BOOLEAN NOT NULL,
+                reason_code TEXT,
+                anomaly_vector JSONB NOT NULL,
+                thresholds JSONB NOT NULL,
+                total_events INTEGER NOT NULL,
+                total_credit_cents BIGINT NOT NULL,
+                baseline_cents BIGINT NOT NULL,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                UNIQUE (abn, tax_type, period_id)
+            )
+            """
+        )
+        conn.commit()
+    finally:
+        cur.close()
+        conn.close()
+
+
+ensure_tables()
+
+
+class ReconReq(BaseModel):
+    abn: str
+    tax_type: str
+    period_id: str
+    thresholds: Dict[str, float] | None = None
+
+
+class ReconResponse(BaseModel):
+    passed: bool
+    reason_code: str | None
+    controls: list[str]
+    next_state: str
+    anomaly_vector: Dict[str, float]
+    thresholds: Dict[str, float]
+    totals: Dict[str, Any]
+
+
+async def fetch_normalized_summary(abn: str, tax_type: str, period_id: str) -> Dict[str, Any]:
+    url = f"{EVENT_NORMALIZER_URL}/periods/{abn}/{tax_type}/{period_id}"
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(url)
+    if resp.status_code == 404:
+        raise HTTPException(status_code=404, detail="period_not_found")
+    resp.raise_for_status()
+    return resp.json()
+
+
+def merge_thresholds(base: Dict[str, float], override: Dict[str, float] | None) -> Dict[str, float]:
+    merged = dict(DEFAULT_THRESHOLDS)
+    merged.update(base)
+    if override:
+        merged.update(override)
+    return merged
+
+
+def evaluate(vector: Dict[str, float], thresholds: Dict[str, float]) -> tuple[bool, str | None]:
+    checks = [
+        (vector.get("variance_ratio", 0.0) <= thresholds["variance_ratio"], "variance_breach"),
+        (vector.get("dup_rate", 0.0) <= thresholds["dup_rate"], "duplicate_detected"),
+        (vector.get("gap_minutes", 0.0) <= thresholds["gap_minutes"], "gap_detected"),
+        (abs(vector.get("delta_vs_baseline", 0.0)) <= thresholds["delta_vs_baseline"], "baseline_delta"),
+    ]
+    for ok, reason in checks:
+        if not ok:
+            return False, reason
+    return True, None
+
+
+def persist_result(req: ReconReq, passed: bool, reason: str | None, vector: Dict[str, float], thresholds: Dict[str, float], totals: Dict[str, Any]) -> None:
+    conn = db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            """
+            INSERT INTO recon_runs(abn, tax_type, period_id, passed, reason_code, anomaly_vector, thresholds, total_events, total_credit_cents, baseline_cents)
+            VALUES (%s,%s,%s,%s,%s,%s::jsonb,%s::jsonb,%s,%s,%s)
+            ON CONFLICT (abn, tax_type, period_id) DO UPDATE SET
+                passed=EXCLUDED.passed,
+                reason_code=EXCLUDED.reason_code,
+                anomaly_vector=EXCLUDED.anomaly_vector,
+                thresholds=EXCLUDED.thresholds,
+                total_events=EXCLUDED.total_events,
+                total_credit_cents=EXCLUDED.total_credit_cents,
+                baseline_cents=EXCLUDED.baseline_cents,
+                created_at=NOW()
+            """,
+            (
+                req.abn,
+                req.tax_type,
+                req.period_id,
+                passed,
+                reason,
+                json.dumps(vector),
+                json.dumps(thresholds),
+                int(totals.get("total_events", 0)),
+                int(totals.get("total_credit_cents", 0)),
+                int(totals.get("baseline_cents", 0)),
+            ),
+        )
+        conn.commit()
+    finally:
+        cur.close()
+        conn.close()
+
+
+@app.post("/recon/run", response_model=ReconResponse)
+async def run(req: ReconReq):
+    conn = db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT thresholds FROM periods WHERE abn=%s AND tax_type=%s AND period_id=%s",
+            (req.abn, req.tax_type, req.period_id),
+        )
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="period_not_found")
+        period_thresholds = row[0] or {}
+    finally:
+        cur.close()
+        conn.close()
+
+    summary = await fetch_normalized_summary(req.abn, req.tax_type, req.period_id)
+    totals = {
+        "total_events": summary.get("counts", {}).get("total_events", 0),
+        "total_credit_cents": summary.get("counts", {}).get("total_credit_cents", 0),
+        "baseline_cents": summary.get("baseline_cents", 0),
+    }
+    anomaly_vector: Dict[str, float] = summary.get("anomaly_vector", {})
+    thresholds = merge_thresholds(period_thresholds or {}, req.thresholds)
+    passed, reason = evaluate(anomaly_vector, thresholds)
+    persist_result(req, passed, reason, anomaly_vector, thresholds, totals)
+
+    controls = ["BAS-GATE", "RPT"] if passed else ["BLOCK"]
+    next_state = "Reconciling" if passed else "Blocked"
+    return ReconResponse(
+        passed=passed,
+        reason_code=reason,
+        controls=controls,
+        next_state=next_state,
+        anomaly_vector=anomaly_vector,
+        thresholds=thresholds,
+        totals=totals,
+    )

--- a/apps/services/recon/requirements.txt
+++ b/apps/services/recon/requirements.txt
@@ -2,3 +2,4 @@
 uvicorn==0.30.6
 pydantic==2.9.2
 psycopg2-binary==2.9.9
+httpx==0.27.2

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,237 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
+import { merkleRootHex } from "../crypto/merkle";
 import { Pool } from "pg";
-const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
-  try {
-    const rpt = await issueRPT(abn, taxType, periodId, thr);
-    return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+const pool = new Pool();
+const RECON_URL = process.env.RECON_URL || "http://recon:8000";
+const BAS_GATE_URL = process.env.BAS_GATE_URL || "http://bas-gate:8101";
+
+interface Thresholds {
+  [key: string]: number;
+}
+
+interface ReconOutcome {
+  passed: boolean;
+  reason_code: string | null;
+  next_state: string;
+  anomaly_vector: Record<string, number>;
+  thresholds: Record<string, number>;
+  totals?: Record<string, any>;
+}
+
+interface ClosureSummary {
+  final_liability_cents: number;
+  credited_to_owa_cents: number;
+  merkle_root: string | null;
+  running_balance_hash: string | null;
+}
+
+const DEFAULT_THRESHOLDS: Thresholds = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+async function ensurePeriod(abn: string, taxType: string, periodId: string) {
+  const r = await pool.query(
+    "select id, state from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
+  if (r.rowCount === 0) {
+    throw new Error("PERIOD_NOT_FOUND");
+  }
+  return r.rows[0];
+}
+
+async function syncTotals(abn: string, taxType: string, periodId: string) {
+  await pool.query("select periods_sync_totals($1,$2,$3)", [abn, taxType, periodId]);
+}
+
+async function computeLedgerClosure(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  thresholds: Thresholds
+): Promise<ClosureSummary> {
+  await syncTotals(abn, taxType, periodId);
+  const ledger = await pool.query(
+    "select id, amount_cents, balance_after_cents, bank_receipt_hash, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+    [abn, taxType, periodId]
+  );
+  const leaves = ledger.rows.map((row) =>
+    [
+      row.id,
+      row.amount_cents,
+      row.balance_after_cents,
+      row.bank_receipt_hash || "",
+      row.hash_after || "",
+    ].join(":")
+  );
+  const merkle_root = leaves.length ? merkleRootHex(leaves) : null;
+  const running_balance_hash = ledger.rows.length
+    ? ledger.rows[ledger.rows.length - 1].hash_after || null
+    : null;
+
+  const update = await pool.query(
+    "update periods set state='CLOSING', merkle_root=$4, running_balance_hash=$5, thresholds=$6::jsonb where abn=$1 and tax_type=$2 and period_id=$3 returning final_liability_cents, credited_to_owa_cents",
+    [abn, taxType, periodId, merkle_root, running_balance_hash, JSON.stringify(thresholds)]
+  );
+  if (update.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+  const row = update.rows[0];
+  return {
+    final_liability_cents: Number(row.final_liability_cents || 0),
+    credited_to_owa_cents: Number(row.credited_to_owa_cents || 0),
+    merkle_root,
+    running_balance_hash,
+  };
+}
+
+async function runRecon(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  thresholds: Thresholds
+): Promise<ReconOutcome> {
+  const resp = await fetch(`${RECON_URL}/recon/run`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      thresholds,
+    }),
+  });
+  if (!resp.ok) {
+    const body = await resp.text();
+    throw new Error(`RECON_ERROR:${resp.status}:${body}`);
+  }
+  const data = (await resp.json()) as ReconOutcome;
+  return data;
+}
+
+async function transitionBasGate(
+  periodId: string,
+  targetState: string,
+  recon?: ReconOutcome
+) {
+  const payload: any = {
+    period_id: periodId,
+    target_state: targetState,
+  };
+  if (recon) {
+    payload.recon = {
+      passed: recon.passed,
+      reason_code: recon.reason_code,
+      anomaly_vector: recon.anomaly_vector,
+      thresholds: recon.thresholds,
+    };
+  }
+  const resp = await fetch(`${BAS_GATE_URL}/gate/transition`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(`BAS_GATE_ERROR:${resp.status}:${text}`);
   }
 }
 
-export async function payAto(req:any, res:any) {
+function mergeThresholds(thr?: Thresholds): Thresholds {
+  return { ...DEFAULT_THRESHOLDS, ...(thr || {}) };
+}
+
+function mapBlockState(reason: string | null): "BLOCKED_ANOMALY" | "BLOCKED_DISCREPANCY" {
+  if (reason === "baseline_delta") return "BLOCKED_DISCREPANCY";
+  return "BLOCKED_ANOMALY";
+}
+
+export async function closeAndIssue(req: any, res: any) {
+  const { abn, taxType, periodId, thresholds } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+  const thr = mergeThresholds(thresholds);
+  try {
+    await ensurePeriod(abn, taxType, periodId);
+    const closure = await computeLedgerClosure(abn, taxType, periodId, thr);
+    const recon = await runRecon(abn, taxType, periodId, thr);
+
+    await pool.query(
+      "update periods set anomaly_vector=$4::jsonb where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId, JSON.stringify(recon.anomaly_vector)]
+    );
+
+    if (!recon.passed) {
+      const blockState = mapBlockState(recon.reason_code);
+      await pool.query(
+        "update periods set state=$4 where abn=$1 and tax_type=$2 and period_id=$3",
+        [abn, taxType, periodId, blockState]
+      );
+      await transitionBasGate(periodId, "Blocked", recon);
+      return res.status(409).json({
+        error: recon.reason_code || "RECON_FAILED",
+        anomaly_vector: recon.anomaly_vector,
+        thresholds: recon.thresholds,
+      });
+    }
+
+    await transitionBasGate(periodId, "Reconciling", recon);
+    const rpt = await issueRPT(abn, taxType, periodId, thr);
+    await transitionBasGate(periodId, "RPT-Issued", recon);
+
+    return res.json({
+      rpt,
+      anomaly_vector: recon.anomaly_vector,
+      closure,
+    });
+  } catch (e: any) {
+    return res.status(400).json({ error: e.message || "PRE_CLOSE_FAILED" });
+  }
+}
+
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }


### PR DESCRIPTION
## Summary
- compute ledger closure data before RPT issuance, run recon checks, and transition the BAS gate accordingly
- expose normalized ledger processors via the event normalizer and surface anomaly summaries over HTTP
- replace the recon service stub with deterministic variance/duplicate/gap checks and persist their outcomes for gating

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e23221d4a88327a832a2d68c375fbc