### PR TITLE
Expand mock data to cover multi-quarter scenarios

### DIFF
--- a/src/utils/mockData.ts
+++ b/src/utils/mockData.ts
@@ -1,19 +1,63 @@
 // src/mockData.ts
+// Demo data for the fictitious "Northern Rivers Creative Co" used across the app UI.
 import type { BASHistory } from '../types/tax';
 
 export const mockPayroll = [
-  { employee: "Alice", gross: 3000, withheld: 750 },
-  { employee: "Bob", gross: 3500, withheld: 850 },
+  { employee: "Alice Nguyen", gross: 3200, withheld: 780 },
+  { employee: "Bob Patel", gross: 4100, withheld: 980 },
+  { employee: "Celia Ford", gross: 2850, withheld: 640 },
+  { employee: "Diego Romero", gross: 3600, withheld: 860 },
+  { employee: "Ella Zhang", gross: 5400, withheld: 1350 },
 ];
 
 export const mockSales = [
-  { id: "INV-001", amount: 12000, exempt: false },
-  { id: "INV-002", amount: 8000, exempt: true },
+  { id: "INV-001", amount: 18250, exempt: false },
+  { id: "INV-002", amount: 9400, exempt: false },
+  { id: "INV-003", amount: 7300, exempt: true },
+  { id: "INV-004", amount: 15200, exempt: false },
+  { id: "INV-005", amount: 4200, exempt: true },
 ];
 
 // 👇 This line is the key: explicitly declare the array type!
 export const mockBasHistory: BASHistory[] = [
-  { period: new Date('2025-03-31'), paygwPaid: 1600, gstPaid: 1100, status: "On Time", daysLate: 0, penalties: 0 },
-  { period: new Date('2025-02-28'), paygwPaid: 1700, gstPaid: 1150, status: "Late", daysLate: 3, penalties: 45 },
-  { period: new Date('2025-01-31'), paygwPaid: 1650, gstPaid: 1125, status: "Partial", daysLate: 0, penalties: 0 }
+  {
+    period: new Date("2025-06-30"),
+    paygwPaid: 21500,
+    gstPaid: 14850,
+    status: "On Time",
+    daysLate: 0,
+    penalties: 0,
+  },
+  {
+    period: new Date("2025-03-31"),
+    paygwPaid: 20560,
+    gstPaid: 13920,
+    status: "Late",
+    daysLate: 7,
+    penalties: 320,
+  },
+  {
+    period: new Date("2024-12-31"),
+    paygwPaid: 19875,
+    gstPaid: 12540,
+    status: "Partial",
+    daysLate: 12,
+    penalties: 210,
+  },
+  {
+    period: new Date("2024-09-30"),
+    paygwPaid: 18820,
+    gstPaid: 11710,
+    status: "Late",
+    daysLate: 18,
+    penalties: 740,
+  },
+  {
+    period: new Date("2024-06-30"),
+    paygwPaid: 17640,
+    gstPaid: 11090,
+    status: "On Time",
+    daysLate: 0,
+    penalties: 0,
+  },
 ];


### PR DESCRIPTION
## Summary
- refresh payroll and sales mocks with a richer team roster and taxable/exempt mix
- extend BAS history to span five recent quarters with on-time, late, and partial outcomes for demo storytelling
- annotate the dataset as belonging to the fictitious Northern Rivers Creative Co

## Testing
- pnpm lint *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*

------
https://chatgpt.com/codex/tasks/task_e_68e23a1adfc48327908e0cf3d3588663