### PR TITLE
Enrich evidence bundle with BAS summaries and discrepancy logs

### DIFF
--- a/migrations/003_evidence_support.sql
+++ b/migrations/003_evidence_support.sql
@@ -1,0 +1,45 @@
+-- 003_evidence_support.sql
+-- Support tables for evidence bundles: BAS label mappings, reconciliation diffs, supporting documents
+
+CREATE TABLE IF NOT EXISTS ledger_bas_mappings (
+  id            BIGSERIAL PRIMARY KEY,
+  ledger_id     BIGINT      NOT NULL REFERENCES owa_ledger(id) ON DELETE CASCADE,
+  label         TEXT        NOT NULL CHECK (label IN ('W1','W2','1A','1B')),
+  amount_cents  BIGINT,
+  metadata      JSONB       NOT NULL DEFAULT '{}'::JSONB,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (ledger_id, label)
+);
+
+CREATE TABLE IF NOT EXISTS reconciliation_diffs (
+  id             BIGSERIAL PRIMARY KEY,
+  abn            TEXT        NOT NULL,
+  tax_type       TEXT        NOT NULL,
+  period_id      TEXT        NOT NULL,
+  diff_type      TEXT        NOT NULL,
+  description    TEXT,
+  expected_cents BIGINT,
+  actual_cents   BIGINT,
+  metadata       JSONB       NOT NULL DEFAULT '{}'::JSONB,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_reconciliation_diffs_period
+  ON reconciliation_diffs (abn, tax_type, period_id, created_at);
+
+CREATE TABLE IF NOT EXISTS supporting_documents (
+  id         BIGSERIAL PRIMARY KEY,
+  abn        TEXT        NOT NULL,
+  tax_type   TEXT        NOT NULL,
+  period_id  TEXT        NOT NULL,
+  doc_type   TEXT        NOT NULL CHECK (doc_type IN ('BANK_RECEIPT','PROOF','ATO','INTERNAL')),
+  reference  TEXT,
+  uri        TEXT,
+  hash       TEXT,
+  metadata   JSONB       NOT NULL DEFAULT '{}'::JSONB,
+  ledger_id  BIGINT      REFERENCES owa_ledger(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_supporting_documents_period
+  ON supporting_documents (abn, tax_type, period_id, created_at);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "node --test --import tsx tests/evidence.bundle.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,231 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { Pool } from "pg";
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
-  };
-  return bundle;
+type BasLabelKey = "W1" | "W2" | "1A" | "1B";
+
+type BasLabels = Record<BasLabelKey, number>;
+
+type LedgerEntry = {
+  id: number;
+  amount_cents: number;
+  balance_after_cents: number | null;
+  bank_receipt_hash: string | null;
+  prev_hash: string | null;
+  hash_after: string | null;
+  created_at: string;
+};
+
+type SupportingDocument = {
+  doc_type: string;
+  reference: string | null;
+  uri: string | null;
+  hash: string | null;
+  metadata: Record<string, unknown>;
+  ledger_id: number | null;
+  created_at: string;
+};
+
+type DiscrepancyLogEntry = {
+  diff_type: string;
+  description: string | null;
+  expected_cents: number | null;
+  actual_cents: number | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+};
+
+export type EvidenceBundle = {
+  meta: { generated_at: string; abn: string; taxType: string; periodId: string };
+  period: {
+    state: string;
+    accrued_cents: number;
+    credited_to_owa_cents: number;
+    final_liability_cents: number;
+    merkle_root: string | null;
+    running_balance_hash: string | null;
+    anomaly_vector: Record<string, unknown>;
+    thresholds: Record<string, unknown>;
+  } | null;
+  rpt: {
+    payload: unknown;
+    payload_c14n: string | null;
+    payload_sha256: string | null;
+    signature: string;
+    created_at: string;
+  } | null;
+  owa_ledger: LedgerEntry[];
+  bas_labels: BasLabels;
+  supporting_documents: SupportingDocument[];
+  discrepancy_log: DiscrepancyLogEntry[];
+};
+
+export class EvidenceNotFoundError extends Error {
+  readonly statusCode = 404;
+  constructor(message = "EVIDENCE_NOT_FOUND") {
+    super(message);
+    this.name = "EvidenceNotFoundError";
+  }
+}
+
+let sharedPool: Pool | null = null;
+
+export function setEvidenceDbPool(pool: Pool | null) {
+  sharedPool = pool;
+}
+
+function getPool(): Pool {
+  if (!sharedPool) {
+    sharedPool = new Pool();
+  }
+  return sharedPool;
+}
+
+export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string): Promise<EvidenceBundle> {
+  const pool = getPool();
+  const client = await pool.connect();
+  try {
+    const periodRes = await client.query("SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [
+      abn,
+      taxType,
+      periodId,
+    ]);
+
+    if (periodRes.rowCount === 0) {
+      throw new EvidenceNotFoundError();
+    }
+
+    const periodRow = periodRes.rows[0];
+
+    const [rptRes, ledgerRes, basRes, docRes, diffRes] = await Promise.all([
+      client.query(
+        "SELECT payload, payload_c14n, payload_sha256, signature, created_at FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY created_at DESC LIMIT 1",
+        [abn, taxType, periodId]
+      ),
+      client.query(
+        "SELECT id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id",
+        [abn, taxType, periodId]
+      ),
+      client.query(
+        `SELECT m.label, SUM(COALESCE(m.amount_cents, CASE WHEN l.amount_cents < 0 THEN -l.amount_cents ELSE l.amount_cents END)) AS total
+         FROM ledger_bas_mappings m
+         JOIN owa_ledger l ON l.id = m.ledger_id
+         WHERE l.abn=$1 AND l.tax_type=$2 AND l.period_id=$3
+         GROUP BY m.label`,
+        [abn, taxType, periodId]
+      ),
+      client.query(
+        "SELECT doc_type, reference, uri, hash, metadata, ledger_id, created_at FROM supporting_documents WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY created_at",
+        [abn, taxType, periodId]
+      ),
+      client.query(
+        "SELECT diff_type, description, expected_cents, actual_cents, metadata, created_at FROM reconciliation_diffs WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY created_at",
+        [abn, taxType, periodId]
+      ),
+    ]);
+
+    const basLabels: BasLabels = { W1: 0, W2: 0, "1A": 0, "1B": 0 };
+    for (const row of basRes.rows as Array<{ label: BasLabelKey; total: string | number | null }>) {
+      if (!row.label) continue;
+      const total = row.total == null ? 0 : typeof row.total === "number" ? row.total : Number(row.total);
+      basLabels[row.label] = total;
+    }
+
+    const ledgerEntries: LedgerEntry[] = (ledgerRes.rows as Array<Record<string, any>>).map((row) => ({
+      id: Number(row.id),
+      amount_cents: typeof row.amount_cents === "number" ? row.amount_cents : Number(row.amount_cents),
+      balance_after_cents:
+        row.balance_after_cents == null
+          ? null
+          : typeof row.balance_after_cents === "number"
+          ? row.balance_after_cents
+          : Number(row.balance_after_cents),
+      bank_receipt_hash: row.bank_receipt_hash ?? null,
+      prev_hash: row.prev_hash ?? null,
+      hash_after: row.hash_after ?? null,
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    }));
+
+    const docRows = docRes.rows as Array<Record<string, any>>;
+    const docs: SupportingDocument[] = docRows.map((row) => ({
+      doc_type: row.doc_type,
+      reference: row.reference ?? null,
+      uri: row.uri ?? null,
+      hash: row.hash ?? null,
+      metadata: row.metadata ?? {},
+      ledger_id: row.ledger_id == null ? null : Number(row.ledger_id),
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    }));
+
+    const receiptRefs = new Set(
+      docs.filter((d) => d.doc_type === "BANK_RECEIPT" && d.reference).map((d) => d.reference as string)
+    );
+    for (const entry of ledgerEntries) {
+      if (entry.bank_receipt_hash && !receiptRefs.has(entry.bank_receipt_hash)) {
+        docs.push({
+          doc_type: "BANK_RECEIPT",
+          reference: entry.bank_receipt_hash,
+          uri: null,
+          hash: entry.hash_after ?? null,
+          metadata: { ledger_id: entry.id },
+          ledger_id: entry.id,
+          created_at: entry.created_at,
+        });
+        receiptRefs.add(entry.bank_receipt_hash);
+      }
+    }
+
+    const discrepancyLog: DiscrepancyLogEntry[] = (diffRes.rows as Array<Record<string, any>>).map((row) => ({
+      diff_type: row.diff_type,
+      description: row.description ?? null,
+      expected_cents:
+        row.expected_cents == null
+          ? null
+          : typeof row.expected_cents === "number"
+          ? row.expected_cents
+          : Number(row.expected_cents),
+      actual_cents:
+        row.actual_cents == null
+          ? null
+          : typeof row.actual_cents === "number"
+          ? row.actual_cents
+          : Number(row.actual_cents),
+      metadata: row.metadata ?? {},
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : String(row.created_at),
+    }));
+
+    const rptRow = rptRes.rows[0];
+    const rpt = rptRow
+      ? {
+          payload: rptRow.payload,
+          payload_c14n: rptRow.payload_c14n ?? null,
+          payload_sha256: rptRow.payload_sha256 ?? null,
+          signature: rptRow.signature,
+          created_at: rptRow.created_at instanceof Date ? rptRow.created_at.toISOString() : String(rptRow.created_at),
+        }
+      : null;
+
+    const period = periodRow
+      ? {
+          state: periodRow.state,
+          accrued_cents: Number(periodRow.accrued_cents ?? 0),
+          credited_to_owa_cents: Number(periodRow.credited_to_owa_cents ?? 0),
+          final_liability_cents: Number(periodRow.final_liability_cents ?? 0),
+          merkle_root: periodRow.merkle_root ?? null,
+          running_balance_hash: periodRow.running_balance_hash ?? null,
+          anomaly_vector: periodRow.anomaly_vector ?? {},
+          thresholds: periodRow.thresholds ?? {},
+        }
+      : null;
+
+    return {
+      meta: { generated_at: new Date().toISOString(), abn, taxType, periodId },
+      period,
+      rpt,
+      owa_ledger: ledgerEntries,
+      bas_labels: basLabels,
+      supporting_documents: docs,
+      discrepancy_log: discrepancyLog,
+    };
+  } finally {
+    client.release();
+  }
 }

--- a/tests/evidence.bundle.test.ts
+++ b/tests/evidence.bundle.test.ts
@@ -1,0 +1,327 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { buildEvidenceBundle, setEvidenceDbPool } from "../src/evidence/bundle";
+import { evidence } from "../src/routes/reconcile";
+
+type PeriodRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  accrued_cents: number;
+  credited_to_owa_cents: number;
+  final_liability_cents: number;
+  merkle_root: string | null;
+  running_balance_hash: string | null;
+  anomaly_vector: Record<string, unknown>;
+  thresholds: Record<string, unknown>;
+};
+
+type LedgerRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  amount_cents: number;
+  balance_after_cents: number | null;
+  bank_receipt_hash: string | null;
+  prev_hash: string | null;
+  hash_after: string | null;
+  created_at: string;
+};
+
+type BasMappingRow = { ledger_id: number; label: string; amount_cents: number | null };
+type DocRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  doc_type: string;
+  reference: string | null;
+  uri: string | null;
+  hash: string | null;
+  metadata: Record<string, unknown>;
+  ledger_id: number | null;
+  created_at: string;
+};
+
+type DiffRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  diff_type: string;
+  description: string | null;
+  expected_cents: number | null;
+  actual_cents: number | null;
+  metadata: Record<string, unknown>;
+  created_at: string;
+};
+
+type RptRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  payload: unknown;
+  payload_c14n: string | null;
+  payload_sha256: string | null;
+  signature: string;
+  created_at: string;
+};
+
+type FakeState = {
+  periods: PeriodRow[];
+  ledger: LedgerRow[];
+  basMappings: BasMappingRow[];
+  docs: DocRow[];
+  diffs: DiffRow[];
+  rpt: RptRow[];
+};
+
+class FakeClient {
+  constructor(private readonly state: FakeState) {}
+
+  async query(text: string, params: any[] = []) {
+    const sql = text.toLowerCase();
+    if (sql.includes("from periods")) {
+      const [abn, tax, period] = params;
+      const rows = this.state.periods.filter(
+        (p) => p.abn === abn && p.tax_type === tax && p.period_id === period
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from rpt_tokens")) {
+      const [abn, tax, period] = params;
+      const rows = this.state.rpt
+        .filter((r) => r.abn === abn && r.tax_type === tax && r.period_id === period)
+        .slice(-1);
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from owa_ledger")) {
+      const [abn, tax, period] = params;
+      const rows = this.state.ledger
+        .filter((l) => l.abn === abn && l.tax_type === tax && l.period_id === period)
+        .sort((a, b) => a.id - b.id);
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from ledger_bas_mappings")) {
+      const [abn, tax, period] = params;
+      const ledgerRows = this.state.ledger.filter(
+        (l) => l.abn === abn && l.tax_type === tax && l.period_id === period
+      );
+      const ledgerById = new Map(ledgerRows.map((row) => [row.id, row]));
+      const totals = new Map<string, number>();
+      for (const mapping of this.state.basMappings) {
+        const ledger = ledgerById.get(mapping.ledger_id);
+        if (!ledger) continue;
+        const key = mapping.label;
+        const amount = mapping.amount_cents ?? Math.abs(ledger.amount_cents);
+        totals.set(key, (totals.get(key) ?? 0) + amount);
+      }
+      const rows = Array.from(totals.entries()).map(([label, total]) => ({ label, total }));
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from supporting_documents")) {
+      const [abn, tax, period] = params;
+      const rows = this.state.docs.filter(
+        (d) => d.abn === abn && d.tax_type === tax && d.period_id === period
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from reconciliation_diffs")) {
+      const [abn, tax, period] = params;
+      const rows = this.state.diffs.filter(
+        (d) => d.abn === abn && d.tax_type === tax && d.period_id === period
+      );
+      return { rows, rowCount: rows.length };
+    }
+    throw new Error(`Unsupported query in fake client: ${text}`);
+  }
+
+  release() {
+    // no-op
+  }
+}
+
+class FakePool {
+  constructor(private readonly state: FakeState) {}
+
+  async connect() {
+    return new FakeClient(this.state);
+  }
+
+  async end() {
+    // no-op
+  }
+}
+
+function seededState(): FakeState {
+  const now = new Date().toISOString();
+  return {
+    periods: [
+      {
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        state: "RELEASED",
+        accrued_cents: 10000,
+        credited_to_owa_cents: 8000,
+        final_liability_cents: 8000,
+        merkle_root: "root",
+        running_balance_hash: "hash",
+        anomaly_vector: { variance: 0.1 },
+        thresholds: { epsilon: 50 },
+      },
+    ],
+    ledger: [
+      {
+        id: 1,
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        amount_cents: 12000,
+        balance_after_cents: 12000,
+        bank_receipt_hash: "rcpt:one",
+        prev_hash: null,
+        hash_after: "hash1",
+        created_at: now,
+      },
+      {
+        id: 2,
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        amount_cents: 5000,
+        balance_after_cents: 17000,
+        bank_receipt_hash: "rcpt:two",
+        prev_hash: "hash1",
+        hash_after: "hash2",
+        created_at: now,
+      },
+      {
+        id: 3,
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        amount_cents: -8000,
+        balance_after_cents: 9000,
+        bank_receipt_hash: null,
+        prev_hash: "hash2",
+        hash_after: "hash3",
+        created_at: now,
+      },
+    ],
+    basMappings: [
+      { ledger_id: 1, label: "1A", amount_cents: 1000 },
+      { ledger_id: 2, label: "W1", amount_cents: null },
+      { ledger_id: 3, label: "1B", amount_cents: 500 },
+    ],
+    docs: [
+      {
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        doc_type: "BANK_RECEIPT",
+        reference: "rcpt:one",
+        uri: null,
+        hash: "hash1",
+        metadata: { provider: "bank" },
+        ledger_id: 1,
+        created_at: now,
+      },
+    ],
+    diffs: [
+      {
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        diff_type: "SHORTFALL",
+        description: "Bank transfer missing",
+        expected_cents: 8000,
+        actual_cents: 7500,
+        metadata: { source: "bank" },
+        created_at: now,
+      },
+    ],
+    rpt: [
+      {
+        abn: "12345678901",
+        tax_type: "GST",
+        period_id: "2025-09",
+        payload: { amount_cents: 8000, reference: "ABC123" },
+        payload_c14n: JSON.stringify({ amount_cents: 8000, reference: "ABC123" }),
+        payload_sha256: "sha256-demo",
+        signature: "sig",
+        created_at: now,
+      },
+    ],
+  };
+}
+
+async function createFakePool() {
+  const state = seededState();
+  const pool = new FakePool(state);
+  return {
+    pool: pool as unknown as any,
+    cleanup: async () => {
+      setEvidenceDbPool(null);
+    },
+  };
+}
+
+test("buildEvidenceBundle aggregates ledger into BAS labels", async () => {
+  const { pool, cleanup } = await createFakePool();
+  setEvidenceDbPool(pool);
+
+  const bundle = await buildEvidenceBundle("12345678901", "GST", "2025-09");
+
+  assert.equal(bundle.period?.state, "RELEASED");
+  assert.equal(bundle.bas_labels["1A"], 1000);
+  assert.equal(bundle.bas_labels.W1, 5000);
+  assert.equal(bundle.bas_labels["1B"], 500);
+  assert.equal(bundle.bas_labels.W2, 0);
+
+  assert.equal(bundle.rpt?.signature, "sig");
+  assert.equal(bundle.rpt?.payload_sha256, "sha256-demo");
+
+  assert.ok(bundle.supporting_documents.some((doc) => doc.reference === "rcpt:one"));
+  assert.ok(
+    bundle.supporting_documents.some(
+      (doc) => doc.doc_type === "BANK_RECEIPT" && doc.reference === "rcpt:two"
+    ),
+    "expected derived bank receipt entry"
+  );
+
+  assert.equal(bundle.discrepancy_log.length, 1);
+  assert.equal(bundle.discrepancy_log[0].diff_type, "SHORTFALL");
+
+  await cleanup();
+});
+
+test("evidence route respects extended contract and missing periods", async () => {
+  const { pool, cleanup } = await createFakePool();
+  setEvidenceDbPool(pool);
+
+  const captured: any[] = [];
+  const res = {
+    statusCode: 200,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      captured.push({ status: this.statusCode ?? 200, payload });
+      return this;
+    },
+  };
+
+  await evidence({ query: { abn: "12345678901", taxType: "GST", periodId: "2025-09" } } as any, res as any);
+  assert.equal(captured[0].status, 200);
+  assert.ok(captured[0].payload.bas_labels);
+  assert.ok(Array.isArray(captured[0].payload.supporting_documents));
+
+  captured.length = 0;
+  await evidence({ query: { abn: "NOPE", taxType: "GST", periodId: "2025-09" } } as any, res as any);
+  assert.equal(captured[0]?.status, 404);
+
+  await cleanup();
+});


### PR DESCRIPTION
## Summary
- add support tables for BAS label mappings, reconciliation diffs, and supporting documents
- update the evidence bundle builder to surface BAS label totals, RPT artifacts, derived receipts, and discrepancy logs while handling missing periods
- extend the /api/evidence handler, add a focused regression test, and expose an npm test script

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e2321f771c8327a9beedca80ea5ff1