### PR TITLE
Add request ID aware request logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 ﻿// src/index.ts
-import express from "express";
+import express, { type Request } from "express";
 import dotenv from "dotenv";
+import { randomUUID } from "crypto";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
@@ -12,8 +13,60 @@ dotenv.config();
 const app = express();
 app.use(express.json({ limit: "2mb" }));
 
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+type RequestWithId = Request & { reqId?: string };
+
+type LogLevel = "info" | "error" | "warn" | "debug";
+
+const log = (level: LogLevel, payload: Record<string, unknown>) => {
+  const entry = {
+    level,
+    time: new Date().toISOString(),
+    ...payload,
+  };
+  console.log(JSON.stringify(entry));
+};
+
+const ensureRequestId = (req: RequestWithId): string => {
+  const incoming = req.headers["x-request-id"];
+  if (typeof incoming === "string" && incoming.length > 0) {
+    req.reqId = incoming;
+    return incoming;
+  }
+  if (Array.isArray(incoming) && incoming.length > 0) {
+    const value = incoming[0];
+    req.headers["x-request-id"] = value;
+    req.reqId = value;
+    return value;
+  }
+
+  const generated = randomUUID();
+  req.headers["x-request-id"] = generated;
+  req.reqId = generated;
+  return generated;
+};
+
+app.use((req, res, next) => {
+  const request = req as RequestWithId;
+  const reqId = ensureRequestId(request);
+  res.setHeader("x-request-id", reqId);
+  res.locals.reqId = reqId;
+
+  const start = process.hrtime.bigint();
+
+  res.on("finish", () => {
+    const durationMs = Number((process.hrtime.bigint() - start) / BigInt(1_000_000));
+    log("info", {
+      msg: "request completed",
+      reqId,
+      method: request.method,
+      url: request.originalUrl ?? request.url,
+      statusCode: res.statusCode,
+      durationMs,
+    });
+  });
+
+  next();
+});
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
@@ -35,4 +88,4 @@ app.use("/api", api);
 app.use((_req, res) => res.status(404).send("Not found"));
 
 const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+app.listen(port, () => log("info", { msg: "APGMS server listening", port }));


### PR DESCRIPTION
## Summary
- ensure each request has an x-request-id header and expose it on the response
- add structured request completion logging that includes the stable request id
- log server startup through the same structured logger

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e242bb9c3c83279792a24bf7f5e903