### PR TITLE
Add documentation for KmsPort implementations

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
 ﻿# APGMS
 Skeleton monorepo for Automated PAYGW & GST Management System.
-See ADRs in /docs/adr and architecture diagrams in Mermaid in /docs/diagrams.
+
+- See ADRs in `/docs/adr` and architecture diagrams in Mermaid in `/docs/diagrams`.
+- Component deep-dives live alongside the ADRs, for example [`behind-kms-port.md`](./behind-kms-port.md).

--- a/docs/behind-kms-port.md
+++ b/docs/behind-kms-port.md
@@ -1,0 +1,29 @@
+# Behind `KmsPort`
+
+## Implementations
+
+- **`kms/mock`**
+  - Maintains signing keys in memory.
+  - Exposes a rotation endpoint for exercising key rollover in development.
+  - Publishes a development JWKS for local consumers.
+- **`kms/real`**
+  - Delegates signing and rotation to the cloud KMS or HSM provider.
+  - Uses the provider's API for key rotation instead of an application endpoint.
+  - Serves the JWKS out of the signed store used in production.
+
+## Shared contract
+
+- Both adapters emit key IDs using the format `app:env:date:rand`.
+- Signing always uses the `RS256` algorithm so consumers receive a consistent signature type.
+
+## External dependencies
+
+- The anti-replay store that tracks recent signatures lives outside the adapter layer and is shared by every backend, so changing providers does not require touching it.
+
+## Contract tests
+
+Automated tests assert the common behavior across implementations:
+
+1. Sign/verify round-trip succeeds for each backend.
+2. Rotation window logic behaves the same regardless of provider.
+3. Signatures stay within the established size limits.


### PR DESCRIPTION
## Summary
- add a behind-the-scenes document describing the mock and real KmsPort adapters
- capture shared key ID and algorithm details plus contract test coverage
- link the new deep-dive document from the docs index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24cc62e6c83279fb6de1cccf69124