### PR TITLE
Enforce integral RPT money handling behind feature flag

### DIFF
--- a/config/flags/rpt_integral_amounts.yaml
+++ b/config/flags/rpt_integral_amounts.yaml
@@ -1,0 +1,18 @@
+# Feature flag definition for enforcing integer-based money values in RPT payloads.
+flag: apgms.rpt.enforce_integral_amounts
+summary: Require PAYGW and GST totals to be expressed in integer cents.
+default: true
+owner: platform
+rollout:
+  environments:
+    dev: true
+    staging: true
+    prod: true
+controls:
+  env_var: APGMS_RPT_ALLOW_FLOAT_INPUTS
+  invert: true
+  description: |
+    Set to "1" to temporarily permit float inputs while downstream systems are migrated.
+safeguards:
+  - Always prefer integers/decimals for financial values.
+  - Monitor RPT build errors for TypeError spikes during rollout.

--- a/docs/ops/rpt-integral-amounts.md
+++ b/docs/ops/rpt-integral-amounts.md
@@ -1,0 +1,24 @@
+# RPT Integral Amounts Rollout
+
+## Summary
+We now sign remittance protection tokens (RPT) using integer-cent amounts to eliminate floating-point drift. This change is
+behind the `apgms.rpt.enforce_integral_amounts` feature flag (default **on**).
+
+## Enabling / Disabling
+- Default behaviour rejects float inputs. Override temporarily with `APGMS_RPT_ALLOW_FLOAT_INPUTS=1`.
+- Never leave the override enabled longer than a single incident response cycle.
+
+## Runbook
+1. **Symptoms**: Downstream callers still sending floats will see `TypeError: Money values must be expressed...`.
+2. **Immediate mitigation**: Set `APGMS_RPT_ALLOW_FLOAT_INPUTS=1` in the affected environment's secrets store.
+3. **Verification**: Re-run the failed job/request; monitor logs for matching `trace_id`/`idempotency_key` pairs to ensure
+   only the intended call retried.
+4. **Cleanup**: Coordinate with owning team to deploy integer/decimal fixes, then remove the override and confirm no new
+   TypeErrors within two monitoring intervals.
+
+## Observability
+- Track error counts on the RPT build path with filters for `trace_id` and `idempotency_key` to preserve auditability.
+- Add a temporary alert on the `apgms.rpt.enforce_integral_amounts` flag if it stays disabled > 24h.
+
+## Testing
+Use `pytest tests/compliance/test_rpt_money_integrity.py` to confirm enforcement logic before rollout.

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,0 +1,3 @@
+"""Python package marker for shared APGMS libraries."""
+
+# Keeping this namespace explicit helps pytest discovery and other tooling.

--- a/libs/rpt/rpt.py
+++ b/libs/rpt/rpt.py
@@ -1,14 +1,61 @@
-﻿# libs/rpt/rpt.py
-import json, hmac, hashlib, os, time
-from typing import Dict, Any
+"""Utilities for signing and verifying remittance protection tokens (RPT)."""
+
+from __future__ import annotations
+
+import json
+import hmac
+import hashlib
+import os
+import time
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from typing import Any, Dict, Union
+
+MoneyLike = Union[int, str, Decimal]
+
 
 def _key() -> bytes:
+    """Derive the shared secret for HMAC signing."""
     k = os.getenv("APGMS_RPT_SECRET", "dev-secret-change-me")
     return k.encode("utf-8")
 
+
+def _allow_float_inputs() -> bool:
+    """Feature flag controlling legacy float handling for money fields."""
+    flag = os.getenv("APGMS_RPT_ALLOW_FLOAT_INPUTS", "false").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+def _normalize_money(value: MoneyLike, *, allow_float_inputs: bool) -> int:
+    """Normalise money-like inputs to integer cents."""
+
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, Decimal):
+        cents = (value * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+        return int(cents)
+
+    if isinstance(value, str):
+        try:
+            parsed = Decimal(value)
+        except InvalidOperation as exc:
+            raise ValueError(f"Invalid decimal string for money value: {value!r}") from exc
+        return int((parsed * 100).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+    if allow_float_inputs and isinstance(value, float):
+        # Floats are stringified to avoid binary rounding artefacts.
+        return _normalize_money(Decimal(str(value)), allow_float_inputs=False)
+
+    raise TypeError(
+        "Money values must be expressed as integer cents, Decimal, or string. "
+        "Set APGMS_RPT_ALLOW_FLOAT_INPUTS=1 to coerce float inputs during migration."
+    )
+
+
 def sign(payload: Dict[str, Any]) -> str:
-    msg = json.dumps(payload, sort_keys=True, separators=(",",":")).encode("utf-8")
+    msg = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hmac.new(_key(), msg, hashlib.sha256).hexdigest()
+
 
 def verify(payload: Dict[str, Any], signature: str) -> bool:
     try:
@@ -17,20 +64,24 @@ def verify(payload: Dict[str, Any], signature: str) -> bool:
     except Exception:
         return False
 
-def build(period_id: str,
-          paygw_total: float,
-          gst_total: float,
-          source_digests: Dict[str,str],
-          anomaly_score: float,
-          ttl_seconds: int = 3600) -> Dict[str, Any]:
+
+def build(
+    period_id: str,
+    paygw_total: MoneyLike,
+    gst_total: MoneyLike,
+    source_digests: Dict[str, str],
+    anomaly_score: float,
+    ttl_seconds: int = 3600,
+) -> Dict[str, Any]:
+    allow_float_inputs = _allow_float_inputs()
     rpt = {
         "period_id": period_id,
-        "paygw_total": round(paygw_total,2),
-        "gst_total": round(gst_total,2),
+        "paygw_total_cents": _normalize_money(paygw_total, allow_float_inputs=allow_float_inputs),
+        "gst_total_cents": _normalize_money(gst_total, allow_float_inputs=allow_float_inputs),
         "source_digests": source_digests,
         "anomaly_score": anomaly_score,
-        "expires_at": int(time.time()) + ttl_seconds,
-        "nonce": os.urandom(8).hex()
+        "expires_at": int(time.time()) + int(ttl_seconds),
+        "nonce": os.urandom(8).hex(),
     }
     rpt["signature"] = sign(rpt)
     return rpt

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,6 @@
 [pytest]
-pythonpath = apps/services/tax-engine
+pythonpath =
+    .
+    apps/services/tax-engine
+    libs
+    libs/py-sdk

--- a/tests/acceptance/test_patent_paths.py
+++ b/tests/acceptance/test_patent_paths.py
@@ -1,18 +1,20 @@
-﻿# tests/acceptance/test_patent_paths.py
-import json, time
+# tests/acceptance/test_patent_paths.py
+from decimal import Decimal
+
 from libs.rpt.rpt import build, verify
 
+
 def test_rpt_sign_verify():
-    rpt = build("2024Q4", 100.0, 200.0, {"payroll":"abc","pos":"def"}, 0.1, ttl_seconds=60)
+    rpt = build("2024Q4", 10_000, 20_000, {"payroll": "abc", "pos": "def"}, 0.1, ttl_seconds=60)
     assert "signature" in rpt
-    payload = {k:v for k,v in rpt.items() if k!="signature"}
+    payload = {k: v for k, v in rpt.items() if k != "signature"}
     assert verify(payload, rpt["signature"])
 
+
 def test_recon_pass_example():
-    # Fake math: equality within tolerance and anomaly ok
-    paygw_total, gst_total = 100.00, 200.00
-    owa_paygw, owa_gst = 100.00, 200.00
-    anomaly_score = 0.1
-    assert abs(paygw_total - owa_paygw) <= 0.01
-    assert abs(gst_total - owa_gst) <= 0.01
-    assert anomaly_score < 0.8
+    paygw_total_cents, gst_total_cents = 10_000, 20_000
+    owa_paygw_cents, owa_gst_cents = 10_000, 20_000
+    anomaly_score = Decimal("0.1")
+    assert paygw_total_cents == owa_paygw_cents
+    assert gst_total_cents == owa_gst_cents
+    assert anomaly_score < Decimal("0.8")

--- a/tests/compliance/test_rpt_money_integrity.py
+++ b/tests/compliance/test_rpt_money_integrity.py
@@ -1,0 +1,21 @@
+import pytest
+
+from libs.rpt import rpt
+
+
+def test_build_uses_integer_cents():
+    token = rpt.build("2024Q4", 12345, 67890, {"src": "digest"}, 0.0, ttl_seconds=30)
+    assert token["paygw_total_cents"] == 12345
+    assert token["gst_total_cents"] == 67890
+
+
+def test_float_inputs_rejected_by_default():
+    with pytest.raises(TypeError):
+        rpt.build("2024Q4", 100.0, 200.0, {"src": "digest"}, 0.0)
+
+
+def test_float_inputs_can_be_flagged_on(monkeypatch):
+    monkeypatch.setenv("APGMS_RPT_ALLOW_FLOAT_INPUTS", "1")
+    token = rpt.build("2024Q4", 100.0, 200.0, {"src": "digest"}, 0.0)
+    assert token["paygw_total_cents"] == 10_000
+    assert token["gst_total_cents"] == 20_000


### PR DESCRIPTION
## Summary
- enforce integer-cent money handling in the RPT builder with a feature-flagged float compatibility shim
- expose shared libs to pytest discovery and document the rollout controls
- add targeted compliance coverage for the new behaviour and acceptance test updates to integer amounts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e24b5b24fc8327a319f235b7713d3e