### PR TITLE
Add layered configuration loader and profile helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,28 @@ ps:
 	@docker compose ps
 
 fmt:
-	@echo "No formatter configured; add ruff/black if desired."
+        @echo "No formatter configured; add ruff/black if desired."
+
+profile-dev:
+	@echo "export APP_PROFILE=dev"
+	@echo "export SHADOW_MODE=true"
+	@echo "export PROTO_KILL_SWITCH=false"
+	@echo "export TZ=UTC"
+	@echo "export MOCK_BANK=true"
+	@echo "export MOCK_KMS=true"
+	@echo "export MOCK_RATES=true"
+	@echo "export MOCK_IDP=true"
+	@echo "export MOCK_STATEMENTS=true"
+	@echo "# eval \$$(make profile-dev) to apply in your shell"
+
+profile-prod:
+	@echo "export APP_PROFILE=prod"
+	@echo "export SHADOW_MODE=false"
+	@echo "export PROTO_KILL_SWITCH=false"
+	@echo "export TZ=UTC"
+	@echo "export MOCK_BANK=false"
+	@echo "export MOCK_KMS=false"
+	@echo "export MOCK_RATES=false"
+	@echo "export MOCK_IDP=false"
+	@echo "export MOCK_STATEMENTS=false"
+	@echo "# eval \$$(make profile-prod) to apply in your shell"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,14 @@
+providers:
+  bank: https://bank.example.internal
+  kms: https://kms.example.internal
+  rates: https://rates.example.internal
+  idp: https://idp.example.internal
+  statements: https://statements.example.internal
+PROTO_KILL_SWITCH: false
+SHADOW_MODE: false
+TZ: UTC
+MOCK_BANK: false
+MOCK_KMS: false
+MOCK_RATES: false
+MOCK_IDP: false
+MOCK_STATEMENTS: false

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -1,0 +1,14 @@
+providers:
+  bank: http://localhost:6101
+  kms: http://localhost:6102
+  rates: http://localhost:6103
+  idp: http://localhost:6104
+  statements: http://localhost:6105
+PROTO_KILL_SWITCH: false
+SHADOW_MODE: true
+TZ: UTC
+MOCK_BANK: true
+MOCK_KMS: true
+MOCK_RATES: true
+MOCK_IDP: true
+MOCK_STATEMENTS: true

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -1,0 +1,14 @@
+providers:
+  bank: https://bank.prod.example.com
+  kms: https://kms.prod.example.com
+  rates: https://rates.prod.example.com
+  idp: https://idp.prod.example.com
+  statements: https://statements.prod.example.com
+PROTO_KILL_SWITCH: false
+SHADOW_MODE: false
+TZ: UTC
+MOCK_BANK: false
+MOCK_KMS: false
+MOCK_RATES: false
+MOCK_IDP: false
+MOCK_STATEMENTS: false

--- a/config/stage.yaml
+++ b/config/stage.yaml
@@ -1,0 +1,14 @@
+providers:
+  bank: https://bank.stage.example.internal
+  kms: https://kms.stage.example.internal
+  rates: https://rates.stage.example.internal
+  idp: https://idp.stage.example.internal
+  statements: https://statements.stage.example.internal
+PROTO_KILL_SWITCH: false
+SHADOW_MODE: true
+TZ: UTC
+MOCK_BANK: false
+MOCK_KMS: false
+MOCK_RATES: false
+MOCK_IDP: false
+MOCK_STATEMENTS: false

--- a/docs/ops/configuration.md
+++ b/docs/ops/configuration.md
@@ -1,0 +1,48 @@
+# Runtime configuration
+
+The server supports layered configuration with the following precedence:
+
+1. Environment variables
+2. Profile file (`config/<profile>.yaml`)
+3. Defaults (`config/default.yaml`)
+
+`APP_PROFILE` selects which profile file to load. If it is unset the loader falls back to the `dev` profile.
+
+## Provider endpoints
+
+| Key | Description | Default profile value |
+| --- | --- | --- |
+| `providers.bank` | Banking rails adapter endpoint | `https://bank.example.internal` |
+| `providers.kms` | KMS / secrets provider endpoint | `https://kms.example.internal` |
+| `providers.rates` | FX rate provider endpoint | `https://rates.example.internal` |
+| `providers.idp` | Identity provider endpoint | `https://idp.example.internal` |
+| `providers.statements` | Statement retrieval endpoint | `https://statements.example.internal` |
+
+Override any provider endpoint with one of the following environment variables:
+
+- `PROVIDERS_BANK`
+- `PROVIDERS_KMS`
+- `PROVIDERS_RATES`
+- `PROVIDERS_IDP`
+- `PROVIDERS_STATEMENTS`
+
+The legacy alias `BANK_PROVIDER` is also honored for the banking provider.
+
+## Global flags
+
+| Flag | Type | Purpose |
+| --- | --- | --- |
+| `PROTO_KILL_SWITCH` | boolean | Hard-disables prototype features when set to `true`. |
+| `SHADOW_MODE` | boolean | Enables dual-write/monitor-only flows without impacting production systems. |
+| `TZ` | string | Forces the process timezone when the OS environment does not provide one. |
+| `MOCK_*` | boolean/string | Any flag beginning with `MOCK_` is captured and exposed to the application for mock integrations. |
+
+Boolean flags accept `true/false`, `1/0`, `yes/no`, or `on/off` (case insensitive).
+
+## Profiles
+
+- `config/dev.yaml`: local development defaults (localhost providers, mocks enabled, shadow mode on).
+- `config/stage.yaml`: staging defaults (stage endpoints, mocks disabled, shadow mode on).
+- `config/prod.yaml`: production defaults (production endpoints, all mocks disabled).
+
+Use `make profile-dev` or `make profile-prod` to export an appropriate `APP_PROFILE` together with commonly used overrides for the current shell session.

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,0 +1,277 @@
+import fs from "fs";
+import path from "path";
+
+export type ProviderKey = "bank" | "kms" | "rates" | "idp" | "statements";
+
+export interface ProvidersConfig {
+  bank: string;
+  kms: string;
+  rates: string;
+  idp: string;
+  statements: string;
+}
+
+export interface AppConfig {
+  profile: string;
+  providers: ProvidersConfig;
+  globals: {
+    PROTO_KILL_SWITCH: boolean;
+    SHADOW_MODE: boolean;
+    TZ: string;
+    mocks: Record<string, string | boolean>;
+  };
+  raw: Record<string, unknown>;
+}
+
+type Primitive = string | number | boolean | null;
+type YamlValue = Primitive | YamlObject;
+interface YamlObject {
+  [key: string]: YamlValue;
+}
+
+const CONFIG_DIR = path.resolve(__dirname, "..", "..", "config");
+const DEFAULT_PROFILE = "dev";
+
+function parseBoolean(value: string): boolean | string {
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) {
+    return true;
+  }
+  if (["0", "false", "no", "off"].includes(normalized)) {
+    return false;
+  }
+  return value;
+}
+
+function parsePrimitive(value: string): Primitive | string {
+  const trimmed = value.trim();
+  if (trimmed === "") {
+    return "";
+  }
+  if (trimmed === "null" || trimmed === "~") {
+    return null;
+  }
+  if (/^-?\d+$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  const booleanish = parseBoolean(trimmed);
+  if (booleanish === true || booleanish === false) {
+    return booleanish;
+  }
+  return trimmed;
+}
+
+function parseSimpleYaml(contents: string): YamlObject {
+  const root: YamlObject = {};
+  const stack: Array<{ indent: number; value: YamlObject }> = [{ indent: -1, value: root }];
+
+  const lines = contents
+    .split(/\r?\n/)
+    .map((line) => line.replace(/#.*$/, ""))
+    .map((line) => line.replace(/\s+$/, ""))
+    .filter((line) => line.length > 0);
+
+  for (const originalLine of lines) {
+    const indentMatch = originalLine.match(/^\s*/);
+    const indent = indentMatch ? indentMatch[0].length : 0;
+    const line = originalLine.trim();
+
+    while (stack.length > 1 && indent <= stack[stack.length - 1].indent) {
+      stack.pop();
+    }
+
+    const current = stack[stack.length - 1].value;
+
+    if (line.endsWith(":")) {
+      const key = line.slice(0, -1).trim();
+      const child: YamlObject = {};
+      current[key] = child;
+      stack.push({ indent, value: child });
+      continue;
+    }
+
+    const separatorIndex = line.indexOf(":");
+    if (separatorIndex === -1) {
+      throw new Error(`Unsupported YAML line: "${originalLine}"`);
+    }
+
+    const key = line.slice(0, separatorIndex).trim();
+    const valuePortion = line.slice(separatorIndex + 1);
+    current[key] = parsePrimitive(valuePortion);
+  }
+
+  return root;
+}
+
+function readYamlFile(filePath: string): YamlObject {
+  if (!fs.existsSync(filePath)) {
+    return {};
+  }
+  const contents = fs.readFileSync(filePath, "utf8");
+  if (contents.trim().length === 0) {
+    return {};
+  }
+  return parseSimpleYaml(contents);
+}
+
+function deepMerge(base: YamlObject, override: YamlObject): YamlObject {
+  const output: YamlObject = { ...base };
+
+  for (const [key, value] of Object.entries(override)) {
+    if (
+      value &&
+      typeof value === "object" &&
+      !Array.isArray(value) &&
+      key in output &&
+      output[key] &&
+      typeof output[key] === "object" &&
+      !Array.isArray(output[key])
+    ) {
+      output[key] = deepMerge(output[key] as YamlObject, value as YamlObject);
+    } else {
+      output[key] = value;
+    }
+  }
+
+  return output;
+}
+
+function asString(input: unknown, context: string): string {
+  if (typeof input !== "string") {
+    throw new Error(`${context} must be a string, received ${typeof input}`);
+  }
+  if (input.length === 0) {
+    throw new Error(`${context} must not be empty`);
+  }
+  return input;
+}
+
+function asBoolean(input: unknown, context: string): boolean {
+  if (typeof input === "boolean") {
+    return input;
+  }
+  if (typeof input === "string") {
+    const parsed = parseBoolean(input);
+    if (parsed === true || parsed === false) {
+      return parsed;
+    }
+  }
+  throw new Error(`${context} must be a boolean-like value`);
+}
+
+function normalizeProfileName(profile?: string): string {
+  if (!profile) {
+    return DEFAULT_PROFILE;
+  }
+  return profile.toLowerCase();
+}
+
+function collectEnvOverrides(): Record<string, unknown> {
+  const overrides: Record<string, unknown> = {};
+  const explicitEnv: Array<[string, string]> = [
+    ["providers.bank", process.env.PROVIDERS_BANK ?? process.env.BANK_PROVIDER ?? ""],
+    ["providers.kms", process.env.PROVIDERS_KMS ?? ""],
+    ["providers.rates", process.env.PROVIDERS_RATES ?? ""],
+    ["providers.idp", process.env.PROVIDERS_IDP ?? ""],
+    ["providers.statements", process.env.PROVIDERS_STATEMENTS ?? ""],
+    ["PROTO_KILL_SWITCH", process.env.PROTO_KILL_SWITCH ?? ""],
+    ["SHADOW_MODE", process.env.SHADOW_MODE ?? ""],
+    ["TZ", process.env.TZ ?? ""],
+  ];
+
+  for (const [key, value] of explicitEnv) {
+    if (value !== "") {
+      overrides[key] = value;
+    }
+  }
+
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.startsWith("MOCK_") && value !== undefined) {
+      overrides[key] = value;
+    }
+  }
+
+  return overrides;
+}
+
+function applyPath(target: YamlObject, dottedPath: string, value: unknown): void {
+  const segments = dottedPath.split(".");
+  let cursor: YamlObject = target;
+  for (let i = 0; i < segments.length - 1; i += 1) {
+    const segment = segments[i];
+    if (!(segment in cursor) || typeof cursor[segment] !== "object" || cursor[segment] === null) {
+      cursor[segment] = {};
+    }
+    cursor = cursor[segment] as YamlObject;
+  }
+  cursor[segments[segments.length - 1]] = value as YamlValue;
+}
+
+export function loadConfig(): AppConfig {
+  const profile = normalizeProfileName(process.env.APP_PROFILE);
+  const defaults = readYamlFile(path.join(CONFIG_DIR, "default.yaml"));
+  const profilePath = path.join(CONFIG_DIR, `${profile}.yaml`);
+  const profileConfig = readYamlFile(profilePath);
+
+  const merged = deepMerge(defaults, profileConfig);
+  const envOverrides = collectEnvOverrides();
+
+  for (const [pathKey, value] of Object.entries(envOverrides)) {
+    if (pathKey.includes(".")) {
+      applyPath(merged, pathKey, value);
+    } else {
+      merged[pathKey] = value as YamlValue;
+    }
+  }
+
+  const providers = merged.providers as YamlObject;
+  if (!providers) {
+    throw new Error("providers configuration is required");
+  }
+
+  const normalizedProviders: Partial<ProvidersConfig> = {};
+  (Object.keys({ bank: "", kms: "", rates: "", idp: "", statements: "" }) as ProviderKey[]).forEach((key) => {
+    normalizedProviders[key] = asString(providers[key], `providers.${key}`);
+  });
+
+  const protoKillSwitch = asBoolean(merged.PROTO_KILL_SWITCH, "PROTO_KILL_SWITCH");
+  const shadowMode = asBoolean(merged.SHADOW_MODE, "SHADOW_MODE");
+  const timezone = asString(merged.TZ, "TZ");
+
+  const mocks: Record<string, string | boolean> = {};
+  for (const [key, value] of Object.entries(merged)) {
+    if (key.startsWith("MOCK_")) {
+      if (typeof value === "boolean") {
+        mocks[key] = value;
+      } else if (typeof value === "string") {
+        const parsed = parseBoolean(value);
+        mocks[key] = parsed === value ? value : (parsed as boolean);
+      }
+    }
+  }
+
+  return {
+    profile,
+    providers: normalizedProviders as ProvidersConfig,
+    globals: {
+      PROTO_KILL_SWITCH: protoKillSwitch,
+      SHADOW_MODE: shadowMode,
+      TZ: timezone,
+      mocks,
+    },
+    raw: merged,
+  };
+}
+
+let cachedConfig: AppConfig | null = null;
+
+export function getAppConfig(): AppConfig {
+  if (!cachedConfig) {
+    cachedConfig = loadConfig();
+    if (!process.env.TZ) {
+      process.env.TZ = cachedConfig.globals.TZ;
+    }
+  }
+
+  return cachedConfig;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,17 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { getAppConfig } from "./config";
 
 dotenv.config();
 
+const appConfig = getAppConfig();
 const app = express();
+app.locals.config = appConfig;
 app.use(express.json({ limit: "2mb" }));
 
 // (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+app.use((req, _res, next) => { console.log(`[app:${appConfig.profile}] ${req.method} ${req.url}`); next(); });
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));


### PR DESCRIPTION
## Summary
- add layered YAML configuration for providers and global flags across default, dev, stage, and prod profiles
- implement a TypeScript loader that merges defaults, profile files, and environment overrides
- document the configuration surface and add make targets to export dev/prod profile variables

## Testing
- npx ts-node -O '{"module":"commonjs"}' -e "const { loadConfig } = require('./src/config'); console.log(loadConfig());"

------
https://chatgpt.com/codex/tasks/task_e_68e24ca2202083279a2ab03928144058