### PR TITLE
Add trigger to compute ledger hash head

### DIFF
--- a/migrations/004_hash_chain.sql
+++ b/migrations/004_hash_chain.sql
@@ -1,0 +1,20 @@
+create or replace function ledger_hash_head_fn() returns trigger as $$
+declare prev text;
+begin
+  if TG_OP = 'INSERT' then
+    select max(hash_head) into prev from ledger where abn = NEW.abn and coalesce(period_id,-1) = coalesce(NEW.period_id,-1);
+    NEW.hash_head := encode(digest(coalesce(prev,'') || json_build_object(
+      'direction', NEW.direction,
+      'amount_cents', NEW.amount_cents,
+      'source', NEW.source,
+      'meta', NEW.meta,
+      'ts', now()
+    )::text, 'sha256'), 'hex');
+  end if;
+  return NEW;
+end;
+$$ language plpgsql;
+
+drop trigger if exists trg_ledger_hash_head on ledger;
+create trigger trg_ledger_hash_head before insert on ledger
+for each row execute function ledger_hash_head_fn();


### PR DESCRIPTION
## Summary
- add a migration that defines a trigger-driven hash chain function for ledger rows
- compute the hash_head field automatically during ledger inserts so clients no longer need to supply it

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e23da1f8608327b4f1faf9ac9ce16d