### PR TITLE
Align issuer anomaly handling with deterministic thresholds

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 ﻿# APGMS
 Skeleton monorepo for Automated PAYGW & GST Management System.
+
+- [Anomaly vector contract](./anomaly-vector.md) – shared keys for recon and issuer services.
 See ADRs in /docs/adr and architecture diagrams in Mermaid in /docs/diagrams.

--- a/docs/anomaly-vector.md
+++ b/docs/anomaly-vector.md
@@ -1,0 +1,22 @@
+# Anomaly vector contract
+
+The reconciliation and issuer services both derive risk decisions from a shared
+"anomaly vector" that describes period level telemetry. The vector is a JSON
+object with the following canonical keys:
+
+| Key | Description |
+| --- | --- |
+| `variance_ratio` | Rolling variance of lodgements compared to the long term baseline. |
+| `dup_rate` | Estimated duplicate remittance rate within the period. |
+| `gap_minutes` | Largest observed gap between expected settlement events. |
+| `delta_vs_baseline` | Relative delta between the current liability and the long term median. |
+
+Every key should be present even when the underlying metric is zero so that
+both services can apply the same deterministic comparison rules. The issuer
+uses these fields with the thresholds in
+`src/anomaly/deterministic.ts` to determine whether a period should be blocked
+(`BLOCKED_ANOMALY`) or allowed to continue (`READY_RPT`).
+
+If additional anomaly dimensions are introduced they must be added to this
+contract and implemented in both reconciliation and issuer code paths so the
+decision logic remains aligned.

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,18 +1,49 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
+import { isAnomalous, Thresholds as AnomalyThresholds, AnomalyVector } from "../anomaly/deterministic";
+
+type QueryablePool = Pick<Pool, "query">;
+
+const defaultPool: Pool = new Pool();
+let pool: QueryablePool = defaultPool;
+
+export interface IssuerThresholds extends AnomalyThresholds {
+  epsilon_cents?: number;
+}
+
+export function __setIssuerPool(mock: QueryablePool) {
+  pool = mock;
+}
+
+export function __resetIssuerPool() {
+  pool = defaultPool;
+}
+
+function normalizeAnomalyVector(raw: any): AnomalyVector {
+  return {
+    variance_ratio: Number(raw?.variance_ratio ?? 0),
+    dup_rate: Number(raw?.dup_rate ?? 0),
+    gap_minutes: Number(raw?.gap_minutes ?? 0),
+    delta_vs_baseline: Number(raw?.delta_vs_baseline ?? 0),
+  };
+}
+
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: IssuerThresholds = {}
+) {
   const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
+  const anomalyVector = normalizeAnomalyVector(row.anomaly_vector);
+  if (isAnomalous(anomalyVector, thresholds)) {
     await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
@@ -23,15 +54,27 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: anomalyVector,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
+  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)", [
+    abn,
+    taxType,
+    periodId,
+    payload,
+    signature,
+  ]);
   await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
   return { payload, signature };
 }

--- a/tests/unit/issuer.spec.ts
+++ b/tests/unit/issuer.spec.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import type { IssuerThresholds } from "../../src/rpt/issuer";
+
+const secret = Buffer.from(new Uint8Array(64)).toString("base64");
+process.env.RPT_ED25519_SECRET_BASE64 = secret;
+
+type IssuerModule = Awaited<typeof import("../../src/rpt/issuer")>;
+
+type QueryArgs = { text: string; params: unknown[] };
+
+type QueryResult = { rowCount: number; rows?: any[] };
+
+class MockPool {
+  public readonly queries: QueryArgs[] = [];
+  private readonly results: QueryResult[];
+
+  constructor(results: QueryResult[]) {
+    this.results = [...results];
+  }
+
+  async query(text: string, params: unknown[] = []): Promise<QueryResult> {
+    this.queries.push({ text, params });
+    const next = this.results.shift();
+    return next ?? { rowCount: 0, rows: [] };
+  }
+}
+
+function basePeriod(overrides: Partial<Record<string, any>> = {}) {
+  return {
+    id: 1,
+    abn: "12345678901",
+    tax_type: "GST",
+    period_id: "2025-09",
+    state: "CLOSING",
+    final_liability_cents: 1000,
+    credited_to_owa_cents: 1000,
+    merkle_root: "abc",
+    running_balance_hash: "def",
+    anomaly_vector: { variance_ratio: 0.1, dup_rate: 0, gap_minutes: 10, delta_vs_baseline: 0.01 },
+    ...overrides,
+  };
+}
+
+const thresholds: IssuerThresholds = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+async function testBlocksOnAnomaly(issuer: IssuerModule) {
+  const period = basePeriod({ anomaly_vector: { variance_ratio: 0.9 } });
+  const pool = new MockPool([
+    { rowCount: 1, rows: [period] },
+    { rowCount: 1, rows: [] },
+  ]);
+  issuer.__setIssuerPool(pool as any);
+
+  let caught: Error | undefined;
+  try {
+    await issuer.issueRPT(period.abn, period.tax_type, period.period_id, thresholds);
+  } catch (err: any) {
+    caught = err;
+  } finally {
+    issuer.__resetIssuerPool();
+  }
+
+  assert.ok(caught, "expected an error to be thrown");
+  assert.equal(caught?.message, "BLOCKED_ANOMALY");
+  assert.equal(pool.queries.length, 2);
+  assert.ok(
+    pool.queries[1].text.includes("BLOCKED_ANOMALY"),
+    "issuer should update the period to BLOCKED_ANOMALY"
+  );
+}
+
+async function testBlocksOnDiscrepancy(issuer: IssuerModule) {
+  const period = basePeriod({
+    final_liability_cents: 1200,
+    credited_to_owa_cents: 1000,
+  });
+  const pool = new MockPool([
+    { rowCount: 1, rows: [period] },
+    { rowCount: 1, rows: [] },
+  ]);
+  issuer.__setIssuerPool(pool as any);
+
+  let caught: Error | undefined;
+  try {
+    await issuer.issueRPT(period.abn, period.tax_type, period.period_id, thresholds);
+  } catch (err: any) {
+    caught = err;
+  } finally {
+    issuer.__resetIssuerPool();
+  }
+
+  assert.ok(caught, "expected an error to be thrown");
+  assert.equal(caught?.message, "BLOCKED_DISCREPANCY");
+  assert.equal(pool.queries.length, 2);
+  assert.ok(
+    pool.queries[1].text.includes("BLOCKED_DISCREPANCY"),
+    "issuer should update the period to BLOCKED_DISCREPANCY"
+  );
+}
+
+async function testPassesAndUpdatesReadyState(issuer: IssuerModule) {
+  const period = basePeriod();
+  const pool = new MockPool([
+    { rowCount: 1, rows: [period] },
+    { rowCount: 1, rows: [] },
+    { rowCount: 1, rows: [] },
+  ]);
+  issuer.__setIssuerPool(pool as any);
+
+  try {
+    const result = await issuer.issueRPT(period.abn, period.tax_type, period.period_id, thresholds);
+    assert.ok(result.signature, "signature should be returned on success");
+    assert.equal(pool.queries.length, 3);
+    assert.ok(pool.queries[1].text.includes("insert into rpt_tokens"));
+    assert.ok(
+      pool.queries[2].text.includes("READY_RPT"),
+      "issuer should transition the period to READY_RPT"
+    );
+  } finally {
+    issuer.__resetIssuerPool();
+  }
+}
+
+async function main() {
+  const issuer = await import("../../src/rpt/issuer");
+  await testBlocksOnAnomaly(issuer);
+  await testBlocksOnDiscrepancy(issuer);
+  await testPassesAndUpdatesReadyState(issuer);
+  console.log("issuer.spec.ts completed");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- replace the issuer anomaly helper with the shared deterministic `isAnomalous` check and normalize period vectors
- allow the issuer pool to be injected so unit tests can cover the anomaly, discrepancy, and success paths
- document the canonical anomaly vector keys for recon and issuer consumers

## Testing
- npx tsx tests/unit/issuer.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e24a7550e4832795620126dd5ed02d