### PR TITLE
Implement patent recon pre-close workflow

### DIFF
--- a/apps/services/recon/main.py
+++ b/apps/services/recon/main.py
@@ -1,9 +1,107 @@
-﻿# apps/services/recon/main.py
+# apps/services/recon/main.py
 from fastapi import FastAPI
 from pydantic import BaseModel
-import os, psycopg2, json, math
+import os, psycopg2, json, math, requests, logging
 
 app = FastAPI(title="recon")
+logger = logging.getLogger("recon")
+
+
+def db():
+    return psycopg2.connect(
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
+    )
+
+
+def persist_result(req: "ReconReq", passed: bool, reason_code: str | None, metrics: dict[str, bool]):
+    conn = None
+    cur = None
+    try:
+        conn = db()
+        cur = conn.cursor()
+        cur.execute(
+            """
+            CREATE TABLE IF NOT EXISTS recon_results (
+                id SERIAL PRIMARY KEY,
+                period_id TEXT NOT NULL UNIQUE,
+                passed BOOLEAN NOT NULL,
+                reason_code TEXT,
+                payload JSONB NOT NULL,
+                metrics JSONB NOT NULL,
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            """
+        )
+        cur.execute(
+            """
+            INSERT INTO recon_results(period_id, passed, reason_code, payload, metrics)
+            VALUES (%s,%s,%s,%s::jsonb,%s::jsonb)
+            ON CONFLICT (period_id) DO UPDATE
+            SET passed=EXCLUDED.passed,
+                reason_code=EXCLUDED.reason_code,
+                payload=EXCLUDED.payload,
+                metrics=EXCLUDED.metrics,
+                updated_at=NOW()
+            """,
+            (
+                req.period_id,
+                passed,
+                reason_code,
+                json.dumps(req.dict()),
+                json.dumps(metrics),
+            ),
+        )
+        conn.commit()
+        return True, None
+    except Exception as exc:
+        logger.warning("persist_result failed: %s", exc)
+        if conn:
+            conn.rollback()
+        return False, str(exc)
+    finally:
+        if cur:
+            cur.close()
+        if conn:
+            conn.close()
+
+
+def gate_endpoint() -> str:
+    endpoint = os.getenv("BAS_GATE_ENDPOINT")
+    if endpoint:
+        return endpoint
+    base = os.getenv("BAS_GATE_URL")
+    if base:
+        return base.rstrip("/") + "/gate/transition"
+    return "http://localhost:8101/gate/transition"
+
+
+def publish_gate_event(period_id: str, target_state: str, reason_code: str | None):
+    url = gate_endpoint()
+    timeout = float(os.getenv("BAS_GATE_TIMEOUT", "2.5"))
+    try:
+        resp = requests.post(
+            url,
+            json={
+                "period_id": period_id,
+                "target_state": target_state,
+                "reason_code": reason_code,
+            },
+            timeout=timeout,
+        )
+        resp.raise_for_status()
+        try:
+            body = resp.json()
+        except ValueError:
+            body = None
+        return True, body
+    except Exception as exc:
+        logger.warning("publish_gate_event failed: %s", exc)
+        return False, str(exc)
+
 
 class ReconReq(BaseModel):
     period_id: str
@@ -14,12 +112,33 @@ class ReconReq(BaseModel):
     anomaly_score: float
     tolerance: float = 0.01
 
+
 @app.post("/recon/run")
 def run(req: ReconReq):
     pay_ok = math.isclose(req.paygw_total, req.owa_paygw, abs_tol=req.tolerance)
     gst_ok = math.isclose(req.gst_total, req.owa_gst, abs_tol=req.tolerance)
     anomaly_ok = req.anomaly_score < 0.8
-    if pay_ok and gst_ok and anomaly_ok:
-        return {"pass": True, "reason_code": None, "controls": ["BAS-GATE","RPT"], "next_state": "RPT-Issued"}
-    reason = "shortfall" if (not pay_ok or not gst_ok) else "anomaly_breach"
-    return {"pass": False, "reason_code": reason, "controls": ["BLOCK"], "next_state": "Blocked"}
+
+    passed = pay_ok and gst_ok and anomaly_ok
+    reason = None if passed else ("shortfall" if (not pay_ok or not gst_ok) else "anomaly_breach")
+    metrics = {"pay_ok": pay_ok, "gst_ok": gst_ok, "anomaly_ok": anomaly_ok}
+
+    persisted, persist_error = persist_result(req, passed, reason, metrics)
+    target_state = "RPT-Issued" if passed else "Blocked"
+    gate_ok, gate_payload = publish_gate_event(req.period_id, target_state, reason)
+
+    response = {
+        "pass": passed,
+        "reason_code": reason,
+        "controls": ["BAS-GATE", "RPT"] if passed else ["BLOCK"],
+        "next_state": target_state,
+        "metrics": metrics,
+        "persisted": persisted,
+        "gate_event": {"ok": gate_ok, "payload": gate_payload if gate_ok else None},
+    }
+    if persist_error:
+        response["persist_error"] = persist_error
+    if not gate_ok:
+        response["gate_event"]["error"] = gate_payload
+        response["gate_event"]["payload"] = None
+    return response

--- a/apps/services/recon/requirements.txt
+++ b/apps/services/recon/requirements.txt
@@ -1,4 +1,5 @@
-﻿fastapi==0.115.0
+fastapi==0.115.0
 uvicorn==0.30.6
 pydantic==2.9.2
 psycopg2-binary==2.9.9
+requests==2.32.3

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -2,14 +2,28 @@
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
+  const t = `${current}:${evt}`;
   switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
+    case "OPEN:CLOSE":
+    case "CLOSING:CLOSE":
+    case "BLOCKED_DISCREPANCY:CLOSE":
+    case "BLOCKED_ANOMALY:CLOSE":
+    case "BLOCKED_DISCREPANCY:RESOLVE":
+    case "BLOCKED_ANOMALY:RESOLVE":
+      return "CLOSING";
+    case "CLOSING:PASS":
+    case "BLOCKED_DISCREPANCY:WAIVE":
+    case "BLOCKED_ANOMALY:WAIVE":
+      return "READY_RPT";
+    case "CLOSING:FAIL_DISCREPANCY":
+      return "BLOCKED_DISCREPANCY";
+    case "CLOSING:FAIL_ANOMALY":
+      return "BLOCKED_ANOMALY";
+    case "READY_RPT:RELEASED":
+      return "RELEASED";
+    case "RELEASED:FINALIZE":
+      return "FINALIZED";
+    default:
+      return current;
   }
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,127 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
+import { merkleRootHex } from "../crypto/merkle";
+import { nextState, PeriodState, Thresholds } from "../recon/stateMachine";
 import { Pool } from "pg";
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr: Thresholds = thresholds || {
+    epsilon_cents: 50,
+    variance_ratio: 0.25,
+    dup_rate: 0.01,
+    gap_minutes: 60,
+    delta_vs_baseline: 0.2,
+  };
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const periodRes = await client.query(
+      "select * from periods where abn=$1 and tax_type=$2 and period_id=$3 for update",
+      [abn, taxType, periodId]
+    );
+    if (periodRes.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return res.status(404).json({ error: "PERIOD_NOT_FOUND" });
+    }
+
+    const period = periodRes.rows[0];
+    const currentState = period.state as PeriodState;
+    const closingState = nextState(currentState, "CLOSE");
+    if (closingState !== "CLOSING") {
+      await client.query("ROLLBACK");
+      return res.status(409).json({ error: "BAD_STATE", state: currentState });
+    }
+
+    const totals = await client.query(
+      "select credited_cents from v_period_balances where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
+    const credited = Number(totals.rows[0]?.credited_cents ?? period.credited_to_owa_cents ?? 0);
+
+    const ledger = await client.query(
+      "select id, amount_cents, balance_after_cents, bank_receipt_hash, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    );
+    const leaves = ledger.rows.map((row: any) =>
+      JSON.stringify({
+        id: row.id,
+        amount_cents: Number(row.amount_cents),
+        balance_after_cents: Number(row.balance_after_cents),
+        bank_receipt_hash: row.bank_receipt_hash || "",
+        hash_after: row.hash_after || "",
+      })
+    );
+    const merkleRoot = merkleRootHex(leaves);
+    const runningHash = ledger.rows.length ? (ledger.rows[ledger.rows.length - 1].hash_after || "") : "";
+
+    await client.query(
+      `update periods
+         set state=$1,
+             credited_to_owa_cents=$2,
+             final_liability_cents=$3,
+             merkle_root=$4,
+             running_balance_hash=$5,
+             thresholds=$6
+       where id=$7`,
+      [closingState, credited, credited, merkleRoot, runningHash, thr, period.id]
+    );
+    await client.query("COMMIT");
+  } catch (err: any) {
+    await client.query("ROLLBACK");
+    return res.status(400).json({ error: err.message });
+  } finally {
+    client.release();
+  }
+
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }


### PR DESCRIPTION
## Summary
- fix the patent period state machine template literal and add transitions for the anomaly/discrepancy blocks
- compute and persist closing metadata (totals, merkle root, thresholds) before issuing an RPT
- store recon outcomes, publish gate transitions automatically, and add the requests dependency for the service

## Testing
- python -m compileall apps/services/recon/main.py

------
https://chatgpt.com/codex/tasks/task_e_68e23cff16608327a375c14be7f31dd4