### PR TITLE
Implement bank egress integration and allowlist registry

### DIFF
--- a/apps/services/bank-egress/main.py
+++ b/apps/services/bank-egress/main.py
@@ -1,36 +1,352 @@
-﻿# apps/services/bank-egress/main.py
+# apps/services/bank-egress/main.py
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import os, psycopg2, json
+from typing import Any, Dict, Literal, Optional
+import os, psycopg2, json, uuid, hashlib, logging
+import requests
+
 from libs.rpt.rpt import verify
+from libs.audit_chain.chain import link
 
 app = FastAPI(title="bank-egress")
 
+
+class Destination(BaseModel):
+    rail: Literal["EFT", "BPAY", "PAYTO"]
+    reference: str
+    bpay_biller: Optional[str] = None
+    account_bsb: Optional[str] = None
+    account_number: Optional[str] = None
+    mandate_id: Optional[str] = None
+
+
 class EgressReq(BaseModel):
     period_id: str
-    rpt: dict
+    abn: str
+    tax_type: Literal["PAYGW", "GST"]
+    amount_cents: int
+    destination: Destination
+    rpt: Dict[str, Any]
+
+
+class BankApiError(RuntimeError):
+    pass
+
+
+class BankApiClient:
+    def __init__(self) -> None:
+        self.base_url = os.getenv("BANK_API_BASE", "https://bank.local")
+        self.timeout = float(os.getenv("BANK_TIMEOUT_SECONDS", "10"))
+        self.session = requests.Session()
+
+        cert = os.getenv("BANK_TLS_CERT")
+        key = os.getenv("BANK_TLS_KEY")
+        ca = os.getenv("BANK_TLS_CA")
+        if cert and key:
+            self.session.cert = (cert, key)
+        if ca:
+            self.session.verify = ca
+        api_key = os.getenv("BANK_API_KEY")
+        if api_key:
+            self.session.headers["Authorization"] = f"Bearer {api_key}"
+
+    def _post(self, path: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        url = f"{self.base_url.rstrip('/')}/{path.lstrip('/')}"
+        headers = {"Idempotency-Key": str(uuid.uuid4())}
+        resp = self.session.post(url, json=payload, headers=headers, timeout=self.timeout)
+        if resp.status_code >= 400:
+            raise BankApiError(f"{resp.status_code}: {resp.text.strip()}")
+        try:
+            return resp.json()
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise BankApiError("invalid JSON from bank API") from exc
+
+    def eft(self, amount_cents: int, dest: Destination, meta: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {
+            "amount_cents": amount_cents,
+            "destination": {
+                "bsb": dest.account_bsb,
+                "account": dest.account_number,
+            },
+            "meta": meta,
+        }
+        return self._post("/payments/eft", payload)
+
+    def bpay(self, amount_cents: int, dest: Destination, meta: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {
+            "amount_cents": amount_cents,
+            "destination": {
+                "biller": dest.bpay_biller,
+                "crn": dest.reference,
+            },
+            "meta": meta,
+        }
+        return self._post("/payments/bpay", payload)
+
+    def payto(self, amount_cents: int, dest: Destination, meta: Dict[str, Any]) -> Dict[str, Any]:
+        payload = {
+            "amount_cents": amount_cents,
+            "reference": dest.reference,
+            "mandate_id": dest.mandate_id,
+            "meta": meta,
+        }
+        return self._post("/payto/debits", payload)
+
 
 def db():
     return psycopg2.connect(
-        host=os.getenv("PGHOST","127.0.0.1"),
-        user=os.getenv("PGUSER","postgres"),
-        password=os.getenv("PGPASSWORD","postgres"),
-        dbname=os.getenv("PGDATABASE","postgres"),
-        port=int(os.getenv("PGPORT","5432"))
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
     )
+
+
+def sanitize_numeric(value: Optional[str]) -> str:
+    return "" if value is None else "".join(ch for ch in value if ch.isdigit())
+
+
+def sanitize_reference(value: Optional[str]) -> str:
+    return "" if value is None else "".join(value.split())
+
+
+def ensure_allowlisted(cur, req: EgressReq) -> None:
+    dest = req.destination
+    if dest.rail == "BPAY":
+        cur.execute(
+            """
+            SELECT 1 FROM remittance_destinations
+             WHERE abn=%s AND rail='BPAY' AND reference=%s
+             LIMIT 1
+            """,
+            (req.abn, sanitize_reference(dest.reference)),
+        )
+        if cur.fetchone() is None:
+            raise HTTPException(403, "destination not allow-listed")
+        return
+
+    if dest.rail == "EFT":
+        bsb = sanitize_numeric(dest.account_bsb)
+        acct = sanitize_reference(dest.account_number)
+        if not bsb or not acct:
+            raise HTTPException(400, "missing EFT banking details")
+        cur.execute(
+            """
+            SELECT 1 FROM remittance_destinations
+             WHERE abn=%s AND rail='EFT'
+               AND regexp_replace(account_bsb,'[^0-9]','', 'g')=%s
+               AND regexp_replace(account_number,'\\s','', 'g')=%s
+             LIMIT 1
+            """,
+            (req.abn, bsb, acct),
+        )
+        if cur.fetchone() is None:
+            raise HTTPException(403, "destination not allow-listed")
+        return
+
+    # PAYTO allow-listing may be handled by mandate approval workflows.
+
+
+def append_audit(cur, actor: str, action: str, payload: Dict[str, Any]) -> str:
+    cur.execute("SELECT terminal_hash FROM audit_log ORDER BY seq DESC LIMIT 1")
+    row = cur.fetchone()
+    prev_hash = row[0] if row else None
+    payload_json = json.dumps(payload, separators=(",", ":"))
+    payload_hash = hashlib.sha256(payload_json.encode("utf-8")).hexdigest()
+    h = hashlib.sha256()
+    if prev_hash:
+        h.update(prev_hash.encode("utf-8"))
+    h.update(payload_hash.encode("utf-8"))
+    terminal_hash = h.hexdigest()
+    cur.execute(
+        """
+        INSERT INTO audit_log(actor, action, payload_hash, prev_hash, terminal_hash)
+        VALUES (%s,%s,%s,%s,%s)
+        """,
+        (actor, action, payload_hash, prev_hash, terminal_hash),
+    )
+    return terminal_hash
+
+
+def transition_gate(cur, period_id: str, target_state: str, reason_code: Optional[str], payload: Dict[str, Any]) -> str:
+    cur.execute("SELECT hash_this FROM bas_gate_states WHERE period_id=%s", (period_id,))
+    row = cur.fetchone()
+    prev = row[0] if row else None
+    payload_json = json.dumps(payload, separators=(",", ":"))
+    new_hash = link(prev, payload_json)
+    if row:
+        cur.execute(
+            """
+            UPDATE bas_gate_states
+               SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s
+             WHERE period_id=%s
+            """,
+            (target_state, reason_code, prev, new_hash, period_id),
+        )
+    else:
+        cur.execute(
+            """
+            INSERT INTO bas_gate_states(period_id, state, reason_code, hash_prev, hash_this)
+            VALUES (%s,%s,%s,%s,%s)
+            """,
+            (period_id, target_state, reason_code, prev, new_hash),
+        )
+    return new_hash
+
+
+def persist_receipt(cur, req: EgressReq, provider_receipt_id: str, receipt_hash: str) -> None:
+    metadata = {
+        "rail": req.destination.rail,
+        "mandate_id": req.destination.mandate_id,
+        "bpay_biller": req.destination.bpay_biller,
+    }
+    cur.execute(
+        """
+        INSERT INTO bank_transfer_receipts(
+            abn, tax_type, period_id, rail, reference, amount_cents,
+            provider_receipt_id, receipt_hash, metadata
+        ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s::jsonb)
+        ON CONFLICT (provider_receipt_id)
+          DO UPDATE SET receipt_hash = EXCLUDED.receipt_hash
+        """,
+        (
+            req.abn,
+            req.tax_type,
+            req.period_id,
+            req.destination.rail,
+            sanitize_reference(req.destination.reference),
+            req.amount_cents,
+            provider_receipt_id,
+            receipt_hash,
+            json.dumps(metadata),
+        ),
+    )
+
+
+def notify_monitoring(event: str, payload: Dict[str, Any]) -> None:
+    url = os.getenv("MONITORING_WEBHOOK_URL")
+    if not url:
+        return
+    try:
+        requests.post(url, json={"event": event, "payload": payload}, timeout=3)
+    except Exception:  # pragma: no cover - monitoring failures should not break flow
+        logging.getLogger("bank-egress").warning("monitoring webhook failed", exc_info=True)
+
+
+client: Optional[BankApiClient] = None
+
+
+def get_client() -> BankApiClient:
+    global client
+    if client is None:
+        client = BankApiClient()
+    return client
+
 
 @app.post("/egress/remit")
 def remit(req: EgressReq):
-    if "signature" not in req.rpt or not verify({k:v for k,v in req.rpt.items() if k!="signature"}, req.rpt["signature"]):
+    rpt_sig = req.rpt.get("signature")
+    payload = {k: v for k, v in req.rpt.items() if k != "signature"}
+    if not rpt_sig or not verify(payload, rpt_sig):
         raise HTTPException(400, "invalid RPT signature")
-    conn = db(); cur = conn.cursor()
-    cur.execute("SELECT state FROM bas_gate_states WHERE period_id=%s", (req.period_id,))
-    row = cur.fetchone()
-    if not row or row[0] != "RPT-Issued":
-        raise HTTPException(409, "gate not in RPT-Issued")
-    # Here you would call the real bank API via mTLS. For now, we just log.
-    payload = json.dumps({"period_id": req.period_id, "action": "remit"})
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('egress',%s,NULL,NULL)", (payload,))
-    cur.execute("UPDATE bas_gate_states SET state='Remitted', updated_at=NOW() WHERE period_id=%s", (req.period_id,))
-    conn.commit(); cur.close(); conn.close()
-    return {"ok": True}
+    if payload.get("period_id") and payload["period_id"] != req.period_id:
+        raise HTTPException(400, "RPT period mismatch")
+
+    conn = db()
+    conn.autocommit = False
+    cur = conn.cursor()
+    try:
+        cur.execute("SELECT state FROM bas_gate_states WHERE period_id=%s FOR UPDATE", (req.period_id,))
+        row = cur.fetchone()
+        if not row or row[0] != "RPT-Issued":
+            raise HTTPException(409, "gate not in RPT-Issued")
+
+        cur.execute(
+            "SELECT final_liability_cents FROM periods WHERE abn=%s AND tax_type=%s AND period_id=%s",
+            (req.abn, req.tax_type, req.period_id),
+        )
+        period = cur.fetchone()
+        if period and int(period[0]) != int(req.amount_cents):
+            raise HTTPException(400, "amount mismatch with period")
+
+        ensure_allowlisted(cur, req)
+
+        bank_client = get_client()
+        meta = {
+            "abn": req.abn,
+            "tax_type": req.tax_type,
+            "period_id": req.period_id,
+            "nonce": payload.get("nonce"),
+        }
+
+        if req.destination.rail == "EFT":
+            bank_resp = bank_client.eft(req.amount_cents, req.destination, meta)
+        elif req.destination.rail == "BPAY":
+            bank_resp = bank_client.bpay(req.amount_cents, req.destination, meta)
+        else:
+            bank_resp = bank_client.payto(req.amount_cents, req.destination, meta)
+
+        provider_receipt_id = (
+            bank_resp.get("receipt_id")
+            or bank_resp.get("bank_ref")
+            or bank_resp.get("reference")
+        )
+        if not provider_receipt_id:
+            raise BankApiError("missing receipt identifier")
+
+        receipt_hash = hashlib.sha256(str(provider_receipt_id).encode("utf-8")).hexdigest()
+        persist_receipt(cur, req, str(provider_receipt_id), receipt_hash)
+
+        gate_payload = {
+            "period_id": req.period_id,
+            "state": "Remitted",
+            "receipt_hash": receipt_hash,
+        }
+        transition_gate(cur, req.period_id, "Remitted", None, gate_payload)
+
+        audit_payload = {
+            "period_id": req.period_id,
+            "rail": req.destination.rail,
+            "amount_cents": req.amount_cents,
+            "receipt_hash": receipt_hash,
+        }
+        append_audit(cur, "bank-egress", "remit", audit_payload)
+
+        conn.commit()
+        return {
+            "ok": True,
+            "receipt_hash": receipt_hash,
+            "provider_receipt_id": provider_receipt_id,
+        }
+
+    except BankApiError as exc:
+        conn.rollback()
+        failure_payload = {
+            "period_id": req.period_id,
+            "rail": req.destination.rail,
+            "error": str(exc),
+        }
+        transition_gate(cur, req.period_id, "Blocked", "BANK_FAILURE", failure_payload)
+        append_audit(cur, "bank-egress", "remit_failed", failure_payload)
+        conn.commit()
+        notify_monitoring("bank_egress_failure", failure_payload)
+        raise HTTPException(502, "bank transfer failed")
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception as exc:  # pragma: no cover - defensive path
+        conn.rollback()
+        failure_payload = {
+            "period_id": req.period_id,
+            "rail": req.destination.rail,
+            "error": str(exc),
+        }
+        transition_gate(cur, req.period_id, "Blocked", "UNEXPECTED_FAILURE", failure_payload)
+        append_audit(cur, "bank-egress", "remit_failed", failure_payload)
+        conn.commit()
+        notify_monitoring("bank_egress_failure", failure_payload)
+        raise HTTPException(500, "unexpected remit failure")
+    finally:
+        cur.close()
+        conn.close()

--- a/apps/services/payments/src/utils/allowlist.ts
+++ b/apps/services/payments/src/utils/allowlist.ts
@@ -1,7 +1,163 @@
-﻿import pg from "pg";
+import pg from "pg";
+import axios from "axios";
+
 export type Dest = { bsb?: string; acct?: string; bpay_biller?: string; crn?: string };
 
-export function isAllowlisted(abn: string, dest: Dest): boolean {
-  if (dest.bpay_biller === "75556" && dest.crn && dest.crn.length >= 10) return true;
-  return false;
+const { Pool } = pg;
+
+type Rail = "BPAY" | "EFT";
+
+type NormalizedDest = {
+  rail: Rail;
+  reference: string;
+  bpay_biller?: string;
+  bsb?: string;
+  acct?: string;
+};
+
+export interface AllowlistProvider {
+  isAllowlisted(abn: string, dest: NormalizedDest): Promise<boolean>;
+}
+
+let provider: AllowlistProvider | null = null;
+
+function sanitizeNumeric(value: string) {
+  return value.replace(/[^0-9]/g, "");
+}
+
+function sanitizeReference(value: string) {
+  return value.replace(/\s+/g, "");
+}
+
+function normalizeDest(dest: Dest): NormalizedDest | null {
+  if (dest.bpay_biller && dest.crn) {
+    return {
+      rail: "BPAY",
+      reference: sanitizeReference(dest.crn),
+      bpay_biller: sanitizeReference(dest.bpay_biller)
+    };
+  }
+  if (dest.bsb && dest.acct) {
+    return {
+      rail: "EFT",
+      reference: sanitizeReference(dest.acct),
+      bsb: sanitizeNumeric(dest.bsb),
+      acct: sanitizeReference(dest.acct)
+    };
+  }
+  return null;
+}
+
+class DatabaseAllowlistProvider implements AllowlistProvider {
+  private pool: pg.Pool;
+
+  constructor() {
+    const sslMode = process.env.PGSSLMODE;
+    const ssl = sslMode === "require" ? { rejectUnauthorized: false } : undefined;
+    this.pool = new Pool({
+      connectionString: process.env.DATABASE_URL,
+      ssl
+    });
+  }
+
+  async isAllowlisted(abn: string, dest: NormalizedDest): Promise<boolean> {
+    if (!abn) return false;
+    if (dest.rail === "BPAY") {
+      const { rows } = await this.pool.query(
+        `SELECT 1
+         FROM remittance_destinations
+         WHERE abn = $1
+           AND rail = 'BPAY'
+           AND reference = $2
+         LIMIT 1`,
+        [abn, dest.reference]
+      );
+      return rows.length > 0;
+    }
+
+    if (!dest.bsb || !dest.acct) return false;
+    const { rows } = await this.pool.query(
+      `SELECT 1
+       FROM remittance_destinations
+       WHERE abn = $1
+         AND rail = 'EFT'
+         AND regexp_replace(account_bsb, '[^0-9]', '', 'g') = $2
+         AND regexp_replace(account_number, '\\s', '', 'g') = $3
+       LIMIT 1`,
+      [abn, dest.bsb, dest.acct]
+    );
+    return rows.length > 0;
+  }
+}
+
+type RegistryRow = {
+  abn: string;
+  rail: Rail;
+  reference?: string;
+  account_bsb?: string;
+  account_number?: string;
+  bpay_biller?: string;
+};
+
+class HttpAllowlistProvider implements AllowlistProvider {
+  private cache: RegistryRow[] = [];
+  private fetchedAt = 0;
+  private readonly ttlMs: number;
+
+  constructor(private readonly url: string) {
+    this.ttlMs = Number(process.env.ALLOWLIST_REGISTRY_TTL_MS || "60000");
+  }
+
+  private async refresh() {
+    if (Date.now() - this.fetchedAt < this.ttlMs && this.cache.length) return;
+    const timeout = Number(process.env.ALLOWLIST_REGISTRY_TIMEOUT_MS || "5000");
+    const res = await axios.get(this.url, { timeout });
+    const data = Array.isArray(res.data) ? res.data : [];
+    this.cache = data
+      .filter((row: any) => row && typeof row === "object")
+      .map((row: any) => {
+        const rail = String(row.rail || "").toUpperCase();
+        if (rail !== "BPAY" && rail !== "EFT") return null;
+        return {
+          abn: String(row.abn || "").trim(),
+          rail: rail as Rail,
+          reference: row.reference ? sanitizeReference(String(row.reference)) : undefined,
+          account_bsb: row.account_bsb ? sanitizeNumeric(String(row.account_bsb)) : undefined,
+          account_number: row.account_number ? sanitizeReference(String(row.account_number)) : undefined,
+          bpay_biller: row.bpay_biller ? sanitizeReference(String(row.bpay_biller)) : undefined
+        } as RegistryRow | null;
+      })
+      .filter((row: RegistryRow | null): row is RegistryRow => !!row);
+    this.fetchedAt = Date.now();
+  }
+
+  async isAllowlisted(abn: string, dest: NormalizedDest): Promise<boolean> {
+    await this.refresh();
+    return this.cache.some((row) => {
+      if (!row.abn || row.abn !== abn || row.rail !== dest.rail) return false;
+      if (dest.rail === "BPAY") {
+        return !!row.reference && row.reference === dest.reference && (!row.bpay_biller || row.bpay_biller === dest.bpay_biller);
+      }
+      return !!row.account_bsb && !!row.account_number && row.account_bsb === dest.bsb && row.account_number === dest.acct;
+    });
+  }
+}
+
+function getProvider(): AllowlistProvider {
+  if (provider) return provider;
+  const registryUrl = process.env.REMITTANCE_REGISTRY_URL || process.env.ALLOWLIST_REGISTRY_URL;
+  provider = registryUrl ? new HttpAllowlistProvider(registryUrl) : new DatabaseAllowlistProvider();
+  return provider;
+}
+
+export function setAllowlistProvider(p: AllowlistProvider | null) {
+  provider = p;
+}
+
+export async function isAllowlisted(abn: string, dest: Dest): Promise<boolean> {
+  if (!dest) return false;
+  const normalized = normalizeDest(dest);
+  if (!normalized) return false;
+  const prov = getProvider();
+  return prov.isAllowlisted(abn.trim(), normalized);
 }

--- a/apps/services/payments/test/allowlist.test.ts
+++ b/apps/services/payments/test/allowlist.test.ts
@@ -1,7 +1,45 @@
-import { isAllowlisted } from "../src/utils/allowlist";
-test("allowlist ok for ATO BPAY", () => {
-  expect(isAllowlisted("123", { bpay_biller:"75556", crn:"12345678901" })).toBe(true);
-});
-test("deny non-ATO", () => {
-  expect(isAllowlisted("123", { bsb:"012345", acct:"999999" })).toBe(false);
+import { AllowlistProvider, isAllowlisted, setAllowlistProvider } from "../src/utils/allowlist";
+
+type Row = {
+  abn: string;
+  rail: "BPAY" | "EFT";
+  reference?: string;
+  bpay_biller?: string;
+  bsb?: string;
+  acct?: string;
+};
+
+class MemoryProvider implements AllowlistProvider {
+  constructor(private readonly rows: Row[]) {}
+
+  async isAllowlisted(abn: string, dest: any): Promise<boolean> {
+    return this.rows.some((row) => {
+      if (row.abn !== abn || row.rail !== dest.rail) return false;
+      if (row.rail === "BPAY") {
+        return row.reference === dest.reference && (!row.bpay_biller || row.bpay_biller === dest.bpay_biller);
+      }
+      return row.bsb === dest.bsb && row.acct === dest.acct;
+    });
+  }
+}
+
+describe("allowlist lookups", () => {
+  beforeAll(() => {
+    setAllowlistProvider(
+      new MemoryProvider([
+        { abn: "123", rail: "BPAY", reference: "12345678901", bpay_biller: "75556" },
+        { abn: "123", rail: "EFT", bsb: "092009", acct: "12345678" }
+      ])
+    );
+  });
+
+  afterAll(() => setAllowlistProvider(null));
+
+  test("allowlist ok for ATO BPAY", async () => {
+    await expect(isAllowlisted("123", { bpay_biller: "75556", crn: "12345678901" })).resolves.toBe(true);
+  });
+
+  test("deny non-ATO", async () => {
+    await expect(isAllowlisted("123", { bsb: "012-345", acct: "999999" })).resolves.toBe(false);
+  });
 });

--- a/migrations/003_bank_transfer_receipts.sql
+++ b/migrations/003_bank_transfer_receipts.sql
@@ -1,0 +1,20 @@
+-- 003_bank_transfer_receipts.sql
+CREATE TABLE IF NOT EXISTS bank_transfer_receipts (
+  id BIGSERIAL PRIMARY KEY,
+  abn TEXT,
+  tax_type TEXT,
+  period_id TEXT,
+  rail TEXT NOT NULL,
+  reference TEXT NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  provider_receipt_id TEXT NOT NULL,
+  receipt_hash TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ux_bank_receipts_provider
+  ON bank_transfer_receipts (provider_receipt_id);
+
+CREATE INDEX IF NOT EXISTS ix_bank_receipts_period
+  ON bank_transfer_receipts (abn, tax_type, period_id);

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,124 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+import axios, { AxiosInstance } from "axios";
+import https from "https";
+import { randomUUID, createHash } from "crypto";
+import { readFileSync } from "fs";
+import { Pool } from "pg";
+
+/** PayTo BAS Sweep adapter */
+export interface PayToDebitResult {
+  status: "OK" | "INSUFFICIENT_FUNDS" | "BANK_ERROR";
+  bank_ref?: string;
+  receipt_hash?: string;
+}
+
+interface PayToClient {
+  createMandate(abn: string, capCents: number, reference: string): Promise<{ status: string; mandateId: string }>;
+  debit(abn: string, amountCents: number, reference: string): Promise<{ status: PayToDebitResult["status"]; receipt_id?: string; bank_ref?: string }>;
+  cancelMandate(mandateId: string): Promise<{ status: string }>;
+}
+
+const pool = new Pool();
+
+class MtlsPayToClient implements PayToClient {
+  private readonly client: AxiosInstance;
+
+  constructor() {
+    const agent = new https.Agent({
+      ca: process.env.BANK_TLS_CA ? readFileSync(process.env.BANK_TLS_CA) : undefined,
+      cert: process.env.BANK_TLS_CERT ? readFileSync(process.env.BANK_TLS_CERT) : undefined,
+      key: process.env.BANK_TLS_KEY ? readFileSync(process.env.BANK_TLS_KEY) : undefined,
+      rejectUnauthorized: process.env.BANK_TLS_REJECT_UNAUTHORIZED !== "false"
+    });
+    const baseURL = process.env.BANK_API_BASE || "https://bank.local";
+    const timeout = Number(process.env.BANK_TIMEOUT_MS || "8000");
+    this.client = axios.create({ baseURL, timeout, httpsAgent: agent });
+    const apiKey = process.env.BANK_API_KEY;
+    if (apiKey) {
+      this.client.defaults.headers.common["Authorization"] = `Bearer ${apiKey}`;
+    }
+  }
+
+  async createMandate(abn: string, capCents: number, reference: string) {
+    const payload = { abn, cap_cents: capCents, reference };
+    const { data } = await this.client.post("/payto/mandates", payload, {
+      headers: { "Idempotency-Key": randomUUID() }
+    });
+    return {
+      status: String(data?.status || "OK"),
+      mandateId: String(data?.mandate_id || data?.mandateId || "")
+    };
+  }
+
+  async debit(abn: string, amountCents: number, reference: string) {
+    const payload = { abn, amount_cents: amountCents, reference };
+    const { data } = await this.client.post("/payto/debits", payload, {
+      headers: { "Idempotency-Key": randomUUID() }
+    });
+    return {
+      status: (data?.status || "OK") as PayToDebitResult["status"],
+      receipt_id: data?.receipt_id || data?.bank_ref,
+      bank_ref: data?.bank_ref
+    };
+  }
+
+  async cancelMandate(mandateId: string) {
+    const { data } = await this.client.post(`/payto/mandates/${mandateId}/cancel`, {}, {
+      headers: { "Idempotency-Key": randomUUID() }
+    });
+    return { status: String(data?.status || "OK") };
+  }
+}
+
+let activeClient: PayToClient | null = null;
+
+function getClient(): PayToClient {
+  if (!activeClient) activeClient = new MtlsPayToClient();
+  return activeClient;
+}
+
+export function setPayToClient(client: PayToClient | null) {
+  activeClient = client;
+}
+
+async function persistReceipt(params: {
+  abn: string;
+  amountCents: number;
+  reference: string;
+  bankRef: string;
+  receiptHash: string;
+}) {
+  const metadata = { rail: "PAYTO" };
+  await pool.query(
+    `INSERT INTO bank_transfer_receipts (abn, rail, reference, amount_cents, provider_receipt_id, receipt_hash, metadata)
+     VALUES ($1,'PAYTO',$2,$3,$4,$5,$6)
+     ON CONFLICT (provider_receipt_id) DO UPDATE SET receipt_hash = EXCLUDED.receipt_hash`,
+    [
+      params.abn,
+      params.reference,
+      params.amountCents,
+      params.bankRef,
+      params.receiptHash,
+      JSON.stringify(metadata)
+    ]
+  );
+}
+
+export async function createMandate(abn: string, capCents: number, reference: string) {
+  return getClient().createMandate(abn, capCents, reference);
+}
+
+export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> {
+  const client = getClient();
+  const res = await client.debit(abn, amountCents, reference);
+  if (res.status === "OK" && res.receipt_id) {
+    const bankRef = String(res.receipt_id);
+    const receiptHash = createHash("sha256").update(bankRef).digest("hex");
+    await persistReceipt({ abn, amountCents, reference, bankRef, receiptHash });
+    return { status: res.status, bank_ref: res.bank_ref || bankRef, receipt_hash: receiptHash };
+  }
+  return { status: res.status, bank_ref: res.bank_ref };
+}
+
+export async function cancelMandate(mandateId: string) {
+  return getClient().cancelMandate(mandateId);
+}


### PR DESCRIPTION
## Summary
- load the payments allowlist from Postgres or an external registry with injectable providers for testing
- add a PayTo API client that performs mTLS authenticated calls and stores receipt hashes in the new bank_transfer_receipts table
- replace the bank-egress stub with a typed client that drives EFT/BPAY/PayTo flows, persists receipts, updates BAS gate state, emits audit records, and adds monitoring hooks

## Testing
- npx jest --runTestsByPath test/allowlist.test.ts *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e23d0232d48327b69b3a2eb717aee6