### PR TITLE
Expose anomaly guard helper and cover recon transitions

### DIFF
--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -20,3 +20,24 @@ export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
     Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
   );
 }
+
+export function exceeds(
+  v: Partial<AnomalyVector>,
+  thr: Partial<Thresholds> = {}
+): boolean {
+  const vector: AnomalyVector = {
+    variance_ratio: Number(v.variance_ratio ?? 0),
+    dup_rate: Number(v.dup_rate ?? 0),
+    gap_minutes: Number(v.gap_minutes ?? 0),
+    delta_vs_baseline: Number(v.delta_vs_baseline ?? 0),
+  };
+
+  const thresholds: Thresholds = {
+    variance_ratio: thr.variance_ratio,
+    dup_rate: thr.dup_rate,
+    gap_minutes: thr.gap_minutes,
+    delta_vs_baseline: thr.delta_vs_baseline,
+  };
+
+  return isAnomalous(vector, thresholds);
+}

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -2,13 +2,20 @@
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
+  const t = `${current}:${evt}`;
   switch (t) {
     case "OPEN:CLOSE": return "CLOSING";
     case "CLOSING:PASS": return "READY_RPT";
     case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
     case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
+    case "BLOCKED_DISCREPANCY:RECONCILED":
+    case "BLOCKED_DISCREPANCY:RETRY":
+    case "BLOCKED_ANOMALY:RETRY":
+    case "BLOCKED_ANOMALY:OVERRIDE":
+      return "CLOSING";
+    case "READY_RPT:RELEASE":
+    case "READY_RPT:RELEASED":
+      return "RELEASED";
     case "RELEASED:FINALIZE": return "FINALIZED";
     default: return current;
   }

--- a/tests/anomaly/deterministic.test.ts
+++ b/tests/anomaly/deterministic.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { exceeds, isAnomalous } from "../../src/anomaly/deterministic";
+
+describe("deterministic anomaly checks", () => {
+  it("flags vectors exceeding provided thresholds", () => {
+    const vector = {
+      variance_ratio: 0.3,
+      dup_rate: 0.02,
+      gap_minutes: 15,
+      delta_vs_baseline: 0.15,
+    };
+
+    assert.equal(
+      exceeds(vector, {
+        variance_ratio: 0.35,
+        dup_rate: 0.05,
+        gap_minutes: 60,
+        delta_vs_baseline: 0.2,
+      }),
+      false,
+      "vector should not exceed relaxed thresholds",
+    );
+
+    assert.equal(
+      exceeds(vector, {
+        variance_ratio: 0.25,
+        dup_rate: 0.01,
+        gap_minutes: 60,
+        delta_vs_baseline: 0.2,
+      }),
+      true,
+      "higher variance ratio should trip guard",
+    );
+  });
+
+  it("falls back to defaults for missing metrics", () => {
+    const sparseVector = { variance_ratio: 0.1 };
+
+    assert.equal(isAnomalous({
+      variance_ratio: 0.1,
+      dup_rate: 0.01,
+      gap_minutes: 5,
+      delta_vs_baseline: 0.05,
+    }), false, "baseline vector should be considered normal");
+
+    assert.equal(
+      exceeds(sparseVector, {}),
+      false,
+      "sparse vector should normalise missing fields",
+    );
+
+    assert.equal(
+      exceeds({ delta_vs_baseline: 0.5 }, {}),
+      true,
+      "large delta_vs_baseline should be anomalous",
+    );
+  });
+});

--- a/tests/recon/stateMachine.test.ts
+++ b/tests/recon/stateMachine.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { PeriodState, nextState } from "../../src/recon/stateMachine";
+
+describe("recon state machine", () => {
+  it("supports the happy path from open to finalized", () => {
+    const closing = nextState("OPEN", "CLOSE");
+    assert.equal(closing, "CLOSING");
+
+    const ready = nextState(closing, "PASS");
+    assert.equal(ready, "READY_RPT");
+
+    const released = nextState(ready, "RELEASE");
+    assert.equal(released, "RELEASED");
+
+    const finalized = nextState(released, "FINALIZE");
+    assert.equal(finalized, "FINALIZED");
+  });
+
+  it("routes blocking events back through closing once resolved", () => {
+    const blocked = nextState("CLOSING", "FAIL_ANOMALY");
+    assert.equal(blocked, "BLOCKED_ANOMALY");
+
+    const retried = nextState(blocked, "RETRY");
+    assert.equal(retried, "CLOSING");
+
+    const blockedDiscrepancy = nextState("CLOSING", "FAIL_DISCREPANCY");
+    assert.equal(blockedDiscrepancy, "BLOCKED_DISCREPANCY");
+
+    const reconciled = nextState(blockedDiscrepancy, "RECONCILED");
+    assert.equal(reconciled, "CLOSING");
+  });
+
+  it("is idempotent for unsupported transitions", () => {
+    const state: PeriodState = "READY_RPT";
+    assert.equal(nextState(state, "UNKNOWN"), state);
+  });
+});


### PR DESCRIPTION
## Summary
- export an anomaly `exceeds` helper so the issuer uses the deterministic guard thresholds
- repair the recon state machine transition key and add coverage for release/unblock events
- exercise anomaly and reconciliation paths with node:test suites

## Testing
- `npx tsx --test tests/**/*.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e2421e676483279e593510f8168ed4