### PR TITLE
Add Swagger UI documentation endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "swagger-ui-express": "^5.0.1",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -1,0 +1,27 @@
+import swaggerUi from "swagger-ui-express";
+import { Router } from "express";
+
+export const openapiDoc = {
+  openapi: "3.0.0",
+  info: { title: "APGMS API", version: "1.0.0" },
+  paths: {
+    "/api/balance/{abn}": {
+      get: {
+        parameters: [
+          { name: "abn", in: "path", required: true, schema: { type: "string" } }
+        ],
+        responses: { "200": { description: "OK" } }
+      }
+    },
+    "/api/reconcile/close-and-issue": {
+      post: {
+        requestBody: { required: true },
+        responses: { "200": { description: "OK" } }
+      }
+    }
+  }
+} as const;
+
+export function mountOpenapi(router: Router) {
+  router.use("/docs", swaggerUi.serve, swaggerUi.setup(openapiDoc as any));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { mountOpenapi } from "./http/openapi";
 
 dotenv.config();
 
@@ -14,6 +15,8 @@ app.use(express.json({ limit: "2mb" }));
 
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+
+mountOpenapi(app);
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));


### PR DESCRIPTION
## Summary
- add an OpenAPI definition and Swagger UI mount helper
- expose the OpenAPI documentation at `/docs`
- add swagger-ui-express dependency for serving documentation

## Testing
- Not run (dependency install blocked in environment)

------
https://chatgpt.com/codex/tasks/task_e_68e23d8cc85883278b75ddcec29d30c3