### PR TITLE
Fix SQL parameter placeholders across reconciliation flows

### DIFF
--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -8,7 +8,7 @@ export async function appendAudit(actor: string, action: string, payload: any) {
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values ($1,$2,$3,$4,$5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -2,9 +2,24 @@
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (
+    await pool.query(
+      "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -6,10 +6,16 @@ export function idempotency() {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query(
+        "insert into idempotency_keys(key,last_status) values($1,$2)",
+        [key, "INIT"]
+      );
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
+      const r = await pool.query(
+        "select last_status, response_hash from idempotency_keys where key=$1",
+        [key]
+      );
       return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
   };

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,32 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query(
+      "insert into idempotency_keys(key,last_status) values($1,$2)",
+      [transfer_uuid, "INIT"]
+    );
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query(
+    "update idempotency_keys set last_status=$1 where key=$2",
+    ["DONE", transfer_uuid]
+  );
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -6,19 +6,22 @@ const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +33,10 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }


### PR DESCRIPTION
## Summary
- update reconciliation, idempotency, RPT, evidence, and rails SQL to use positional placeholders with matching parameter arrays
- ensure period and ledger updates/selects include the correct predicates for ABN, tax type, and period identifiers
- align audit log insertion with explicit column lists and placeholder counts

## Testing
- npm test *(fails: local jest binary missing because registry access is restricted in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2421d4d6c8327a2e87ea230a43888