### PR TITLE
Integrate managed signing and verification for RPT tokens

### DIFF
--- a/apps/services/payments/src/kms/kmsProvider.ts
+++ b/apps/services/payments/src/kms/kmsProvider.ts
@@ -1,42 +1,73 @@
-﻿// apps/services/payments/src/kms/kmsProvider.ts
-import { IKms } from "./IKms";
-import { LocalKeyProvider } from "./localKey";
-export interface KmsProvider {
-  getKeyId(): string;
-  signEd25519(data: Uint8Array, keyIdOverride?: string): Promise<Uint8Array>;
-  verifyEd25519(data: Uint8Array, sig: Uint8Array, pubKey: Uint8Array): Promise<boolean>;
+// apps/services/payments/src/kms/kmsProvider.ts
+
+export interface ManagedKms {
+  getPublicKey(kid: string): Promise<Uint8Array>;
+  sign(kid: string, message: Uint8Array): Promise<Uint8Array>;
+  verify(kid: string, message: Uint8Array, signature: Uint8Array): Promise<boolean>;
 }
 
 type Backend = "local" | "aws" | "gcp" | "hsm";
 
-/**
- * Lazy-load correct provider using ESM dynamic import().
- * Select with env KMS_BACKEND = local|aws|gcp|hsm (default: local)
- */
-export async function getKms(): Promise<KmsProvider> {
-  const backend = (process.env.KMS_BACKEND ?? "local").toLowerCase() as Backend;
+let cachedProvider: Promise<ManagedKms> | null = null;
 
+function resolveBackend(): Backend {
+  const raw = (process.env.KMS_BACKEND ?? process.env.KMS_PROVIDER ?? "local").toLowerCase();
+  if (raw === "aws" || raw === "gcp" || raw === "hsm" || raw === "local") {
+    return raw as Backend;
+  }
+  return "local";
+}
+
+async function instantiate(backend: Backend): Promise<ManagedKms> {
   switch (backend) {
     case "aws": {
-      const { AwsKmsProvider } = await import("./awsKms.js").catch(() => import("./awsKms"));
-      return new AwsKmsProvider();
+      const mod = await import("./awsKms.js").catch(() => import("./awsKms"));
+      return new mod.AwsKmsProvider();
     }
     case "gcp": {
-      const { GcpKmsProvider } = await import("./gcpKms.js").catch(() => import("./gcpKms"));
-      return new GcpKmsProvider();
+      const mod = await import("./gcpKms.js").catch(() => import("./gcpKms"));
+      return new mod.GcpKmsProvider();
     }
     case "hsm": {
-      const { HsmProvider } = await import("./hsm.js").catch(() => import("./hsm"));
-      return new HsmProvider();
+      throw new Error("HSM backend is not implemented in this environment");
     }
     case "local":
     default: {
-      const { LocalKeyProvider } = await import("./localKey.js").catch(() => import("./localKey"));
-      return new LocalKeyProvider();
+      const mod = await import("./localKey.js").catch(() => import("./localKey"));
+      return new mod.LocalKeyProvider();
     }
   }
 }
 
-export function selectKms(): IKms {
-  return new LocalKeyProvider();
+export async function getManagedKms(): Promise<ManagedKms> {
+  if (!cachedProvider) {
+    cachedProvider = instantiate(resolveBackend());
+  }
+  return cachedProvider;
+}
+
+export function getActiveKeyId(): string {
+  return (
+    process.env.RPT_ACTIVE_KID ||
+    process.env.KMS_KEY_ID ||
+    process.env.RPT_KMS_KEY_ID ||
+    "local-ed25519"
+  );
+}
+
+export async function signWithManagedKms(message: Uint8Array, keyId?: string): Promise<{ kid: string; signature: Uint8Array }>
+{
+  const kms = await getManagedKms();
+  const kid = keyId ?? getActiveKeyId();
+  const signature = await kms.sign(kid, message);
+  return { kid, signature };
+}
+
+export async function verifyWithManagedKms(
+  message: Uint8Array,
+  signature: Uint8Array,
+  keyId: string
+): Promise<boolean> {
+  const kms = await getManagedKms();
+  return kms.verify(keyId, message, signature);
 }

--- a/apps/services/payments/src/kms/localKey.ts
+++ b/apps/services/payments/src/kms/localKey.ts
@@ -1,6 +1,111 @@
-﻿import '../loadEnv.js';
-import { createPublicKey, KeyObject, verify as cryptoVerify } from 'node:crypto';
-import type { IKms } from './IKms';
+import "../loadEnv.js";
+import {
+  createPrivateKey,
+  createPublicKey,
+  KeyObject,
+  sign as cryptoSign,
+  verify as cryptoVerify,
+} from "node:crypto";
+import nacl from "tweetnacl";
+import type { IKms } from "./IKms";
+
+/** Wrapper for local signing/verifying backed by env-configured Ed25519 keys. */
+export class LocalKeyProvider implements IKms {
+  private publicKey: KeyObject;
+  private publicKeyRaw: Uint8Array;
+  private privateKey?: KeyObject;
+  private secretKey?: Uint8Array;
+
+  constructor() {
+    const { keyObject, rawKey } = loadPublicKey();
+    this.publicKey = keyObject;
+    this.publicKeyRaw = rawKey;
+    const signing = loadSigningMaterial();
+    this.privateKey = signing.privateKey;
+    this.secretKey = signing.secretKey;
+  }
+
+  async verify(payload: Buffer, signature: Buffer, _kid?: string): Promise<boolean>;
+  async verify(kid: string, message: Uint8Array, signature: Uint8Array): Promise<boolean>;
+  async verify(arg1: Buffer | string, arg2: Buffer | Uint8Array, arg3?: Uint8Array | string): Promise<boolean> {
+    if (typeof arg1 === "string") {
+      const message = arg2 as Uint8Array;
+      const sig = arg3 as Uint8Array;
+      return this.verifyDetached(message, sig);
+    }
+    const payload = arg1 as Buffer;
+    const sig = arg2 as Buffer;
+    return this.verifyDetached(new Uint8Array(payload), new Uint8Array(sig));
+  }
+
+  async getPublicKey(_kid?: string): Promise<Uint8Array> {
+    return this.publicKeyRaw;
+  }
+
+  async sign(_kid: string, message: Uint8Array): Promise<Uint8Array> {
+    if (this.privateKey) {
+      const sig = cryptoSign(null, Buffer.from(message), this.privateKey);
+      return new Uint8Array(sig);
+    }
+    if (this.secretKey) {
+      return nacl.sign.detached(message, this.secretKey);
+    }
+    throw new Error("LocalKeyProvider: signing key not configured");
+  }
+
+  private async verifyDetached(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+    if (this.privateKey) {
+      return cryptoVerify(null, Buffer.from(message), this.publicKey, Buffer.from(signature));
+    }
+    if (this.secretKey) {
+      return nacl.sign.detached.verify(message, signature, this.publicKeyRaw);
+    }
+    return cryptoVerify(null, Buffer.from(message), this.publicKey, Buffer.from(signature));
+  }
+}
+
+function loadSigningMaterial(): { privateKey?: KeyObject; secretKey?: Uint8Array } {
+  const pem = process.env.ED25519_PRIVATE_KEY_PEM || process.env.RPT_ED25519_PRIVATE_KEY_PEM;
+  if (pem) {
+    return { privateKey: createPrivateKey(pem) };
+  }
+
+  const raw = process.env.RPT_ED25519_SECRET_BASE64 || process.env.ED25519_PRIV_RAW_BASE64;
+  if (!raw) return {};
+
+  const buf = Buffer.from(raw, "base64");
+  if (buf.length === 64) {
+    return { secretKey: new Uint8Array(buf) };
+  }
+  if (buf.length === 32) {
+    const kp = nacl.sign.keyPair.fromSeed(new Uint8Array(buf));
+    return { secretKey: kp.secretKey };
+  }
+  throw new Error(`RPT_ED25519_SECRET_BASE64 must be 32-byte seed or 64-byte secret; got ${buf.length} bytes`);
+}
+
+function loadPublicKey(): { keyObject: KeyObject; rawKey: Uint8Array } {
+  const pem = process.env.ED25519_PUBLIC_KEY_PEM || process.env.RPT_PUBLIC_KEY_PEM;
+  const raw64 = process.env.ED25519_PUBLIC_KEY_BASE64 || process.env.RPT_PUBLIC_BASE64;
+
+  if (pem) {
+    const key = createPublicKey(pem);
+    const der = key.export({ format: "der", type: "spki" }) as Buffer;
+    const rawKey = new Uint8Array(der.slice(-32));
+    return { keyObject: key, rawKey };
+  }
+
+  if (raw64) {
+    const raw = Buffer.from(raw64, "base64");
+    if (raw.length !== 32) {
+      throw new Error(`RPT_PUBLIC_BASE64 must be 32 bytes (got ${raw.length})`);
+    }
+    const key = createPublicKey(pemFromSpki(spkiFromRawEd25519(raw)));
+    return { keyObject: key, rawKey: new Uint8Array(raw) };
+  }
+
+  throw new Error("No public key found. Set ED25519_PUBLIC_KEY_PEM or RPT_PUBLIC_BASE64 in .env.local");
+}
 
 /** Build a PEM SPKI from a raw 32-byte Ed25519 public key (OID 1.3.101.112). */
 function spkiFromRawEd25519(raw: Buffer): Buffer {
@@ -14,33 +119,6 @@ function spkiFromRawEd25519(raw: Buffer): Buffer {
 }
 
 function pemFromSpki(spki: Buffer): string {
-  const b64 = spki.toString('base64').match(/.{1,64}/g)!.join('\n');
+  const b64 = spki.toString("base64").match(/.{1,64}/g)!.join("\n");
   return `-----BEGIN PUBLIC KEY-----\n${b64}\n-----END PUBLIC KEY-----\n`;
 }
-
-function loadPublicKey(): KeyObject {
-  const pem   = process.env.ED25519_PUBLIC_KEY_PEM || process.env.RPT_PUBLIC_KEY_PEM;
-  const raw64 = process.env.ED25519_PUBLIC_KEY_BASE64 || process.env.RPT_PUBLIC_BASE64;
-
-  if (pem) return createPublicKey(pem);
-
-  if (raw64) {
-    const raw = Buffer.from(raw64, 'base64');
-    if (raw.length !== 32) throw new Error(`RPT_PUBLIC_BASE64 must be 32 bytes (got ${raw.length})`);
-    const spki = spkiFromRawEd25519(raw);
-    return createPublicKey(pemFromSpki(spki));
-  }
-
-  throw new Error('No public key found. Set ED25519_PUBLIC_KEY_PEM or RPT_PUBLIC_BASE64 in .env.local');
-}
-
-export class LocalKeyProvider implements IKms {
-  private key: KeyObject;
-  constructor() { this.key = loadPublicKey(); }
-
-  async verify(payload: Buffer, signature: Buffer): Promise<boolean> {
-    // Ed25519 => pass null algorithm and raw payload
-    return cryptoVerify(null, payload, this.key, signature);
-  }
-}
-

--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -1,10 +1,11 @@
 // apps/services/payments/src/middleware/rptGate.ts
 import { Request, Response, NextFunction } from "express";
 import pg from "pg"; const { Pool } = pg;
+import { TextEncoder } from "util";
 import { sha256Hex } from "../utils/crypto";
-import { selectKms } from "../kms/kmsProvider";
+import { getManagedKms } from "../kms/kmsProvider";
 
-const kms = selectKms();
+const kmsPromise = getManagedKms();
 const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 export async function rptGate(req: Request, res: Response, next: NextFunction) {
@@ -16,10 +17,10 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
 
     // Accept pending/active. Order by created_at so newest wins.
     const q = `
-      SELECT id as rpt_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce
+      SELECT id as rpt_id, kid, payload_c14n, payload_sha256, signature, expires_at, status, nonce
       FROM rpt_tokens
       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
-        AND status IN ('pending','active')
+        AND status IN ('pending','active','ISSUED')
       ORDER BY created_at DESC
       LIMIT 1
     `;
@@ -38,9 +39,11 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
     }
 
     // Signature verify (signature is stored as base64 text in your seed)
-    const payload = Buffer.from(r.payload_c14n);
+    const kms = await kmsPromise;
+    const payload = new TextEncoder().encode(r.payload_c14n);
     const sig = Buffer.from(r.signature, "base64");
-    const ok = await kms.verify(payload, sig);
+    const keyId = r.kid || process.env.RPT_ACTIVE_KID || process.env.KMS_KEY_ID || "local-ed25519";
+    const ok = await kms.verify(keyId, payload, new Uint8Array(sig));
     if (!ok) return res.status(403).json({ error: "RPT signature invalid" });
 
     (req as any).rpt = { rpt_id: r.rpt_id, nonce: r.nonce, payload_sha256: r.payload_sha256 };

--- a/apps/services/rpt-verify/main.py
+++ b/apps/services/rpt-verify/main.py
@@ -1,22 +1,191 @@
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-import nacl.signing, nacl.encoding, hashlib
+from __future__ import annotations
 
-app = FastAPI()
+import base64
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from nacl.encoding import RawEncoder
+from nacl.exceptions import BadSignatureError
+from nacl.signing import VerifyKey
+from pydantic import BaseModel
+from psycopg import errors
+from psycopg_pool import ConnectionPool
+
+app = FastAPI(title="rpt-verify")
+
 
 class VerifyIn(BaseModel):
-    kid: str
     payload_c14n: str
     signature_b64: str
-    pubkey_b64: str
+    kid: Optional[str] = None
+
+
+def build_conninfo() -> str:
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+    host = os.getenv("PGHOST", "127.0.0.1")
+    port = os.getenv("PGPORT", "5432")
+    db = os.getenv("PGDATABASE", "apgms")
+    user = os.getenv("PGUSER", "postgres")
+    password = os.getenv("PGPASSWORD")
+    parts = [f"host={host}", f"port={port}", f"dbname={db}", f"user={user}"]
+    if password:
+        parts.append(f"password={password}")
+    return " ".join(parts)
+
+
+pool = ConnectionPool(build_conninfo(), min_size=1, max_size=5, kwargs={"autocommit": True})
+
+
+@lru_cache(maxsize=1)
+def env_keyring() -> Dict[str, str]:
+    raw = os.getenv("RPT_TRUSTED_KEYS_JSON")
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        if isinstance(data, dict):
+            return {str(k): str(v) for k, v in data.items()}
+    except json.JSONDecodeError:
+        pass
+    return {}
+
+
+def decode_b64(value: str) -> bytes:
+    cleaned = value.strip()
+    try:
+        return base64.b64decode(cleaned, validate=True)
+    except Exception:
+        padding = "=" * ((4 - len(cleaned) % 4) % 4)
+        return base64.urlsafe_b64decode(cleaned + padding)
+
+
+def fetch_trusted_key(kid: str) -> bytes:
+    query = (
+        "SELECT public_key_b64 FROM rpt_trusted_keys "
+        "WHERE kid = %s AND (revoked_at IS NULL OR revoked_at > NOW()) "
+        "ORDER BY created_at DESC LIMIT 1"
+    )
+    with pool.connection() as conn:
+        with conn.cursor() as cur:
+            try:
+                cur.execute(query, (kid,))
+                row = cur.fetchone()
+            except errors.UndefinedTable:
+                row = None
+    if row and row[0]:
+        return decode_b64(row[0])
+    mapping = env_keyring()
+    if kid in mapping:
+        return decode_b64(mapping[kid])
+    raise HTTPException(status_code=404, detail=f"Unknown key id: {kid}")
+
+
+def fetch_token(abn: str, tax_type: str, period_id: str, nonce: str) -> Dict[str, Any]:
+    sql = (
+        "SELECT kid, payload_sha256, signature, status, expires_at, nonce "
+        "FROM rpt_tokens WHERE abn=%s AND tax_type=%s AND period_id=%s AND nonce=%s "
+        "ORDER BY created_at DESC LIMIT 1"
+    )
+    with pool.connection() as conn:
+        with conn.cursor() as cur:
+            try:
+                cur.execute(sql, (abn, tax_type, period_id, nonce))
+            except errors.UndefinedColumn:
+                fallback_sql = (
+                    "SELECT key_id AS kid, payload_sha256, signature, status, expires_at, nonce "
+                    "FROM rpt_tokens WHERE abn=%s AND tax_type=%s AND period_id=%s AND nonce=%s "
+                    "ORDER BY created_at DESC LIMIT 1"
+                )
+                cur.execute(fallback_sql, (abn, tax_type, period_id, nonce))
+            row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="No RPT found for period/nonce")
+    return {
+        "kid": row[0],
+        "payload_sha256": row[1],
+        "signature": row[2],
+        "status": row[3],
+        "expires_at": row[4],
+        "nonce": row[5],
+    }
+
+
+def parse_payload(payload_c14n: str) -> Dict[str, Any]:
+    try:
+        return json.loads(payload_c14n)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid canonical payload JSON: {exc}")
+
+
+@app.get("/trusted-keys/{kid}")
+def get_trusted_key(kid: str):
+    key = fetch_trusted_key(kid)
+    return {"kid": kid, "public_key_b64": base64.b64encode(key).decode("ascii")}
+
 
 @app.post("/verify")
-def verify(v: VerifyIn):
+def verify(in_payload: VerifyIn):
+    payload_json = parse_payload(in_payload.payload_c14n)
+    kid = in_payload.kid or payload_json.get("kid") or payload_json.get("key_id")
+    if not kid:
+        raise HTTPException(status_code=400, detail="Payload missing kid")
+
+    abn = payload_json.get("abn") or payload_json.get("entity_id")
+    tax_type = payload_json.get("tax_type") or payload_json.get("taxType")
+    period_id = payload_json.get("period_id") or payload_json.get("periodId")
+    nonce = payload_json.get("nonce")
+
+    if not all([abn, tax_type, period_id, nonce]):
+        raise HTTPException(status_code=400, detail="Payload missing abn/tax_type/period_id/nonce")
+
+    record = fetch_token(str(abn), str(tax_type), str(period_id), str(nonce))
+
+    stored_kid = record.get("kid")
+    if stored_kid and stored_kid != kid:
+        raise HTTPException(status_code=409, detail="Key id mismatch for period")
+
+    payload_bytes = in_payload.payload_c14n.encode("utf-8")
+    payload_hash = hashlib.sha256(payload_bytes).hexdigest()
+    stored_hash = record.get("payload_sha256")
+    if stored_hash and str(stored_hash) != payload_hash:
+        raise HTTPException(status_code=409, detail="Payload hash mismatch")
+
+    expires_at = record.get("expires_at")
+    if expires_at:
+        if isinstance(expires_at, str):
+            normalized = expires_at.replace("Z", "+00:00")
+            expires_dt = datetime.fromisoformat(normalized)
+        else:
+            expires_dt = expires_at
+        if expires_dt.tzinfo is None:
+            expires_dt = expires_dt.replace(tzinfo=timezone.utc)
+        if datetime.now(timezone.utc) > expires_dt:
+            raise HTTPException(status_code=400, detail="RPT expired")
+
+    trusted_key = fetch_trusted_key(kid)
+    verify_key = VerifyKey(trusted_key, encoder=RawEncoder)
+
     try:
-        payload_hash = hashlib.sha256(v.payload_c14n.encode("utf-8")).hexdigest()
-        verify_key = nacl.signing.VerifyKey(v.pubkey_b64, encoder=nacl.encoding.Base64Encoder)
-        sig = nacl.encoding.Base64Encoder.decode(v.signature_b64)
-        verify_key.verify(v.payload_c14n.encode("utf-8"), sig)
-        return {"ok": True, "payload_sha256": payload_hash}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        signature = decode_b64(in_payload.signature_b64)
+        verify_key.verify(payload_bytes, signature)
+    except (BadSignatureError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=f"Invalid signature: {exc}")
+
+    status = record.get("status")
+    if status and str(status).upper() not in {"ISSUED", "ACTIVE"}:
+        raise HTTPException(status_code=403, detail=f"Token status not valid: {status}")
+
+    return {
+        "ok": True,
+        "kid": kid,
+        "payload_sha256": payload_hash,
+        "status": status,
+        "expires_at": expires_at.isoformat() if hasattr(expires_at, "isoformat") else expires_at,
+    }

--- a/apps/services/rpt-verify/requirements.txt
+++ b/apps/services/rpt-verify/requirements.txt
@@ -2,3 +2,4 @@ fastapi==0.115.0
 uvicorn==0.30.6
 pydantic==2.9.2
 PyNaCl==1.5.0
+psycopg[binary]==3.2.1

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,190 @@
-﻿import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
 import crypto from "crypto";
-import { signRpt, RptPayload } from "../crypto/ed25519";
+import { TextEncoder } from "util";
+import { canonicalJson, sha256Hex } from "../../apps/services/payments/src/utils/crypto";
+import {
+  getActiveKeyId,
+  signWithManagedKms,
+} from "../../apps/services/payments/src/kms/kmsProvider";
 import { exceeds } from "../anomaly/deterministic";
+
+type ThresholdMap = Record<string, number>;
+
+type PeriodRow = {
+  id: number;
+  abn: string;
+  tax_type: "PAYGW" | "GST";
+  period_id: string;
+  state: string;
+  anomaly_vector: Record<string, number> | null;
+  final_liability_cents: string | number;
+  credited_to_owa_cents: string | number;
+  merkle_root: string;
+  running_balance_hash: string;
+};
+
 const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-  if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
-  const row = p.rows[0];
-  if (row.state !== "CLOSING") throw new Error("BAD_STATE");
+function sanitizeGateBase(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
-    throw new Error("BLOCKED_ANOMALY");
+async function requestBasGateApproval(abn: string, taxType: string, periodId: string) {
+  const base = sanitizeGateBase(process.env.BAS_GATE_URL || "http://localhost:8101");
+  const gatePeriodId = `${abn}:${taxType}:${periodId}`;
+  const resp = await globalThis.fetch(`${base}/gate/transition`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ period_id: gatePeriodId, target_state: "RPT-Issued" })
+  });
+  if (!resp.ok) {
+    throw new Error(`BAS_GATE_ERROR_${resp.status}`);
   }
-  const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
-  if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
-    throw new Error("BLOCKED_DISCREPANCY");
+  const body: any = await resp.json().catch(() => ({}));
+  if (!body?.ok) {
+    throw new Error("BAS_GATE_DENIED");
   }
+}
 
-  const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+async function loadPeriod(client: PoolClient, abn: string, taxType: "PAYGW" | "GST", periodId: string): Promise<PeriodRow> {
+  const q = "select * from periods where abn=$1 and tax_type=$2 and period_id=$3";
+  const res = await client.query(q, [abn, taxType, periodId]);
+  if (res.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+  return res.rows[0] as PeriodRow;
+}
+
+function buildPayload(row: PeriodRow, thresholds: ThresholdMap, issuedAt: string, expiresAt: string, nonce: string, kid: string) {
+  const anomalyVector = row.anomaly_vector || {};
+  return {
+    abn: row.abn,
+    tax_type: row.tax_type,
+    period_id: row.period_id,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    credited_cents: Number(row.credited_to_owa_cents),
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: anomalyVector,
+    thresholds,
+    rail_id: "EFT" as const,
+    reference: process.env.ATO_PRN || "",
+    issued_at: issuedAt,
+    expires_at: expiresAt,
+    nonce,
+    kid,
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+}
+
+async function persistRpt(
+  client: PoolClient,
+  abn: string,
+  taxType: string,
+  periodId: string,
+  payload: any,
+  payloadC14n: string,
+  payloadSha256: string,
+  signatureB64: string,
+  kid: string,
+  expiresAt: string,
+  nonce: string
+) {
+  const insertSql = `
+    INSERT INTO rpt_tokens (
+      abn, tax_type, period_id, payload, signature, status,
+      payload_c14n, payload_sha256, kid, nonce, expires_at
+    ) VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,$8,$9,$10,$11)
+    RETURNING id
+  `;
+  await client.query(insertSql, [
+    abn,
+    taxType,
+    periodId,
+    JSON.stringify(payload),
+    signatureB64,
+    "ISSUED",
+    payloadC14n,
+    payloadSha256,
+    kid,
+    nonce,
+    expiresAt,
+  ]);
+}
+
+async function updatePeriodState(client: PoolClient, periodId: number, kid: string) {
+  try {
+    await client.query("update periods set state='READY_RPT', rpt_key_id=$1 where id=$2", [kid, periodId]);
+  } catch (err: any) {
+    if (err?.code === "42703") {
+      await client.query("update periods set state='READY_RPT' where id=$1", [periodId]);
+    } else {
+      throw err;
+    }
+  }
+}
+
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: ThresholdMap
+) {
+  const client = await pool.connect();
+  let committed = false;
+  try {
+    await client.query("BEGIN");
+    const row = await loadPeriod(client, abn, taxType, periodId);
+    if (row.state !== "CLOSING") throw new Error("BAD_STATE");
+
+    const anomalyVector = row.anomaly_vector || {};
+    if (exceeds(anomalyVector, thresholds)) {
+      await client.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
+      await client.query("COMMIT");
+      committed = true;
+      throw new Error("BLOCKED_ANOMALY");
+    }
+
+    const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
+    if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
+      await client.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
+      await client.query("COMMIT");
+      committed = true;
+      throw new Error("BLOCKED_DISCREPANCY");
+    }
+
+    await requestBasGateApproval(abn, taxType, periodId);
+
+    const issuedAt = new Date().toISOString();
+    const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+    const nonce = crypto.randomUUID();
+    const activeKid = getActiveKeyId();
+
+    const payload = buildPayload(row, thresholds, issuedAt, expiresAt, nonce, activeKid);
+    const payloadC14n = canonicalJson(payload);
+    const payloadSha256 = sha256Hex(payloadC14n);
+
+    const msg = new TextEncoder().encode(payloadC14n);
+    const { kid, signature } = await signWithManagedKms(msg, activeKid);
+    const signatureB64 = Buffer.from(signature).toString("base64");
+
+    await persistRpt(client, abn, taxType, periodId, payload, payloadC14n, payloadSha256, signatureB64, kid, expiresAt, nonce);
+    await updatePeriodState(client, row.id, kid);
+
+    await client.query("COMMIT");
+    committed = true;
+    return {
+      kid,
+      payload,
+      payload_c14n: payloadC14n,
+      payload_sha256: payloadSha256,
+      signature: signatureB64,
+      nonce,
+      expires_at: expiresAt,
+    };
+  } catch (err) {
+    if (!committed) {
+      await client.query("ROLLBACK");
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }


### PR DESCRIPTION
## Summary
- extend the RPT issuer to gate issuance, canonicalize payloads, sign via the managed KMS helper, and persist key metadata alongside canonical hashes
- update the payments KMS helpers and gate middleware to support signing, public key lookup, and kid-aware verification
- overhaul the rpt-verify service to source trusted keys from the database, enforce nonce/period checks, and expose a key lookup endpoint for relying parties

## Testing
- `npx tsc --noEmit` *(fails: pre-existing TypeScript errors in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2321acf9483279b2e8765dabba0ca