### PR TITLE
Reconcile ledger and audit schemas

### DIFF
--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -18,7 +18,8 @@ def bundle(period_id: str):
     conn = db(); cur = conn.cursor()
     cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
     rpt = cur.fetchone()
-    cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
-    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []
+    cur.execute("SELECT ts, COALESCE(category, action), COALESCE(message, '') FROM audit_log WHERE message LIKE %s ORDER BY ts",
+                (f'%\"period_id\":\"{period_id}\"%',))
+    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]} for r in cur.fetchall()]
     cur.close(); conn.close()
     return {"period_id": period_id, "rpt": rpt[0] if rpt else None, "audit": logs}

--- a/apps/services/bank-egress/main.py
+++ b/apps/services/bank-egress/main.py
@@ -1,6 +1,7 @@
 ﻿# apps/services/bank-egress/main.py
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
+import hashlib
 import os, psycopg2, json
 from libs.rpt.rpt import verify
 
@@ -29,8 +30,16 @@ def remit(req: EgressReq):
     if not row or row[0] != "RPT-Issued":
         raise HTTPException(409, "gate not in RPT-Issued")
     # Here you would call the real bank API via mTLS. For now, we just log.
-    payload = json.dumps({"period_id": req.period_id, "action": "remit"})
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('egress',%s,NULL,NULL)", (payload,))
+    payload = json.dumps({"period_id": req.period_id, "action": "remit"}, separators=(",",":"))
+    payload_hash = hashlib.sha256(payload.encode("utf-8")).hexdigest()
+    cur.execute("SELECT terminal_hash FROM audit_log ORDER BY seq DESC LIMIT 1")
+    prev_row = cur.fetchone()
+    prev_hash = prev_row[0] if prev_row else None
+    terminal_hash = hashlib.sha256(((prev_hash or "") + payload_hash).encode("utf-8")).hexdigest()
+    cur.execute(
+        "INSERT INTO audit_log(actor,action,category,message,payload_hash,prev_hash,terminal_hash) VALUES (%s,%s,%s,%s,%s,%s,%s)",
+        ("bank-egress", "remit", "egress", payload, payload_hash, prev_hash, terminal_hash)
+    )
     cur.execute("UPDATE bas_gate_states SET state='Remitted', updated_at=NOW() WHERE period_id=%s", (req.period_id,))
     conn.commit(); cur.close(); conn.close()
     return {"ok": True}

--- a/migrations/001_apgms_core.sql
+++ b/migrations/001_apgms_core.sql
@@ -1,4 +1,6 @@
 -- 001_apgms_core.sql
+
+create extension if not exists "pgcrypto";
 create table if not exists periods (
   id serial primary key,
   abn text not null,
@@ -21,13 +23,13 @@ create table if not exists owa_ledger (
   abn text not null,
   tax_type text not null,
   period_id text not null,
-  transfer_uuid uuid not null,
+  transfer_uuid uuid not null default gen_random_uuid(),
   amount_cents bigint not null,
   balance_after_cents bigint not null,
   bank_receipt_hash text,
   prev_hash text,
   hash_after text,
-  created_at timestamptz default now(),
+  created_at timestamptz not null default now(),
   unique (transfer_uuid)
 );
 
@@ -46,10 +48,12 @@ create table if not exists rpt_tokens (
 
 create table if not exists audit_log (
   seq bigserial primary key,
-  ts timestamptz default now(),
-  actor text not null,
-  action text not null,
-  payload_hash text not null,
+  ts timestamptz not null default now(),
+  actor text,
+  action text,
+  category text,
+  message text,
+  payload_hash text,
   prev_hash text,
   terminal_hash text
 );

--- a/migrations/003_reconcile_owa_audit.sql
+++ b/migrations/003_reconcile_owa_audit.sql
@@ -1,0 +1,165 @@
+-- 003_reconcile_owa_audit.sql
+-- Normalize legacy patent schemas for owa_ledger and audit_log
+
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+
+DO $$
+DECLARE
+  has_kind boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'owa_ledger' AND column_name = 'kind'
+  ) INTO has_kind;
+
+  IF has_kind THEN
+    -- Ensure canonical columns exist
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS abn text;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS tax_type text;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS period_id text;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS transfer_uuid uuid;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS amount_cents bigint;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS balance_after_cents bigint;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS bank_receipt_hash text;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS prev_hash text;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS hash_after text;
+    ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS created_at timestamptz;
+
+    UPDATE owa_ledger
+      SET tax_type = COALESCE(tax_type, kind);
+
+    UPDATE owa_ledger
+      SET amount_cents = COALESCE(amount_cents, (credit_amount * 100)::bigint);
+
+    UPDATE owa_ledger
+      SET bank_receipt_hash = COALESCE(bank_receipt_hash, source_ref);
+
+    UPDATE owa_ledger
+      SET hash_after = COALESCE(hash_after, audit_hash);
+
+    UPDATE owa_ledger
+      SET created_at = COALESCE(created_at, NOW());
+
+    UPDATE owa_ledger
+      SET abn = COALESCE(abn, '__legacy__');
+
+    UPDATE owa_ledger
+      SET period_id = COALESCE(period_id, '__legacy__');
+
+    UPDATE owa_ledger
+      SET transfer_uuid = COALESCE(transfer_uuid, gen_random_uuid());
+
+    -- Running balances and chain repair
+    WITH running AS (
+      SELECT id,
+             SUM(COALESCE(amount_cents, 0)) OVER (
+               PARTITION BY COALESCE(abn, '__legacy__'), COALESCE(tax_type, 'UNKNOWN'), COALESCE(period_id, '__legacy__')
+               ORDER BY id
+             ) AS bal
+      FROM owa_ledger
+    )
+    UPDATE owa_ledger o
+      SET balance_after_cents = running.bal
+    FROM running
+    WHERE o.id = running.id;
+
+    WITH chain AS (
+      SELECT id,
+             LAG(hash_after) OVER (
+               PARTITION BY COALESCE(abn, '__legacy__'), COALESCE(tax_type, 'UNKNOWN'), COALESCE(period_id, '__legacy__')
+               ORDER BY id
+             ) AS prev
+      FROM owa_ledger
+    )
+    UPDATE owa_ledger o
+      SET prev_hash = COALESCE(o.prev_hash, chain.prev)
+    FROM chain
+    WHERE o.id = chain.id;
+
+    ALTER TABLE owa_ledger
+      ALTER COLUMN abn SET NOT NULL,
+      ALTER COLUMN tax_type SET NOT NULL,
+      ALTER COLUMN period_id SET NOT NULL,
+      ALTER COLUMN transfer_uuid SET NOT NULL,
+      ALTER COLUMN amount_cents SET NOT NULL,
+      ALTER COLUMN balance_after_cents SET NOT NULL,
+      ALTER COLUMN created_at SET NOT NULL;
+
+    ALTER TABLE owa_ledger
+      ALTER COLUMN transfer_uuid SET DEFAULT gen_random_uuid(),
+      ALTER COLUMN created_at SET DEFAULT now();
+
+    ALTER TABLE owa_ledger
+      ALTER COLUMN created_at TYPE timestamptz USING created_at::timestamptz;
+
+    ALTER TABLE owa_ledger
+      DROP COLUMN IF EXISTS kind,
+      DROP COLUMN IF EXISTS credit_amount,
+      DROP COLUMN IF EXISTS source_ref,
+      DROP COLUMN IF EXISTS audit_hash;
+  END IF;
+END$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'seq'
+  ) THEN
+    ALTER TABLE audit_log RENAME COLUMN id TO seq;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'event_time'
+  ) THEN
+    ALTER TABLE audit_log RENAME COLUMN event_time TO ts;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'hash_prev'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'prev_hash'
+  ) THEN
+    ALTER TABLE audit_log RENAME COLUMN hash_prev TO prev_hash;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'hash_this'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'audit_log' AND column_name = 'terminal_hash'
+  ) THEN
+    ALTER TABLE audit_log RENAME COLUMN hash_this TO terminal_hash;
+  END IF;
+
+  ALTER TABLE audit_log
+    ADD COLUMN IF NOT EXISTS actor text,
+    ADD COLUMN IF NOT EXISTS action text,
+    ADD COLUMN IF NOT EXISTS category text,
+    ADD COLUMN IF NOT EXISTS message text,
+    ADD COLUMN IF NOT EXISTS payload_hash text,
+    ADD COLUMN IF NOT EXISTS prev_hash text,
+    ADD COLUMN IF NOT EXISTS terminal_hash text;
+
+  UPDATE audit_log
+    SET actor = COALESCE(actor, 'system'),
+        action = COALESCE(action, COALESCE(category, 'event')),
+        category = COALESCE(category, action),
+        message = COALESCE(message, ''),
+        prev_hash = NULLIF(prev_hash, ''),
+        payload_hash = COALESCE(payload_hash, encode(digest(message::text, 'sha256'), 'hex')),
+        terminal_hash = COALESCE(terminal_hash, encode(digest(COALESCE(prev_hash, '') || encode(digest(message::text, 'sha256'), 'hex'), 'sha256'), 'hex'))
+  WHERE payload_hash IS NULL OR terminal_hash IS NULL OR actor IS NULL;
+
+  ALTER TABLE audit_log
+    ALTER COLUMN ts TYPE timestamptz USING ts::timestamptz,
+    ALTER COLUMN ts SET NOT NULL,
+    ALTER COLUMN ts SET DEFAULT now();
+END$$;


### PR DESCRIPTION
## Summary
- align the base migrations on a single OWA ledger and audit log structure and ensure pgcrypto is available
- add a reconciliation migration that upgrades legacy patent tables to the canonical layout
- update BAS gate, bank egress, and audit services plus deployment scaffolding to use the canonical columns

## Testing
- not run (environment lacks PostgreSQL/docker)


------
https://chatgpt.com/codex/tasks/task_e_68e24a776ba083278112a005ad30146b