### PR TITLE
Add seed script and pool helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "seed": "ts-node --transpile-only scripts/seed.ts",
+        "smoke": "curl -sS localhost:8080/healthz && echo OK"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,29 @@
+import { getPool } from "../src/db/pool";
+
+async function main() {
+  const db = getPool();
+  await db.query(
+    "truncate ledger, periods, bas_labels, recon_inputs, idempotency, rpt_tokens, evidence_bundles restart identity cascade"
+  );
+  await db.query(
+    "insert into periods (abn, state, policy_threshold_bps) values ('11122233344','OPEN',100)"
+  );
+  const pid = (
+    await db.query("select id from periods where abn='11122233344'")
+  ).rows[0].id;
+  await db.query(
+    "insert into bas_labels (abn, period_id, label, value_cents) values ('11122233344',$1,'W1',500000),('11122233344',$1,'W2',50000)",
+    [pid]
+  );
+  await db.query(
+    "insert into recon_inputs (abn, period_id, expected_cents) values ('11122233344',$1,1000000)",
+    [pid]
+  );
+  await db.end();
+  console.log("seeded abn=11122233344 period_id=" + pid);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,17 @@
+import { Pool } from "pg";
+
+let pool: Pool | undefined;
+
+export function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool();
+  }
+  return pool;
+}
+
+export async function endPool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = undefined;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable PostgreSQL pool helper to share database connections
- add a TypeScript seeding script that truncates and inserts a happy-path period
- expose npm scripts for seeding data and running a basic smoke health check

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e23dd1b5548327a67fd01fecce8baf