### PR TITLE
Add JWT auth middleware to protect patent endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import { auth } from "../http/auth";
+import { idempotency } from "../middleware/idempotency";
+import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "../routes/reconcile";
+
+export const api = Router();
+
+const reconcile = Router();
+const payMiddleware = [idempotency(), payAto] as const;
+
+reconcile.post("/pay", ...payMiddleware);
+reconcile.post("/close-issue", closeAndIssue);
+reconcile.post("/settlement/webhook", settlementWebhook);
+
+api.use("/reconcile", auth(["accountant", "admin"]), reconcile);
+
+api.post("/pay", auth(["accountant", "admin"]), ...payMiddleware);
+api.post("/close-issue", auth(["accountant", "admin"]), closeAndIssue);
+api.post("/settlement/webhook", auth(["accountant", "admin"]), settlementWebhook);
+
+const payto = Router();
+payto.post("/sweep", paytoSweep);
+api.use("/payto", auth(["accountant", "admin"]), payto);
+
+const evidenceRouter = Router();
+evidenceRouter.get("/", evidence);
+api.use("/evidence", auth(["auditor", "accountant", "admin"]), evidenceRouter);

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+const SECRET = process.env.API_JWT_SECRET || "dev-secret-change-me";
+export type Role = "auditor"|"accountant"|"admin";
+
+export function auth(required?: Role[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const hdr = req.headers.authorization || "";
+    const token = hdr.startsWith("Bearer ") ? hdr.slice(7) : null;
+    if (!token) return res.status(401).json({ error: "unauthorized" });
+    try {
+      const payload = jwt.verify(token, SECRET) as { sub: string; roles?: Role[] };
+      (req as any).user = payload;
+      if (required && required.length) {
+        const roles = new Set(payload.roles || []);
+        const ok = required.some(r => roles.has(r));
+        if (!ok) return res.status(403).json({ error: "forbidden" });
+      }
+      next();
+    } catch { return res.status(401).json({ error: "unauthorized" }); }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@
 import express from "express";
 import dotenv from "dotenv";
 
-import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -17,13 +15,6 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
-
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/types/jsonwebtoken.d.ts
+++ b/src/types/jsonwebtoken.d.ts
@@ -1,0 +1,19 @@
+declare module "jsonwebtoken" {
+  export interface JwtPayload {
+    [key: string]: unknown;
+    sub?: string;
+    roles?: string[];
+  }
+
+  export interface VerifyOptions {
+    algorithms?: string[];
+  }
+
+  export function verify(token: string, secretOrPublicKey: string, options?: VerifyOptions): JwtPayload | string;
+
+  const jwt: {
+    verify: typeof verify;
+  };
+
+  export default jwt;
+}


### PR DESCRIPTION
## Summary
- add a minimal JWT-based auth middleware with role checks for patent APIs
- route reconcile, evidence, and payto endpoints through the shared router with the new guards
- tidy the server entrypoint to rely on the router and declare a fallback type stub for jsonwebtoken

## Testing
- npx tsc --noEmit *(fails: existing syntax errors in src/recon/stateMachine.ts)*
- npm install *(fails: 403 Forbidden fetching jsonwebtoken from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e242946af08327ae2cb5d65dc105cf