### PR TITLE
Refactor monetary handling to cents

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,37 @@
+const MONEY_NAME_PATTERN = "/(amount|cents|money|balance|liability|total|owed)/i";
+
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  parserOptions: {
+    project: "./tsconfig.json",
+    tsconfigRootDir: __dirname,
+  },
+  overrides: [
+    {
+      files: ["src/**/*.ts", "src/**/*.tsx", "libs/**/*.ts", "pages/api/**/*.ts"],
+      rules: {
+        "no-restricted-syntax": [
+          "error",
+          {
+            selector: `TSTypeAnnotation[parent.type="Identifier"][parent.name=${MONEY_NAME_PATTERN}] > TSNumberKeyword`,
+            message: "Do not use 'number' for monetary identifier; use MoneyCents instead.",
+          },
+          {
+            selector: `TSPropertySignature[key.type="Identifier"][key.name=${MONEY_NAME_PATTERN}] TSTypeAnnotation > TSNumberKeyword`,
+            message: "Do not use 'number' for monetary property; use MoneyCents instead.",
+          },
+          {
+            selector: `TSParameterProperty > Identifier[name=${MONEY_NAME_PATTERN}] > TSTypeAnnotation > TSNumberKeyword`,
+            message: "Do not use 'number' for monetary parameter; use MoneyCents instead.",
+          },
+          {
+            selector: `Identifier[name=${MONEY_NAME_PATTERN}] > TSTypeAnnotation > TSNumberKeyword`,
+            message: "Do not use 'number' for monetary identifier; use MoneyCents instead.",
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/apps/services/tax-engine/app/money.py
+++ b/apps/services/tax-engine/app/money.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import NewType, Union
+
+MoneyCents = NewType("MoneyCents", int)
+
+CENTS_PER_DOLLAR = Decimal("100")
+BASIS_POINTS_SCALE = 10_000
+HALF_BASIS_POINTS = BASIS_POINTS_SCALE // 2
+
+NumberLike = Union[int, str, Decimal, MoneyCents]
+
+
+def _to_decimal(value: Union[str, int, float, Decimal]) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, MoneyCents)):
+        return Decimal(int(value))
+    if isinstance(value, float):
+        return Decimal(str(value))
+    return Decimal(str(value))
+
+
+def from_cents(value: NumberLike) -> MoneyCents:
+    if isinstance(value, MoneyCents):
+        return value
+    if isinstance(value, Decimal):
+        cents = int(value)
+    elif isinstance(value, str):
+        if value.strip() == "":
+            raise ValueError("empty string is not a valid cents value")
+        cents = int(value.strip())
+    else:
+        cents = int(value)
+    return MoneyCents(cents)
+
+
+def to_cents(amount: MoneyCents) -> int:
+    return int(amount)
+
+
+def mul_bp(amount: MoneyCents, basis_points: int) -> MoneyCents:
+    if basis_points < 0:
+        raise ValueError("basis_points must be non-negative")
+    cents = to_cents(amount)
+    result = (cents * basis_points + HALF_BASIS_POINTS) // BASIS_POINTS_SCALE
+    return MoneyCents(result)
+
+
+def round_ato(value: Union[str, int, float, Decimal]) -> MoneyCents:
+    quantized = _to_decimal(value).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    cents = int((quantized * CENTS_PER_DOLLAR).to_integral_value())
+    return MoneyCents(cents)

--- a/apps/services/tax-engine/tests/test_tax_rules.py
+++ b/apps/services/tax-engine/tests/test_tax_rules.py
@@ -1,7 +1,12 @@
-﻿from app.tax_rules import gst_line_tax, paygw_weekly
+from app.money import from_cents, to_cents
+from app.tax_rules import gst_line_tax, paygw_weekly
+
+
 def test_gst_line_tax():
-    assert gst_line_tax(10000,'GST')==1000
-    assert gst_line_tax(10000,'GST_FREE')==0
+    assert to_cents(gst_line_tax(from_cents(10000), 'GST')) == 1000
+    assert to_cents(gst_line_tax(from_cents(10000), 'GST_FREE')) == 0
+
+
 def test_paygw_weekly():
-    assert paygw_weekly(50000)==7500
-    assert paygw_weekly(100000)>15000
+    assert to_cents(paygw_weekly(from_cents(50000))) == 7500
+    assert to_cents(paygw_weekly(from_cents(100000))) > 15000

--- a/libs/money.ts
+++ b/libs/money.ts
@@ -1,0 +1,105 @@
+import assert from "node:assert";
+
+export type MoneyCents = number & { readonly __brand: unique symbol };
+
+function ensureSafeInteger(value: number): asserts value is number {
+  assert(Number.isSafeInteger(value), `Expected safe integer cents but received ${value}`);
+}
+
+function normalizeCents(value: number | bigint): number {
+  const cents = typeof value === "bigint" ? Number(value) : value;
+  ensureSafeInteger(cents);
+  return cents;
+}
+
+export function fromCents(value: number | bigint | string): MoneyCents {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!/^[-+]?\d+$/.test(trimmed)) {
+      throw new Error(`Invalid cents string: ${value}`);
+    }
+    return fromCents(BigInt(trimmed));
+  }
+  return normalizeCents(value) as MoneyCents;
+}
+
+export function toCents(money: MoneyCents): number {
+  return money as number;
+}
+
+const BP_SCALE = 10_000n;
+const HALF_BP = BP_SCALE / 2n;
+
+export function mulBp(amount: MoneyCents, basisPoints: number | bigint): MoneyCents {
+  if (typeof basisPoints === "number" && !Number.isInteger(basisPoints)) {
+    throw new Error(`Basis points must be integer, received ${basisPoints}`);
+  }
+  const bp = typeof basisPoints === "bigint" ? basisPoints : BigInt(basisPoints);
+  const raw = BigInt(toCents(amount)) * bp;
+  const cents = (raw + HALF_BP) / BP_SCALE;
+  return fromCents(cents);
+}
+
+function parseDecimalInput(input: string): { sign: bigint; dollars: string; fraction: string } {
+  const trimmed = input.trim();
+  const match = trimmed.match(/^([+-]?)(\d+)(?:\.(\d{0,}))?$/);
+  if (!match) {
+    throw new Error(`Invalid decimal monetary value: ${input}`);
+  }
+  const [, signPart, dollars, fractionRaw = ""] = match;
+  const sign = signPart === "-" ? -1n : 1n;
+  return { sign, dollars, fraction: fractionRaw };
+}
+
+export function roundATO(value: string | number | bigint): MoneyCents {
+  if (typeof value === "bigint") {
+    return fromCents(value);
+  }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) {
+      throw new Error(`Invalid numeric value: ${value}`);
+    }
+    const asString = value.toString();
+    if (/e/i.test(asString)) {
+      throw new Error("Scientific notation is not supported for monetary values");
+    }
+    return roundATO(asString);
+  }
+  const { sign, dollars, fraction } = parseDecimalInput(value);
+  const centDigits = (fraction + "00").slice(0, 3);
+  const centsPortion = BigInt(centDigits.slice(0, 2));
+  const roundingDigit = Number(centDigits[2] ?? "0");
+  let cents = BigInt(dollars) * 100n + centsPortion;
+  if (roundingDigit >= 5) {
+    cents += 1n;
+  }
+  return fromCents(sign * cents);
+}
+
+export function expectMoneyCents(value: unknown, field: string): MoneyCents {
+  if (typeof value === "number") {
+    if (!Number.isInteger(value)) {
+      throw new Error(`${field} must be integer cents`);
+    }
+    return fromCents(value);
+  }
+  if (typeof value === "bigint") {
+    return fromCents(value);
+  }
+  if (typeof value === "string") {
+    if (!/^[-+]?\d+$/.test(value.trim())) {
+      throw new Error(`${field} must be an integer cents string`);
+    }
+    return fromCents(value);
+  }
+  throw new Error(`${field} must be provided as integer cents`);
+}
+
+export function formatDollars(amount: MoneyCents): string {
+  const cents = BigInt(toCents(amount));
+  const sign = cents < 0 ? "-" : "";
+  const abs = cents < 0 ? -cents : cents;
+  const dollars = abs / 100n;
+  const remainder = abs % 100n;
+  return `${sign}${dollars}.${remainder.toString().padStart(2, "0")}`;
+}

--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -1,7 +1,9 @@
 // libs/paymentsClient.ts
+import { MoneyCents, expectMoneyCents } from "./money";
+
 type Common = { abn: string; taxType: string; periodId: string };
-export type DepositArgs = Common & { amountCents: number };   // > 0
-export type ReleaseArgs = Common & { amountCents: number };   // < 0
+export type DepositArgs = Common & { amountCents: MoneyCents };   // > 0
+export type ReleaseArgs = Common & { amountCents: MoneyCents };   // < 0
 
 // Prefer NEXT_PUBLIC_ (browser-safe), then server-only, then default
 const BASE =
@@ -22,18 +24,20 @@ async function handle(res: Response) {
 
 export const Payments = {
   async deposit(args: DepositArgs) {
+    const body = { ...args, amountCents: expectMoneyCents(args.amountCents, "amountCents") };
     const res = await fetch(`${BASE}/deposit`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(args),
+      body: JSON.stringify(body),
     });
     return handle(res);
   },
   async payAto(args: ReleaseArgs) {
+    const body = { ...args, amountCents: expectMoneyCents(args.amountCents, "amountCents") };
     const res = await fetch(`${BASE}/payAto`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify(args),
+      body: JSON.stringify(body),
     });
     return handle(res);
   },

--- a/migrations/003_money_refactor.sql
+++ b/migrations/003_money_refactor.sql
@@ -1,0 +1,27 @@
+BEGIN;
+
+-- Ensure ledger amounts are non-negative and track entry kind
+ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS entry_kind text;
+UPDATE owa_ledger
+SET entry_kind = CASE WHEN amount_cents < 0 THEN 'DEBIT' ELSE 'CREDIT' END,
+    amount_cents = ABS(amount_cents)
+WHERE entry_kind IS NULL;
+
+ALTER TABLE owa_ledger ADD COLUMN IF NOT EXISTS amount_value DECIMAL(18,2);
+UPDATE owa_ledger SET amount_value = amount_cents::numeric / 100.0 WHERE amount_value IS NULL;
+
+ALTER TABLE owa_ledger
+  ALTER COLUMN entry_kind SET NOT NULL,
+  ADD CONSTRAINT owa_ledger_entry_kind_chk CHECK (entry_kind IN ('DEBIT','CREDIT')),
+  ADD CONSTRAINT owa_ledger_amount_nonneg CHECK (amount_cents >= 0);
+
+ALTER TABLE owa_ledger ALTER COLUMN amount_value SET NOT NULL;
+ALTER TABLE owa_ledger ADD CONSTRAINT owa_ledger_amount_value_nonneg CHECK (amount_value >= 0);
+
+-- Period aggregates must stay non-negative
+ALTER TABLE periods
+  ADD CONSTRAINT periods_accrued_nonneg CHECK (accrued_cents >= 0),
+  ADD CONSTRAINT periods_credited_nonneg CHECK (credited_to_owa_cents >= 0),
+  ADD CONSTRAINT periods_final_liability_nonneg CHECK (final_liability_cents >= 0);
+
+COMMIT;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "lint:money": "./scripts/check_no_floats.py"
     },
     "version": "0.1.0",
     "name": "apgms",
@@ -13,6 +14,9 @@
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
+        "eslint": "^8.57.0",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"

--- a/pages/api/deposit/index.ts
+++ b/pages/api/deposit/index.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { Payments } from "../../../libs/paymentsClient";
+import { MoneyCents, expectMoneyCents, toCents } from "../../../libs/money";
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== "POST") {
@@ -8,13 +9,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
   try {
     const { abn, taxType, periodId, amountCents } = req.body || {};
-    if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
+    if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing fields" });
     }
-    if (amountCents <= 0) {
+    let cents: MoneyCents;
+    try {
+      cents = expectMoneyCents(amountCents, "amountCents");
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || "Invalid amount" });
+    }
+    if (toCents(cents) <= 0) {
       return res.status(400).json({ error: "Deposit must be positive" });
     }
-    const data = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const data = await Payments.deposit({ abn, taxType, periodId, amountCents: cents });
     return res.status(200).json(data);
   } catch (err: any) {
     return res.status(400).json({ error: err?.message || "Deposit failed" });

--- a/pages/api/payments.ts
+++ b/pages/api/payments.ts
@@ -1,19 +1,26 @@
 // server/api/payments.ts
 import express from "express";
 import { Payments } from "../../libs/paymentsClient"; // adjust path
+import { MoneyCents, expectMoneyCents, toCents } from "../../libs/money";
 
 export const router = express.Router();
 
 router.post("/deposit", async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body;
-    if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
+    if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing fields" });
     }
-    if (amountCents <= 0) {
+    let cents: MoneyCents;
+    try {
+      cents = expectMoneyCents(amountCents, "amountCents");
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || "Invalid amount" });
+    }
+    if (toCents(cents) <= 0) {
       return res.status(400).json({ error: "Deposit must be positive" });
     }
-    const result = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const result = await Payments.deposit({ abn, taxType, periodId, amountCents: cents });
     res.json(result);
   } catch (err: any) {
     // Payments client throws Error with message from the service on 4xx
@@ -24,13 +31,19 @@ router.post("/deposit", async (req, res) => {
 router.post("/release", async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body;
-    if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
+    if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing fields" });
     }
-    if (amountCents >= 0) {
+    let cents: MoneyCents;
+    try {
+      cents = expectMoneyCents(amountCents, "amountCents");
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || "Invalid amount" });
+    }
+    if (toCents(cents) >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
-    const result = await Payments.payAto({ abn, taxType, periodId, amountCents });
+    const result = await Payments.payAto({ abn, taxType, periodId, amountCents: cents });
     res.json(result);
   } catch (err: any) {
     res.status(400).json({ error: err.message || "Release failed" });

--- a/pages/api/payments/deposit.ts
+++ b/pages/api/payments/deposit.ts
@@ -1,12 +1,14 @@
 // app/api/payments/deposit/route.ts
 import { NextResponse } from "next/server";
 import { Payments } from "@/libs/paymentsClient";
+import { MoneyCents, expectMoneyCents, toCents } from "@/libs/money";
 
 export async function POST(req: Request) {
   try {
     const { abn, taxType, periodId, amountCents } = await req.json();
-    if (amountCents <= 0) return NextResponse.json({ error: "Deposit must be positive" }, { status: 400 });
-    const out = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const cents: MoneyCents = expectMoneyCents(amountCents, "amountCents");
+    if (toCents(cents) <= 0) return NextResponse.json({ error: "Deposit must be positive" }, { status: 400 });
+    const out = await Payments.deposit({ abn, taxType, periodId, amountCents: cents });
     return NextResponse.json(out);
   } catch (err: any) {
     return NextResponse.json({ error: err.message || "Deposit failed" }, { status: 400 });

--- a/pages/api/payments/release.ts
+++ b/pages/api/payments/release.ts
@@ -1,12 +1,14 @@
 // app/api/payments/deposit/route.ts
 import { NextResponse } from "next/server";
 import { Payments } from "@/libs/paymentsClient";
+import { MoneyCents, expectMoneyCents, toCents } from "@/libs/money";
 
 export async function POST(req: Request) {
   try {
     const { abn, taxType, periodId, amountCents } = await req.json();
-    if (amountCents <= 0) return NextResponse.json({ error: "Deposit must be positive" }, { status: 400 });
-    const out = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const cents: MoneyCents = expectMoneyCents(amountCents, "amountCents");
+    if (toCents(cents) >= 0) return NextResponse.json({ error: "Release must be negative" }, { status: 400 });
+    const out = await Payments.payAto({ abn, taxType, periodId, amountCents: cents });
     return NextResponse.json(out);
   } catch (err: any) {
     return NextResponse.json({ error: err.message || "Deposit failed" }, { status: 400 });

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ orjson==3.10.7
 nats-py==2.7.2
 prometheus-client==0.20.0
 httpx==0.27.2
+hypothesis==6.112.1

--- a/scripts/check_no_floats.py
+++ b/scripts/check_no_floats.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCAN_ROOTS = [
+    ROOT / "src" / "routes",
+    ROOT / "src" / "api",
+    ROOT / "src" / "rails",
+    ROOT / "libs",
+    ROOT / "tests",
+    ROOT / "pages" / "api",
+    ROOT / "apps" / "services" / "tax-engine",
+]
+TARGET_EXTENSIONS = {".ts", ".tsx", ".js", ".py"}
+EXCLUDE_DIRS = {"node_modules", "__pycache__", "dist", "build", ".git", ".venv"}
+FLOAT_PATTERN = re.compile(r"(?<![\"'])\b\d+\.\d+\b(?![\"'])")
+KEYWORDS = ("amount", "_cents", "balance", "money", "penalty", "liability", "owed")
+
+
+def should_scan(path: Path) -> bool:
+    if path.suffix not in TARGET_EXTENSIONS:
+        return False
+    for parent in path.parents:
+        if parent.name in EXCLUDE_DIRS:
+            return False
+    return True
+
+
+def main() -> int:
+    violations: list[str] = []
+    for base in SCAN_ROOTS:
+        if not base.exists():
+            continue
+        for file in base.rglob("*"):
+            if not should_scan(file):
+                continue
+            text = file.read_text(encoding="utf-8", errors="ignore")
+            for idx, line in enumerate(text.splitlines(), start=1):
+                for match in FLOAT_PATTERN.finditer(line):
+                    window = line[max(0, match.start() - 40): match.end() + 40].lower()
+                    if any(k in window for k in KEYWORDS):
+                        violations.append(f"{file.relative_to(ROOT)}:{idx}: {line.strip()}")
+                        break
+    if violations:
+        print("Floating point literal usage detected in money-sensitive code:", file=sys.stderr)
+        for v in violations:
+            print(v, file=sys.stderr)
+        print("Use integer cents helpers instead.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/crypto/ed25519.ts
+++ b/src/crypto/ed25519.ts
@@ -1,10 +1,11 @@
-﻿import nacl from "tweetnacl";
+import nacl from "tweetnacl";
+import { MoneyCents } from "../../libs/money";
 
 export interface RptPayload {
-  entity_id: string; period_id: string; tax_type: "PAYGW"|"GST";
-  amount_cents: number; merkle_root: string; running_balance_hash: string;
+  entity_id: string; period_id: string; tax_type: "PAYGW" | "GST";
+  amount_cents: MoneyCents; merkle_root: string; running_balance_hash: string;
   anomaly_vector: Record<string, number>; thresholds: Record<string, number>;
-  rail_id: "EFT"|"BPAY"|"PayTo"; reference: string; expiry_ts: string; nonce: string;
+  rail_id: "EFT" | "BPAY" | "PayTo"; reference: string; expiry_ts: string; nonce: string;
 }
 
 export function signRpt(payload: RptPayload, secretKey: Uint8Array): string {

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,21 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+/** PayTo BAS Sweep adapter (stub) */
+import { MoneyCents, expectMoneyCents } from "../../libs/money";
+
+export interface PayToDebitResult {
+  status: "OK" | "INSUFFICIENT_FUNDS" | "BANK_ERROR";
+  bank_ref?: string;
+}
+
+export async function createMandate(abn: string, capCents: MoneyCents, reference: string) {
+  expectMoneyCents(capCents, "capCents");
+  return { status: "OK", mandateId: "demo-mandate" };
+}
+
+export async function debit(abn: string, amountCents: MoneyCents, reference: string): Promise<PayToDebitResult> {
+  expectMoneyCents(amountCents, "amountCents");
+  return { status: "OK", bank_ref: "payto:" + reference.slice(0, 12) };
+}
+
+export async function cancelMandate(mandateId: string) {
+  return { status: "OK" };
+}

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,6 +1,7 @@
 ﻿import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { MoneyCents, expectMoneyCents, toCents, formatDollars } from "../../libs/money";
 
 export async function deposit(req: Request, res: Response) {
   try {
@@ -8,8 +9,13 @@ export async function deposit(req: Request, res: Response) {
     if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
-    const amt = Number(amountCents);
-    if (!Number.isFinite(amt) || amt <= 0) {
+    let amt: MoneyCents;
+    try {
+      amt = expectMoneyCents(amountCents, "amountCents");
+    } catch (err: any) {
+      return res.status(400).json({ error: err?.message || "Invalid amount" });
+    }
+    if (toCents(amt) <= 0) {
       return res.status(400).json({ error: "amountCents must be positive for a deposit" });
     }
 
@@ -23,15 +29,25 @@ export async function deposit(req: Request, res: Response) {
          ORDER BY id DESC LIMIT 1`,
         [abn, taxType, periodId]
       );
-      const prevBal = last[0]?.balance_after_cents ?? 0;
-      const newBal = prevBal + amt;
+      const prevBalRaw = last[0]?.balance_after_cents ?? 0;
+      const prevBal = expectMoneyCents(prevBalRaw, "balance_after_cents");
+      const newBal = toCents(prevBal) + toCents(amt);
 
       const { rows: ins } = await client.query(
         `INSERT INTO owa_ledger
-           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,now())
+           (abn,tax_type,period_id,transfer_uuid,amount_cents,amount_value,entry_kind,balance_after_cents,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,now())
          RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
+        [
+          abn,
+          taxType,
+          periodId,
+          randomUUID(),
+          toCents(amt),
+          formatDollars(amt),
+          "CREDIT",
+          newBal,
+        ]
       );
 
       await client.query("COMMIT");

--- a/src/utils/penalties.ts
+++ b/src/utils/penalties.ts
@@ -1,5 +1,15 @@
-export function calculatePenalties(daysLate: number, amountDue: number): number {
-  const basePenalty = amountDue * 0.05;
-  const dailyInterest = amountDue * 0.0002;
-  return basePenalty + (dailyInterest * daysLate);
+import { MoneyCents, expectMoneyCents, fromCents, mulBp, toCents } from "../../libs/money";
+
+const BASE_PENALTY_BP = 500; // 5%
+const DAILY_INTEREST_BP = 20; // 0.20%
+
+export function calculatePenalties(daysLate: number, amountDue: MoneyCents | number): MoneyCents {
+  const cents = expectMoneyCents(amountDue, "amountDue");
+  if (!Number.isInteger(daysLate) || daysLate < 0) {
+    throw new Error("daysLate must be a non-negative integer");
+  }
+  const basePenalty = mulBp(cents, BASE_PENALTY_BP);
+  const dailyInterest = mulBp(cents, DAILY_INTEREST_BP);
+  const total = toCents(basePenalty) + toCents(dailyInterest) * daysLate;
+  return fromCents(total);
 }

--- a/tests/test_ledger_property.py
+++ b/tests/test_ledger_property.py
@@ -1,0 +1,30 @@
+from hypothesis import given, strategies as st
+
+from app.money import from_cents, to_cents
+
+
+def generate_balanced_ledger(credit_cents: list[int], debit_seeds: list[int]):
+    credits = [from_cents(v) for v in credit_cents if v > 0]
+    total = sum(credit_cents)
+    debits: list[int] = []
+    remaining = total
+    for seed in (v for v in debit_seeds if v > 0):
+        if remaining <= 0:
+            break
+        take = min(seed, remaining)
+        debits.append(take)
+        remaining -= take
+    if remaining > 0:
+        debits.append(remaining)
+    debit_entries = [from_cents(v) for v in debits]
+    return credits, debit_entries
+
+
+@given(
+    st.lists(st.integers(min_value=1, max_value=500_000), min_size=1, max_size=8),
+    st.lists(st.integers(min_value=1, max_value=500_000), min_size=1, max_size=8),
+)
+def test_generated_ledgers_balance(credit_values, debit_seeds):
+    credits, debits = generate_balanced_ledger(credit_values, debit_seeds)
+    assert sum(credit_values) == sum(to_cents(d) for d in debits)
+    assert sum(to_cents(c) for c in credits) == sum(to_cents(d) for d in debits)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -1,4 +1,6 @@
 import pytest
+
+from app.money import from_cents, to_cents
 from app.tax_rules import gst_line_tax, paygw_weekly
 
 @pytest.mark.parametrize("amount_cents, expected", [
@@ -7,7 +9,7 @@ from app.tax_rules import gst_line_tax, paygw_weekly
     (999, 100),    # rounding check
 ])
 def test_gst(amount_cents, expected):
-    assert gst_line_tax(amount_cents, "GST") == expected
+    assert to_cents(gst_line_tax(from_cents(amount_cents), "GST")) == expected
 
 @pytest.mark.parametrize("gross, expected", [
     (50_000, 7_500),     # 15% below bracket
@@ -15,4 +17,4 @@ def test_gst(amount_cents, expected):
     (100_000, 16_000),   # 12,000 + 20% of 20,000
 ])
 def test_paygw(gross, expected):
-    assert paygw_weekly(gross) == expected
+    assert to_cents(paygw_weekly(from_cents(gross))) == expected

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "libs/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add shared MoneyCents helpers for TypeScript and Python domains and update API routes to validate and serialize monetary values
- tighten ledger persistence with entry direction, DECIMAL columns, and non-negative checks via a new migration
- enforce money linting with eslint guards and a CI float detector script plus property-based ledger balance coverage

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'apgms_sdk' / 'hypothesis')*
- scripts/check_no_floats.py


------
https://chatgpt.com/codex/tasks/task_e_68e24b71e22483278424947c53466f61