### PR TITLE
feat: queue and expose pending anomalies

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx tests/anomaly.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -1,22 +1,60 @@
-﻿export interface AnomalyVector {
-  variance_ratio: number;
-  dup_rate: number;
-  gap_minutes: number;
-  delta_vs_baseline: number;
+const DEFAULT_SIGMA_THRESHOLD = 3.0;
+const MIN_MATERIALITY_CENTS = 500;
+
+type AnomalyStats = {
+  flagged: boolean;
+  sigmaThreshold: number;
+  materialityThreshold: number;
+  deviation: number;
+  zScore: number;
+};
+
+type EvaluateFn = (
+  totalCents: number,
+  baselineCents: number,
+  sigma?: number,
+  materialityCents?: number
+) => AnomalyStats;
+
+interface IsAnomalousFn {
+  (totalCents: number, baselineCents: number, sigma?: number): boolean;
+  evaluate: EvaluateFn;
 }
 
-export interface Thresholds {
-  variance_ratio?: number;
-  dup_rate?: number;
-  gap_minutes?: number;
-  delta_vs_baseline?: number;
-}
+const evaluate: EvaluateFn = (
+  totalCents,
+  baselineCents,
+  sigma = DEFAULT_SIGMA_THRESHOLD,
+  materialityCents = MIN_MATERIALITY_CENTS
+) => {
+  const safeTotal = Number.isFinite(totalCents) ? Number(totalCents) : 0;
+  const safeBaseline = Number.isFinite(baselineCents) ? Number(baselineCents) : 0;
+  const deviation = Math.abs(safeTotal - safeBaseline);
+  const materialityThreshold = Math.max(MIN_MATERIALITY_CENTS, Math.abs(materialityCents));
+  if (deviation < materialityThreshold) {
+    return {
+      flagged: false,
+      sigmaThreshold: sigma,
+      materialityThreshold,
+      deviation,
+      zScore: 0
+    };
+  }
 
-export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
-  return (
-    v.variance_ratio > (thr.variance_ratio ?? 0.25) ||
-    v.dup_rate > (thr.dup_rate ?? 0.05) ||
-    v.gap_minutes > (thr.gap_minutes ?? 60) ||
-    Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
-  );
-}
+  const varianceBasis = Math.max(Math.abs(safeBaseline), materialityThreshold);
+  const stdDev = Math.sqrt(varianceBasis);
+  const zScore = stdDev === 0 ? Number.POSITIVE_INFINITY : deviation / stdDev;
+  return {
+    flagged: zScore >= sigma,
+    sigmaThreshold: sigma,
+    materialityThreshold,
+    deviation,
+    zScore
+  };
+};
+
+export const isAnomalous: IsAnomalousFn = Object.assign(
+  (totalCents: number, baselineCents: number, sigma: number = DEFAULT_SIGMA_THRESHOLD) =>
+    evaluate(totalCents, baselineCents, sigma).flagged,
+  { evaluate }
+);

--- a/src/anomaly/pendingQueue.ts
+++ b/src/anomaly/pendingQueue.ts
@@ -1,0 +1,72 @@
+type TaxType = "PAYGW" | "GST" | string;
+
+export interface PendingAnomaly {
+  id: string;
+  abn: string;
+  taxType: TaxType;
+  periodId: string;
+  observedCents: number;
+  baselineCents: number;
+  sigmaThreshold: number;
+  materialityCents: number;
+  zScore: number;
+  deviationCents: number;
+  createdAt: string;
+  operatorNote: string;
+  provenance?: string;
+}
+
+export interface PendingAnomalyInput {
+  abn: string;
+  taxType: TaxType;
+  periodId: string;
+  observedCents: number;
+  baselineCents: number;
+  sigmaThreshold: number;
+  materialityCents: number;
+  zScore: number;
+  deviationCents: number;
+  note?: string;
+  provenance?: string;
+}
+
+const queue: PendingAnomaly[] = [];
+let sequence = 0;
+
+const makeId = () => `anom-${(sequence++).toString(36).padStart(4, "0")}`;
+
+export function enqueuePendingAnomaly(input: PendingAnomalyInput): PendingAnomaly {
+  const entry: PendingAnomaly = {
+    id: makeId(),
+    abn: input.abn,
+    taxType: input.taxType,
+    periodId: input.periodId,
+    observedCents: input.observedCents,
+    baselineCents: input.baselineCents,
+    sigmaThreshold: input.sigmaThreshold,
+    materialityCents: input.materialityCents,
+    zScore: input.zScore,
+    deviationCents: input.deviationCents,
+    operatorNote: input.note ?? "",
+    createdAt: new Date().toISOString(),
+    provenance: input.provenance
+  };
+  queue.unshift(entry);
+  return { ...entry };
+}
+
+export function listPendingAnomalies(): PendingAnomaly[] {
+  return queue.map(item => ({ ...item }));
+}
+
+export function updateOperatorNote(id: string, note: string): PendingAnomaly | null {
+  const item = queue.find(entry => entry.id === id);
+  if (!item) return null;
+  item.operatorNote = note;
+  return { ...item };
+}
+
+export function resetPendingAnomalies() {
+  queue.length = 0;
+  sequence = 0;
+}

--- a/src/components/PendingAnomaliesPanel.tsx
+++ b/src/components/PendingAnomaliesPanel.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useMemo, useState } from "react";
+import type { PendingAnomaly } from "../types/anomaly";
+
+type PendingAnomalyView = PendingAnomaly & {
+  draftNote: string;
+  saving: boolean;
+  error?: string;
+};
+
+const stub: PendingAnomaly[] = [
+  {
+    id: "anom-stub1",
+    abn: "12345678901",
+    taxType: "GST",
+    periodId: "2025Q1",
+    observedCents: 128_500,
+    baselineCents: 119_000,
+    sigmaThreshold: 3.0,
+    materialityCents: 500,
+    zScore: 3.42,
+    deviationCents: 9500,
+    createdAt: new Date().toISOString(),
+    operatorNote: "",
+    provenance: "stub"
+  }
+];
+
+const centsToDollars = (cents: number) => `$${(cents / 100).toFixed(2)}`;
+
+export default function PendingAnomaliesPanel() {
+  const [items, setItems] = useState<PendingAnomalyView[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      try {
+        setLoading(true);
+        const res = await fetch("/api/anomalies/pending");
+        if (!res.ok) throw new Error(`fetch failed: ${res.status}`);
+        const data = await res.json();
+        const anomalies: PendingAnomaly[] = Array.isArray(data?.anomalies) ? data.anomalies : [];
+        if (!cancelled) {
+          setItems(
+            anomalies.map(item => ({
+              ...item,
+              draftNote: item.operatorNote,
+              saving: false,
+              error: undefined
+            }))
+          );
+          setError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError("Using stub data (offline)");
+          setItems(
+            stub.map(item => ({
+              ...item,
+              draftNote: item.operatorNote,
+              saving: false,
+              error: undefined
+            }))
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const hasContent = items.length > 0;
+
+  const rows = useMemo(
+    () =>
+      items.map(item => (
+        <tr key={item.id} className="border-t">
+          <td className="px-3 py-2 text-sm">{item.createdAt ? new Date(item.createdAt).toLocaleString() : ""}</td>
+          <td className="px-3 py-2 text-sm">
+            <div className="font-semibold">{item.abn}</div>
+            <div className="text-xs text-gray-500">{item.taxType} · {item.periodId}</div>
+          </td>
+          <td className="px-3 py-2 text-sm">
+            <div>Observed: {centsToDollars(item.observedCents)}</div>
+            <div>Baseline: {centsToDollars(item.baselineCents)}</div>
+            <div className="text-xs text-gray-500">Δ {centsToDollars(item.deviationCents)} · z={item.zScore.toFixed(2)}</div>
+          </td>
+          <td className="px-3 py-2 text-sm">
+            <textarea
+              value={item.draftNote}
+              onChange={evt =>
+                setItems(current =>
+                  current.map(row =>
+                    row.id === item.id
+                      ? { ...row, draftNote: evt.target.value }
+                      : row
+                  )
+                )
+              }
+              className="w-full border rounded p-2 text-sm"
+              rows={3}
+              placeholder="Add operator note"
+            />
+            <div className="mt-2 flex items-center gap-2">
+              <button
+                className="px-3 py-1 bg-[#00716b] text-white rounded disabled:opacity-50"
+                disabled={item.saving || item.draftNote === item.operatorNote}
+                onClick={async () => {
+                  setItems(current =>
+                    current.map(row =>
+                      row.id === item.id ? { ...row, saving: true, error: undefined } : row
+                    )
+                  );
+                  try {
+                    const res = await fetch(`/api/anomalies/pending/${item.id}/note`, {
+                      method: "POST",
+                      headers: { "Content-Type": "application/json" },
+                      body: JSON.stringify({ note: item.draftNote })
+                    });
+                    if (!res.ok) throw new Error(`save failed: ${res.status}`);
+                    const data = await res.json();
+                    const updated = data?.anomaly as PendingAnomaly | undefined;
+                    setItems(current =>
+                      current.map(row =>
+                        row.id === item.id
+                          ? {
+                              ...row,
+                              operatorNote: updated?.operatorNote ?? row.draftNote,
+                              draftNote: updated?.operatorNote ?? row.draftNote,
+                              saving: false,
+                              error: undefined
+                            }
+                          : row
+                      )
+                    );
+                  } catch (err: any) {
+                    setItems(current =>
+                      current.map(row =>
+                        row.id === item.id
+                          ? { ...row, saving: false, error: err?.message || "Save failed" }
+                          : row
+                      )
+                    );
+                  }
+                }}
+              >
+                Save note
+              </button>
+              {item.error && <span className="text-xs text-red-600">{item.error}</span>}
+            </div>
+          </td>
+        </tr>
+      )),
+    [items]
+  );
+
+  return (
+    <div className="bg-white p-4 rounded-xl shadow space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold text-[#00716b]">Pending anomalies</h2>
+        {loading && <span className="text-xs text-gray-500">Loading…</span>}
+      </div>
+      {error && <div className="text-xs text-amber-600">{error}</div>}
+      {hasContent ? (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-left text-sm border border-gray-200 rounded-lg">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-3 py-2">Detected</th>
+                <th className="px-3 py-2">Entity</th>
+                <th className="px-3 py-2">Variance</th>
+                <th className="px-3 py-2">Operator note</th>
+              </tr>
+            </thead>
+            <tbody>{rows}</tbody>
+          </table>
+        </div>
+      ) : (
+        <div className="text-sm text-gray-500">No pending anomalies 🎉</div>
+      )}
+    </div>
+  );
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,11 +1,13 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+import { listPendingAnomalies } from "../anomaly/pendingQueue";
+
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
   const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
   const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const last = deltas[deltas.length - 1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
     rpt_payload: rpt?.payload ?? null,
@@ -13,7 +15,10 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [],  // TODO: populate from recon diffs
+    pending_anomalies: listPendingAnomalies().filter(
+      a => a.abn === abn && a.taxType === taxType && a.periodId === periodId
+    )
   };
   return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { pendingAnomalies, saveOperatorNote } from "./routes/anomalies";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -24,6 +25,8 @@ app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
+app.get("/api/anomalies/pending", pendingAnomalies);
+app.post("/api/anomalies/pending/:id/note", saveOperatorNote);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/pages/Fraud.tsx
+++ b/src/pages/Fraud.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import PendingAnomaliesPanel from "../components/PendingAnomaliesPanel";
 
 export default function Fraud() {
   const [alerts] = useState([
@@ -6,19 +7,22 @@ export default function Fraud() {
     { date: "16/05/2025", detail: "GST transfer lower than usual" }
   ]);
   return (
-    <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
-      <h3>Alerts</h3>
-      <ul>
-        {alerts.map((row, i) => (
-          <li key={i} style={{ color: "#e67c00", fontWeight: 500, marginBottom: 7 }}>
-            {row.date}: {row.detail}
-          </li>
-        ))}
-      </ul>
-      <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
-        (Machine learning analysis coming soon.)
+    <div className="main-card space-y-6">
+      <div>
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
+        <h3>Alerts</h3>
+        <ul>
+          {alerts.map((row, i) => (
+            <li key={i} style={{ color: "#e67c00", fontWeight: 500, marginBottom: 7 }}>
+              {row.date}: {row.detail}
+            </li>
+          ))}
+        </ul>
+        <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
+          (Machine learning analysis coming soon.)
+        </div>
       </div>
+      <PendingAnomaliesPanel />
     </div>
   );
 }

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -2,7 +2,7 @@
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
+  const t = `${current}:${evt}`;
   switch (t) {
     case "OPEN:CLOSE": return "CLOSING";
     case "CLOSING:PASS": return "READY_RPT";

--- a/src/routes/anomalies.ts
+++ b/src/routes/anomalies.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from "express";
+import { listPendingAnomalies, updateOperatorNote } from "../anomaly/pendingQueue";
+
+export function pendingAnomalies(_req: Request, res: Response) {
+  res.json({ anomalies: listPendingAnomalies() });
+}
+
+export function saveOperatorNote(req: Request, res: Response) {
+  const { id } = req.params;
+  const { note } = req.body ?? {};
+  if (typeof id !== "string" || id.length === 0) {
+    return res.status(400).json({ error: "INVALID_ID" });
+  }
+  if (typeof note !== "string") {
+    return res.status(400).json({ error: "INVALID_NOTE" });
+  }
+  const updated = updateOperatorNote(id, note.trim());
+  if (!updated) {
+    return res.status(404).json({ error: "NOT_FOUND" });
+  }
+  res.json({ anomaly: updated });
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -9,7 +9,7 @@ const pool = new Pool();
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr = thresholds || { epsilon_cents: 50, sigma: 3.0, materiality_cents: 500 };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,33 +1,99 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
+import { isAnomalous } from "../anomaly/deterministic";
+import { enqueuePendingAnomaly } from "../anomaly/pendingQueue";
+
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+const PROTO_BLOCK_ON_ANOMALY = String(process.env.PROTO_BLOCK_ON_ANOMALY || "false").toLowerCase() === "true";
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number> = {}
+) {
   const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
-    throw new Error("BLOCKED_ANOMALY");
+  const effectiveThresholds = { ...thresholds } as Record<string, unknown>;
+  const epsilonLimit = Number(effectiveThresholds["epsilon_cents"] ?? 0);
+  const sigmaCandidate = effectiveThresholds["sigma"];
+  const sigmaThreshold = Number.isFinite(Number(sigmaCandidate)) ? Number(sigmaCandidate) : undefined;
+  const materialityCents = Math.max(Number(effectiveThresholds["materiality_cents"] ?? 500), 500);
+  const baselineCandidate = effectiveThresholds["baseline_cents"];
+  const baselineParsed = Number(baselineCandidate);
+  const baselineCents = Number.isFinite(baselineParsed)
+    ? baselineParsed
+    : Number(row.accrued_cents ?? row.final_liability_cents ?? 0);
+
+  const totalCents = Number(row.final_liability_cents ?? 0);
+  const anomalyEvaluation = isAnomalous.evaluate(totalCents, baselineCents, sigmaThreshold, materialityCents);
+  if (anomalyEvaluation.flagged) {
+    const entry = enqueuePendingAnomaly({
+      abn,
+      taxType,
+      periodId,
+      observedCents: totalCents,
+      baselineCents,
+      sigmaThreshold: anomalyEvaluation.sigmaThreshold,
+      materialityCents: anomalyEvaluation.materialityThreshold,
+      zScore: anomalyEvaluation.zScore,
+      deviationCents: anomalyEvaluation.deviation,
+      note: "Auto-detected variance",
+      provenance: "issueRPT"
+    });
+
+    if (PROTO_BLOCK_ON_ANOMALY) {
+      await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+      throw new Error("BLOCKED_ANOMALY");
+    }
+
+    console.warn(
+      `[anomaly] ${abn}/${taxType}/${periodId} pending review; z=${anomalyEvaluation.zScore.toFixed(2)} Δ=${anomalyEvaluation.deviation}¢ (#${entry.id})`
+    );
   }
+
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
-  if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
+  if (epsilon > epsilonLimit) {
     await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
+  const thresholdsPayload: Record<string, number> = {
+    epsilon_cents: epsilonLimit,
+    sigma: anomalyEvaluation.sigmaThreshold,
+    materiality_cents: anomalyEvaluation.materialityThreshold,
+    baseline_cents: baselineCents
+  };
+  for (const [key, value] of Object.entries(effectiveThresholds)) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      thresholdsPayload[key] = parsed;
+    }
+  }
+
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
-    amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
+    amount_cents: totalCents,
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: {
+      baseline_cents: baselineCents,
+      observed_cents: totalCents,
+      deviation_cents: anomalyEvaluation.deviation,
+      z_score: Number(anomalyEvaluation.zScore.toFixed(4))
+    },
+    thresholds: thresholdsPayload,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
   await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",

--- a/src/types/anomaly.ts
+++ b/src/types/anomaly.ts
@@ -1,0 +1,15 @@
+export interface PendingAnomaly {
+  id: string;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  observedCents: number;
+  baselineCents: number;
+  sigmaThreshold: number;
+  materialityCents: number;
+  zScore: number;
+  deviationCents: number;
+  createdAt: string;
+  operatorNote: string;
+  provenance?: string;
+}

--- a/tests/anomaly.test.ts
+++ b/tests/anomaly.test.ts
@@ -1,0 +1,63 @@
+import assert from "assert";
+import { isAnomalous } from "../src/anomaly/deterministic";
+import {
+  enqueuePendingAnomaly,
+  listPendingAnomalies,
+  resetPendingAnomalies
+} from "../src/anomaly/pendingQueue";
+
+const createRng = (seed: number) => {
+  let state = seed >>> 0;
+  return () => {
+    state = (state * 1664525 + 1013904223) >>> 0;
+    return state / 0x100000000;
+  };
+};
+
+const rng = createRng(0x5eed);
+const baseline = 125_000;
+const sigmaThreshold = 3.0;
+const materiality = 500;
+const totals = Array.from({ length: 8 }, () => Math.round(baseline + (rng() - 0.5) * 25_000));
+
+const evaluations = totals.map(total =>
+  isAnomalous.evaluate(total, baseline, sigmaThreshold, materiality)
+);
+
+const flaggedCount = evaluations.filter(result => result.flagged).length;
+const quietCount = evaluations.length - flaggedCount;
+
+assert.ok(flaggedCount >= 1, "expected at least one anomaly");
+assert.ok(quietCount >= 1, "expected at least one non-anomalous sample");
+
+const firstFlagged = evaluations.find(result => result.flagged)!;
+const firstQuiet = evaluations.find(result => !result.flagged)!;
+
+assert.ok(firstFlagged.zScore >= sigmaThreshold, "flagged sample respects sigma threshold");
+assert.ok(firstQuiet.zScore < sigmaThreshold, "non-flagged sample stays under sigma threshold");
+
+resetPendingAnomalies();
+
+evaluations.forEach((evaluation, index) => {
+  if (evaluation.flagged) {
+    enqueuePendingAnomaly({
+      abn: "11111111111",
+      taxType: "GST",
+      periodId: `2025Q${index + 1}`,
+      observedCents: totals[index],
+      baselineCents: baseline,
+      sigmaThreshold: evaluation.sigmaThreshold,
+      materialityCents: evaluation.materialityThreshold,
+      zScore: evaluation.zScore,
+      deviationCents: evaluation.deviation,
+      note: "seeded-test",
+      provenance: "unit-test"
+    });
+  }
+});
+
+const queued = listPendingAnomalies();
+assert.strictEqual(queued.length, flaggedCount, "all flagged entries should be queued");
+assert.ok(queued.every(item => item.operatorNote === "seeded-test"), "notes stored from enqueue");
+
+console.log("anomaly tests passed");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- replace the anomaly helper with a sigma/materiality aware `isAnomalous` evaluator
- add an in-memory pending anomaly queue with API routes and a Fraud page review panel
- update RPT issuance to enqueue flagged periods, honour `PROTO_BLOCK_ON_ANOMALY`, and surface queue data in evidence
- add deterministic anomaly unit test coverage and wire up a `pnpm test` script

## Testing
- npx tsx tests/anomaly.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e24b8996088327a96d8d26f53ba54a