### PR TITLE
Enhance evidence bundle with audit metadata

### DIFF
--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -1,24 +1,111 @@
-﻿# apps/services/audit/main.py
+# apps/services/audit/main.py
 from fastapi import FastAPI
-import os, psycopg2, json
+import hashlib
+import json
+import os
+import psycopg2
+from typing import Any
 
 app = FastAPI(title="audit")
 
 def db():
     return psycopg2.connect(
-        host=os.getenv("PGHOST","127.0.0.1"),
-        user=os.getenv("PGUSER","postgres"),
-        password=os.getenv("PGPASSWORD","postgres"),
-        dbname=os.getenv("PGDATABASE","postgres"),
-        port=int(os.getenv("PGPORT","5432"))
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
     )
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def parse_message(message: Any) -> Any:
+    if isinstance(message, str):
+        payload = message.strip()
+        if (payload.startswith("{") and payload.endswith("}")) or (payload.startswith("[") and payload.endswith("]")):
+            try:
+                return json.loads(payload)
+            except json.JSONDecodeError:
+                return message
+        return message
+    return message
+
 
 @app.get("/audit/bundle/{period_id}")
 def bundle(period_id: str):
-    conn = db(); cur = conn.cursor()
-    cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
-    rpt = cur.fetchone()
-    cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
-    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []
-    cur.close(); conn.close()
-    return {"period_id": period_id, "rpt": rpt[0] if rpt else None, "audit": logs}
+    conn = db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT abn, tax_type FROM periods WHERE period_id=%s ORDER BY updated_at DESC LIMIT 1",
+            (period_id,),
+        )
+        period_row = cur.fetchone()
+        abn = period_row[0] if period_row else None
+        tax_type = period_row[1] if period_row else None
+
+        cur.execute(
+            "SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1",
+            (period_id,),
+        )
+        rpt_row = cur.fetchone()
+        rpt_payload = None
+        rpt_signature = None
+        rpt_issued_at = None
+        payload_sha256 = None
+        if rpt_row:
+            raw_payload = rpt_row[0]
+            if isinstance(raw_payload, str):
+                try:
+                    rpt_payload = json.loads(raw_payload)
+                except json.JSONDecodeError:
+                    rpt_payload = raw_payload
+            else:
+                rpt_payload = raw_payload
+            rpt_signature = rpt_row[1]
+            rpt_issued_at = rpt_row[2]
+            payload_sha256 = hashlib.sha256(canonical_json(rpt_payload).encode("utf-8")).hexdigest()
+
+        pattern = f'%"period_id":"{period_id}"%'
+        cur.execute(
+            "SELECT event_time, category, message, hash_prev, hash_this FROM audit_log WHERE message LIKE %s ORDER BY event_time",
+            (pattern,),
+        )
+        audit_rows = cur.fetchall()
+        audit_entries = []
+        for row in audit_rows:
+            event_time, category, message, hash_prev, hash_this = row
+            audit_entries.append(
+                {
+                    "event_time": event_time.isoformat() if hasattr(event_time, "isoformat") else event_time,
+                    "category": category,
+                    "message": parse_message(message),
+                    "hash_prev": hash_prev,
+                    "hash_this": hash_this,
+                }
+            )
+        audit_payload = {
+            "entries": audit_entries,
+            "head": audit_entries[-1]["hash_this"] if audit_entries else None,
+            "tail": audit_entries[0]["hash_prev"] if audit_entries else None,
+        }
+        rpt_record = None
+        if rpt_payload is not None or rpt_signature is not None:
+            rpt_record = {
+                "payload": rpt_payload,
+                "signature": rpt_signature,
+                "issued_at": rpt_issued_at.isoformat() if hasattr(rpt_issued_at, "isoformat") else rpt_issued_at,
+                "payload_sha256": payload_sha256,
+            }
+        return {
+            "period_id": period_id,
+            "abn": abn,
+            "tax_type": tax_type,
+            "rpt": rpt_record,
+            "audit": audit_payload,
+        }
+    finally:
+        cur.close()
+        conn.close()

--- a/apps/services/payments/jest.config.cjs
+++ b/apps/services/payments/jest.config.cjs
@@ -1,0 +1,15 @@
+module.exports = {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "node",
+  roots: ["<rootDir>/test"],
+  extensionsToTreatAsEsm: [".ts"],
+  globals: {
+    "ts-jest": {
+      useESM: true,
+      tsconfig: "<rootDir>/tsconfig.json",
+    },
+  },
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
+};

--- a/apps/services/payments/test/evidence_bundle.test.ts
+++ b/apps/services/payments/test/evidence_bundle.test.ts
@@ -1,3 +1,201 @@
-test("evidence bundle schema basics", () => {
-  expect(true).toBe(true);
+import { createHash } from "crypto";
+import { buildEvidenceBundle } from "../../../../src/evidence/bundle";
+
+type QueryResponse = { rows: any[]; rowCount: number };
+
+type QueryHandler = (text: string, params?: any[]) => QueryResponse | Promise<QueryResponse>;
+
+class FakeClient {
+  constructor(private readonly handler: QueryHandler) {}
+
+  async query(text: string, params: any[] = []): Promise<QueryResponse> {
+    return await this.handler(text, params);
+  }
+}
+
+const canonical = (value: unknown): string => {
+  if (value === null || value === undefined) return "null";
+  if (typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map(canonical).join(",")}]`;
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonical((value as Record<string, unknown>)[key])}`);
+  return `{${entries.join(",")}}`;
+};
+
+describe("buildEvidenceBundle", () => {
+  const baseData = {
+    abn: "12345678901",
+    taxType: "GST",
+    periodId: "2025-10",
+  };
+
+  const samplePayload = {
+    entity_id: baseData.abn,
+    period_id: baseData.periodId,
+    tax_type: baseData.taxType,
+    amount_cents: 123456,
+    anomaly_vector: { variance_ratio: 0.32, dup_rate: 0.01 },
+    thresholds: { variance_ratio: 0.25, dup_rate: 0.02 },
+    rail_id: "EFT",
+    reference: "ABC123",
+  };
+
+  const tables = {
+    periods: [
+      {
+        abn: baseData.abn,
+        tax_type: baseData.taxType,
+        period_id: baseData.periodId,
+        anomaly_vector: { variance_ratio: 0.32 },
+        thresholds: { variance_ratio: 0.25 },
+      },
+    ],
+    rpt_tokens: [
+      {
+        abn: baseData.abn,
+        tax_type: baseData.taxType,
+        period_id: baseData.periodId,
+        payload: samplePayload,
+        signature: "sig-123",
+      },
+    ],
+    owa_ledger: [
+      {
+        created_at: new Date("2025-10-01T00:00:00Z"),
+        amount_cents: 60000,
+        hash_after: "hash-a",
+        bank_receipt_hash: "rcpt-a",
+      },
+      {
+        created_at: new Date("2025-10-03T00:00:00Z"),
+        amount_cents: 63456,
+        hash_after: "hash-b",
+        bank_receipt_hash: "rcpt-b",
+      },
+    ],
+    bas_recon_results: [
+      { abn: baseData.abn, tax_type: baseData.taxType, period_id: baseData.periodId, label: "W1", value_cents: 175000 },
+      { abn: baseData.abn, tax_type: baseData.taxType, period_id: baseData.periodId, label: "W2", value_cents: 56000 },
+      { abn: baseData.abn, tax_type: baseData.taxType, period_id: baseData.periodId, label: "1A", value_cents: 16000 },
+      { abn: baseData.abn, tax_type: baseData.taxType, period_id: baseData.periodId, label: "1B", value_cents: 4000 },
+    ],
+    recon_discrepancies: [
+      {
+        abn: baseData.abn,
+        tax_type: baseData.taxType,
+        period_id: baseData.periodId,
+        metric: "variance_ratio",
+        observed_value: 0.32,
+        expected_value: 0.25,
+        threshold_value: 0.25,
+        status: "EXCEEDED",
+        notes: "variance exceeds threshold",
+      },
+    ],
+    audit_log: [
+      {
+        event_time: new Date("2025-10-02T00:00:00Z"),
+        category: "bas_gate",
+        message: JSON.stringify({ period_id: baseData.periodId, state: "CLOSING" }),
+        hash_prev: null,
+        hash_this: "hash-close",
+      },
+      {
+        event_time: new Date("2025-10-04T00:00:00Z"),
+        category: "bas_gate",
+        message: JSON.stringify({ period_id: baseData.periodId, state: "READY_RPT" }),
+        hash_prev: "hash-close",
+        hash_this: "hash-ready",
+      },
+    ],
+  };
+
+  const handler: QueryHandler = (text, params = []) => {
+    const sql = text.toLowerCase();
+    if (sql.includes("from periods")) {
+      const rows = tables.periods.filter(
+        (row) => row.abn === params[0] && row.tax_type === params[1] && row.period_id === params[2]
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from rpt_tokens")) {
+      const rows = tables.rpt_tokens.filter(
+        (row) => row.abn === params[0] && row.tax_type === params[1] && row.period_id === params[2]
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from owa_ledger")) {
+      const rows = tables.owa_ledger.map((row, idx) => ({ ...row, id: idx + 1 }));
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from bas_recon_results")) {
+      const rows = tables.bas_recon_results.filter(
+        (row) => row.abn === params[0] && row.tax_type === params[1] && row.period_id === params[2]
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from recon_discrepancies")) {
+      const rows = tables.recon_discrepancies.filter(
+        (row) => row.abn === params[0] && row.tax_type === params[1] && row.period_id === params[2]
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.includes("from audit_log")) {
+      const pattern: string = params[0];
+      const periodFragment = pattern.replace(/%/g, "").split(":").pop()?.replace(/"/g, "");
+      const rows = tables.audit_log.filter((row) =>
+        typeof row.message === "string" && row.message.includes(periodFragment ?? "")
+      );
+      return { rows, rowCount: rows.length };
+    }
+    return { rows: [], rowCount: 0 };
+  };
+
+  it("returns an evidence bundle with recon labels and audit hashes", async () => {
+    const client = new FakeClient(handler);
+    const bundle = await buildEvidenceBundle(baseData.abn, baseData.taxType, baseData.periodId, client as any);
+
+    expect(bundle.bas_labels).toMatchObject({ W1: 175000, W2: 56000, "1A": 16000, "1B": 4000 });
+    expect(bundle.owa_ledger_deltas).toHaveLength(2);
+    expect(bundle.bank_receipt_hash).toBe("rcpt-b");
+    expect(bundle.rpt_signature).toBe("sig-123");
+    expect(bundle.rpt_payload).toEqual(samplePayload);
+    expect(bundle.discrepancy_log).toEqual([
+      expect.objectContaining({
+        source: "recon",
+        metric: "variance_ratio",
+        status: "EXCEEDED",
+      }),
+    ]);
+    expect(bundle.audit_trail).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ hash_this: "hash-close" }),
+        expect.objectContaining({ hash_this: "hash-ready", hash_prev: "hash-close" }),
+      ])
+    );
+
+    const expectedSha = createHash("sha256").update(canonical(samplePayload)).digest("hex");
+    expect(bundle.payload_sha256).toBe(expectedSha);
+  });
+
+  it("falls back to anomaly vector when recon discrepancies are absent", async () => {
+    const noReconHandler: QueryHandler = (text, params = []) => {
+      if (text.toLowerCase().includes("from recon_discrepancies")) {
+        return { rows: [], rowCount: 0 };
+      }
+      return handler(text, params);
+    };
+    const client = new FakeClient(noReconHandler);
+    const bundle = await buildEvidenceBundle(baseData.abn, baseData.taxType, baseData.periodId, client as any);
+    expect(bundle.discrepancy_log).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ source: "anomaly", metric: "variance_ratio", status: "EXCEEDED" }),
+      ])
+    );
+  });
 });

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,246 @@
-﻿import { Pool } from "pg";
+import { createHash } from "crypto";
+import { Pool } from "pg";
+
+type Queryable = {
+  query: (text: string, params?: any[]) => Promise<any>;
+};
+
+type BasLabel = "W1" | "W2" | "1A" | "1B";
+type BasLabels = Record<BasLabel, number | null>;
+
+type DiscrepancyLogEntry = {
+  source: "recon" | "anomaly";
+  metric: string;
+  observed: number | null;
+  expected?: number | null;
+  threshold?: number | null;
+  status: "OK" | "EXCEEDED";
+  notes?: string | null;
+};
+
+type AuditTrailEntry = {
+  event_time: string | null;
+  category: string;
+  message: unknown;
+  hash_prev: string | null;
+  hash_this: string | null;
+};
+
 const pool = new Pool();
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+function canonicalString(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "null";
+  }
+  if (typeof value !== "object") {
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      return JSON.stringify(String(value));
+    }
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => canonicalString(v)).join(",")}]`;
+  }
+  const entries = Object.keys(value as Record<string, unknown>)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalString((value as Record<string, unknown>)[key])}`);
+  return `{${entries.join(",")}}`;
+}
+
+function toNumberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const num = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(num) ? num : null;
+}
+
+async function safeQuery<T = any>(client: Queryable, sql: string, params: any[] = []): Promise<{ rows: T[]; rowCount: number }> {
+  try {
+    const result = await client.query(sql, params);
+    const rows: T[] = result?.rows ?? [];
+    const rowCount: number = typeof result?.rowCount === "number" ? result.rowCount : rows.length;
+    return { rows, rowCount };
+  } catch (err: any) {
+    if (err?.code === "42P01" || err?.code === "42703") {
+      return { rows: [], rowCount: 0 };
+    }
+    throw err;
+  }
+}
+
+async function loadBasLabels(client: Queryable, abn: string, taxType: string, periodId: string): Promise<BasLabels> {
+  const labels: BasLabels = { W1: null, W2: null, "1A": null, "1B": null };
+  const { rows } = await safeQuery<{ label: string; value_cents: unknown }>(
+    client,
+    "SELECT label, value_cents FROM bas_recon_results WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
+  for (const row of rows) {
+    const key = row.label as keyof BasLabels;
+    if (key in labels) {
+      labels[key] = toNumberOrNull(row.value_cents);
+    }
+  }
+  return labels;
+}
+
+async function loadDiscrepancyLog(
+  client: Queryable,
+  abn: string,
+  taxType: string,
+  periodId: string,
+  anomalyVector: Record<string, unknown>,
+  thresholds: Record<string, unknown>
+): Promise<DiscrepancyLogEntry[]> {
+  const { rows, rowCount } = await safeQuery<{
+    metric: string;
+    observed_value?: unknown;
+    expected_value?: unknown;
+    threshold_value?: unknown;
+    status?: string;
+    notes?: string | null;
+  }>(
+    client,
+    "SELECT metric, observed_value, expected_value, threshold_value, status, notes FROM recon_discrepancies WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY observed_at",
+    [abn, taxType, periodId]
+  );
+  if (rowCount > 0) {
+    return rows.map((row) => {
+      const observed = toNumberOrNull(row.observed_value);
+      const expected = toNumberOrNull(row.expected_value);
+      const threshold = toNumberOrNull(row.threshold_value);
+      const exceeded = threshold !== null && observed !== null ? Math.abs(observed) > threshold : false;
+      return {
+        source: "recon",
+        metric: row.metric,
+        observed,
+        expected,
+        threshold,
+        status: exceeded || row.status === "EXCEEDED" ? "EXCEEDED" : "OK",
+        notes: row.notes ?? null,
+      } satisfies DiscrepancyLogEntry;
+    });
+  }
+  const entries: DiscrepancyLogEntry[] = [];
+  for (const [metric, value] of Object.entries(anomalyVector ?? {})) {
+    const observed = toNumberOrNull(value);
+    const threshold = toNumberOrNull((thresholds ?? {})[metric]);
+    const exceeded = threshold !== null && observed !== null ? Math.abs(observed) > threshold : false;
+    entries.push({
+      source: "anomaly",
+      metric,
+      observed,
+      threshold,
+      status: exceeded ? "EXCEEDED" : "OK",
+      notes: exceeded ? "anomaly vector exceeded threshold" : null,
+    });
+  }
+  return entries;
+}
+
+function parseAuditMessage(input: any): unknown {
+  if (input === null || input === undefined) return null;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+      try {
+        return JSON.parse(trimmed);
+      } catch {
+        return input;
+      }
+    }
+    return input;
+  }
+  return input;
+}
+
+async function loadAuditTrail(client: Queryable, periodId: string): Promise<AuditTrailEntry[]> {
+  const pattern = `%"period_id":"${periodId}"%`;
+  const { rows } = await safeQuery<{
+    event_time: Date | string | null;
+    category: string;
+    message: unknown;
+    hash_prev: string | null;
+    hash_this: string | null;
+  }>(
+    client,
+    "SELECT event_time, category, message, hash_prev, hash_this FROM audit_log WHERE message LIKE $1 ORDER BY event_time",
+    [pattern]
+  );
+  return rows.map((row) => ({
+    event_time:
+      row.event_time instanceof Date
+        ? row.event_time.toISOString()
+        : row.event_time !== null
+        ? String(row.event_time)
+        : null,
+    category: row.category,
+    message: parseAuditMessage(row.message),
+    hash_prev: row.hash_prev ?? null,
+    hash_this: row.hash_this ?? null,
+  }));
+}
+
+export async function buildEvidenceBundle(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  client: Queryable = pool
+) {
+  const periodResult = await safeQuery<any>(
+    client,
+    "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
+  const periodRow = periodResult.rows[0] ?? null;
+
+  const rptResult = await safeQuery<any>(
+    client,
+    "SELECT payload, signature FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY created_at DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
+  const rptRow = rptResult.rows[0] ?? null;
+
+  const deltasResult = await safeQuery<any>(
+    client,
+    "SELECT created_at AS ts, amount_cents, hash_after, bank_receipt_hash FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id",
+    [abn, taxType, periodId]
+  );
+  const owaLedger = deltasResult.rows.map((row) => ({
+    ...row,
+    amount_cents: toNumberOrNull(row.amount_cents) ?? row.amount_cents,
+  }));
+  const lastLedger = owaLedger[owaLedger.length - 1];
+
+  const basLabels = await loadBasLabels(client, abn, taxType, periodId);
+  const anomalyVector = (periodRow?.anomaly_vector as Record<string, unknown>) ?? {};
+  const thresholds = (periodRow?.thresholds as Record<string, unknown>) ?? {};
+  const discrepancyLog = await loadDiscrepancyLog(client, abn, taxType, periodId, anomalyVector, thresholds);
+  const auditTrail = await loadAuditTrail(client, periodId);
+
+  const rawPayload = rptRow?.payload ?? null;
+  let parsedPayload: unknown = rawPayload;
+  if (typeof parsedPayload === "string") {
+    try {
+      parsedPayload = JSON.parse(parsedPayload);
+    } catch {
+      parsedPayload = rawPayload;
+    }
+  }
+  let payloadSha256: string | null = null;
+  if (parsedPayload !== null && parsedPayload !== undefined) {
+    const canonical = canonicalString(parsedPayload);
+    payloadSha256 = createHash("sha256").update(canonical).digest("hex");
+  }
+
+  return {
+    bas_labels: basLabels,
+    rpt_payload: rawPayload ?? null,
+    rpt_signature: rptRow?.signature ?? null,
+    payload_sha256: payloadSha256,
+    owa_ledger_deltas: owaLedger,
+    bank_receipt_hash: lastLedger?.bank_receipt_hash ?? null,
+    anomaly_thresholds: thresholds,
+    discrepancy_log: discrepancyLog,
+    audit_trail: auditTrail,
   };
-  return bundle;
 }


### PR DESCRIPTION
## Summary
- enrich the evidence bundle with reconciled BAS labels, anomaly fallback discrepancies, canonical payload hashes, and audit trail data
- expose hashed audit log entries and payload digests from the audit service for the requested period
- add Jest configuration and unit tests that simulate a close/release cycle and assert bundle contents

## Testing
- npm --prefix apps/services/payments test *(fails: Jest binary unavailable because dependencies cannot be downloaded in this environment)*
- pytest *(fails: optional SDK modules such as `apgms_sdk` are not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23d013e808327be1ec14073e2ca96