### PR TITLE
feat: validate env config and expose RPT signer

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dependencies": {
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
+        "envalid": "^8.0.0",
         "express": "^5.1.0",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,0 +1,14 @@
+import "dotenv/config";
+import { cleanEnv, str, url, bool, num } from "envalid";
+
+export const env = cleanEnv(process.env, {
+  NODE_ENV:               str({ choices: ["development","test","production"], default: "development" }),
+  PORT:                   num({ default: 8080 }),
+  DATABASE_URL:           str(),
+  LOG_LEVEL:              str({ default: "info" }),
+  RPT_ED25519_SECRET_BASE64: str(),        // REQUIRED for RPT signing
+  MTLS_CERT:              str({ default: "" }),
+  MTLS_KEY:               str({ default: "" }),
+  MTLS_CA:                str({ default: "" }),
+  ALLOWLIST_ABNS:         str({ default: "" }),
+});

--- a/src/crypto/rptSigner.ts
+++ b/src/crypto/rptSigner.ts
@@ -1,0 +1,41 @@
+import { env } from "../config/env";
+import { createPrivateKey, createPublicKey, sign as nodeSign, verify as nodeVerify } from "crypto";
+
+function b64ToBufStrict(b64: string, errorMessage: string) {
+  try {
+    const normalized = b64.replace(/\s+/g, "");
+    const buf = Buffer.from(normalized, "base64");
+    if (buf.length === 0) throw new Error();
+    const reencoded = buf.toString("base64");
+    if (reencoded.replace(/=+$/, "") !== normalized.replace(/=+$/, "")) {
+      throw new Error();
+    }
+    return buf;
+  } catch {
+    throw new Error(errorMessage);
+  }
+}
+
+const secret = env.RPT_ED25519_SECRET_BASE64.trim();
+if (!secret) throw new Error("RPT_ED25519_SECRET_BASE64 missing");
+const privSeed = b64ToBufStrict(secret, "RPT_ED25519_SECRET_BASE64 is not valid base64");
+if (privSeed.length !== 32 && privSeed.length !== 64) {
+  throw new Error("RPT_ED25519_SECRET_BASE64 must decode to 32 or 64 bytes for an ed25519 seed");
+}
+
+// Convert the 32-byte seed into a PKCS#8 ed25519 private key for Node's crypto API.
+const PKCS8_PREFIX = Buffer.from("302e020100300506032b657004220420", "hex");
+const seed = privSeed.slice(0, 32);
+const privateKey = createPrivateKey({ key: Buffer.concat([PKCS8_PREFIX, seed]), format: "der", type: "pkcs8" });
+const publicKey = createPublicKey(privateKey);
+
+export const rptSigner = {
+  async sign(payload: string) {
+    const sig = nodeSign(null, Buffer.from(payload), privateKey);
+    return sig.toString("base64");
+  },
+  async verify(payload: string, signatureB64: string) {
+    const signature = b64ToBufStrict(signatureB64, "RPT signature is not valid base64");
+    return nodeVerify(null, Buffer.from(payload), publicKey, signature);
+  },
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 ﻿// src/index.ts
 import express from "express";
-import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
-dotenv.config();
+import { env } from "./config/env";
+console.log(`[apgms] starting in ${env.NODE_ENV}, port=${env.PORT}`);
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
@@ -34,5 +34,5 @@ app.use("/api", api);
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));
 
-const port = Number(process.env.PORT) || 3000;
+const port = env.PORT;
 app.listen(port, () => console.log("APGMS server listening on", port));


### PR DESCRIPTION
## Summary
- add an envalid-powered environment loader to validate required configuration values
- expose an Ed25519 RPT signer that loads the secret from configuration
- wire the server bootstrap to use the validated configuration and log its startup context

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e242895ff88327bed7f9998a1d06a7