### PR TITLE
Align ledger and RPT schema with per-period model

### DIFF
--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -16,7 +16,16 @@ def db():
 @app.get("/audit/bundle/{period_id}")
 def bundle(period_id: str):
     conn = db(); cur = conn.cursor()
-    cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
+    cur.execute(
+        """
+        SELECT payload, signature, created_at
+        FROM rpt_tokens
+        WHERE period_id=%s
+        ORDER BY created_at DESC
+        LIMIT 1
+        """,
+        (period_id,)
+    )
     rpt = cur.fetchone()
     cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
     logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []

--- a/apps/services/payments/src/evidence/evidenceBundle.ts
+++ b/apps/services/payments/src/evidence/evidenceBundle.ts
@@ -12,7 +12,7 @@ type BuildParams = {
 
 export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
   const rpt = await client.query(
-    "SELECT rpt_id, payload_c14n, payload_sha256, signature FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED' ORDER BY created_at DESC LIMIT 1",
+    "SELECT id as rpt_id, payload_c14n, payload_sha256, signature FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED' ORDER BY created_at DESC LIMIT 1",
     [p.abn, p.taxType, p.periodId]
   );
   if (!rpt.rows.length) throw new Error("Missing RPT for bundle");
@@ -23,7 +23,7 @@ export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
   const normalization = { payroll_hash: "NA", pos_hash: "NA" };
 
   const beforeQ = await client.query(
-    "SELECT COALESCE(SUM(amount_cents),0) bal FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND entry_id < (SELECT max(entry_id) FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3)",
+    "SELECT COALESCE(SUM(amount_cents),0) bal FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND id < (SELECT max(id) FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3)",
     [p.abn, p.taxType, p.periodId]
   );
   const afterQ = await client.query(

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { sha256Hex } from "../utils/crypto";
 
 export async function deposit(req: Request, res: Response) {
   try {
@@ -14,24 +15,36 @@ export async function deposit(req: Request, res: Response) {
       await client.query("BEGIN");
 
       const { rows: last } = await client.query(
-        `SELECT balance_after_cents FROM owa_ledger
+        `SELECT balance_after_cents, hash_after FROM owa_ledger
          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
          ORDER BY id DESC LIMIT 1`,
         [abn, taxType, periodId]
       );
       const prevBal = last[0]?.balance_after_cents ?? 0;
+      const prevHash = last[0]?.hash_after ?? "";
       const newBal = prevBal + amt;
+      const transfer_uuid = randomUUID();
+      const bankReceiptHash = `synthetic:deposit:${transfer_uuid.slice(0, 12)}`;
+      const hashAfter = sha256Hex(prevHash + bankReceiptHash + String(newBal));
 
       const { rows: ins } = await client.query(
         `INSERT INTO owa_ledger
-           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,now())
-         RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
+           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,
+            bank_receipt_hash,prev_hash,hash_after,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())
+         RETURNING id,transfer_uuid,balance_after_cents,hash_after`,
+        [abn, taxType, periodId, transfer_uuid, amt, newBal, bankReceiptHash, prevHash, hashAfter]
       );
 
       await client.query("COMMIT");
-      return res.json({ ok: true, ledger_id: ins[0].id, balance_after_cents: ins[0].balance_after_cents });
+      return res.json({
+        ok: true,
+        ledger_id: ins[0].id,
+        transfer_uuid: ins[0].transfer_uuid,
+        bank_receipt_hash: bankReceiptHash,
+        balance_after_cents: ins[0].balance_after_cents,
+        hash_after: ins[0].hash_after
+      });
 
     } catch (e:any) {
       await client.query("ROLLBACK");

--- a/apps/services/payments/test/owa_constraints.test.ts
+++ b/apps/services/payments/test/owa_constraints.test.ts
@@ -5,11 +5,11 @@ test("OWA deposit-only constraint", async () => {
   const c = await pool.connect();
   try {
     await c.query("BEGIN");
-    await c.query("INSERT INTO owa_ledger (abn,tax_type,period_id,amount_cents) VALUES ($1,$2,$3,$4)",
-      ["111", "PAYGW", "2025-09", 1000]);
+    await c.query("INSERT INTO owa_ledger (abn,tax_type,period_id,amount_cents,balance_after_cents) VALUES ($1,$2,$3,$4,$5)",
+      ["111", "PAYGW", "2025-09", 1000, 1000]);
     await expect(c.query(
-      "INSERT INTO owa_ledger (abn,tax_type,period_id,amount_cents) VALUES ($1,$2,$3,$4)",
-      ["111", "PAYGW", "2025-09", -500]
+      "INSERT INTO owa_ledger (abn,tax_type,period_id,amount_cents,balance_after_cents) VALUES ($1,$2,$3,$4,$5)",
+      ["111", "PAYGW", "2025-09", -500, 500]
     )).rejects.toThrow();
   } finally {
     await c.query("ROLLBACK");

--- a/migrations/002_apgms_patent_core.sql
+++ b/migrations/002_apgms_patent_core.sql
@@ -1,5 +1,5 @@
-﻿-- 002_apgms_patent_core.sql
--- BAS Gate state machine, OWA ledger, audit hash chain, RPT store
+-- 002_apgms_patent_core.sql
+-- BAS Gate state machine and canonical OWA/RPT helpers aligned with per-period ledger
 
 CREATE TABLE IF NOT EXISTS bas_gate_states (
   id SERIAL PRIMARY KEY,
@@ -13,35 +13,179 @@ CREATE TABLE IF NOT EXISTS bas_gate_states (
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_bas_gate_period ON bas_gate_states (period_id);
 
+-- If a legacy aggregate-only ledger exists, park it so the canonical table can be created.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'owa_ledger'
+      AND column_name = 'credit_amount'
+  ) THEN
+    ALTER TABLE owa_ledger RENAME TO owa_ledger_aggregate_legacy;
+  END IF;
+END $$;
+
+-- Ensure the per-period ledger has the expected columns and guard rails.
 CREATE TABLE IF NOT EXISTS owa_ledger (
-  id SERIAL PRIMARY KEY,
-  kind VARCHAR(10) NOT NULL CHECK (kind IN ('PAYGW','GST')),
-  credit_amount NUMERIC(18,2) NOT NULL,
-  source_ref VARCHAR(64),
-  created_at TIMESTAMP NOT NULL DEFAULT NOW(),
-  audit_hash CHAR(64)
+  id BIGSERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  transfer_uuid UUID NOT NULL DEFAULT gen_random_uuid(),
+  amount_cents BIGINT NOT NULL,
+  balance_after_cents BIGINT NOT NULL,
+  bank_receipt_hash TEXT,
+  prev_hash TEXT,
+  hash_after TEXT,
+  rpt_verified BOOLEAN NOT NULL DEFAULT false,
+  release_uuid UUID,
+  bank_receipt_id TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT owa_release_guard
+    CHECK (
+      amount_cents >= 0
+      OR (amount_cents < 0 AND rpt_verified = true AND release_uuid IS NOT NULL)
+    ),
+  UNIQUE (transfer_uuid)
 );
+
+ALTER TABLE owa_ledger
+  ALTER COLUMN balance_after_cents SET NOT NULL,
+  ALTER COLUMN created_at SET NOT NULL,
+  ALTER COLUMN rpt_verified SET NOT NULL;
+
+ALTER TABLE owa_ledger
+  ALTER COLUMN transfer_uuid SET DEFAULT gen_random_uuid();
+
+ALTER TABLE owa_ledger
+  ALTER COLUMN transfer_uuid SET NOT NULL;
+
+ALTER TABLE owa_ledger
+  ADD COLUMN IF NOT EXISTS rpt_verified BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS release_uuid UUID,
+  ADD COLUMN IF NOT EXISTS bank_receipt_id TEXT,
+  ADD COLUMN IF NOT EXISTS bank_receipt_hash TEXT,
+  ADD COLUMN IF NOT EXISTS prev_hash TEXT,
+  ADD COLUMN IF NOT EXISTS hash_after TEXT,
+  ADD COLUMN IF NOT EXISTS balance_after_cents BIGINT NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS transfer_uuid UUID NOT NULL DEFAULT gen_random_uuid(),
+  ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT now();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'owa_release_guard'
+  ) THEN
+    ALTER TABLE owa_ledger ADD CONSTRAINT owa_release_guard
+      CHECK (
+        amount_cents >= 0
+        OR (amount_cents < 0 AND rpt_verified = true AND release_uuid IS NOT NULL)
+      );
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS owa_uniq_bank_receipt
+  ON owa_ledger (abn, tax_type, period_id, bank_receipt_hash)
+  WHERE bank_receipt_hash IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS owa_release_uuid_uidx
+  ON owa_ledger (release_uuid)
+  WHERE release_uuid IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS owa_single_release_uidx
+  ON owa_ledger (abn, tax_type, period_id)
+  WHERE amount_cents < 0;
+
+CREATE INDEX IF NOT EXISTS owa_ledger_period_order_idx
+  ON owa_ledger (abn, tax_type, period_id, id);
+
+-- Audit log: rename legacy aggregate chain if encountered, otherwise ensure canonical structure.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'audit_log'
+      AND column_name = 'message'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'audit_log'
+          AND column_name = 'payload_hash'
+      )
+  ) THEN
+    ALTER TABLE audit_log RENAME TO audit_log_legacy;
+  END IF;
+END $$;
 
 CREATE TABLE IF NOT EXISTS audit_log (
-  id BIGSERIAL PRIMARY KEY,
-  event_time TIMESTAMP NOT NULL DEFAULT NOW(),
-  category VARCHAR(32) NOT NULL, -- bas_gate, rpt, egress, security
-  message TEXT NOT NULL,
-  hash_prev CHAR(64),
-  hash_this CHAR(64)
+  seq BIGSERIAL PRIMARY KEY,
+  ts TIMESTAMPTZ DEFAULT now(),
+  actor TEXT NOT NULL,
+  action TEXT NOT NULL,
+  payload_hash TEXT NOT NULL,
+  prev_hash TEXT,
+  terminal_hash TEXT
 );
 
-CREATE TABLE IF NOT EXISTS rpt_store (
+-- RPT tokens: retire duplicate store and ensure canonical columns exist.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'rpt_store'
+  ) THEN
+    ALTER TABLE rpt_store RENAME TO rpt_store_legacy;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS rpt_tokens (
   id BIGSERIAL PRIMARY KEY,
-  period_id VARCHAR(32) NOT NULL,
-  rpt_json JSONB NOT NULL,
-  rpt_sig  TEXT NOT NULL,
-  issued_at TIMESTAMP NOT NULL DEFAULT NOW()
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  payload JSONB NOT NULL,
+  payload_c14n TEXT,
+  payload_sha256 TEXT,
+  signature TEXT NOT NULL,
+  key_id TEXT,
+  nonce TEXT,
+  expires_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'ISSUED',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
--- Minimal guard view: no generic debit primitive
+ALTER TABLE rpt_tokens
+  ADD COLUMN IF NOT EXISTS payload JSONB,
+  ADD COLUMN IF NOT EXISTS payload_c14n TEXT,
+  ADD COLUMN IF NOT EXISTS payload_sha256 TEXT,
+  ADD COLUMN IF NOT EXISTS key_id TEXT,
+  ADD COLUMN IF NOT EXISTS nonce TEXT,
+  ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'ISSUED';
+
+ALTER TABLE rpt_tokens
+  ALTER COLUMN payload SET NOT NULL,
+  ALTER COLUMN signature SET NOT NULL,
+  ALTER COLUMN created_at SET NOT NULL,
+  ALTER COLUMN status SET NOT NULL,
+  ALTER COLUMN status SET DEFAULT 'ISSUED';
+
+CREATE INDEX IF NOT EXISTS rpt_tokens_lookup_idx
+  ON rpt_tokens (abn, tax_type, period_id, status);
+
+-- Canonical balance view keyed by period.
+DROP VIEW IF EXISTS owa_balance;
 CREATE VIEW owa_balance AS
-SELECT kind, COALESCE(SUM(credit_amount),0) AS balance
-FROM owa_ledger GROUP BY kind;
-
--- Transition helper skeletons (fill with business rules in services)
+SELECT
+  abn,
+  tax_type,
+  period_id,
+  COALESCE(SUM(amount_cents), 0)::bigint AS balance_cents,
+  MAX(id) AS last_entry_id
+FROM owa_ledger
+GROUP BY abn, tax_type, period_id;

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,8 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    `select * from remittance_destinations
+     where abn=$1 and rail=$2 and reference=$3`,
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -17,15 +18,22 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
+  const release_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query(
+      "insert into idempotency_keys(key,last_status) values($1,$2)",
+      [transfer_uuid, "INIT"]
+    );
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    `select balance_after_cents, hash_after
+     from owa_ledger
+     where abn=$1 and tax_type=$2 and period_id=$3
+     order by id desc limit 1`,
     [abn, taxType, periodId]);
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
@@ -33,10 +41,16 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
+    `insert into owa_ledger(
+       abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,
+       bank_receipt_hash,prev_hash,hash_after,rpt_verified,release_uuid
+     ) values ($1,$2,$3,$4,$5,$6,$7,$8,$9,true,$10)`,
+    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter, release_uuid]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
+  await pool.query(
+    "update idempotency_keys set last_status=$1 where key=$2",
+    ["DONE", transfer_uuid]
+  );
+  return { transfer_uuid, release_uuid, bank_receipt_hash };
 }

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,6 +1,7 @@
 ﻿import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { sha256Hex } from "../crypto/merkle";
 
 export async function deposit(req: Request, res: Response) {
   try {
@@ -18,20 +19,25 @@ export async function deposit(req: Request, res: Response) {
       await client.query("BEGIN");
 
       const { rows: last } = await client.query(
-        `SELECT balance_after_cents FROM owa_ledger
+        `SELECT balance_after_cents, hash_after FROM owa_ledger
          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
          ORDER BY id DESC LIMIT 1`,
         [abn, taxType, periodId]
       );
       const prevBal = last[0]?.balance_after_cents ?? 0;
+      const prevHash = last[0]?.hash_after ?? "";
       const newBal = prevBal + amt;
+      const transfer_uuid = randomUUID();
+      const bankReceiptHash = `synthetic:deposit:${transfer_uuid.slice(0,12)}`;
+      const hashAfter = sha256Hex(prevHash + bankReceiptHash + String(newBal));
 
       const { rows: ins } = await client.query(
         `INSERT INTO owa_ledger
-           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,now())
-         RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
+           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,
+            bank_receipt_hash,prev_hash,hash_after,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())
+         RETURNING id,transfer_uuid,balance_after_cents,hash_after`,
+        [abn, taxType, periodId, transfer_uuid, amt, newBal, bankReceiptHash, prevHash, hashAfter]
       );
 
       await client.query("COMMIT");
@@ -39,7 +45,9 @@ export async function deposit(req: Request, res: Response) {
         ok: true,
         ledger_id: ins[0].id,
         transfer_uuid: ins[0].transfer_uuid,
-        balance_after_cents: ins[0].balance_after_cents
+        bank_receipt_hash: bankReceiptHash,
+        balance_after_cents: ins[0].balance_after_cents,
+        hash_after: ins[0].hash_after
       });
 
     } catch (e:any) {


### PR DESCRIPTION
## Summary
- unify the base and patent migrations around the per-period OWA ledger/RPT schema, add guard rails, and retire the legacy store
- refresh helper SQL, evidence pipelines, and the payments service deposit/release flows to maintain hash chaining and expose receipt metadata
- update RPT issuance/storage utilities, audit queries, and tests so downstream code works with the canonical columns

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e23d0028e08327a6d0dbb8f38472ae