### PR TITLE
Implement PayTo adapter and bank egress integrations

### DIFF
--- a/apps/services/bank-egress/main.py
+++ b/apps/services/bank-egress/main.py
@@ -1,36 +1,184 @@
-﻿# apps/services/bank-egress/main.py
+# apps/services/bank-egress/main.py
 from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
-import os, psycopg2, json
+import hashlib
+import json
+import os
+from typing import Any, Dict
+
+import httpx
+import psycopg2
+
+from libs.audit_chain import chain
 from libs.rpt.rpt import verify
 
 app = FastAPI(title="bank-egress")
+
 
 class EgressReq(BaseModel):
     period_id: str
     rpt: dict
 
+
 def db():
     return psycopg2.connect(
-        host=os.getenv("PGHOST","127.0.0.1"),
-        user=os.getenv("PGUSER","postgres"),
-        password=os.getenv("PGPASSWORD","postgres"),
-        dbname=os.getenv("PGDATABASE","postgres"),
-        port=int(os.getenv("PGPORT","5432"))
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
     )
+
+
+_http_client: httpx.Client | None = None
+
+
+def _client() -> httpx.Client:
+    global _http_client
+    if _http_client is not None:
+        return _http_client
+
+    base_url = os.getenv("BANK_API_BASE")
+    if not base_url:
+        raise RuntimeError("BANK_API_BASE is not configured")
+
+    timeout = float(os.getenv("BANK_TIMEOUT_SEC") or 0.0)
+    if not timeout:
+        timeout = float(os.getenv("BANK_TIMEOUT_MS") or 8000) / 1000.0
+
+    verify_path = os.getenv("BANK_TLS_CA")
+    cert_path = os.getenv("BANK_TLS_CERT")
+    key_path = os.getenv("BANK_TLS_KEY")
+    cert = (cert_path, key_path) if cert_path and key_path else None
+
+    _http_client = httpx.Client(
+        base_url=base_url,
+        timeout=timeout,
+        verify=verify_path if verify_path else True,
+        cert=cert,
+    )
+    return _http_client
+
+
+def _post_bank(payload: Dict[str, Any]) -> Dict[str, Any]:
+    resp = _client().post("/bas/remit", json=payload)
+    resp.raise_for_status()
+    return resp.json()
+
 
 @app.post("/egress/remit")
 def remit(req: EgressReq):
-    if "signature" not in req.rpt or not verify({k:v for k,v in req.rpt.items() if k!="signature"}, req.rpt["signature"]):
+    if "signature" not in req.rpt or not verify(
+        {k: v for k, v in req.rpt.items() if k != "signature"}, req.rpt["signature"]
+    ):
         raise HTTPException(400, "invalid RPT signature")
-    conn = db(); cur = conn.cursor()
-    cur.execute("SELECT state FROM bas_gate_states WHERE period_id=%s", (req.period_id,))
-    row = cur.fetchone()
-    if not row or row[0] != "RPT-Issued":
-        raise HTTPException(409, "gate not in RPT-Issued")
-    # Here you would call the real bank API via mTLS. For now, we just log.
-    payload = json.dumps({"period_id": req.period_id, "action": "remit"})
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('egress',%s,NULL,NULL)", (payload,))
-    cur.execute("UPDATE bas_gate_states SET state='Remitted', updated_at=NOW() WHERE period_id=%s", (req.period_id,))
-    conn.commit(); cur.close(); conn.close()
-    return {"ok": True}
+
+    conn = db()
+    cur = conn.cursor()
+    try:
+        cur.execute(
+            "SELECT state, hash_this FROM bas_gate_states WHERE period_id=%s",
+            (req.period_id,),
+        )
+        row = cur.fetchone()
+        if not row or row[0] != "RPT-Issued":
+            raise HTTPException(409, "gate not in RPT-Issued")
+
+        gate_prev_hash = row[1]
+
+        try:
+            bank_payload = _post_bank({"period_id": req.period_id, "rpt": req.rpt})
+        except httpx.HTTPError as exc:  # pragma: no cover - handled in tests via stub
+            raise HTTPException(502, f"bank error: {exc}") from exc
+
+        receipt_value = bank_payload.get("receipt") or bank_payload.get("receipt_id")
+        if not receipt_value:
+            raise HTTPException(502, "bank response missing receipt")
+
+        receipt_hash = hashlib.sha256(str(receipt_value).encode("utf-8")).hexdigest()
+        bank_reference = bank_payload.get("bank_reference") or bank_payload.get("reference")
+        if not bank_reference:
+            raise HTTPException(502, "bank response missing reference")
+
+        bank_status = str(bank_payload.get("status", "UNKNOWN"))
+
+        cur.execute(
+            """
+            INSERT INTO bank_remittances(period_id, rpt_json, bank_reference, bank_status, receipt_hash, bank_payload, updated_at)
+            VALUES (%s,%s,%s,%s,%s,%s,NOW())
+            ON CONFLICT (period_id) DO UPDATE
+              SET bank_reference=EXCLUDED.bank_reference,
+                  bank_status=EXCLUDED.bank_status,
+                  receipt_hash=EXCLUDED.receipt_hash,
+                  bank_payload=EXCLUDED.bank_payload,
+                  updated_at=NOW()
+            """,
+            (
+                req.period_id,
+                json.dumps(req.rpt),
+                bank_reference,
+                bank_status,
+                receipt_hash,
+                json.dumps(bank_payload),
+            ),
+        )
+
+        gate_payload = json.dumps(
+            {
+                "period_id": req.period_id,
+                "state": "Remitted",
+                "receipt_hash": receipt_hash,
+            },
+            separators=(",", ":"),
+        )
+        new_gate_hash = chain.link(gate_prev_hash, gate_payload)
+
+        cur.execute(
+            """
+            UPDATE bas_gate_states
+               SET state='Remitted',
+                   reason_code=%s,
+                   updated_at=NOW(),
+                   hash_prev=%s,
+                   hash_this=%s
+             WHERE period_id=%s
+            """,
+            ("BANK_OK", gate_prev_hash, new_gate_hash, req.period_id),
+        )
+
+        cur.execute(
+            "SELECT hash_this FROM audit_log WHERE category='egress' ORDER BY id DESC LIMIT 1"
+        )
+        audit_prev = cur.fetchone()
+        prev_hash = audit_prev[0] if audit_prev and audit_prev[0] else None
+
+        audit_payload = json.dumps(
+            {
+                "period_id": req.period_id,
+                "bank_reference": bank_reference,
+                "receipt_hash": receipt_hash,
+                "status": bank_status,
+            },
+            separators=(",", ":"),
+        )
+        audit_hash = chain.link(prev_hash, audit_payload)
+
+        cur.execute(
+            "INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES (%s,%s,%s,%s)",
+            ("egress", audit_payload, prev_hash, audit_hash),
+        )
+
+        conn.commit()
+        return JSONResponse(
+            {
+                "ok": True,
+                "bank_reference": bank_reference,
+                "receipt_hash": receipt_hash,
+                "status": bank_status,
+            }
+        )
+    finally:
+        cur.close()
+        conn.close()
+

--- a/apps/services/bank-egress/requirements.txt
+++ b/apps/services/bank-egress/requirements.txt
@@ -1,4 +1,5 @@
-﻿fastapi==0.115.0
+fastapi==0.115.0
 uvicorn==0.30.6
 pydantic==2.9.2
 psycopg2-binary==2.9.9
+httpx==0.27.2

--- a/migrations/003_payto_integrations.sql
+++ b/migrations/003_payto_integrations.sql
@@ -1,0 +1,47 @@
+-- 003_payto_integrations.sql
+-- PayTo mandate + debit persistence and bank remittance receipts
+
+CREATE TABLE IF NOT EXISTS payto_mandates (
+  id                SERIAL PRIMARY KEY,
+  abn               TEXT NOT NULL,
+  reference         TEXT NOT NULL,
+  bank_mandate_id   TEXT NOT NULL,
+  cap_cents         BIGINT NOT NULL,
+  consumed_cents    BIGINT NOT NULL DEFAULT 0,
+  status            TEXT NOT NULL,
+  meta              JSONB DEFAULT '{}'::jsonb,
+  last_receipt_hash TEXT,
+  created_at        TIMESTAMPTZ DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ DEFAULT NOW(),
+  CONSTRAINT payto_mandate_unique_ref UNIQUE (abn, reference),
+  CONSTRAINT payto_mandate_unique_bank UNIQUE (bank_mandate_id)
+);
+
+CREATE TABLE IF NOT EXISTS payto_debits (
+  id             BIGSERIAL PRIMARY KEY,
+  mandate_id     TEXT NOT NULL REFERENCES payto_mandates(bank_mandate_id) ON DELETE CASCADE,
+  abn            TEXT NOT NULL,
+  amount_cents   BIGINT NOT NULL,
+  status         TEXT NOT NULL,
+  bank_reference TEXT,
+  receipt_hash   TEXT,
+  failure_reason TEXT,
+  response       JSONB,
+  created_at     TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS payto_debits_mandate_created_idx
+  ON payto_debits (mandate_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS bank_remittances (
+  id             BIGSERIAL PRIMARY KEY,
+  period_id      TEXT NOT NULL UNIQUE,
+  rpt_json       JSONB NOT NULL,
+  bank_reference TEXT NOT NULL,
+  bank_status    TEXT NOT NULL,
+  receipt_hash   TEXT NOT NULL,
+  bank_payload   JSONB,
+  created_at     TIMESTAMPTZ DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ DEFAULT NOW()
+);
+

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "node --test --import tsx tests/payto/adapter.test.js"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,319 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+// src/payto/adapter.ts
+import http from "http";
+import https from "https";
+import { readFileSync } from "fs";
+import { URL } from "url";
+import { Pool } from "pg";
+
+import { sha256Hex } from "../crypto/merkle";
+
+export interface PayToDebitResult {
+  status: "OK" | "INSUFFICIENT_FUNDS" | "BANK_ERROR";
+  bank_ref?: string;
+  receipt_hash?: string;
+  mandate_id?: string;
+  failure_reason?: string;
+  remainingCapCents?: number;
+}
+
+type Queryable = {
+  query: (text: string, params?: any[]) => Promise<{ rows: any[]; rowCount: number }>;
+};
+
+type BankRequester = <T = any>(method: string, path: string, payload?: unknown) => Promise<T>;
+
+let db: Queryable = new Pool();
+
+function readOptional(path?: string | null) {
+  return path ? readFileSync(path) : undefined;
+}
+
+function boolFromEnv(value: string | undefined, defaultValue: boolean) {
+  if (value === undefined) return defaultValue;
+  return !(value.toLowerCase() === "false" || value === "0");
+}
+
+function createBankRequester(): BankRequester {
+  const base = process.env.PAYTO_API_BASE || process.env.BANK_API_BASE;
+  if (!base) {
+    return async () => {
+      throw new Error("PAYTO_API_BASE (or BANK_API_BASE) is not configured");
+    };
+  }
+
+  const baseUrl = new URL(base);
+  const timeoutMs = Number(process.env.PAYTO_TIMEOUT_MS || process.env.BANK_TIMEOUT_MS || "8000");
+  const rejectUnauthorized = boolFromEnv(process.env.PAYTO_TLS_REJECT_UNAUTHORIZED, true);
+  const ca = readOptional(process.env.PAYTO_TLS_CA || process.env.BANK_TLS_CA || undefined);
+  const cert = readOptional(process.env.PAYTO_TLS_CERT || process.env.BANK_TLS_CERT || undefined);
+  const key = readOptional(process.env.PAYTO_TLS_KEY || process.env.BANK_TLS_KEY || undefined);
+
+  const agent = baseUrl.protocol === "https:" ? new https.Agent({
+    ca,
+    cert,
+    key,
+    keepAlive: true,
+    rejectUnauthorized,
+  }) : undefined;
+
+  return async <T>(method: string, path: string, payload?: unknown): Promise<T> => {
+    const url = new URL(path, baseUrl);
+    const body = payload !== undefined ? JSON.stringify(payload) : undefined;
+    const headers: Record<string, string> = { "content-type": "application/json" };
+    if (body) headers["content-length"] = Buffer.byteLength(body).toString();
+
+    const options: https.RequestOptions = {
+      method,
+      hostname: url.hostname,
+      port: url.port ? Number(url.port) : url.protocol === "https:" ? 443 : 80,
+      path: url.pathname + url.search,
+      headers,
+      timeout: timeoutMs,
+    };
+
+    if (url.protocol === "https:" && agent) {
+      options.agent = agent;
+    }
+
+    const transport = url.protocol === "https:" ? https : http;
+
+    return await new Promise<T>((resolve, reject) => {
+      const req = transport.request(options, (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+        res.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf-8");
+          if ((res.statusCode || 0) >= 200 && (res.statusCode || 0) < 300) {
+            try {
+              resolve((text ? JSON.parse(text) : {}) as T);
+            } catch (err) {
+              reject(new Error(`Failed to parse PayTo response: ${err instanceof Error ? err.message : String(err)}`));
+            }
+          } else {
+            const error = new Error(`PayTo API ${res.statusCode}: ${text}`);
+            (error as any).statusCode = res.statusCode;
+            reject(error);
+          }
+        });
+      });
+      req.on("error", reject);
+      req.setTimeout(timeoutMs, () => {
+        req.destroy(new Error("PayTo request timed out"));
+      });
+      if (body) req.write(body);
+      req.end();
+    });
+  };
+}
+
+let bankRequest: BankRequester = createBankRequester();
+
+export function __setDb(testDb: Queryable) {
+  db = testDb;
+}
+
+export function __resetDb() {
+  db = new Pool();
+}
+
+export function __setBankRequester(requester: BankRequester) {
+  bankRequest = requester;
+}
+
+export function __resetBankRequester() {
+  bankRequest = createBankRequester();
+}
+
+interface MandateRow {
+  abn: string;
+  reference: string;
+  bank_mandate_id: string;
+  cap_cents: string | number;
+  consumed_cents: string | number;
+  status: string;
+}
+
+function toNumber(value: string | number | null | undefined) {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "number") return value;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function loadMandate(abn: string, reference: string): Promise<MandateRow | null> {
+  const { rows } = await db.query(
+    "SELECT abn, reference, bank_mandate_id, cap_cents, consumed_cents, status FROM payto_mandates WHERE abn=$1 AND reference=$2",
+    [abn, reference]
+  );
+  return rows[0] || null;
+}
+
+async function upsertMandate(
+  abn: string,
+  reference: string,
+  mandateId: string,
+  capCents: number,
+  status: string,
+  consumedCents: number,
+  lastReceiptHash: string | null,
+  meta: unknown
+) {
+  await db.query(
+    `INSERT INTO payto_mandates(abn, reference, bank_mandate_id, cap_cents, consumed_cents, status, last_receipt_hash, meta, updated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,NOW())
+     ON CONFLICT (bank_mandate_id) DO UPDATE
+       SET cap_cents=EXCLUDED.cap_cents,
+           consumed_cents=EXCLUDED.consumed_cents,
+           status=EXCLUDED.status,
+           last_receipt_hash=EXCLUDED.last_receipt_hash,
+           meta=EXCLUDED.meta,
+           updated_at=NOW()`,
+    [abn, reference, mandateId, capCents, consumedCents, status, lastReceiptHash, meta]
+  );
+}
+
+async function recordDebit(
+  mandate: MandateRow,
+  amountCents: number,
+  status: "SUCCEEDED" | "FAILED",
+  bankReference: string | undefined,
+  receiptHash: string | undefined,
+  failureReason: string | undefined,
+  bankPayload: unknown
+) {
+  await db.query(
+    `INSERT INTO payto_debits(mandate_id, abn, amount_cents, status, bank_reference, receipt_hash, failure_reason, response)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`,
+    [
+      mandate.bank_mandate_id,
+      mandate.abn,
+      amountCents,
+      status,
+      bankReference || null,
+      receiptHash || null,
+      failureReason || null,
+      bankPayload || null,
+    ]
+  );
+
+  if (status === "SUCCEEDED") {
+    await db.query(
+      `UPDATE payto_mandates
+         SET consumed_cents = consumed_cents + $1,
+             last_receipt_hash = COALESCE($2, last_receipt_hash),
+             updated_at = NOW()
+       WHERE bank_mandate_id=$3`,
+      [amountCents, receiptHash || null, mandate.bank_mandate_id]
+    );
+  } else {
+    await db.query(`UPDATE payto_mandates SET updated_at=NOW() WHERE bank_mandate_id=$1`, [mandate.bank_mandate_id]);
+  }
+}
+
+export async function createMandate(abn: string, capCents: number, reference: string) {
+  const response = await bankRequest<{ mandate_id?: string; mandateId?: string; status?: string; consumed_cents?: number }>(
+    "POST",
+    "/payto/mandates",
+    { abn, cap_cents: capCents, reference }
+  );
+
+  const mandateId = response.mandate_id || response.mandateId;
+  if (!mandateId) {
+    throw new Error("Bank did not return a mandate identifier");
+  }
+  const status = (response.status || "PENDING").toUpperCase();
+  const consumed = toNumber(response.consumed_cents);
+
+  await upsertMandate(abn, reference, mandateId, capCents, status, consumed, null, response);
+
+  return { status, mandateId };
+}
+
+function mapBankStatus(status: string | undefined, code: string | undefined): PayToDebitResult["status"] {
+  const normalisedStatus = status ? status.toUpperCase() : "";
+  const normalisedCode = code ? code.toUpperCase() : "";
+
+  if (["ACCEPTED", "SETTLED", "SUCCESS", "OK"].includes(normalisedStatus)) return "OK";
+  if (["INSUFFICIENT_FUNDS", "CAP_EXCEEDED"].includes(normalisedStatus) || normalisedCode === "INSUFFICIENT_FUNDS") {
+    return "INSUFFICIENT_FUNDS";
+  }
+  return "BANK_ERROR";
+}
+
+export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> {
+  const mandate = await loadMandate(abn, reference);
+  if (!mandate) {
+    throw new Error(`No PayTo mandate registered for ${abn} (${reference})`);
+  }
+
+  if (mandate.status.toUpperCase() === "CANCELLED") {
+    await recordDebit(mandate, amountCents, "FAILED", undefined, undefined, "MANDATE_CANCELLED", { error: "cancelled" });
+    return {
+      status: "BANK_ERROR",
+      failure_reason: "MANDATE_CANCELLED",
+      mandate_id: mandate.bank_mandate_id,
+    };
+  }
+
+  const cap = toNumber(mandate.cap_cents);
+  const consumed = toNumber(mandate.consumed_cents);
+  const remaining = cap - consumed;
+
+  if (amountCents > remaining) {
+    await recordDebit(mandate, amountCents, "FAILED", undefined, undefined, "CAP_EXCEEDED", { remaining });
+    return {
+      status: "INSUFFICIENT_FUNDS",
+      failure_reason: "CAP_EXCEEDED",
+      mandate_id: mandate.bank_mandate_id,
+      remainingCapCents: Math.max(remaining, 0),
+    };
+  }
+
+  const bankResponse = await bankRequest<{
+    status?: string;
+    code?: string;
+    bank_reference?: string;
+    bank_ref?: string;
+    receipt?: string;
+    receipt_hash?: string;
+    mandate_id?: string;
+  }>("POST", `/payto/mandates/${encodeURIComponent(mandate.bank_mandate_id)}/debit`, {
+    amount_cents: amountCents,
+    reference,
+  });
+
+  const bankRef = bankResponse.bank_reference || bankResponse.bank_ref;
+  const receipt = bankResponse.receipt;
+  const receiptHash = bankResponse.receipt_hash || (receipt ? sha256Hex(receipt) : undefined);
+  const resultStatus = mapBankStatus(bankResponse.status, bankResponse.code);
+
+  if (resultStatus === "OK") {
+    await recordDebit(mandate, amountCents, "SUCCEEDED", bankRef, receiptHash, undefined, bankResponse);
+    return {
+      status: "OK",
+      bank_ref: bankRef,
+      receipt_hash: receiptHash,
+      mandate_id: mandate.bank_mandate_id,
+      remainingCapCents: remaining - amountCents,
+    };
+  }
+
+  const failureReason = bankResponse.code || bankResponse.status || "BANK_ERROR";
+  await recordDebit(mandate, amountCents, "FAILED", bankRef, receiptHash, failureReason, bankResponse);
+
+  return {
+    status: resultStatus,
+    bank_ref: bankRef,
+    receipt_hash: receiptHash,
+    mandate_id: mandate.bank_mandate_id,
+    failure_reason: failureReason,
+    remainingCapCents: remaining,
+  };
+}
+
+export async function cancelMandate(mandateId: string) {
+  const response = await bankRequest<{ status?: string }>("POST", `/payto/mandates/${encodeURIComponent(mandateId)}/cancel`, {});
+  await db.query(`UPDATE payto_mandates SET status='CANCELLED', updated_at=NOW() WHERE bank_mandate_id=$1`, [mandateId]);
+  return response;
+}
+

--- a/tests/integration/test_bank_egress.py
+++ b/tests/integration/test_bank_egress.py
@@ -1,0 +1,188 @@
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+from fastapi.testclient import TestClient
+
+import sys
+import types
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+sys.modules.setdefault("psycopg2", types.SimpleNamespace(connect=lambda *args, **kwargs: None))
+
+from libs.rpt.rpt import sign
+
+
+def load_bank_app_module():
+    module_path = Path(__file__).resolve().parents[2] / "apps" / "services" / "bank-egress" / "main.py"
+    spec = importlib.util.spec_from_file_location("bank_egress_main", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+bank_app = load_bank_app_module()
+
+
+class FakeCursor:
+    def __init__(self, conn: "FakeConn") -> None:
+        self.conn = conn
+        self._result: Optional[Any] = None
+
+    def execute(self, sql: str, params: Optional[tuple] = None) -> None:
+        sql = sql.strip()
+        params = params or tuple()
+        self._result = None
+
+        if sql.startswith("SELECT state, hash_this FROM bas_gate_states"):
+            period_id = params[0]
+            row = self.conn.gate_states.get(period_id)
+            if row:
+                self._result = (row["state"], row.get("hash_this"))
+        elif sql.startswith("INSERT INTO bank_remittances"):
+            period_id, rpt_json, bank_reference, bank_status, receipt_hash, bank_payload = params
+            self.conn.bank_remittances[period_id] = {
+                "rpt_json": json.loads(rpt_json),
+                "bank_reference": bank_reference,
+                "bank_status": bank_status,
+                "receipt_hash": receipt_hash,
+                "bank_payload": json.loads(bank_payload),
+            }
+        elif sql.startswith("UPDATE bas_gate_states"):
+            reason_code, hash_prev, hash_this, period_id = params
+            gate = self.conn.gate_states.setdefault(period_id, {})
+            gate.update(
+                {
+                    "state": "Remitted",
+                    "reason_code": reason_code,
+                    "hash_prev": hash_prev,
+                    "hash_this": hash_this,
+                }
+            )
+        elif sql.startswith("SELECT hash_this FROM audit_log"):
+            if self.conn.audit_log:
+                self._result = (self.conn.audit_log[-1]["hash_this"],)
+            else:
+                self._result = (None,)
+        elif sql.startswith("INSERT INTO audit_log"):
+            category, message, hash_prev, hash_this = params
+            self.conn.audit_log.append(
+                {
+                    "category": category,
+                    "message": json.loads(message),
+                    "hash_prev": hash_prev,
+                    "hash_this": hash_this,
+                }
+            )
+        elif sql.startswith("SELECT state FROM bas_gate_states"):
+            period_id = params[0]
+            row = self.conn.gate_states.get(period_id)
+            if row:
+                self._result = (row.get("state"),)
+        else:  # pragma: no cover - guard for unexpected SQL
+            raise AssertionError(f"Unhandled SQL: {sql}")
+
+    def fetchone(self):
+        return self._result
+
+    def close(self) -> None:  # pragma: no cover - interface compatibility
+        pass
+
+
+class FakeConn:
+    def __init__(self) -> None:
+        self.gate_states: Dict[str, Dict[str, Any]] = {}
+        self.bank_remittances: Dict[str, Dict[str, Any]] = {}
+        self.audit_log: list[Dict[str, Any]] = []
+        self.committed = False
+
+    def cursor(self) -> FakeCursor:
+        return FakeCursor(self)
+
+    def commit(self) -> None:
+        self.committed = True
+
+    def close(self) -> None:  # pragma: no cover
+        pass
+
+
+@pytest.fixture
+def fake_conn(monkeypatch):
+    conn = FakeConn()
+    conn.gate_states["2025-09"] = {"state": "RPT-Issued", "hash_this": "prevhash"}
+    monkeypatch.setattr(bank_app, "db", lambda: conn)
+    return conn
+
+
+def make_signed_rpt(period_id: str) -> Dict[str, Any]:
+    payload = {
+        "period_id": period_id,
+        "paygw_total": 100.0,
+        "gst_total": 200.0,
+        "source_digests": {},
+        "anomaly_score": 0.05,
+        "expires_at": 1_700_000_000,
+        "nonce": "abc123",
+    }
+    payload["signature"] = sign(payload)
+    return payload
+
+
+def test_remit_success(monkeypatch, fake_conn):
+    def fake_bank(payload: Dict[str, Any]):
+        assert payload["period_id"] == "2025-09"
+        assert "rpt" in payload
+        return {
+            "status": "SETTLED",
+            "bank_reference": "BR-001",
+            "receipt": "rcpt-xyz",
+        }
+
+    monkeypatch.setattr(bank_app, "_post_bank", fake_bank)
+
+    client = TestClient(bank_app.app)
+    rpt = make_signed_rpt("2025-09")
+    response = client.post("/egress/remit", json={"period_id": "2025-09", "rpt": rpt})
+
+    assert response.status_code == 200
+    data = response.json()
+    expected_hash = hashlib.sha256(b"rcpt-xyz").hexdigest()
+    assert data == {
+        "ok": True,
+        "bank_reference": "BR-001",
+        "receipt_hash": expected_hash,
+        "status": "SETTLED",
+    }
+
+    remit = fake_conn.bank_remittances["2025-09"]
+    assert remit["bank_reference"] == "BR-001"
+    assert remit["receipt_hash"] == expected_hash
+    assert fake_conn.gate_states["2025-09"]["state"] == "Remitted"
+    assert fake_conn.audit_log[-1]["message"]["receipt_hash"] == expected_hash
+
+
+def test_bank_error_rolls_back(monkeypatch, fake_conn):
+    import httpx
+
+    def fake_bank(_payload: Dict[str, Any]):
+        raise httpx.HTTPError("bank down")
+
+    monkeypatch.setattr(bank_app, "_post_bank", fake_bank)
+
+    client = TestClient(bank_app.app)
+    rpt = make_signed_rpt("2025-09")
+    response = client.post("/egress/remit", json={"period_id": "2025-09", "rpt": rpt})
+
+    assert response.status_code == 502
+    assert "bank error" in response.text
+    assert fake_conn.bank_remittances == {}
+    assert fake_conn.gate_states["2025-09"]["state"] == "RPT-Issued"
+    assert not fake_conn.audit_log
+

--- a/tests/payto/adapter.test.js
+++ b/tests/payto/adapter.test.js
@@ -1,0 +1,178 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  __resetBankRequester,
+  __resetDb,
+  __setBankRequester,
+  __setDb,
+  createMandate,
+  debit,
+} from "../../src/payto/adapter";
+import { sha256Hex } from "../../src/crypto/merkle";
+
+class FakePool {
+  constructor() {
+    this.mandates = new Map();
+    this.refIndex = new Map();
+    this.debits = [];
+  }
+
+  async query(text, params = []) {
+    if (text.startsWith("INSERT INTO payto_mandates")) {
+      const [abn, reference, mandateId, capCents, consumedCents, status, lastReceiptHash, meta] = params;
+      const record = {
+        abn,
+        reference,
+        bank_mandate_id: mandateId,
+        cap_cents: Number(capCents),
+        consumed_cents: Number(consumedCents ?? 0),
+        status,
+        last_receipt_hash: lastReceiptHash ?? null,
+        meta,
+      };
+      this.mandates.set(mandateId, { ...this.mandates.get(mandateId), ...record });
+      this.refIndex.set(`${abn}:${reference}`, mandateId);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (text.startsWith("SELECT abn, reference")) {
+      const [abn, reference] = params;
+      const mandateId = this.refIndex.get(`${abn}:${reference}`);
+      const record = mandateId ? this.mandates.get(mandateId) : undefined;
+      return { rows: record ? [record] : [], rowCount: record ? 1 : 0 };
+    }
+
+    if (text.startsWith("INSERT INTO payto_debits")) {
+      const [mandateId, abn, amountCents, status, bankReference, receiptHash, failureReason, response] = params;
+      this.debits.push({
+        mandate_id: mandateId,
+        abn,
+        amount_cents: Number(amountCents),
+        status,
+        bank_reference: bankReference ?? null,
+        receipt_hash: receiptHash ?? null,
+        failure_reason: failureReason ?? null,
+        response,
+      });
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (text.startsWith("UPDATE payto_mandates\n         SET consumed_cents")) {
+      const [amount, receiptHash, mandateId] = params;
+      const record = this.mandates.get(mandateId);
+      assert.ok(record, "Mandate not found");
+      record.consumed_cents += Number(amount);
+      if (receiptHash) record.last_receipt_hash = receiptHash;
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (text.startsWith("UPDATE payto_mandates SET updated_at=NOW()")) {
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (text.startsWith("UPDATE payto_mandates SET status='CANCELLED'")) {
+      const [mandateId] = params;
+      const record = this.mandates.get(mandateId);
+      if (record) record.status = "CANCELLED";
+      return { rows: [], rowCount: 1 };
+    }
+
+    throw new Error(`Unsupported query: ${text}`);
+  }
+}
+
+let pool;
+
+beforeEach(() => {
+  __resetBankRequester();
+  __resetDb();
+  pool = new FakePool();
+  __setDb(pool);
+});
+
+test("records successful debits and receipt hashes", async () => {
+  const calls = [];
+  __setBankRequester(async (_method, path) => {
+    calls.push(path);
+    if (path === "/payto/mandates") {
+      return { mandate_id: "mand-1", status: "ACTIVE", consumed_cents: 0 };
+    }
+    if (path === "/payto/mandates/mand-1/debit") {
+      return { status: "ACCEPTED", bank_reference: "BR-123", receipt: "rcpt-001" };
+    }
+    throw new Error("unexpected path");
+  });
+
+  await createMandate("12345678901", 1_000, "BAS-2025-09");
+  const result = await debit("12345678901", 400, "BAS-2025-09");
+
+  assert.deepStrictEqual(result, {
+    status: "OK",
+    bank_ref: "BR-123",
+    receipt_hash: sha256Hex("rcpt-001"),
+    mandate_id: "mand-1",
+    remainingCapCents: 600,
+  });
+  assert.strictEqual(calls.length, 2);
+
+  assert.strictEqual(pool.debits.length, 1);
+  assert.deepStrictEqual(pool.debits[0], {
+    mandate_id: "mand-1",
+    abn: "12345678901",
+    amount_cents: 400,
+    status: "SUCCEEDED",
+    bank_reference: "BR-123",
+    receipt_hash: sha256Hex("rcpt-001"),
+    failure_reason: null,
+    response: { status: "ACCEPTED", bank_reference: "BR-123", receipt: "rcpt-001" },
+  });
+  assert.strictEqual(pool.mandates.get("mand-1").consumed_cents, 400);
+});
+
+test("enforces caps locally", async () => {
+  let called = false;
+  __setBankRequester(async (_method, path) => {
+    if (path === "/payto/mandates") {
+      return { mandate_id: "mand-cap", status: "ACTIVE", consumed_cents: 0 };
+    }
+    called = true;
+    return {};
+  });
+
+  await createMandate("12345678901", 500, "BAS-2025-09");
+  const result = await debit("12345678901", 600, "BAS-2025-09");
+
+  assert.strictEqual(called, false);
+  assert.strictEqual(result.status, "INSUFFICIENT_FUNDS");
+  assert.strictEqual(result.failure_reason, "CAP_EXCEEDED");
+  assert.strictEqual(pool.debits[0].status, "FAILED");
+  assert.strictEqual(pool.debits[0].failure_reason, "CAP_EXCEEDED");
+});
+
+test("propagates bank insufficiency", async () => {
+  __setBankRequester(async (_method, path) => {
+    if (path === "/payto/mandates") {
+      return { mandate_id: "mand-2", status: "ACTIVE", consumed_cents: 0 };
+    }
+    if (path === "/payto/mandates/mand-2/debit") {
+      return {
+        status: "REJECTED",
+        code: "INSUFFICIENT_FUNDS",
+        bank_reference: "BR-FAIL",
+        receipt: "rcpt-fail",
+      };
+    }
+    throw new Error("unexpected path");
+  });
+
+  await createMandate("12345678901", 1_000, "BAS-2025-10");
+  const result = await debit("12345678901", 200, "BAS-2025-10");
+
+  assert.strictEqual(result.status, "INSUFFICIENT_FUNDS");
+  assert.strictEqual(result.bank_ref, "BR-FAIL");
+  assert.strictEqual(result.receipt_hash, sha256Hex("rcpt-fail"));
+  assert.strictEqual(pool.debits[0].failure_reason, "INSUFFICIENT_FUNDS");
+  assert.strictEqual(pool.mandates.get("mand-2").consumed_cents, 0);
+});
+


### PR DESCRIPTION
## Summary
- replace the PayTo adapter stub with a TLS-enabled bank client that persists mandate lifecycle data and handles cap/receipt logic in Postgres
- add database structures for PayTo mandates, debits, and bank remittance receipts and wire the bank-egress service to call the bank API over mTLS while hashing receipts
- add sandbox tests covering PayTo debit flows and bank egress reconciliation plus npm tooling to run them

## Testing
- npm test
- pytest tests/integration/test_bank_egress.py

------
https://chatgpt.com/codex/tasks/task_e_68e24a77ef2c8327b293014ffd0c2a8c