### PR TITLE
Add BAS golden vectors and CI validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  golden:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run BAS golden vectors
+        shell: pwsh
+        run: ./tools/run_golden.ps1 --all

--- a/goldens/bas_amendments/events.json
+++ b/goldens/bas_amendments/events.json
@@ -1,0 +1,75 @@
+{
+  "abn": "53004085616",
+  "period_id": "2025-09",
+  "events": [
+    {
+      "event_type": "payroll",
+      "period_id": "2025-09",
+      "dedupe_key": "pay-100",
+      "monotonic_seq": 1,
+      "gross_cents": 300000,
+      "withholding_cents": 45000,
+      "signed_at": "2025-09-05T02:00:00Z"
+    },
+    {
+      "event_type": "payroll",
+      "period_id": "2025-09",
+      "dedupe_key": "pay-100",
+      "amends": "pay-100",
+      "monotonic_seq": 2,
+      "gross_cents": 305000,
+      "withholding_cents": 47000,
+      "signed_at": "2025-09-06T04:15:00Z"
+    },
+    {
+      "event_type": "payroll",
+      "period_id": "2025-08",
+      "reported_period": "2025-09",
+      "dedupe_key": "pay-099",
+      "monotonic_seq": 3,
+      "gross_cents": 180000,
+      "withholding_cents": 12000,
+      "signed_at": "2025-09-10T01:00:00Z"
+    },
+    {
+      "event_type": "pos",
+      "period_id": "2025-09",
+      "txn_id": "sale-500",
+      "monotonic_seq": 10,
+      "signed_at": "2025-09-02T00:30:00Z",
+      "lines": [
+        { "sku": "BUNDLE-01", "qty": 6, "unit_price_cents": 7500, "tax_code": "GST" }
+      ]
+    },
+    {
+      "event_type": "pos",
+      "period_id": "2025-09",
+      "txn_id": "sale-500",
+      "amends": "sale-500",
+      "monotonic_seq": 11,
+      "signed_at": "2025-09-03T00:30:00Z",
+      "lines": [
+        { "sku": "BUNDLE-01", "qty": 5, "unit_price_cents": 7500, "tax_code": "GST" }
+      ]
+    },
+    {
+      "event_type": "pos",
+      "period_id": "2025-09",
+      "txn_id": "return-501",
+      "monotonic_seq": 12,
+      "signed_at": "2025-09-20T06:45:00Z",
+      "lines": [
+        { "sku": "RET-01", "qty": -1, "unit_price_cents": 9000, "tax_code": "GST" }
+      ]
+    },
+    {
+      "event_type": "bank",
+      "period_id": "2025-09",
+      "monotonic_seq": 40,
+      "direction": "DEBIT",
+      "signed_at": "2025-09-27T09:30:00Z",
+      "amount_cents": 13200,
+      "gst_credit_cents": 1200
+    }
+  ]
+}

--- a/goldens/bas_amendments/expected.json
+++ b/goldens/bas_amendments/expected.json
@@ -1,0 +1,32 @@
+{
+  "bas": {
+    "labels_cents": {
+      "1A": 2850,
+      "1B": 1200,
+      "W1": 485000,
+      "W2": 59000
+    },
+    "period_id": "2025-09",
+    "totals": {
+      "gst_cents": 1650,
+      "paygw_cents": 59000
+    }
+  },
+  "rpt": {
+    "payload": {
+      "anomaly_score": 0.0,
+      "expires_at": 4102444800,
+      "gst_total": 16.5,
+      "nonce": "1b7dafe3e2db65a1",
+      "paygw_total": 590.0,
+      "period_id": "2025-09",
+      "source_digests": {
+        "bank": "29ddcc2b02f745ad1be94d8d56614c3c7dc392c1e9dbadffee1ea260da9230eb",
+        "payroll": "091b8478afe9be3a1003dd9d954a9112d32adcc7937920a0614c87aab38a6442",
+        "pos": "6162996ff075d5c41d3ca9549c4c67a1b9baf6d212b7701b424272f05dc86e7a"
+      }
+    },
+    "payload_sha256": "fd63c98ded48e83ed8d30a874be2f9f18e367d4e8d1881a0551ce5bc782acbb2",
+    "signature": "274ad66c0c2b2c6760e0001e73728bce43436e50efc4ffeb3fef9651f137df58"
+  }
+}

--- a/goldens/bas_happy/events.json
+++ b/goldens/bas_happy/events.json
@@ -1,0 +1,54 @@
+{
+  "abn": "53004085616",
+  "period_id": "2025-09",
+  "events": [
+    {
+      "event_type": "payroll",
+      "period_id": "2025-09",
+      "dedupe_key": "pay-001",
+      "monotonic_seq": 1,
+      "gross_cents": 500000,
+      "withholding_cents": 95000,
+      "signed_at": "2025-09-07T05:02:00Z"
+    },
+    {
+      "event_type": "payroll",
+      "period_id": "2025-09",
+      "dedupe_key": "pay-002",
+      "monotonic_seq": 2,
+      "gross_cents": 420000,
+      "withholding_cents": 63000,
+      "signed_at": "2025-09-21T05:02:00Z"
+    },
+    {
+      "event_type": "pos",
+      "period_id": "2025-09",
+      "txn_id": "sale-100",
+      "monotonic_seq": 10,
+      "signed_at": "2025-09-03T01:12:00Z",
+      "lines": [
+        { "sku": "SKU-AAA", "qty": 10, "unit_price_cents": 5500, "discount_cents": 500, "tax_code": "GST" },
+        { "sku": "SKU-BBB", "qty": 2, "unit_price_cents": 12000, "tax_code": "GST_FREE" }
+      ]
+    },
+    {
+      "event_type": "pos",
+      "period_id": "2025-09",
+      "txn_id": "sale-101",
+      "monotonic_seq": 11,
+      "signed_at": "2025-09-14T04:05:00Z",
+      "lines": [
+        { "sku": "SKU-CCC", "qty": 5, "unit_price_cents": 8000, "tax_code": "GST" }
+      ]
+    },
+    {
+      "event_type": "bank",
+      "period_id": "2025-09",
+      "monotonic_seq": 30,
+      "signed_at": "2025-09-28T08:45:00Z",
+      "direction": "CREDIT",
+      "amount_cents": 118500,
+      "gst_credit_cents": 0
+    }
+  ]
+}

--- a/goldens/bas_happy/expected.json
+++ b/goldens/bas_happy/expected.json
@@ -1,0 +1,32 @@
+{
+  "bas": {
+    "labels_cents": {
+      "1A": 9450,
+      "1B": 0,
+      "W1": 920000,
+      "W2": 158000
+    },
+    "period_id": "2025-09",
+    "totals": {
+      "gst_cents": 9450,
+      "paygw_cents": 158000
+    }
+  },
+  "rpt": {
+    "payload": {
+      "anomaly_score": 0.0,
+      "expires_at": 4102444800,
+      "gst_total": 94.5,
+      "nonce": "dc8180315117a3b7",
+      "paygw_total": 1580.0,
+      "period_id": "2025-09",
+      "source_digests": {
+        "bank": "4f9199921049f04246b746c9e5b1864b1208f92a27dc58c6a8d480b04894be9c",
+        "payroll": "53b58fb02ee4a6b74d1a32345d20579c84a714deba8fabf091e7e70f3863d2d8",
+        "pos": "1c5008c48b15876eab9c18065620403dd284ebd277d185a312c73d307c76683d"
+      }
+    },
+    "payload_sha256": "3e85768dac05856bc6e3483c71b911feebbddfc6d9f696657feed4a7d58f7e72",
+    "signature": "19effcf18a8c550d3d325382d30c6d31c1d3e14472529d1c320a89e3c1e27d2a"
+  }
+}

--- a/tools/golden_eval.py
+++ b/tools/golden_eval.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Golden vector evaluator for BAS totals and RPT hash.
+
+Usage:
+  python tools/golden_eval.py --events goldens/foo/events.json --expected goldens/foo/expected.json
+
+The script computes BAS label totals from canonical events and derives a
+signature hash for the RPT payload using the lightweight libs/rpt module.
+If --expected is supplied the JSON is compared byte-for-byte after
+canonicalisation and a non-zero exit status is returned on mismatch.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+# Ensure we can import the simple tax helpers and HMAC signer.
+sys.path.insert(0, str(REPO_ROOT / "apps" / "services" / "tax-engine"))
+from app.tax_rules import gst_line_tax  # type: ignore  # noqa: E402
+
+sys.path.insert(0, str(REPO_ROOT / "libs"))
+from rpt.rpt import sign as rpt_sign  # type: ignore  # noqa: E402
+
+
+def _canonical(data: Any) -> str:
+    """JSON canonical form used for digests and comparisons."""
+    return json.dumps(data, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _round_cents_to_dollars(cents: int) -> float:
+    return round(cents / 100.0, 2)
+
+
+@dataclass
+class Totals:
+    w1: int = 0
+    w2: int = 0
+    one_a: int = 0
+    one_b: int = 0
+
+    @property
+    def paygw_cents(self) -> int:
+        return self.w2
+
+    @property
+    def gst_cents(self) -> int:
+        return self.one_a - self.one_b
+
+
+def _event_sort_key(evt: Dict[str, Any]) -> Tuple[Any, ...]:
+    return (
+        evt.get("period_id"),
+        evt.get("reported_period"),
+        evt.get("event_type"),
+        evt.get("monotonic_seq"),
+        evt.get("dedupe_key"),
+        evt.get("txn_id"),
+        evt.get("signed_at"),
+        _canonical(evt),
+    )
+
+
+def _collect_source_digest(events: Iterable[Dict[str, Any]]) -> str:
+    ordered = sorted((json.loads(_canonical(e)) for e in events), key=_event_sort_key)
+    return hashlib.sha256(_canonical(ordered).encode("utf-8")).hexdigest()
+
+
+def _ensure_int(value: Any) -> int:
+    if isinstance(value, bool):  # bool is subclass of int
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(round(value))
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Expected integer-like value, got {value!r}") from exc
+
+
+def _process_events(bundle: Dict[str, Any]) -> Tuple[Totals, Dict[str, List[Dict[str, Any]]]]:
+    period = bundle.get("period_id")
+    if not isinstance(period, str):
+        raise ValueError("bundle.period_id must be a string")
+
+    totals = Totals()
+    source_events: Dict[str, List[Dict[str, Any]]] = {}
+
+    payroll_seen: Dict[str, Tuple[int, int]] = {}
+    pos_seen: Dict[str, Tuple[int, int]] = {}
+
+    for raw_evt in bundle.get("events", []):
+        if not isinstance(raw_evt, dict):
+            continue
+        evt = json.loads(_canonical(raw_evt))  # deep copy + stable types
+        event_type = evt.get("event_type")
+        if not event_type:
+            continue
+
+        reported_period = evt.get("reported_period") or evt.get("period_id") or period
+        if reported_period != period:
+            continue
+
+        source_events.setdefault(event_type, []).append(evt)
+
+        if event_type == "payroll":
+            dedupe = evt.get("dedupe_key") or f"payroll:{evt.get('monotonic_seq', '')}"
+            if not isinstance(dedupe, str) or not dedupe:
+                raise ValueError("payroll event missing dedupe_key")
+
+            ref = evt.get("amends")
+            if isinstance(ref, str) and ref:
+                prev = payroll_seen.pop(ref, None)
+                if prev:
+                    prev_gross, prev_withheld = prev
+                    totals.w1 -= prev_gross
+                    totals.w2 -= prev_withheld
+
+            prev = payroll_seen.get(dedupe)
+            if prev:
+                prev_gross, prev_withheld = prev
+                totals.w1 -= prev_gross
+                totals.w2 -= prev_withheld
+
+            gross = _ensure_int(evt.get("gross_cents"))
+            withheld = _ensure_int(evt.get("withholding_cents"))
+            payroll_seen[dedupe] = (gross, withheld)
+            totals.w1 += gross
+            totals.w2 += withheld
+
+        elif event_type == "pos":
+            key = evt.get("txn_id") or evt.get("dedupe_key") or f"pos:{evt.get('monotonic_seq', '')}"
+            if not isinstance(key, str) or not key:
+                raise ValueError("pos event missing txn_id/dedupe_key")
+
+            ref = evt.get("amends")
+            if isinstance(ref, str) and ref:
+                prev = pos_seen.pop(ref, None)
+                if prev:
+                    prev_gst, prev_credit = prev
+                    totals.one_a -= prev_gst
+                    totals.one_b -= prev_credit
+
+            prev = pos_seen.get(key)
+            if prev:
+                prev_gst, prev_credit = prev
+                totals.one_a -= prev_gst
+                totals.one_b -= prev_credit
+
+            gst_sum = 0
+            credit_sum = _ensure_int(evt.get("gst_credit_cents"))
+            for line in evt.get("lines", []):
+                if not isinstance(line, dict):
+                    continue
+                qty = float(line.get("qty", 0))
+                unit = _ensure_int(line.get("unit_price_cents"))
+                discount = _ensure_int(line.get("discount_cents"))
+                line_total = int(round(qty * unit)) - discount
+                tax_code = (line.get("tax_code") or "GST").upper()
+                line_gst = gst_line_tax(abs(line_total), tax_code)
+                if line_total < 0:
+                    line_gst = -line_gst
+                gst_sum += line_gst
+
+            pos_seen[key] = (gst_sum, credit_sum)
+            totals.one_a += gst_sum
+            totals.one_b += credit_sum
+
+        elif event_type == "bank":
+            credit = _ensure_int(evt.get("gst_credit_cents"))
+            totals.one_b += credit
+
+    return totals, source_events
+
+
+def compute_bundle(events_path: Path) -> Dict[str, Any]:
+    bundle = json.loads(events_path.read_text(encoding="utf-8"))
+    totals, source_events = _process_events(bundle)
+
+    bas = {
+        "period_id": bundle.get("period_id"),
+        "labels_cents": {
+            "W1": totals.w1,
+            "W2": totals.w2,
+            "1A": totals.one_a,
+            "1B": totals.one_b,
+        },
+        "totals": {
+            "paygw_cents": totals.paygw_cents,
+            "gst_cents": totals.gst_cents,
+        },
+    }
+
+    digests = {
+        et: _collect_source_digest(evts)
+        for et, evts in sorted(source_events.items())
+        if evts
+    }
+
+    anomaly_score = float(bundle.get("anomaly_score", 0.0))
+    nonce_seed = f"{bas['period_id']}|{totals.paygw_cents}|{totals.gst_cents}|{_canonical(digests)}"
+    nonce = hashlib.sha256(nonce_seed.encode("utf-8")).hexdigest()[:16]
+
+    expires_at = int(bundle.get("expires_at", 4102444800))
+
+    rpt_payload = {
+        "period_id": bas["period_id"],
+        "paygw_total": _round_cents_to_dollars(totals.paygw_cents),
+        "gst_total": _round_cents_to_dollars(totals.gst_cents),
+        "source_digests": digests,
+        "anomaly_score": anomaly_score,
+        "expires_at": expires_at,
+        "nonce": nonce,
+    }
+
+    payload_c14n = _canonical(rpt_payload)
+    signature = rpt_sign(json.loads(payload_c14n))
+    payload_sha256 = hashlib.sha256(payload_c14n.encode("utf-8")).hexdigest()
+
+    rpt = {
+        "payload": rpt_payload,
+        "payload_sha256": payload_sha256,
+        "signature": signature,
+    }
+
+    return {"bas": bas, "rpt": rpt}
+
+
+def main(argv: List[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Compute BAS/RPT goldens")
+    parser.add_argument("--events", required=True, type=Path, help="Path to events.json")
+    parser.add_argument("--expected", type=Path, help="Optional expected.json for comparison")
+    parser.add_argument("--write", type=Path, help="Write computed output to this path")
+    parser.add_argument("--pretty", action="store_true", help="Print the computed JSON")
+    args = parser.parse_args(argv)
+
+    result = compute_bundle(args.events)
+    result_json = json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+    if args.write:
+        args.write.write_text(result_json, encoding="utf-8")
+
+    if args.expected:
+        expected = json.loads(args.expected.read_text(encoding="utf-8"))
+        if result != expected:
+            actual_c14n = _canonical(result)
+            expected_c14n = _canonical(expected)
+            sys.stderr.write("Golden mismatch for " + str(args.events) + "\n")
+            sys.stderr.write("Expected:\n" + expected_c14n + "\n")
+            sys.stderr.write("Actual:\n" + actual_c14n + "\n")
+            return 1
+
+    if args.pretty or not args.expected:
+        sys.stdout.write(result_json)
+    return 0
+
+
+if __name__ == "__main__":
+    os.environ.setdefault("APGMS_RPT_SECRET", "dev-secret-change-me")
+    raise SystemExit(main())

--- a/tools/run_golden.ps1
+++ b/tools/run_golden.ps1
@@ -1,0 +1,69 @@
+param(
+  [string]$Name,
+  [switch]$All
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSCommandPath
+$goldenRoot = Join-Path $repoRoot 'goldens'
+if (-not (Test-Path $goldenRoot -PathType Container)) {
+  throw "Missing goldens directory: $goldenRoot"
+}
+
+function Resolve-Python {
+  foreach ($cmd in @('python3','python')) {
+    try {
+      $p = Get-Command $cmd -ErrorAction Stop
+      return $p.Source
+    } catch {
+      continue
+    }
+  }
+  throw "python executable not found"
+}
+
+$python = Resolve-Python
+
+if ($All) {
+  $targets = Get-ChildItem -Path $goldenRoot -Directory | Sort-Object Name
+} elseif ($Name) {
+  $dir = Join-Path $goldenRoot $Name
+  if (-not (Test-Path $dir -PathType Container)) {
+    throw "Golden '$Name' not found under $goldenRoot"
+  }
+  $targets = ,(Get-Item $dir)
+} else {
+  throw "Specify --all or --name"
+}
+
+$failed = @()
+foreach ($t in $targets) {
+  $events = Join-Path $t.FullName 'events.json'
+  $expected = Join-Path $t.FullName 'expected.json'
+  if (-not (Test-Path $events -PathType Leaf)) {
+    Write-Error "Missing events.json in $($t.FullName)"
+    $failed += $t.Name
+    continue
+  }
+  if (-not (Test-Path $expected -PathType Leaf)) {
+    Write-Error "Missing expected.json in $($t.FullName)"
+    $failed += $t.Name
+    continue
+  }
+
+  Write-Host "== Golden: $($t.Name) ==" -ForegroundColor Cyan
+  & $python (Join-Path $repoRoot 'tools/golden_eval.py') --events $events --expected $expected | Out-String | Write-Host
+  if ($LASTEXITCODE -ne 0) {
+    $failed += $t.Name
+  } else {
+    Write-Host "  ✔ matched" -ForegroundColor Green
+  }
+}
+
+if ($failed.Count -gt 0) {
+  Write-Error ("Golden mismatch: {0}" -f ($failed -join ', '))
+  exit 1
+}
+
+Write-Host "All golden vectors verified" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add a Python harness that canonicalises event bundles and produces BAS totals plus an RPT hash
- capture baseline and amendment/backdated golden fixtures with expected outputs
- provide a PowerShell runner and GitHub Actions workflow to enforce the goldens in CI

## Testing
- python tools/golden_eval.py --events goldens/bas_happy/events.json --expected goldens/bas_happy/expected.json
- python tools/golden_eval.py --events goldens/bas_amendments/events.json --expected goldens/bas_amendments/expected.json

------
https://chatgpt.com/codex/tasks/task_e_68e24b981e8c83278a760141c72bde91