### PR TITLE
Add prototype flag helpers and kill switch handling

### DIFF
--- a/apps/services/payments/src/flags.ts
+++ b/apps/services/payments/src/flags.ts
@@ -1,0 +1,57 @@
+// apps/services/payments/src/flags.ts
+// Centralised prototype feature flags with typed accessors.
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+const FALSE_VALUES = new Set(["0", "false", "no", "off"]);
+const warnedInvalid = new Set<string>();
+
+export type ProtoFlagName =
+  | "PROTO_KILL_SWITCH"
+  | "PROTO_ENABLE_IDEMPOTENCY"
+  | "PROTO_ENABLE_RPT"
+  | "PROTO_BLOCK_ON_ANOMALY"
+  | "PROTO_ALLOW_OVERRIDES"
+  | "PROTO_ENABLE_REAL_BANK";
+
+export interface ProtoFlagsSnapshot {
+  PROTO_KILL_SWITCH: boolean;
+  PROTO_ENABLE_IDEMPOTENCY: boolean;
+  PROTO_ENABLE_RPT: boolean;
+  PROTO_BLOCK_ON_ANOMALY: boolean;
+  PROTO_ALLOW_OVERRIDES: boolean;
+  PROTO_ENABLE_REAL_BANK: boolean;
+}
+
+function parseBooleanFlag(name: ProtoFlagName, defaultValue: boolean): boolean {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return defaultValue;
+  }
+
+  const normalized = raw.trim().toLowerCase();
+  if (TRUE_VALUES.has(normalized)) return true;
+  if (FALSE_VALUES.has(normalized)) return false;
+
+  if (!warnedInvalid.has(name)) {
+    console.warn(`[flags] Ignoring invalid boolean for ${name}: ${raw}`);
+    warnedInvalid.add(name);
+  }
+  return defaultValue;
+}
+
+export function getProtoFlags(): ProtoFlagsSnapshot {
+  return {
+    PROTO_KILL_SWITCH: parseBooleanFlag("PROTO_KILL_SWITCH", true),
+    PROTO_ENABLE_IDEMPOTENCY: parseBooleanFlag("PROTO_ENABLE_IDEMPOTENCY", false),
+    PROTO_ENABLE_RPT: parseBooleanFlag("PROTO_ENABLE_RPT", true),
+    PROTO_BLOCK_ON_ANOMALY: parseBooleanFlag("PROTO_BLOCK_ON_ANOMALY", false),
+    PROTO_ALLOW_OVERRIDES: parseBooleanFlag("PROTO_ALLOW_OVERRIDES", false),
+    PROTO_ENABLE_REAL_BANK: parseBooleanFlag("PROTO_ENABLE_REAL_BANK", false),
+  };
+}
+
+export function isProtoKillSwitchEnabled(): boolean {
+  return getProtoFlags().PROTO_KILL_SWITCH;
+}
+
+export const PROTOTYPE_KILL_SWITCH_MESSAGE = "Prototype mode: egress disabled";

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -10,6 +10,7 @@ import { payAtoRelease } from './routes/payAto.js';
 import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
+import { getProtoFlags } from './flags.js';
 
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -28,6 +29,9 @@ app.use(express.json());
 
 // Health check
 app.get('/health', (_req, res) => res.json({ ok: true }));
+app.get('/debug/flags', (_req, res) => {
+  res.json({ flags: getProtoFlags() });
+});
 
 // Endpoints
 app.post('/deposit', deposit);

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,9 +1,14 @@
 import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { isProtoKillSwitchEnabled, PROTOTYPE_KILL_SWITCH_MESSAGE } from "../flags.js";
 
 export async function deposit(req: Request, res: Response) {
   try {
+    if (isProtoKillSwitchEnabled()) {
+      return res.status(503).json({ error: PROTOTYPE_KILL_SWITCH_MESSAGE });
+    }
+
     const { abn, taxType, periodId, amountCents } = req.body || {};
     if (!abn || !taxType || !periodId) return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     const amt = Number(amountCents);

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import crypto from 'crypto';
 import pg from 'pg'; const { Pool } = pg;
 import { pool } from '../index.js';
+import { isProtoKillSwitchEnabled, PROTOTYPE_KILL_SWITCH_MESSAGE } from '../flags.js';
 
 function genUUID() {
   return crypto.randomUUID();
@@ -16,6 +17,10 @@ function genUUID() {
  */
 export async function payAtoRelease(req: Request, res: Response) {
   const { abn, taxType, periodId, amountCents } = req.body || {};
+  if (isProtoKillSwitchEnabled()) {
+    return res.status(503).json({ error: PROTOTYPE_KILL_SWITCH_MESSAGE });
+  }
+
   if (!abn || !taxType || !periodId) {
     return res.status(400).json({ error: 'Missing abn/taxType/periodId' });
   }

--- a/portal-api/app.py
+++ b/portal-api/app.py
@@ -1,7 +1,9 @@
-from fastapi import FastAPI, Query
+from fastapi import FastAPI
 from pydantic import BaseModel
 from typing import List, Dict, Any
 import time
+
+from flags import get_proto_flags_dict
 
 app = FastAPI(title="APGMS Portal API", version="0.1.0")
 
@@ -15,6 +17,11 @@ def metrics():
         "# TYPE portal_up gauge",
         "portal_up 1"
     ]))
+
+
+@app.get("/debug/flags")
+def debug_flags():
+    return {"flags": get_proto_flags_dict()}
 
 @app.get("/dashboard/yesterday")
 def yesterday():

--- a/portal-api/flags.py
+++ b/portal-api/flags.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+"""Shared prototype feature flag helpers for the portal API."""
+
+from dataclasses import asdict, dataclass
+import logging
+import os
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+_warned_invalid: set[str] = set()
+
+
+def _parse_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        return default
+
+    normalized = raw.strip().lower()
+    if normalized in _TRUE_VALUES:
+        return True
+    if normalized in _FALSE_VALUES:
+        return False
+
+    if name not in _warned_invalid:
+        logger.warning("[flags] Ignoring invalid boolean for %s: %s", name, raw)
+        _warned_invalid.add(name)
+    return default
+
+
+@dataclass(frozen=True)
+class ProtoFlags:
+    PROTO_KILL_SWITCH: bool
+    PROTO_ENABLE_IDEMPOTENCY: bool
+    PROTO_ENABLE_RPT: bool
+    PROTO_BLOCK_ON_ANOMALY: bool
+    PROTO_ALLOW_OVERRIDES: bool
+    PROTO_ENABLE_REAL_BANK: bool
+
+
+def get_proto_flags() -> ProtoFlags:
+    return ProtoFlags(
+        PROTO_KILL_SWITCH=_parse_bool("PROTO_KILL_SWITCH", True),
+        PROTO_ENABLE_IDEMPOTENCY=_parse_bool("PROTO_ENABLE_IDEMPOTENCY", False),
+        PROTO_ENABLE_RPT=_parse_bool("PROTO_ENABLE_RPT", True),
+        PROTO_BLOCK_ON_ANOMALY=_parse_bool("PROTO_BLOCK_ON_ANOMALY", False),
+        PROTO_ALLOW_OVERRIDES=_parse_bool("PROTO_ALLOW_OVERRIDES", False),
+        PROTO_ENABLE_REAL_BANK=_parse_bool("PROTO_ENABLE_REAL_BANK", False),
+    )
+
+
+def get_proto_flags_dict() -> Dict[str, bool]:
+    """Return the current flag snapshot as a serialisable dictionary."""
+
+    return asdict(get_proto_flags())
+
+
+def is_proto_kill_switch_enabled() -> bool:
+    return get_proto_flags().PROTO_KILL_SWITCH
+
+
+PROTOTYPE_KILL_SWITCH_MESSAGE = "Prototype mode: egress disabled"


### PR DESCRIPTION
## Summary
- add shared prototype flag helpers for the payments service and portal API
- enforce the PROTO_KILL_SWITCH on payout endpoints and expose a /debug/flags snapshot
- surface the flag snapshot through the portal API for visibility

## Testing
- `npx tsc -p apps/services/payments/tsconfig.json --noEmit` *(fails: TypeScript configuration requires NodeNext module pairing)*
- `python -m compileall portal-api`


------
https://chatgpt.com/codex/tasks/task_e_68e24bcc18b483278fa94d2209272016