### PR TITLE
Add proto issue templates and roadmap plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,74 @@
+name: Bug
+description: Document a defect impacting expected behavior.
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the observed problem and affected experience.
+      placeholder: Provide a brief overview of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: steps_to_reproduce
+    attributes:
+      label: Steps to Reproduce
+      description: Provide detailed steps that consistently reproduce the issue.
+      placeholder: |
+        1. Step one
+        2. Step two
+        3. Observe failure
+    validations:
+      required: true
+  - type: input
+    id: expected_behavior
+    attributes:
+      label: Expected Behavior
+      description: Explain what should happen instead.
+      placeholder: The system should...
+    validations:
+      required: true
+  - type: input
+    id: actual_behavior
+    attributes:
+      label: Actual Behavior
+      description: Describe what is happening currently.
+      placeholder: The system actually...
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the conditions that confirm the bug has been resolved.
+      placeholder: |
+        - [ ] Scenario 1 fixed
+        - [ ] Scenario 2 verified
+    validations:
+      required: true
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test Plan
+      description: Detail regression, automation, or monitoring needed to validate the fix.
+      placeholder: Include unit, integration, and manual checks.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback_notes
+    attributes:
+      label: Rollback Notes
+      description: Describe how to revert the change if it introduces regressions.
+      placeholder: Link to prior version, toggles, or recovery steps.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment & Logs
+      description: Capture environment details, logs, or screenshots relevant to the bug.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/proto-feature.yml
+++ b/.github/ISSUE_TEMPLATE/proto-feature.yml
@@ -1,0 +1,47 @@
+name: Proto Feature
+description: Capture requirements for a new proto feature proposal.
+title: "[Proto Feature] "
+labels:
+  - feature
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Provide a concise description of the proto feature.
+      placeholder: Outline the user value and core behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Enumerate the conditions that must be satisfied for the feature to be considered complete.
+      placeholder: |
+        - [ ] Condition 1
+        - [ ] Condition 2
+    validations:
+      required: true
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test Plan
+      description: Describe manual and automated validation needed to confirm the feature works as expected.
+      placeholder: List unit, integration, and exploratory testing steps.
+    validations:
+      required: true
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Rollout / Rollback Notes
+      description: Outline deployment sequencing, monitoring, and rollback actions.
+      placeholder: Include rollout stages, alerting, and recovery procedure.
+    validations:
+      required: true
+  - type: textarea
+    id: dependencies
+    attributes:
+      label: Dependencies & Risks
+      description: Note any cross-team coordination, known risks, or external dependencies.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/runbook.yml
+++ b/.github/ISSUE_TEMPLATE/runbook.yml
@@ -1,0 +1,47 @@
+name: Runbook
+description: Track authoring or updates to operational runbooks.
+title: "[Runbook] "
+labels:
+  - documentation
+body:
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Describe the service or procedure covered by the runbook.
+      placeholder: Include relevant background and goals.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance_criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the requirements that define a complete and actionable runbook.
+      placeholder: |
+        - [ ] Covers detection triggers
+        - [ ] Provides on-call escalation path
+    validations:
+      required: true
+  - type: textarea
+    id: test_plan
+    attributes:
+      label: Test Plan / Dry Run
+      description: Explain how the runbook was validated, including tabletop or production dry runs.
+      placeholder: Document rehearsals, feedback, or sign-offs.
+    validations:
+      required: true
+  - type: textarea
+    id: rollback_notes
+    attributes:
+      label: Rollback Notes
+      description: Outline how to revert to prior procedures if the new runbook introduces issues.
+      placeholder: Mention superseded docs and restoration steps.
+    validations:
+      required: true
+  - type: textarea
+    id: stakeholders
+    attributes:
+      label: Stakeholders & Approvals
+      description: Identify reviewers, approvers, and teams who must sign off.
+    validations:
+      required: false

--- a/docs/roadmap/proto_cut_01.md
+++ b/docs/roadmap/proto_cut_01.md
@@ -1,0 +1,52 @@
+# Proto Cut 01 Roadmap
+
+## Objective
+Increase proto launch readiness from **3/10** to approximately **5.5/10** over a two-week execution window by hardening critical systems, validating monetization pathways, and preparing operational playbooks.
+
+## Guiding Principles
+- Prioritize idempotent, observable workflows so that each deployment is safe to retry.
+- Pair delivery milestones with validation artifacts (tests, audits, sign-offs) to ensure readiness sticks.
+- Maintain cross-functional alignment through daily checkpoints and demoable progress.
+
+## Timeline & Milestones
+| Day | Milestone | Key Activities | Owner(s) | Exit Criteria |
+| --- | --- | --- | --- | --- |
+| D0 | Kickoff & Planning | Confirm scope, owners, and environments. Baseline readiness scorecard at 3/10. | Eng, PM, Ops | Plan approved, comms cadence scheduled. |
+| D3 | Idempotency + Money Audit in CI green | Harden retry logic for critical jobs, ensure CI pipelines validate idempotency. Automate revenue recognition audit checks in CI. | Eng | Automated suites pass; CI gate blocks merges failing idempotency/money audit. |
+| D5 | State Machine constraints + Golden pack v1 | Lock state transitions with guardrails; produce first golden dataset pack for regression runs. | Eng, QA | State machine schema merged; golden pack stored with checksum and replay docs. |
+| D7 | RPT v0.1 end-to-end signed | Deliver Reporting Pipeline Tool v0.1, run end-to-end validation with stakeholders. | Eng, Data, PM | Stakeholder sign-off recorded; RPT outputs match golden pack tolerances. |
+| D9 | Recon ingest + matching rules | Stand up reconciliation ingest path and deterministic matching rules. | Eng, Finance | Recon jobs ingest sample data; matching accuracy ≥95% on golden pack. |
+| D12 | Operator UI queues + basic a11y | Implement operator queues with accessible navigation, screen reader labels, and contrast checks. | Eng, Design | Accessibility smoke test passes; queue SLAs monitored. |
+| D14 | Threat model + dashboards + demo script | Complete lightweight threat model, ship readiness dashboards, and finalize demo narrative. | Eng, Sec, PM | Threat model reviewed; dashboards live; scripted demo ready for leadership review. |
+
+## Workstreams
+### Platform Reliability
+- Codify idempotent execution patterns and include rollback hooks per deployment.
+- Expand telemetry coverage and funnel critical metrics into readiness dashboards (D14).
+
+### Financial Integrity
+- Integrate money audit assertions into CI with blocking checks (D3).
+- Finalize reconciliation ingest and matching logic with Finance partnership (D9).
+
+### Experience & Operations
+- Develop golden regression pack for QA (D5) and run through RPT end-to-end validation (D7).
+- Deliver operator UI enhancements and ensure foundational accessibility compliance (D12).
+
+### Risk & Communication
+- Threat modeling sessions culminate in tracked mitigations and dashboard alerts (D14).
+- Maintain demo script aligning narrative to readiness score improvements.
+
+## Acceptance Criteria
+- Readiness scorecard reflects ≥5.5/10 with supporting evidence from audits, validations, and dashboards.
+- All milestones documented with owner sign-offs and linked artifacts.
+- Runbooks updated with rollback notes for new functionality prior to launch review.
+
+## Test Plan
+- Daily CI runs covering idempotency, money audit, and regression pack replay.
+- Scheduled dry-runs for RPT v0.1 and operator workflows with stakeholder feedback captured.
+- Accessibility smoke tests using automated tooling plus manual keyboard navigation checks.
+
+## Rollback Notes
+- Maintain feature toggles for new workflows; ensure toggles have documented rollback paths.
+- Preserve prior stable golden pack snapshots for quick reversion if regression is detected.
+- Document rollback procedures for operator UI changes and reconciliation pipelines within associated runbooks.


### PR DESCRIPTION
## Summary
- add GitHub issue templates for proto feature, bug, and runbook workflows with acceptance criteria, test plan, and rollback sections
- document two-week proto readiness roadmap with milestones and supporting guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e24bbdd53c8327933a54555c02d0fe