### PR TITLE
Add validation middleware and centralized error handling

### DIFF
--- a/src/http/errors.ts
+++ b/src/http/errors.ts
@@ -1,0 +1,6 @@
+import { Request, Response, NextFunction } from "express";
+
+export function errorHandler(err: any, _req: Request, res: Response, _next: NextFunction) {
+  const status = err?.statusCode || 500;
+  res.status(status).json({ error: status === 500 ? "internal_error" : err?.message || "error" });
+}

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,22 @@
+import { AnyZodObject, ZodError } from "zod";
+import { Request, Response, NextFunction } from "express";
+
+export function validate(s: { body?: AnyZodObject; params?: AnyZodObject; query?: AnyZodObject }) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (s.body) {
+        req.body = s.body.parse(req.body);
+      }
+      if (s.params) {
+        req.params = s.params.parse(req.params);
+      }
+      if (s.query) {
+        req.query = s.query.parse(req.query);
+      }
+      next();
+    } catch (e) {
+      const ze = e as ZodError;
+      res.status(400).json({ error: "validation_failed", issues: ze.issues });
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { errorHandler } from "./http/errors";
 
 dotenv.config();
 
@@ -31,8 +32,11 @@ app.use("/api", paymentsApi);
 // Existing API router(s) after
 app.use("/api", api);
 
-// 404 fallback (must be last)
+// 404 fallback for unmatched routes
 app.use((_req, res) => res.status(404).send("Not found"));
+
+// Centralized error handler
+app.use(errorHandler);
 
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => console.log("APGMS server listening on", port));


### PR DESCRIPTION
## Summary
- add reusable request validation middleware returning structured responses
- introduce centralized error handler to standardize server error payloads
- register the error handler in the Express app

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e242a3f9dc8327a4219cd160032be9