### PR TITLE
Fix reconciliation SQL and add integration tests

### DIFF
--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,14 +1,14 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { sha256Hex } from "../crypto/merkle";
+import { getPool } from "../db/pool";
 
 export async function appendAudit(actor: string, action: string, payload: any) {
+  const pool = getPool();
   const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
   const prevHash = rows[0]?.terminal_hash || "";
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values ($1,$2,$3,$4,$5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,31 @@
+import { Pool } from "pg";
+
+export interface QueryResult<T = any> {
+  rows: T[];
+  rowCount: number;
+}
+
+export interface PoolLike {
+  query: (text: string, params?: any[]) => Promise<QueryResult>;
+  end?: () => Promise<void> | void;
+}
+
+let activePool: PoolLike | null = null;
+
+export function getPool(): PoolLike {
+  if (!activePool) {
+    activePool = new Pool();
+  }
+  return activePool;
+}
+
+export function setPool(pool: PoolLike | null) {
+  activePool = pool;
+}
+
+export async function shutdownPool() {
+  if (activePool && typeof activePool.end === "function") {
+    await activePool.end();
+  }
+  activePool = null;
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,10 +1,22 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const pool = getPool();
+  const periodRes = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
+  const p = periodRes.rows[0];
+  const rptRes = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  const rpt = rptRes.rows[0];
+  const deltasRes = await pool.query(
+    "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+    [abn, taxType, periodId]
+  );
+  const deltas = deltasRes.rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,15 +1,16 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
   return async (req:any, res:any, next:any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
+    const pool = getPool();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [key, "INIT"]);
       return next();
-    } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
+    } catch (err:any) {
+      if (err?.code !== "23505") throw err;
+      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=$1", [key]);
       return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
   };

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,13 +1,13 @@
-﻿import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { getPool } from "../db/pool";
 
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+  const pool = getPool();
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -16,27 +16,32 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+  const pool = getPool();
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
-  } catch {
+    await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
+  } catch (err: any) {
+    if (err?.code !== "23505") throw err;
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
-  const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
-  const prevHash = rows[0]?.hash_after ?? "";
+  const { rows: prevRows } = await pool.query(
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  const prevBal = Number(prevRows[0]?.balance_after_cents ?? 0);
+  const prevHash = prevRows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+  const insertLedger = await pool.query(
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9) returning id,balance_after_cents,hash_after,bank_receipt_hash",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
+  if (insertLedger.rowCount === 0) throw new Error("OWA_LEDGER_INSERT_FAILED");
+
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("update idempotency_keys set last_status=$2 where key=$1", [transfer_uuid, "DONE"]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,24 +1,30 @@
-﻿import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+import { isAnomalous } from "../anomaly/deterministic";
+import { getPool } from "../db/pool";
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const pool = getPool();
+  const secretKeyB64 = process.env.RPT_ED25519_SECRET_BASE64 || "";
+  if (!secretKeyB64) throw new Error("NO_RPT_SECRET");
+  const secretKey = Buffer.from(secretKeyB64, "base64");
+
+  const p = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+  if (isAnomalous(v, thresholds)) {
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +36,11 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5) returning id",
+    [abn, taxType, periodId, payload, signature]
+  );
+  const upd = await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
+  if (upd.rowCount === 0) throw new Error("PERIOD_UPDATE_FAILED");
   return { payload, signature };
 }

--- a/tests/integration/fakePool.ts
+++ b/tests/integration/fakePool.ts
@@ -1,0 +1,310 @@
+import type { PoolLike, QueryResult } from "../../src/db/pool";
+
+type PeriodRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  final_liability_cents: number;
+  credited_to_owa_cents: number;
+  anomaly_vector: Record<string, number>;
+  thresholds: Record<string, number>;
+  merkle_root: string;
+  running_balance_hash: string;
+};
+
+type RptTokenRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  payload: any;
+  signature: string;
+  created_at: Date;
+};
+
+type OwaLedgerRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  transfer_uuid: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string;
+  prev_hash: string;
+  hash_after: string;
+  created_at: Date;
+};
+
+type RemittanceDestinationRow = {
+  id: number;
+  abn: string;
+  rail: string;
+  reference: string;
+  metadata?: Record<string, any>;
+};
+
+type IdempotencyKeyRow = {
+  key: string;
+  last_status: string;
+  response_hash?: string | null;
+};
+
+type AuditLogRow = {
+  seq: number;
+  actor: string;
+  action: string;
+  payload_hash: string;
+  prev_hash: string;
+  terminal_hash: string;
+  created_at: Date;
+};
+
+type TableState = {
+  periods: PeriodRow[];
+  rpt_tokens: RptTokenRow[];
+  owa_ledger: OwaLedgerRow[];
+  remittance_destinations: RemittanceDestinationRow[];
+  idempotency_keys: IdempotencyKeyRow[];
+  audit_log: AuditLogRow[];
+};
+
+const clone = <T>(value: T): T => JSON.parse(JSON.stringify(value));
+
+export class FakePool implements PoolLike {
+  private tables: TableState;
+  private seq = {
+    periods: 0,
+    rpt_tokens: 0,
+    owa_ledger: 0,
+    remittance_destinations: 0,
+    audit_log: 0,
+  };
+
+  constructor() {
+    this.tables = this.emptyTables();
+  }
+
+  reset() {
+    this.tables = this.emptyTables();
+    this.seq = { periods: 0, rpt_tokens: 0, owa_ledger: 0, remittance_destinations: 0, audit_log: 0 };
+  }
+
+  snapshot(): TableState {
+    return clone(this.tables);
+  }
+
+  addPeriod(row: Omit<PeriodRow, "id"> & { id?: number }) {
+    const id = row.id ?? ++this.seq.periods;
+    const record: PeriodRow = {
+      id,
+      anomaly_vector: {},
+      thresholds: {},
+      merkle_root: "",
+      running_balance_hash: "",
+      ...row,
+    };
+    this.tables.periods.push(record);
+    this.seq.periods = Math.max(this.seq.periods, id);
+    return record;
+  }
+
+  addOwaLedger(row: Omit<OwaLedgerRow, "id" | "created_at"> & { id?: number; created_at?: Date }) {
+    const id = row.id ?? ++this.seq.owa_ledger;
+    const record: OwaLedgerRow = {
+      id,
+      created_at: row.created_at ?? new Date(),
+      ...row,
+    };
+    this.tables.owa_ledger.push(record);
+    this.seq.owa_ledger = Math.max(this.seq.owa_ledger, id);
+    return record;
+  }
+
+  addRemittanceDestination(row: Omit<RemittanceDestinationRow, "id"> & { id?: number }) {
+    const id = row.id ?? ++this.seq.remittance_destinations;
+    const record: RemittanceDestinationRow = { id, ...row };
+    this.tables.remittance_destinations.push(record);
+    this.seq.remittance_destinations = Math.max(this.seq.remittance_destinations, id);
+    return record;
+  }
+
+  async query(text: string, params: any[] = []): Promise<QueryResult> {
+    const normalized = text.replace(/\s+/g, " ").trim();
+
+    if (/^select \* from periods where abn=\$1 and tax_type=\$2 and period_id=\$3$/i.test(normalized)) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.tables.periods.filter(p => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      return { rows: clone(rows), rowCount: rows.length };
+    }
+
+    if (/^select \* from rpt_tokens where abn=\$1 and tax_type=\$2 and period_id=\$3 order by id desc limit 1$/i.test(normalized)) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.tables.rpt_tokens
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1);
+      return { rows: clone(rows), rowCount: rows.length };
+    }
+
+    if (/^select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=\$1 and tax_type=\$2 and period_id=\$3 order by id$/i.test(normalized)) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.tables.owa_ledger
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => a.id - b.id)
+        .map(r => ({
+          ts: r.created_at.toISOString(),
+          amount_cents: r.amount_cents,
+          hash_after: r.hash_after,
+          bank_receipt_hash: r.bank_receipt_hash,
+        }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (/^select balance_after_cents, hash_after from owa_ledger where abn=\$1 and tax_type=\$2 and period_id=\$3 order by id desc limit 1$/i.test(normalized)) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.tables.owa_ledger
+        .filter(r => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map(r => ({ balance_after_cents: r.balance_after_cents, hash_after: r.hash_after }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (/^select \* from remittance_destinations where abn=\$1 and rail=\$2 and reference=\$3$/i.test(normalized)) {
+      const [abn, rail, reference] = params;
+      const rows = this.tables.remittance_destinations.filter(r => r.abn === abn && r.rail === rail && r.reference === reference);
+      return { rows: clone(rows), rowCount: rows.length };
+    }
+
+    if (/^insert into idempotency_keys\(key,last_status\) values\(\$1,\$2\)$/i.test(normalized)) {
+      const [key, status] = params;
+      if (this.tables.idempotency_keys.some(k => k.key === key)) {
+        const error: any = new Error("duplicate key value violates unique constraint");
+        error.code = "23505";
+        throw error;
+      }
+      this.tables.idempotency_keys.push({ key, last_status: status, response_hash: null });
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (/^update idempotency_keys set last_status=\$2 where key=\$1$/i.test(normalized)) {
+      const [key, status] = params;
+      const row = this.tables.idempotency_keys.find(k => k.key === key);
+      if (row) {
+        row.last_status = status;
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/^select last_status, response_hash from idempotency_keys where key=\$1$/i.test(normalized)) {
+      const [key] = params;
+      const row = this.tables.idempotency_keys.find(k => k.key === key);
+      const rows = row ? [{ last_status: row.last_status, response_hash: row.response_hash ?? null }] : [];
+      return { rows, rowCount: rows.length };
+    }
+
+    if (/^insert into owa_ledger\(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after\) values \(\$1,\$2,\$3,\$4,\$5,\$6,\$7,\$8,\$9\) returning id,balance_after_cents,hash_after,bank_receipt_hash$/i.test(normalized)) {
+      const [abn, taxType, periodId, transfer_uuid, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after] = params;
+      const id = ++this.seq.owa_ledger;
+      const row: OwaLedgerRow = {
+        id,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        transfer_uuid,
+        amount_cents,
+        balance_after_cents,
+        bank_receipt_hash,
+        prev_hash,
+        hash_after,
+        created_at: new Date(),
+      };
+      this.tables.owa_ledger.push(row);
+      return {
+        rows: [{ id, balance_after_cents, hash_after, bank_receipt_hash }],
+        rowCount: 1,
+      };
+    }
+
+    if (/^insert into rpt_tokens\(abn,tax_type,period_id,payload,signature\) values \(\$1,\$2,\$3,\$4,\$5\) returning id$/i.test(normalized)) {
+      const [abn, taxType, periodId, payload, signature] = params;
+      const id = ++this.seq.rpt_tokens;
+      const row: RptTokenRow = {
+        id,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        payload,
+        signature,
+        created_at: new Date(),
+      };
+      this.tables.rpt_tokens.push(row);
+      return { rows: [{ id }], rowCount: 1 };
+    }
+
+    if (/^update periods set state='[^']+' where id=\$1$/i.test(normalized)) {
+      const [id] = params;
+      const match = normalized.match(/set state='([^']+)'/i);
+      const newState = match ? match[1] : undefined;
+      const row = this.tables.periods.find(p => p.id === id);
+      if (row && newState) {
+        row.state = newState;
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (/^update periods set state='[^']+' where abn=\$1 and tax_type=\$2 and period_id=\$3$/i.test(normalized)) {
+      const [abn, taxType, periodId] = params;
+      const match = normalized.match(/set state='([^']+)'/i);
+      const newState = match ? match[1] : undefined;
+      let count = 0;
+      if (newState) {
+        this.tables.periods.forEach(row => {
+          if (row.abn === abn && row.tax_type === taxType && row.period_id === periodId) {
+            row.state = newState;
+            count += 1;
+          }
+        });
+      }
+      return { rows: [], rowCount: count };
+    }
+
+    if (/^select terminal_hash from audit_log order by seq desc limit 1$/i.test(normalized)) {
+      const rows = [...this.tables.audit_log]
+        .sort((a, b) => b.seq - a.seq)
+        .slice(0, 1)
+        .map(r => ({ terminal_hash: r.terminal_hash }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (/^insert into audit_log\(actor,action,payload_hash,prev_hash,terminal_hash\) values \(\$1,\$2,\$3,\$4,\$5\)$/i.test(normalized)) {
+      const [actor, action, payload_hash, prev_hash, terminal_hash] = params;
+      const seq = ++this.seq.audit_log;
+      const row: AuditLogRow = { seq, actor, action, payload_hash, prev_hash, terminal_hash, created_at: new Date() };
+      this.tables.audit_log.push(row);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (/^select now\(\)$/i.test(normalized)) {
+      return { rows: [{ now: new Date().toISOString() }], rowCount: 1 };
+    }
+
+    throw new Error(`Unsupported query: ${normalized}`);
+  }
+
+  private emptyTables(): TableState {
+    return {
+      periods: [],
+      rpt_tokens: [],
+      owa_ledger: [],
+      remittance_destinations: [],
+      idempotency_keys: [],
+      audit_log: [],
+    };
+  }
+}

--- a/tests/integration/reconcile.integration.test.ts
+++ b/tests/integration/reconcile.integration.test.ts
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import express from "express";
+import { AddressInfo } from "node:net";
+import { once } from "node:events";
+import nacl from "tweetnacl";
+import { setPool, shutdownPool } from "../../src/db/pool";
+import { FakePool } from "./fakePool";
+
+async function setupServer() {
+  const fakePool = new FakePool();
+  setPool(fakePool);
+  const [idempotencyModule, reconcile] = await Promise.all([
+    import("../../src/middleware/idempotency"),
+    import("../../src/routes/reconcile"),
+  ]);
+  const idempotency = idempotencyModule.idempotency;
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
+  app.post("/api/pay", idempotency(), reconcile.payAto);
+  app.post("/api/close-issue", reconcile.closeAndIssue);
+  app.post("/api/payto/sweep", reconcile.paytoSweep);
+  app.post("/api/settlement/webhook", reconcile.settlementWebhook);
+  app.get("/api/evidence", reconcile.evidence);
+  const server = app.listen(0);
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  return { fakePool, server, baseUrl };
+}
+
+async function postJson(baseUrl: string, path: string, body: any, headers: Record<string, string> = {}) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+async function getJson(baseUrl: string, path: string) {
+  const res = await fetch(`${baseUrl}${path}`);
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+test("reconcile release flow executes against Postgres queries", async (t) => {
+  const { fakePool, server, baseUrl } = await setupServer();
+  t.after(() => {
+    server.close();
+    return shutdownPool();
+  });
+
+  const keyPair = nacl.sign.keyPair();
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString("base64");
+  process.env.ATO_PRN = "PAYREF123";
+
+  fakePool.reset();
+  const abn = "12345678901";
+  const taxType = "GST";
+  const periodId = "2025-09";
+
+  fakePool.addPeriod({
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    state: "CLOSING",
+    final_liability_cents: 5000,
+    credited_to_owa_cents: 5000,
+    anomaly_vector: {},
+    thresholds: { epsilon_cents: 50 },
+    merkle_root: "merkle",
+    running_balance_hash: "hash0",
+  });
+
+  fakePool.addRemittanceDestination({
+    abn,
+    rail: "EFT",
+    reference: process.env.ATO_PRN!,
+  });
+
+  fakePool.addOwaLedger({
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    transfer_uuid: "seed-ledger",
+    amount_cents: 5000,
+    balance_after_cents: 5000,
+    bank_receipt_hash: "seed",
+    prev_hash: "",
+    hash_after: "hash-seed",
+  });
+
+  const close = await postJson(baseUrl, "/api/close-issue", { abn, taxType, periodId });
+  assert.equal(close.status, 200);
+  assert.equal(close.json.payload.entity_id, abn);
+  assert.ok(close.json.signature);
+
+  const pay = await postJson(
+    baseUrl,
+    "/api/pay",
+    { abn, taxType, periodId, rail: "EFT" },
+    { "Idempotency-Key": "release-1" }
+  );
+  assert.equal(pay.status, 200);
+  assert.match(pay.json.transfer_uuid, /^[0-9a-f-]+$/);
+  assert.ok(pay.json.bank_receipt_hash);
+
+  const evidenceResp = await getJson(baseUrl, `/api/evidence?abn=${abn}&taxType=${taxType}&periodId=${periodId}`);
+  assert.equal(evidenceResp.status, 200);
+  assert.equal(evidenceResp.json.owa_ledger_deltas.length, 2);
+  assert.equal(evidenceResp.json.rpt_payload.entity_id, abn);
+
+  const settlementCsv = "txn_id,gst_cents,net_cents,settlement_ts\\n1,10,90,2025-10-05T00:00:00Z\\n";
+  const settlement = await postJson(baseUrl, "/api/settlement/webhook", { csv: settlementCsv });
+  assert.equal(settlement.status, 200);
+  assert.equal(typeof settlement.json.ingested, "number");
+
+  const snapshot = fakePool.snapshot();
+  assert.equal(snapshot.rpt_tokens.length, 1);
+  assert.equal(snapshot.owa_ledger.length, 2);
+  assert.ok(snapshot.idempotency_keys.some(k => k.last_status === "DONE"));
+  assert.equal(snapshot.periods[0]?.state, "RELEASED");
+});


### PR DESCRIPTION
## Summary
- replace raw `pg` pool usage with a shared helper and parameterised SQL across reconciliation, evidence, and rails modules
- harden release and idempotency flows with RETURNING clauses, error checks, and consistent state updates
- add a FakePool-backed integration test suite that exercises /api/close-issue, /api/pay, /api/evidence, and /api/settlement/webhook

## Testing
- npx tsx --test tests/integration/reconcile.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e24a7417a0832784494924f85aa2e0