### PR TITLE
Add Swagger UI documentation endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
                 "csv-parse": "^6.1.0",
                 "dotenv": "^17.2.3",
                 "express": "^5.1.0",
+                "swagger-ui-express": "^5.0.1",
                 "pg": "^8.16.3",
                 "tweetnacl": "^1.0.3",
                 "uuid": "^13.0.0"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "swagger-ui-express": "^5.0.1",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"

--- a/src/http/openapi.ts
+++ b/src/http/openapi.ts
@@ -1,0 +1,36 @@
+import swaggerUi from "swagger-ui-express";
+import { Router } from "express";
+
+export const spec = {
+  openapi: "3.0.0",
+  info: { title: "APGMS", version: "1.0.0" },
+  paths: {
+    "/api/balance/{abn}": {
+      get: {
+        parameters: [
+          { name: "abn", in: "path", required: true, schema: { type: "string" } }
+        ],
+        responses: { "200": { description: "OK" } }
+      }
+    },
+    "/api/reconcile/close-and-issue": {
+      post: {
+        requestBody: { required: true },
+        responses: { "200": { description: "OK" } }
+      }
+    },
+    "/api/evidence/{abn}/{pid}": {
+      get: {
+        parameters: [
+          { name: "abn", in: "path", required: true, schema: { type: "string" } },
+          { name: "pid", in: "path", required: true, schema: { type: "string" } }
+        ],
+        responses: { "200": { description: "OK" } }
+      }
+    }
+  }
+};
+
+export function mountDocs(app: Router) {
+  app.use("/docs", swaggerUi.serve, swaggerUi.setup(spec as any));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { mountDocs } from "./http/openapi";
 
 dotenv.config();
 
@@ -30,6 +31,8 @@ app.use("/api", paymentsApi);
 
 // Existing API router(s) after
 app.use("/api", api);
+
+mountDocs(app);
 
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));


### PR DESCRIPTION
## Summary
- add an OpenAPI spec that documents balance, close-and-issue, and evidence endpoints
- mount Swagger UI at /docs so partners can inspect the API
- include swagger-ui-express as a runtime dependency

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e242b4b1d08327bad623d73bd70ab4