### PR TITLE
Add dev automation scripts and float guard

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+printf '\n>> Running unit tests (pytest)\n'
+make test-unit
+
+printf '\n>> Running golden tests\n'
+make test-golden
+
+printf '\n>> Checking for float literals\n'
+python tools/hooks/forbid_floats.py

--- a/COMMIT_MSG.txt
+++ b/COMMIT_MSG.txt
@@ -1,0 +1,23 @@
+# Conventional Commits template
+#
+# Summary line format:
+# <type>[optional scope]: <concise summary>
+#
+# Body guidance:
+# - Wrap at 72 columns when practical.
+# - Explain the motivation and the approach.
+# - Reference issues or tickets in the footer as needed.
+#
+# Common types: feat, fix, chore, docs, refactor, test, build, ci, perf, style, revert.
+# Scope examples: normalizer, portal-api, infra.
+#
+# Example:
+# feat(normalizer): add deterministic golden fixtures
+#
+# Body (optional):
+# - detail 1
+# - detail 2
+#
+# Footer (optional):
+# BREAKING CHANGE: description
+# Closes: ABC-123

--- a/Dev-Demo.ps1
+++ b/Dev-Demo.ps1
@@ -1,0 +1,12 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+Write-Host 'python -m pytest tests/golden' -ForegroundColor Cyan
+python -m pytest tests/golden
+
+Write-Host 'Opening http://localhost:8080 in your default browser...' -ForegroundColor Green
+Start-Process 'http://localhost:8080'

--- a/Dev-Down.ps1
+++ b/Dev-Down.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+$composeFiles = @(
+    'docker-compose.yml',
+    'docker-compose.override.yml',
+    'docker-compose.dev.yaml',
+    'docker-compose.gui.yaml',
+    'docker-compose.metrics.yml'
+) | Where-Object { Test-Path $_ }
+
+$arguments = @('compose')
+foreach ($file in $composeFiles) {
+    $arguments += @('-f', $file)
+}
+$arguments += @('down', '-v')
+
+Write-Host "docker $($arguments -join ' ')" -ForegroundColor Cyan
+& docker @arguments

--- a/Dev-Seed.ps1
+++ b/Dev-Seed.ps1
@@ -1,0 +1,12 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+Write-Host 'npm ci --ignore-scripts' -ForegroundColor Cyan
+npm ci --ignore-scripts
+
+Write-Host 'node scripts/seed_rpt_local.mjs' -ForegroundColor Cyan
+node scripts/seed_rpt_local.mjs

--- a/Dev-Up.ps1
+++ b/Dev-Up.ps1
@@ -1,0 +1,23 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $repoRoot
+
+$composeFiles = @(
+    'docker-compose.yml',
+    'docker-compose.override.yml',
+    'docker-compose.dev.yaml',
+    'docker-compose.gui.yaml',
+    'docker-compose.metrics.yml'
+) | Where-Object { Test-Path $_ }
+
+$arguments = @('compose')
+foreach ($file in $composeFiles) {
+    $arguments += @('-f', $file)
+}
+$arguments += @('up', '-d', '--build', '--remove-orphans')
+
+Write-Host "docker $($arguments -join ' ')" -ForegroundColor Cyan
+& docker @arguments

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-﻿SHELL := /bin/bash
+SHELL := /bin/bash
+
+.PHONY: up up-dev down logs shell rebuild ps fmt \
+        dev-up dev-down dev-seed dev-demo test-unit test-golden
+
+DEV_COMPOSE_FILES := docker-compose.yml docker-compose.override.yml \
+        docker-compose.dev.yaml docker-compose.gui.yaml docker-compose.metrics.yml
+DEV_COMPOSE_ARGS := $(foreach file,$(DEV_COMPOSE_FILES),$(if $(wildcard $(file)),-f $(file),))
 
 up:
 	@docker compose up -d --build --remove-orphans
@@ -23,3 +30,27 @@ ps:
 
 fmt:
 	@echo "No formatter configured; add ruff/black if desired."
+
+dev-up:
+	@echo "Starting full developer stack..."
+	@docker compose $(DEV_COMPOSE_ARGS) up -d --build --remove-orphans
+
+dev-down:
+	@echo "Stopping developer stack..."
+	@docker compose $(DEV_COMPOSE_ARGS) down -v
+
+dev-seed:
+	@echo "Installing JavaScript dependencies (npm ci)..."
+	@npm ci --ignore-scripts
+	@echo "Seeding development database via scripts/seed_rpt_local.mjs..."
+	@node scripts/seed_rpt_local.mjs
+
+test-unit:
+	@python -m pytest tests/test_math.py
+
+test-golden:
+	@python -m pytest tests/golden
+
+dev-demo: test-golden
+	@echo "Opening developer UI at http://localhost:8080"
+	@python -m webbrowser http://localhost:8080

--- a/README.md
+++ b/README.md
@@ -37,6 +37,32 @@ npm start
 
 The app will start on http://localhost:3000
 
+## Developer tooling
+
+- `make dev-up` starts the full Docker stack using every available compose file in the repository.
+- `make dev-down` stops the stack and removes volumes so the database can be rebuilt cleanly.
+- `make dev-seed` runs `npm ci --ignore-scripts` and then executes `scripts/seed_rpt_local.mjs` to seed sample data.
+- `make dev-demo` executes the golden tests and opens the UI at <http://localhost:8080>.
+
+Windows users can run the matching PowerShell helpers instead:
+
+- `./Dev-Up.ps1`
+- `./Dev-Down.ps1`
+- `./Dev-Seed.ps1`
+- `./Dev-Demo.ps1`
+
+To enable the provided pre-commit hook (runs unit tests, golden tests, and blocks float literals), configure Git once:
+
+```powershell
+git config core.hooksPath .githooks
+```
+
+The repository also ships with a Conventional Commits template. Opt-in with:
+
+```powershell
+git config commit.template COMMIT_MSG.txt
+```
+
 Build for Production
 
 npm run build

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ orjson==3.10.7
 nats-py==2.7.2
 prometheus-client==0.20.0
 httpx==0.27.2
+pytest==8.3.3

--- a/tests/golden/rpt_token.json
+++ b/tests/golden/rpt_token.json
@@ -1,0 +1,13 @@
+{
+  "anomaly_score": 0,
+  "expires_at": 1700000900,
+  "gst_total": 67890,
+  "nonce": "0102030405060708",
+  "paygw_total": 12345,
+  "period_id": "2025Q1",
+  "signature": "2f5331236d90b629e62baf11e14478a30507c30b61811460b156d771b4adf419",
+  "source_digests": {
+    "payroll": "abc123",
+    "pos": "xyz789"
+  }
+}

--- a/tests/golden/test_rpt_token.py
+++ b/tests/golden/test_rpt_token.py
@@ -1,0 +1,30 @@
+import json
+from pathlib import Path
+
+from libs.rpt import rpt
+
+
+def test_rpt_build_matches_golden(monkeypatch):
+    monkeypatch.setenv("APGMS_RPT_SECRET", "golden-secret")
+
+    def fake_time():
+        return 1_700_000_000
+
+    def fake_urandom(length: int) -> bytes:
+        return bytes(range(1, length + 1))
+
+    monkeypatch.setattr(rpt.time, "time", fake_time)
+    monkeypatch.setattr(rpt.os, "urandom", fake_urandom)
+
+    actual = rpt.build(
+        period_id="2025Q1",
+        paygw_total=12345,
+        gst_total=67890,
+        source_digests={"payroll": "abc123", "pos": "xyz789"},
+        anomaly_score=0,
+        ttl_seconds=900,
+    )
+
+    golden_path = Path(__file__).with_name("rpt_token.json")
+    expected = json.loads(golden_path.read_text(encoding="utf-8"))
+    assert actual == expected

--- a/tools/hooks/forbid_floats.py
+++ b/tools/hooks/forbid_floats.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Fail the commit if newly staged code introduces float literals."""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+FLOAT_PATTERN = re.compile(r"(?<![\w\"'])\d+\.\d+(?:[eE][+-]?\d+)?(?![\w\"'])")
+CHECK_EXTS = {".py", ".pyi", ".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs", ".ps1"}
+
+
+def staged_diff() -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--unified=0", "--diff-filter=ACMRTUXB"],
+        check=True,
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    return result.stdout.splitlines()
+
+
+def should_check(path: str) -> bool:
+    return Path(path).suffix in CHECK_EXTS
+
+
+def main() -> int:
+    diff_lines = staged_diff()
+    current_path: str | None = None
+    violations: list[tuple[str, str]] = []
+
+    for raw in diff_lines:
+        if raw.startswith("+++ b/"):
+            current_path = raw[6:]
+            continue
+        if not current_path or not should_check(current_path):
+            continue
+        if not raw.startswith("+") or raw.startswith("+++"):
+            continue
+        line = raw[1:]
+        match = FLOAT_PATTERN.search(line)
+        if match:
+            violations.append((current_path, line.rstrip()))
+
+    if violations:
+        sys.stderr.write("Float literals detected in staged changes:\n")
+        for path, line in violations:
+            sys.stderr.write(f"  {path}: {line}\n")
+        sys.stderr.write("Use integers, Decimal, or rationals instead of floats.\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add reproducible developer make targets plus Windows PowerShell wrappers
- add deterministic golden test fixtures and npm-based seeding workflow
- configure a pre-commit hook to run tests, block float literals, and document the new workflow

## Testing
- python -m pytest tests/test_math.py tests/golden

------
https://chatgpt.com/codex/tasks/task_e_68e24bc54b08832787eccba4b0b5079f