### PR TITLE
Validate RPT secret and cover issuer scenarios

### DIFF
--- a/.env.rpt.fixture
+++ b/.env.rpt.fixture
@@ -1,0 +1,3 @@
+# Local development fixture used when RPT_ED25519_SECRET_BASE64 is not provided.
+RPT_ED25519_SECRET_BASE64=AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,11 @@
 ﻿# APGMS
 Skeleton monorepo for Automated PAYGW & GST Management System.
 See ADRs in /docs/adr and architecture diagrams in Mermaid in /docs/diagrams.
+
+## Deployment configuration
+
+The Reconciliation & Payments Token (RPT) issuer requires an Ed25519 signing secret.
+Set `RPT_ED25519_SECRET_BASE64` to the base64-encoded 64-byte secret key before
+starting the service in any production-like environment. The local development
+server will fall back to `.env.rpt.fixture`, but production deployments **must**
+provide the environment variable explicitly to avoid start-up failures.

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,24 +1,91 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
+import dotenv from "dotenv";
+import fs from "node:fs";
+import path from "node:path";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+
+const SECRET_ENV_KEY = "RPT_ED25519_SECRET_BASE64";
+const LOCAL_ENV_FIXTURE = ".env.rpt.fixture";
+
+let cachedSecret: Uint8Array | null = null;
+let pool: Pool | null = null;
+let poolFactory: () => Pool = () => new Pool();
+let sign = signRpt;
+let exceedsFn = exceeds;
+
+function readFixtureSecret(): string | undefined {
+  if (process.env.NODE_ENV === "production") return undefined;
+  const envPath = path.resolve(process.cwd(), LOCAL_ENV_FIXTURE);
+  if (!fs.existsSync(envPath)) return undefined;
+  const buffer = fs.readFileSync(envPath);
+  const parsed = dotenv.parse(buffer);
+  return parsed[SECRET_ENV_KEY]?.trim();
+}
+
+function getSecretKey(): Uint8Array {
+  if (cachedSecret) return cachedSecret;
+
+  const base64 = (process.env[SECRET_ENV_KEY] ?? readFixtureSecret() ?? "").trim();
+  if (!base64) {
+    throw new Error(`CONFIG: ${SECRET_ENV_KEY} is required and must be a base64 encoded Ed25519 secret key`);
+  }
+
+  const decoded = Buffer.from(base64, "base64");
+  if (decoded.length !== 64) {
+    throw new Error(`CONFIG: ${SECRET_ENV_KEY} must decode to a 64-byte Ed25519 secret key`);
+  }
+
+  cachedSecret = new Uint8Array(decoded);
+  return cachedSecret;
+}
+
+function getPool(): Pool {
+  if (!pool) pool = poolFactory();
+  return pool;
+}
+
+export function __resetIssuerSecretForTest() {
+  cachedSecret = null;
+}
+
+export const __testHooks = {
+  setPoolFactory(factory: () => Pool) {
+    poolFactory = factory;
+    pool = null;
+  },
+  setSignFn(fn: typeof signRpt) {
+    sign = fn;
+  },
+  setExceedsFn(fn: typeof exceeds) {
+    exceedsFn = fn;
+  },
+  reset() {
+    poolFactory = () => new Pool();
+    pool = null;
+    sign = signRpt;
+    exceedsFn = exceeds;
+    __resetIssuerSecretForTest();
+  }
+};
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const secretKey = getSecretKey();
+
+  const p = await getPool().query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+  if (exceedsFn(v, thresholds)) {
+    await getPool().query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await getPool().query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -29,9 +96,9 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
+  const signature = sign(payload, secretKey);
+  await getPool().query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
     [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await getPool().query("update periods set state='READY_RPT' where id=", [row.id]);
   return { payload, signature };
 }

--- a/tests/rpt/issuer.test.ts
+++ b/tests/rpt/issuer.test.ts
@@ -1,0 +1,108 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const issuerModuleUrl = new URL("../../src/rpt/issuer.ts", import.meta.url).href;
+const issuerModulePromise = import(issuerModuleUrl);
+
+const SECRET_B64 = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDEyMzQ1Njc4OTo7PD0+Pw==";
+
+test("issueRPT persists a signed payload when the secret is configured", async (t) => {
+  const issuerModule = await issuerModulePromise;
+  const { issueRPT, __testHooks, __resetIssuerSecretForTest } = issuerModule;
+
+  __testHooks.reset();
+  __resetIssuerSecretForTest();
+
+  const queries: Array<{ sql: string; params: unknown[] }> = [];
+  let poolConstructed = 0;
+
+  __testHooks.setPoolFactory(() => {
+    poolConstructed += 1;
+    let call = 0;
+    return {
+      async query(sql: string, params: unknown[]) {
+        queries.push({ sql, params });
+        if (call === 0) {
+          call += 1;
+          return {
+            rowCount: 1,
+            rows: [
+              {
+                id: 42,
+                abn: "123456789",
+                tax_type: "GST",
+                period_id: "2024Q4",
+                state: "CLOSING",
+                final_liability_cents: "1000",
+                credited_to_owa_cents: "1000",
+                merkle_root: "abc",
+                running_balance_hash: "def",
+                anomaly_vector: { foo: 1 }
+              }
+            ]
+          };
+        }
+        return { rowCount: 1, rows: [] };
+      }
+    } as any;
+  });
+
+  let signArgs: { payload: any; key: Uint8Array } | null = null;
+  __testHooks.setSignFn((payload, key) => {
+    signArgs = { payload, key };
+    return "signed-token";
+  });
+  __testHooks.setExceedsFn(() => false);
+
+  process.env.RPT_ED25519_SECRET_BASE64 = SECRET_B64;
+  process.env.ATO_PRN = "ATO-PRN";
+
+  const result = await issueRPT("123456789", "GST", "2024Q4", { epsilon_cents: 100 });
+
+  assert.equal(poolConstructed, 1, "expected a pool to be constructed exactly once");
+  assert.ok(signArgs, "signRpt should have been invoked");
+  assert.equal(signArgs!.key.length, 64, "decoded key should be 64 bytes");
+  assert.equal(result.signature, "signed-token");
+  assert.equal(queries.length, 3, "expected three DB operations (select, insert, update)");
+
+  t.after(() => {
+    __testHooks.reset();
+    delete process.env.RPT_ED25519_SECRET_BASE64;
+    delete process.env.ATO_PRN;
+  });
+});
+
+test("issueRPT fails fast when the signing secret is missing", async () => {
+  const issuerModule = await issuerModulePromise;
+  const { issueRPT, __testHooks, __resetIssuerSecretForTest } = issuerModule;
+
+  __testHooks.reset();
+  __resetIssuerSecretForTest();
+
+  let poolConstructed = 0;
+  __testHooks.setPoolFactory(() => {
+    poolConstructed += 1;
+    return {
+      async query() {
+        throw new Error("query should not be called when secret is missing");
+      }
+    } as any;
+  });
+  __testHooks.setSignFn((payload, key) => "should not sign");
+  __testHooks.setExceedsFn(() => false);
+
+  const previousNodeEnv = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  delete process.env.RPT_ED25519_SECRET_BASE64;
+
+  await assert.rejects(
+    () => issueRPT("123", "GST", "2024Q4", {}),
+    /RPT_ED25519_SECRET_BASE64/,
+    "should surface a configuration error"
+  );
+
+  assert.equal(poolConstructed, 0, "database pool should not be constructed when secret is missing");
+
+  process.env.NODE_ENV = previousNodeEnv;
+  __testHooks.reset();
+});


### PR DESCRIPTION
## Summary
- validate the RPT issuer secret before any database access and allow a local `.env.rpt.fixture` fallback
- add documentation and fixture for supplying a 64-byte base64 Ed25519 secret
- add issuer tests that cover successful issuance and the missing-secret failure mode

## Testing
- npx tsx --test tests/rpt/issuer.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e242213cec83279f9efeb79f088dca