### PR TITLE
Parameterize SQL queries and add RPT integration tests

### DIFF
--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -2,9 +2,18 @@
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  )).rows[0];
+  const rpt = (await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  )).rows[0];
+  const deltas = (await pool.query(
+    "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+    [abn, taxType, periodId]
+  )).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -6,10 +6,10 @@ export function idempotency() {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [key, "INIT"]);
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
+      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=$1", [key]);
       return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
   };

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,14 +18,14 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
     [abn, taxType, periodId]);
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
@@ -33,10 +33,10 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("update idempotency_keys set last_status=$1 where key=$2", ["DONE", transfer_uuid]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state=$1 where abn=$2 and tax_type=$3 and period_id=$4",
+      ['RELEASED', abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -6,19 +6,22 @@ const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("update periods set state=$1 where id=$2", ['BLOCKED_ANOMALY', row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state=$1 where id=$2", ['BLOCKED_DISCREPANCY', row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +33,10 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await pool.query("update periods set state=$1 where id=$2", ['READY_RPT', row.id]);
   return { payload, signature };
 }

--- a/tests/integration/mock_server.cjs
+++ b/tests/integration/mock_server.cjs
@@ -1,0 +1,283 @@
+const Module = require('module');
+const crypto = require('node:crypto');
+const nacl = require('tweetnacl');
+
+function createSharedState() {
+  return {
+    periods: [],
+    rptTokens: [],
+    owaLedger: [],
+    periodSeq: 1,
+    rptSeq: 1,
+    ledgerSeq: 1,
+  };
+}
+
+function buildMockPg(state) {
+  class MockPool {
+    constructor() {
+      this.state = state;
+    }
+
+    async query(rawSql, params = []) {
+      const sql = rawSql.replace(/\s+/g, ' ').trim();
+      switch (sql) {
+        case 'insert into periods(abn,tax_type,period_id,state,credited_to_owa_cents,final_liability_cents,merkle_root,running_balance_hash) values ($1,$2,$3,$4,$5,$6,$7,$8)': {
+          const [pAbn, pTax, pPeriod, newState, credited, finalLiability, merkle, balanceHash] = params;
+          const period = {
+            id: state.periodSeq++,
+            abn: pAbn,
+            tax_type: pTax,
+            period_id: pPeriod,
+            state: newState,
+            basis: 'ACCRUAL',
+            accrued_cents: 0,
+            credited_to_owa_cents: credited,
+            final_liability_cents: finalLiability,
+            merkle_root: merkle,
+            running_balance_hash: balanceHash,
+            anomaly_vector: {},
+            thresholds: {},
+          };
+          state.periods.push(period);
+          return { rowCount: 1, rows: [] };
+        }
+        case 'select * from periods where abn=$1 and tax_type=$2 and period_id=$3': {
+          const [pAbn, pTax, pPeriod] = params;
+          const rows = state.periods.filter(
+            (p) => p.abn === pAbn && p.tax_type === pTax && p.period_id === pPeriod
+          );
+          return { rowCount: rows.length, rows };
+        }
+        case 'update periods set state=$1 where id=$2': {
+          const [newState, id] = params;
+          const period = state.periods.find((p) => p.id === id);
+          if (period) {
+            period.state = newState;
+            return { rowCount: 1, rows: [] };
+          }
+          return { rowCount: 0, rows: [] };
+        }
+        case 'update periods set state=$1 where abn=$2 and tax_type=$3 and period_id=$4': {
+          const [newState, pAbn, pTax, pPeriod] = params;
+          let updated = 0;
+          for (const period of state.periods) {
+            if (period.abn === pAbn && period.tax_type === pTax && period.period_id === pPeriod) {
+              period.state = newState;
+              updated++;
+            }
+          }
+          return { rowCount: updated, rows: [] };
+        }
+        case 'insert into rpt_tokens(abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256) values ($1,$2,$3,$4,$5,$6,$7)': {
+          const [pAbn, pTax, pPeriod, payload, signature, payloadStr, payloadSha] = params;
+          const token = {
+            id: state.rptSeq++,
+            abn: pAbn,
+            tax_type: pTax,
+            period_id: pPeriod,
+            payload,
+            signature,
+            payload_c14n: payloadStr,
+            payload_sha256: payloadSha,
+            created_at: new Date().toISOString(),
+          };
+          state.rptTokens.push(token);
+          return { rowCount: 1, rows: [] };
+        }
+        case 'select payload, signature from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1': {
+          const [pAbn, pTax, pPeriod] = params;
+          const rows = state.rptTokens
+            .filter((t) => t.abn === pAbn && t.tax_type === pTax && t.period_id === pPeriod)
+            .sort((a, b) => b.id - a.id)
+            .map(({ payload, signature }) => ({ payload, signature }));
+          return { rowCount: rows.length ? 1 : 0, rows: rows.slice(0, 1) };
+        }
+        case 'select payload, payload_c14n, payload_sha256, signature, created_at from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1': {
+          const [pAbn, pTax, pPeriod] = params;
+          const rows = state.rptTokens
+            .filter((t) => t.abn === pAbn && t.tax_type === pTax && t.period_id === pPeriod)
+            .sort((a, b) => b.id - a.id)
+            .map(({ payload, payload_c14n, payload_sha256, signature, created_at }) => ({
+              payload,
+              payload_c14n,
+              payload_sha256,
+              signature,
+              created_at,
+            }));
+          return { rowCount: rows.length ? 1 : 0, rows: rows.slice(0, 1) };
+        }
+        case 'select balance_after_cents from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1': {
+          const [pAbn, pTax, pPeriod] = params;
+          const rows = state.owaLedger
+            .filter((l) => l.abn === pAbn && l.tax_type === pTax && l.period_id === pPeriod)
+            .sort((a, b) => b.id - a.id)
+            .map((l) => ({ balance_after_cents: l.balance_after_cents }));
+          return { rowCount: rows.length ? 1 : 0, rows: rows.slice(0, 1) };
+        }
+        case 'select balance_after_cents as bal from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1': {
+          const [pAbn, pTax, pPeriod] = params;
+          const rows = state.owaLedger
+            .filter((l) => l.abn === pAbn && l.tax_type === pTax && l.period_id === pPeriod)
+            .sort((a, b) => b.id - a.id)
+            .map((l) => ({ bal: l.balance_after_cents }));
+          return { rowCount: rows.length ? 1 : 0, rows: rows.slice(0, 1) };
+        }
+        case 'select * from owa_append($1,$2,$3,$4,$5)': {
+          const [pAbn, pTax, pPeriod, amount, receipt] = params;
+          if (receipt) {
+            const existing = state.owaLedger.find(
+              (l) => l.abn === pAbn && l.tax_type === pTax && l.period_id === pPeriod && l.bank_receipt_hash === receipt
+            );
+            if (existing) {
+              return {
+                rowCount: 1,
+                rows: [{ id: existing.id, balance_after: existing.balance_after_cents, hash_after: existing.hash_after }],
+              };
+            }
+          }
+          const entries = state.owaLedger.filter(
+            (l) => l.abn === pAbn && l.tax_type === pTax && l.period_id === pPeriod
+          );
+          const prev = entries.length ? entries[entries.length - 1] : null;
+          const prevBalance = prev ? prev.balance_after_cents : 0;
+          const prevHash = prev ? prev.hash_after : '';
+          const balanceAfter = prevBalance + Number(amount);
+          const hash_after = crypto
+            .createHash('sha256')
+            .update(`${prevHash}${receipt || ''}${balanceAfter}`)
+            .digest('hex');
+          const row = {
+            id: state.ledgerSeq++,
+            abn: pAbn,
+            tax_type: pTax,
+            period_id: pPeriod,
+            transfer_uuid: crypto.randomUUID(),
+            amount_cents: Number(amount),
+            balance_after_cents: balanceAfter,
+            bank_receipt_hash: receipt || null,
+            prev_hash: prevHash,
+            hash_after,
+            created_at: new Date().toISOString(),
+          };
+          state.owaLedger.push(row);
+          return { rowCount: 1, rows: [{ id: row.id, balance_after: row.balance_after_cents, hash_after: row.hash_after }] };
+        }
+        case 'select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id': {
+          const [pAbn, pTax, pPeriod] = params;
+          const rows = state.owaLedger
+            .filter((l) => l.abn === pAbn && l.tax_type === pTax && l.period_id === pPeriod)
+            .sort((a, b) => a.id - b.id)
+            .map(({ id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at }) => ({
+              id,
+              amount_cents,
+              balance_after_cents,
+              bank_receipt_hash,
+              prev_hash,
+              hash_after,
+              created_at,
+            }));
+          return { rowCount: rows.length, rows };
+        }
+        default:
+          throw new Error(`Unhandled SQL: ${sql}`);
+      }
+    }
+
+    async end() {
+      return undefined;
+    }
+  }
+
+  return { Pool: MockPool };
+}
+
+async function startMockServer() {
+  const state = createSharedState();
+  const mockPg = buildMockPg(state);
+  const originalLoad = Module._load;
+  Module._load = function patched(request, parent, isMain) {
+    if (request === 'pg') {
+      return mockPg;
+    }
+    return originalLoad(request, parent, isMain);
+  };
+
+  const keyPair = nacl.sign.keyPair();
+  const envBackup = {
+    RPT_ED25519_SECRET_BASE64: process.env.RPT_ED25519_SECRET_BASE64,
+    RPT_PUBLIC_BASE64: process.env.RPT_PUBLIC_BASE64,
+    ATO_PRN: process.env.ATO_PRN,
+    PORT: process.env.PORT,
+    NODE_ENV: process.env.NODE_ENV,
+  };
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString('base64');
+  process.env.RPT_PUBLIC_BASE64 = Buffer.from(keyPair.publicKey).toString('base64');
+  process.env.ATO_PRN = 'PRN123';
+  process.env.PORT = '0';
+  process.env.NODE_ENV = 'test';
+
+  const originalLog = console.log;
+  try {
+    console.log = () => {};
+    var srvMod = require('../../server.js');
+  } finally {
+    console.log = originalLog;
+  }
+  const server = srvMod.server;
+  const pool = srvMod.pool;
+  const addr = server.address();
+  const listenPort = typeof addr === 'object' && addr ? addr.port : addr;
+  const baseUrl = `http://127.0.0.1:${listenPort}`;
+
+  state.periods.push({
+    id: state.periodSeq++,
+    abn: '12345678901',
+    tax_type: 'GST',
+    period_id: '2025-09',
+    state: 'CLOSING',
+    basis: 'ACCRUAL',
+    accrued_cents: 0,
+    credited_to_owa_cents: 1000,
+    final_liability_cents: 1000,
+    merkle_root: 'root',
+    running_balance_hash: 'hash',
+    anomaly_vector: {},
+    thresholds: {},
+  });
+  state.owaLedger.push({
+    id: state.ledgerSeq++,
+    abn: '12345678901',
+    tax_type: 'GST',
+    period_id: '2025-09',
+    transfer_uuid: crypto.randomUUID(),
+    amount_cents: 1000,
+    balance_after_cents: 1000,
+    bank_receipt_hash: 'credit:seed',
+    prev_hash: '',
+    hash_after: crypto.createHash('sha256').update('credit:seed1000').digest('hex'),
+    created_at: new Date().toISOString(),
+  });
+
+  async function close() {
+    await new Promise((resolve) => server.close(resolve));
+    if (pool && typeof pool.end === 'function') {
+      await pool.end();
+    }
+    Module._load = originalLoad;
+    if (envBackup.RPT_ED25519_SECRET_BASE64 === undefined) delete process.env.RPT_ED25519_SECRET_BASE64;
+    else process.env.RPT_ED25519_SECRET_BASE64 = envBackup.RPT_ED25519_SECRET_BASE64;
+    if (envBackup.RPT_PUBLIC_BASE64 === undefined) delete process.env.RPT_PUBLIC_BASE64;
+    else process.env.RPT_PUBLIC_BASE64 = envBackup.RPT_PUBLIC_BASE64;
+    if (envBackup.ATO_PRN === undefined) delete process.env.ATO_PRN;
+    else process.env.ATO_PRN = envBackup.ATO_PRN;
+    if (envBackup.PORT === undefined) delete process.env.PORT;
+    else process.env.PORT = envBackup.PORT;
+    if (envBackup.NODE_ENV === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = envBackup.NODE_ENV;
+  }
+
+  return { baseUrl, state, close };
+}
+
+module.exports = { startMockServer };

--- a/tests/integration/mock_server_runner.cjs
+++ b/tests/integration/mock_server_runner.cjs
@@ -1,0 +1,17 @@
+const { startMockServer } = require('./mock_server.cjs');
+
+(async () => {
+  try {
+    const ctx = await startMockServer();
+    console.log(JSON.stringify({ baseUrl: ctx.baseUrl }));
+    const shutdown = async () => {
+      await ctx.close();
+      process.exit(0);
+    };
+    process.on('SIGTERM', shutdown);
+    process.on('SIGINT', shutdown);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/tests/integration/rpt_flow.test.cjs
+++ b/tests/integration/rpt_flow.test.cjs
@@ -1,0 +1,56 @@
+const { before, after, test } = require('node:test');
+const assert = require('node:assert');
+const { startMockServer } = require('./mock_server.cjs');
+
+const abn = '12345678901';
+const taxType = 'GST';
+const periodId = '2025-09';
+
+let serverCtx;
+
+before(async () => {
+  serverCtx = await startMockServer();
+});
+
+after(async () => {
+  if (serverCtx) {
+    await serverCtx.close();
+  }
+});
+
+test('issue RPT, release debit, and rebuild evidence bundle', async () => {
+  const issueRes = await fetch(`${serverCtx.baseUrl}/rpt/issue`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ abn, taxType, periodId }),
+  });
+  assert.strictEqual(issueRes.status, 200);
+  const issueBody = await issueRes.json();
+  assert.strictEqual(issueBody.payload.period_id, periodId);
+  assert.ok(issueBody.signature);
+
+  const statusRes = await fetch(`${serverCtx.baseUrl}/period/status?abn=${abn}&taxType=${taxType}&periodId=${periodId}`);
+  assert.strictEqual(statusRes.status, 200);
+  const statusBody = await statusRes.json();
+  assert.strictEqual(statusBody.period.state, 'READY_RPT');
+
+  const releaseRes = await fetch(`${serverCtx.baseUrl}/release`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ abn, taxType, periodId }),
+  });
+  assert.strictEqual(releaseRes.status, 200);
+  const releaseBody = await releaseRes.json();
+  assert.strictEqual(releaseBody.released, true);
+  assert.strictEqual(Number(releaseBody.new_balance), 0);
+
+  const evidenceRes = await fetch(`${serverCtx.baseUrl}/evidence?abn=${abn}&taxType=${taxType}&periodId=${periodId}`);
+  assert.strictEqual(evidenceRes.status, 200);
+  const evidenceBody = await evidenceRes.json();
+  assert.strictEqual(evidenceBody.period.state, 'RELEASED');
+  assert.ok(Array.isArray(evidenceBody.owa_ledger));
+  assert.strictEqual(evidenceBody.owa_ledger.length, 2);
+  const debit = evidenceBody.owa_ledger[1];
+  assert.strictEqual(Number(debit.balance_after_cents), 0);
+  assert.ok(debit.bank_receipt_hash);
+});

--- a/tests/integration/test_rpt_flow_fastapi.py
+++ b/tests/integration/test_rpt_flow_fastapi.py
@@ -1,0 +1,92 @@
+import json
+import subprocess
+import time
+from pathlib import Path
+
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+NODE_RUNNER = PROJECT_ROOT / "tests" / "integration" / "mock_server_runner.cjs"
+
+
+def start_mock_server():
+    proc = subprocess.Popen(
+        ["node", str(NODE_RUNNER)],
+        cwd=PROJECT_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    base_url = None
+    start_time = time.time()
+    while time.time() - start_time < 5:
+        line = proc.stdout.readline()
+        if not line:
+            time.sleep(0.1)
+            continue
+        line = line.strip()
+        try:
+            data = json.loads(line)
+            base_url = data["baseUrl"]
+            break
+        except json.JSONDecodeError:
+            continue
+    if not base_url:
+        stderr = proc.stderr.read()
+        proc.terminate()
+        raise RuntimeError(f"Failed to start mock server: {stderr}")
+    return proc, base_url
+
+
+def stop_mock_server(proc):
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_fastapi_rpt_flow_integration():
+    proc, base_url = start_mock_server()
+    try:
+        # Ensure the Node server is ready
+        for _ in range(10):
+            try:
+                httpx.get(f"{base_url}/health", timeout=1.0)
+                break
+            except httpx.RequestError:
+                time.sleep(0.1)
+        app = FastAPI()
+
+        @app.post("/rpt-flow")
+        def orchestrate():
+            issue = httpx.post(
+                f"{base_url}/rpt/issue",
+                json={"abn": "12345678901", "taxType": "GST", "periodId": "2025-09"},
+                timeout=2.0,
+            ).json()
+            release = httpx.post(
+                f"{base_url}/release",
+                json={"abn": "12345678901", "taxType": "GST", "periodId": "2025-09"},
+                timeout=2.0,
+            ).json()
+            evidence = httpx.get(
+                f"{base_url}/evidence",
+                params={"abn": "12345678901", "taxType": "GST", "periodId": "2025-09"},
+                timeout=2.0,
+            ).json()
+            return {"issue": issue, "release": release, "evidence": evidence}
+
+        client = TestClient(app)
+        resp = client.post("/rpt-flow")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["release"]["released"] is True
+        assert data["release"]["new_balance"] == 0
+        assert data["evidence"]["period"]["state"] == "RELEASED"
+        assert len(data["evidence"]["owa_ledger"]) == 2
+    finally:
+        stop_mock_server(proc)


### PR DESCRIPTION
## Summary
- replace raw SQL placeholders with positional parameters across the Node API and supporting services
- add a mock Postgres harness with Node and FastAPI integration tests covering RPT issuance, OWA debit, and evidence rebuild

## Testing
- node --test tests/integration/rpt_flow.test.cjs
- pytest tests/integration/test_rpt_flow_fastapi.py

------
https://chatgpt.com/codex/tasks/task_e_68e23cfdbda48327a19c2486e76bc9a3