### PR TITLE
Add profile switch make targets and Windows scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ﻿# Python / venv
 .venv/
 venv/
+.env
 __pycache__/
 
 # Node / builds

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-﻿SHELL := /bin/bash
+SHELL := /bin/bash
+
+ENV_FILE ?= .env
+HEALTH_CHECK_URL ?= http://localhost:8000/health/capabilities
+
+.PHONY: switch-mock switch-shadow switch-real _write-env
 
 up:
 	@docker compose up -d --build --remove-orphans
@@ -23,3 +28,29 @@ ps:
 
 fmt:
 	@echo "No formatter configured; add ruff/black if desired."
+
+switch-mock:
+	@$(MAKE) _write-env APP_PROFILE=dev \
+	        PROVIDERS="bank=mock;kms=mock;rates=mock;idp=dev;statements=mock" \
+	        SHADOW_MODE=false \
+	        PROTO_KILL_SWITCH=true
+
+switch-shadow:
+	@$(MAKE) _write-env APP_PROFILE=dev \
+	        PROVIDERS="bank=mock;kms=mock;rates=mock;idp=dev;statements=mock" \
+	        SHADOW_MODE=true \
+	        PROTO_KILL_SWITCH=true
+
+switch-real:
+	@curl --fail --silent --show-error "$(HEALTH_CHECK_URL)" >/dev/null
+	@$(MAKE) _write-env APP_PROFILE=prod \
+	        PROVIDERS="bank=real;kms=real;rates=real;idp=prod;statements=real" \
+	        SHADOW_MODE=false \
+	        PROTO_KILL_SWITCH=false
+
+_write-env:
+	@python tools/update_env.py "$(ENV_FILE)" \
+	        "APP_PROFILE=$(APP_PROFILE)" \
+	        "PROVIDERS=$(PROVIDERS)" \
+	        "SHADOW_MODE=$(SHADOW_MODE)" \
+	        "PROTO_KILL_SWITCH=$(PROTO_KILL_SWITCH)"

--- a/scripts/switch-mock.ps1
+++ b/scripts/switch-mock.ps1
@@ -1,0 +1,47 @@
+param(
+    [string]$EnvFile = (Join-Path (Split-Path $PSScriptRoot -Parent) '.env')
+)
+
+function Update-EnvFile {
+    param(
+        [string]$Path,
+        [hashtable]$Updates
+    )
+
+    $existing = @()
+    if (Test-Path $Path) {
+        $existing = Get-Content -Path $Path -Encoding UTF8
+    }
+
+    $output = @()
+    foreach ($line in $existing) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith('#')) {
+            $output += $line
+            continue
+        }
+
+        $parts = $line.Split('=', 2)
+        if ($parts.Length -eq 2 -and $Updates.ContainsKey($parts[0])) {
+            continue
+        }
+
+        $output += $line
+    }
+
+    foreach ($key in $Updates.Keys) {
+        $output += "$key=$($Updates[$key])"
+    }
+
+    $output | Set-Content -Path $Path -Encoding UTF8
+    Write-Host "Updated $Path"
+}
+
+$updates = @{
+    APP_PROFILE      = 'dev'
+    PROVIDERS        = 'bank=mock;kms=mock;rates=mock;idp=dev;statements=mock'
+    SHADOW_MODE      = 'false'
+    PROTO_KILL_SWITCH = 'true'
+}
+
+Update-EnvFile -Path $EnvFile -Updates $updates

--- a/scripts/switch-real.ps1
+++ b/scripts/switch-real.ps1
@@ -1,0 +1,55 @@
+param(
+    [string]$EnvFile = (Join-Path (Split-Path $PSScriptRoot -Parent) '.env'),
+    [string]$HealthCheckUrl = 'http://localhost:8000/health/capabilities'
+)
+
+function Update-EnvFile {
+    param(
+        [string]$Path,
+        [hashtable]$Updates
+    )
+
+    $existing = @()
+    if (Test-Path $Path) {
+        $existing = Get-Content -Path $Path -Encoding UTF8
+    }
+
+    $output = @()
+    foreach ($line in $existing) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith('#')) {
+            $output += $line
+            continue
+        }
+
+        $parts = $line.Split('=', 2)
+        if ($parts.Length -eq 2 -and $Updates.ContainsKey($parts[0])) {
+            continue
+        }
+
+        $output += $line
+    }
+
+    foreach ($key in $Updates.Keys) {
+        $output += "$key=$($Updates[$key])"
+    }
+
+    $output | Set-Content -Path $Path -Encoding UTF8
+    Write-Host "Updated $Path"
+}
+
+try {
+    Invoke-WebRequest -Uri $HealthCheckUrl -UseBasicParsing | Out-Null
+} catch {
+    Write-Error "Health check failed at $HealthCheckUrl. Aborting profile switch."
+    exit 1
+}
+
+$updates = @{
+    APP_PROFILE      = 'prod'
+    PROVIDERS        = 'bank=real;kms=real;rates=real;idp=prod;statements=real'
+    SHADOW_MODE      = 'false'
+    PROTO_KILL_SWITCH = 'false'
+}
+
+Update-EnvFile -Path $EnvFile -Updates $updates

--- a/scripts/switch-shadow.ps1
+++ b/scripts/switch-shadow.ps1
@@ -1,0 +1,47 @@
+param(
+    [string]$EnvFile = (Join-Path (Split-Path $PSScriptRoot -Parent) '.env')
+)
+
+function Update-EnvFile {
+    param(
+        [string]$Path,
+        [hashtable]$Updates
+    )
+
+    $existing = @()
+    if (Test-Path $Path) {
+        $existing = Get-Content -Path $Path -Encoding UTF8
+    }
+
+    $output = @()
+    foreach ($line in $existing) {
+        $trimmed = $line.Trim()
+        if ([string]::IsNullOrWhiteSpace($trimmed) -or $trimmed.StartsWith('#')) {
+            $output += $line
+            continue
+        }
+
+        $parts = $line.Split('=', 2)
+        if ($parts.Length -eq 2 -and $Updates.ContainsKey($parts[0])) {
+            continue
+        }
+
+        $output += $line
+    }
+
+    foreach ($key in $Updates.Keys) {
+        $output += "$key=$($Updates[$key])"
+    }
+
+    $output | Set-Content -Path $Path -Encoding UTF8
+    Write-Host "Updated $Path"
+}
+
+$updates = @{
+    APP_PROFILE      = 'dev'
+    PROVIDERS        = 'bank=mock;kms=mock;rates=mock;idp=dev;statements=mock'
+    SHADOW_MODE      = 'true'
+    PROTO_KILL_SWITCH = 'true'
+}
+
+Update-EnvFile -Path $EnvFile -Updates $updates

--- a/tools/update_env.py
+++ b/tools/update_env.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Utility to update key/value pairs in a dotenv-style file."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict
+
+
+def parse_updates(pairs: list[str]) -> Dict[str, str]:
+    updates: Dict[str, str] = {}
+    for pair in pairs:
+        if "=" not in pair:
+            raise argparse.ArgumentTypeError(f"Invalid key/value pair: {pair!r}")
+        key, value = pair.split("=", 1)
+        if not key:
+            raise argparse.ArgumentTypeError(f"Empty key in pair: {pair!r}")
+        updates[key] = value
+    return updates
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("env_file", help="Path to the environment file to update")
+    parser.add_argument(
+        "pairs",
+        nargs="+",
+        help="Key/value pairs in KEY=VALUE format to upsert into the env file",
+    )
+    args = parser.parse_args()
+
+    env_path = Path(args.env_file)
+    updates = parse_updates(args.pairs)
+
+    existing_lines: list[str] = []
+    if env_path.exists():
+        for line in env_path.read_text().splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                existing_lines.append(line)
+                continue
+            key, sep, value = line.partition("=")
+            if sep and key in updates:
+                continue
+            existing_lines.append(line)
+
+    env_path.write_text(
+        "\n".join(existing_lines + [f"{k}={v}" for k, v in updates.items()]) + "\n"
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Makefile targets to switch between mock, shadow, and real provider profiles using a reusable env writer
- add a Python helper that updates the shared `.env` file and ignore the generated file in git
- provide Windows PowerShell scripts that mirror the profile switch behaviour

## Testing
- make switch-mock
- make switch-shadow

------
https://chatgpt.com/codex/tasks/task_e_68e24cf2e8708327840c5098228f9579