### PR TITLE
Add Zod validation middleware for reconcile and deposit routes

### DIFF
--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -7,7 +7,7 @@ import pg from 'pg'; const { Pool } = pg;
 
 import { rptGate } from './middleware/rptGate.js';
 import { payAtoRelease } from './routes/payAto.js';
-import { deposit } from './routes/deposit';
+import { deposit, depositValidator } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
 
@@ -30,7 +30,7 @@ app.use(express.json());
 app.get('/health', (_req, res) => res.json({ ok: true }));
 
 // Endpoints
-app.post('/deposit', deposit);
+app.post('/deposit', depositValidator, deposit);
 app.post('/payAto', rptGate, payAtoRelease);
 app.get('/balance', balance);
 app.get('/ledger', ledger);

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,14 +1,27 @@
 import { Request, Response } from "express";
-import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
 
-export async function deposit(req: Request, res: Response) {
+import { validate } from "../../../../../src/http/validate";
+import { pool } from "../index.js";
+
+const depositBodySchema = z.object({
+  abn: z.string().min(1),
+  taxType: z.string().min(1),
+  periodId: z.union([z.string().min(1), z.number()]),
+  amountCents: z.coerce.number().int().positive()
+});
+
+export type DepositBody = z.infer<typeof depositBodySchema>;
+
+export const depositValidator = validate({ body: depositBodySchema });
+
+export async function deposit(
+  req: Request<unknown, unknown, DepositBody>,
+  res: Response
+) {
   try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
-    if (!abn || !taxType || !periodId) return res.status(400).json({ error: "Missing abn/taxType/periodId" });
-    const amt = Number(amountCents);
-    if (!Number.isFinite(amt) || amt <= 0) return res.status(400).json({ error: "amountCents must be positive for a deposit" });
-
+    const { abn, taxType, periodId, amountCents } = req.body;
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
@@ -20,26 +33,30 @@ export async function deposit(req: Request, res: Response) {
         [abn, taxType, periodId]
       );
       const prevBal = last[0]?.balance_after_cents ?? 0;
-      const newBal = prevBal + amt;
+      const newBal = prevBal + amountCents;
 
       const { rows: ins } = await client.query(
         `INSERT INTO owa_ledger
            (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
          VALUES ($1,$2,$3,$4,$5,$6,now())
          RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
+        [abn, taxType, periodId, randomUUID(), amountCents, newBal]
       );
 
       await client.query("COMMIT");
-      return res.json({ ok: true, ledger_id: ins[0].id, balance_after_cents: ins[0].balance_after_cents });
-
-    } catch (e:any) {
+      return res.json({
+        ok: true,
+        ledger_id: ins[0].id,
+        transfer_uuid: ins[0].transfer_uuid,
+        balance_after_cents: ins[0].balance_after_cents
+      });
+    } catch (e: any) {
       await client.query("ROLLBACK");
       return res.status(500).json({ error: "Deposit failed", detail: String(e.message || e) });
     } finally {
       client.release();
     }
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(500).json({ error: "Deposit error", detail: String(e.message || e) });
   }
 }

--- a/src/api/payments/index.ts
+++ b/src/api/payments/index.ts
@@ -5,7 +5,7 @@ import { Router } from "express";
 // We import the handlers directly so your main app can proxy them at /api/*
 import { balance } from "../../../apps/services/payments/src/routes/balance.js";
 import { ledger } from "../../../apps/services/payments/src/routes/ledger.js";
-import { deposit } from "../../../apps/services/payments/src/routes/deposit.js";
+import { deposit, depositValidator } from "../../../apps/services/payments/src/routes/deposit.js";
 import { rptGate } from "../../../apps/services/payments/src/middleware/rptGate.js";
 import { payAtoRelease } from "../../../apps/services/payments/src/routes/payAto.js";
 
@@ -16,5 +16,5 @@ paymentsApi.get("/balance", balance);
 paymentsApi.get("/ledger", ledger);
 
 // write
-paymentsApi.post("/deposit", deposit);
+paymentsApi.post("/deposit", depositValidator, deposit);
 paymentsApi.post("/release", rptGate, payAtoRelease);

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,16 @@
+import { AnyZodObject, ZodError } from "zod";
+import { Request, Response, NextFunction } from "express";
+
+export function validate(schema: { body?: AnyZodObject; params?: AnyZodObject; query?: AnyZodObject }) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (schema.body) req.body = schema.body.parse(req.body);
+      if (schema.params) req.params = schema.params.parse(req.params);
+      if (schema.query) req.query = schema.query.parse(req.query);
+      next();
+    } catch (e) {
+      const err = e as ZodError;
+      res.status(400).json({ error: "validation_failed", issues: err.issues });
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { closeAndIssue, closeAndIssueValidator, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -20,7 +20,7 @@ app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
+app.post("/api/close-issue", closeAndIssueValidator, closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,91 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { Request, Response } from "express";
+import { Pool } from "pg";
+import { z } from "zod";
+
 import { buildEvidenceBundle } from "../evidence/bundle";
-import { releasePayment, resolveDestination } from "../rails/adapter";
+import { validate } from "../http/validate";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import { issueRPT } from "../rpt/issuer";
+import { releasePayment, resolveDestination } from "../rails/adapter";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+const closeAndIssueBodySchema = z.object({
+  abn: z.string().min(1),
+  taxType: z.string().min(1),
+  periodId: z.union([z.string().min(1), z.number()]),
+  thresholds: z
+    .object({
+      epsilon_cents: z.coerce.number().nonnegative().optional(),
+      variance_ratio: z.coerce.number().nonnegative().optional(),
+      dup_rate: z.coerce.number().nonnegative().optional(),
+      gap_minutes: z.coerce.number().nonnegative().optional(),
+      delta_vs_baseline: z.coerce.number().nonnegative().optional()
+    })
+    .partial()
+    .optional()
+});
+
+export type CloseAndIssueBody = z.infer<typeof closeAndIssueBodySchema>;
+
+export const closeAndIssueValidator = validate({ body: closeAndIssueBodySchema });
+
+const defaultThresholds: NonNullable<CloseAndIssueBody["thresholds"]> = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2
+};
+
+export async function closeAndIssue(
+  req: Request<unknown, unknown, CloseAndIssueBody>,
+  res: Response
+) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr = thresholds ? { ...defaultThresholds, ...thresholds } : defaultThresholds;
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: Request, res: Response) {
+  const { abn, taxType, periodId, rail } = req.body as any; // EFT|BPAY
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
-  const { abn, amount_cents, reference } = req.body;
+export async function paytoSweep(req: Request, res: Response) {
+  const { abn, amount_cents, reference } = req.body as any;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
+export async function settlementWebhook(req: Request, res: Response) {
+  const csvText = (req.body as any)?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: Request, res: Response) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }


### PR DESCRIPTION
## Summary
- add a shared Zod-powered validate middleware for Express requests
- apply the middleware to the close-and-issue workflow and deposit endpoints
- ensure payments service and proxy routes reuse the validator to return consistent 400 responses

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e23d7e38e48327a74c7f0725fc7c7a