### PR TITLE
Add indexes migration for ledger and related tables

### DIFF
--- a/migrations/006_indexes.sql
+++ b/migrations/006_indexes.sql
@@ -1,0 +1,5 @@
+create index if not exists ix_ledger_abn_period on ledger (abn, period_id);
+create index if not exists ix_evidence_abn_period on evidence_bundles (abn, period_id);
+create index if not exists ix_periods_abn on periods (abn);
+create index if not exists ix_idempotency_key on idempotency (key);
+create index if not exists ix_payto_mandates_abn on payto_mandates (abn);


### PR DESCRIPTION
## Summary
- add a migration that creates indexes on ledger, evidence_bundles, periods, idempotency, and payto_mandates tables
- ensure the migration uses IF NOT EXISTS to remain safe on repeated runs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e242d55c248327b40655faadce7df5