### PR TITLE
feat: implement provider registry architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ ps:
 
 fmt:
 	@echo "No formatter configured; add ruff/black if desired."
+
+provider-contracts:
+	@pnpm provider:contracts

--- a/README.md
+++ b/README.md
@@ -89,3 +89,10 @@ For demonstration and prototyping only—real-world deployments require further 
 Contributing
 Pull requests are welcome!
 For major changes, please open an issue first to discuss what you’d like to change.
+
+## Provider architecture
+
+External integrations (bank egress, KMS, rates, identity, anomaly scoring, statements) are
+selected at runtime via the `PROVIDERS` configuration variable. See
+[docs/provider-architecture.md](docs/provider-architecture.md) for details on the provider
+registry, kill switches, shadow mode, and contract tests.

--- a/Run-ProviderContracts.ps1
+++ b/Run-ProviderContracts.ps1
@@ -1,0 +1,14 @@
+Param(
+    [switch]$Watch
+)
+
+$cmd = "pnpm provider:contracts"
+if ($Watch) {
+    $cmd = "$cmd --watch"
+}
+
+Write-Host "Executing provider contracts: $cmd"
+& cmd /c $cmd
+if ($LASTEXITCODE -ne 0) {
+    throw "Provider contract suite failed with exit code $LASTEXITCODE"
+}

--- a/docs/provider-architecture.md
+++ b/docs/provider-architecture.md
@@ -1,0 +1,57 @@
+# Provider Adapter Architecture
+
+This service now uses a provider/adapter registry so the platform team can swap real SDKs
+for mocks or alternative implementations without touching business logic.
+
+## Configuration
+
+Set the `PROVIDERS` environment variable to map each provider domain to an implementation.
+The format is `key=value` pairs separated by semicolons. Supported keys are `bank`, `kms`,
+`rates`, `idp` (alias for identity), `identity`, `anomaly`, and `statements`.
+
+```bash
+PROVIDERS="bank=mock;kms=mock;rates=mock;idp=dev;statements=mock"
+```
+
+Optional settings:
+
+- `PROVIDERS_SHADOW` enables shadow mode. Provide the same syntax as `PROVIDERS` to define
+  a secondary provider that is invoked asynchronously on every call. Any shadow failures
+  are logged and do not impact the primary result.
+- `PROVIDER_KILL_SWITCHES` accepts a comma or semicolon separated list of providers to
+  disable entirely (for example `PROVIDER_KILL_SWITCHES="bank"`). Calls to a killed provider
+  throw `ProviderKillSwitchError`.
+- `RPT_SIGNING_KEY_ALIAS` overrides the alias used when asking the KMS provider to sign an
+  RPT payload. The default alias is `RPT_ED25519_SECRET`, which maps to the environment
+  variable `RPT_ED25519_SECRET_BASE64` when the `env` KMS provider is active.
+
+## Provider Registry
+
+All business logic imports interfaces from `@core/ports` and obtains implementations via
+`providerRegistry.get(<provider>)`. Concrete SDKs are only referenced inside provider
+factories located under `src/core/providers/*`.
+
+Default primary providers:
+
+| Domain      | Provider      |
+| ----------- | ------------- |
+| bank        | `postgres`    |
+| kms         | `env`         |
+| rates       | `static`      |
+| identity    | `dev`         |
+| anomaly     | `deterministic` |
+| statements  | `local`       |
+
+The registry applies kill switches before invocation and wraps each provider in a proxy that
+forwards calls to the configured shadow implementation when present.
+
+## Contract Tests
+
+Run `npm run provider:contracts` (or `pnpm provider:contracts` / `pnpm test`) to execute the Node.js contract test suite. The
+suite runs the same expectations against both the mock and real adapters for each provider
+family, guaranteeing interface compatibility.
+
+## Make/PowerShell helpers
+
+- `make provider-contracts` — executes the provider contract suite.
+- `./Run-ProviderContracts.ps1` — Windows-friendly PowerShell wrapper.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "provider:contracts": "tsx tests/providerContracts.test.ts",
+        "test": "pnpm provider:contracts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/samples/statements/12345678901_2025Q1.json
+++ b/samples/statements/12345678901_2025Q1.json
@@ -1,0 +1,9 @@
+[
+  {
+    "id": "txn-1",
+    "postedAt": "2025-01-01T00:00:00.000Z",
+    "description": "Payment",
+    "amountCents": -12345,
+    "reference": "ABC123"
+  }
+]

--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -1,22 +1,10 @@
-﻿export interface AnomalyVector {
-  variance_ratio: number;
-  dup_rate: number;
-  gap_minutes: number;
-  delta_vs_baseline: number;
-}
+import { AnomalyEvaluation, Thresholds } from "@core/ports";
+import { createDeterministicAnomalyProvider } from "@core/providers/anomaly/deterministicAnomalyProvider";
 
-export interface Thresholds {
-  variance_ratio?: number;
-  dup_rate?: number;
-  gap_minutes?: number;
-  delta_vs_baseline?: number;
-}
+const provider = createDeterministicAnomalyProvider();
 
-export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
-  return (
-    v.variance_ratio > (thr.variance_ratio ?? 0.25) ||
-    v.dup_rate > (thr.dup_rate ?? 0.05) ||
-    v.gap_minutes > (thr.gap_minutes ?? 60) ||
-    Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
-  );
+export type { AnomalyEvaluation, Thresholds } from "@core/ports";
+
+export async function evaluate(vector: Record<string, number>, thresholds: Thresholds = {}): Promise<AnomalyEvaluation> {
+  return provider.evaluate(vector, thresholds);
 }

--- a/src/core/ports/anomaly.ts
+++ b/src/core/ports/anomaly.ts
@@ -1,0 +1,29 @@
+export interface AnomalyVector {
+  variance_ratio: number;
+  dup_rate: number;
+  gap_minutes: number;
+  delta_vs_baseline: number;
+}
+
+export interface Thresholds {
+  variance_ratio?: number;
+  dup_rate?: number;
+  gap_minutes?: number;
+  delta_vs_baseline?: number;
+}
+
+export interface AnomalyEvaluation {
+  anomalous: boolean;
+  triggers: string[];
+}
+
+export interface AnomalyProvider {
+  evaluate(vector: Partial<AnomalyVector>, thresholds?: Thresholds): Promise<AnomalyEvaluation>;
+}
+
+export class AnomalyProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AnomalyProviderError";
+  }
+}

--- a/src/core/ports/bank.ts
+++ b/src/core/ports/bank.ts
@@ -1,0 +1,35 @@
+export type BankRail = "EFT" | "BPAY";
+
+export interface BankDestination {
+  abn: string;
+  rail: BankRail;
+  reference: string;
+  account_name: string;
+  account_number: string;
+  bsb: string;
+}
+
+export interface BankReleaseResult {
+  transfer_uuid: string;
+  bank_receipt_hash: string;
+  status?: "OK" | "DUPLICATE";
+}
+
+export class BankProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BankProviderError";
+  }
+}
+
+export interface BankEgressProvider {
+  resolveDestination(abn: string, rail: BankRail, reference: string): Promise<BankDestination>;
+  releasePayment(
+    abn: string,
+    taxType: string,
+    periodId: string,
+    amountCents: number,
+    rail: BankRail,
+    reference: string
+  ): Promise<BankReleaseResult>;
+}

--- a/src/core/ports/identity.ts
+++ b/src/core/ports/identity.ts
@@ -1,0 +1,17 @@
+export interface IdentityProfile {
+  id: string;
+  name: string;
+  email: string;
+  scopes: string[];
+}
+
+export interface IdentityProvider {
+  verifyToken(token: string): Promise<IdentityProfile>;
+}
+
+export class IdentityProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "IdentityProviderError";
+  }
+}

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -1,0 +1,6 @@
+export * from "./bank";
+export * from "./kms";
+export * from "./rates";
+export * from "./identity";
+export * from "./anomaly";
+export * from "./statements";

--- a/src/core/ports/kms.ts
+++ b/src/core/ports/kms.ts
@@ -1,0 +1,16 @@
+export interface KmsSignature {
+  signature: Uint8Array;
+  algorithm: "ED25519";
+}
+
+export interface KmsProvider {
+  getKeyAlias(alias: string): Promise<{ publicKey?: Uint8Array; privateKey?: Uint8Array }>;
+  signEd25519(alias: string, payload: Uint8Array): Promise<KmsSignature>;
+}
+
+export class KmsProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "KmsProviderError";
+  }
+}

--- a/src/core/ports/rates.ts
+++ b/src/core/ports/rates.ts
@@ -1,0 +1,17 @@
+export interface RateQuote {
+  pair: string;
+  rate: number;
+  asOf: Date;
+}
+
+export interface RatesProvider {
+  getRate(pair: string): Promise<RateQuote>;
+  listRates(): Promise<RateQuote[]>;
+}
+
+export class RatesProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RatesProviderError";
+  }
+}

--- a/src/core/ports/statements.ts
+++ b/src/core/ports/statements.ts
@@ -1,0 +1,18 @@
+export interface StatementLine {
+  id: string;
+  postedAt: Date;
+  description: string;
+  amountCents: number;
+  reference?: string;
+}
+
+export interface StatementsProvider {
+  fetchStatements(abn: string, periodId: string): Promise<StatementLine[]>;
+}
+
+export class StatementsProviderError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "StatementsProviderError";
+  }
+}

--- a/src/core/providerRegistry.ts
+++ b/src/core/providerRegistry.ts
@@ -1,0 +1,241 @@
+import {
+  AnomalyProvider,
+  BankEgressProvider,
+  IdentityProvider,
+  KmsProvider,
+  RatesProvider,
+  StatementsProvider,
+} from "@core/ports";
+import { createMockBankProvider } from "./providers/bank/mockBankProvider";
+import { createPostgresBankProvider } from "./providers/bank/postgresBankProvider";
+import { createMockKmsProvider } from "./providers/kms/mockKmsProvider";
+import { createEnvKmsProvider } from "./providers/kms/envKmsProvider";
+import { createMockRatesProvider } from "./providers/rates/mockRatesProvider";
+import { createStaticRatesProvider } from "./providers/rates/staticRatesProvider";
+import { createMockIdentityProvider } from "./providers/identity/mockIdentityProvider";
+import { createDevIdentityProvider } from "./providers/identity/devIdentityProvider";
+import { createMockAnomalyProvider } from "./providers/anomaly/mockAnomalyProvider";
+import { createDeterministicAnomalyProvider } from "./providers/anomaly/deterministicAnomalyProvider";
+import { createMockStatementsProvider } from "./providers/statements/mockStatementsProvider";
+import { createLocalStatementsProvider } from "./providers/statements/localStatementsProvider";
+
+export type ProviderKey = "bank" | "kms" | "rates" | "identity" | "anomaly" | "statements";
+
+export type ProviderTypes = {
+  bank: BankEgressProvider;
+  kms: KmsProvider;
+  rates: RatesProvider;
+  identity: IdentityProvider;
+  anomaly: AnomalyProvider;
+  statements: StatementsProvider;
+};
+
+export class ProviderKillSwitchError extends Error {
+  constructor(public readonly provider: ProviderKey) {
+    super(`${provider} provider disabled by kill switch`);
+    this.name = "ProviderKillSwitchError";
+  }
+}
+
+type ProviderFactory<T> = () => T;
+
+export type ProviderFactoryRegistry = {
+  [K in ProviderKey]: Record<string, ProviderFactory<ProviderTypes[K]>>;
+};
+
+export interface ProviderConfig {
+  primary: Partial<Record<ProviderKey, string>>;
+  shadow: Partial<Record<ProviderKey, string>>;
+  killed: Set<ProviderKey>;
+}
+
+const DEFAULT_PROVIDER_SELECTION: Record<ProviderKey, string> = {
+  bank: "postgres",
+  kms: "env",
+  rates: "static",
+  identity: "dev",
+  anomaly: "deterministic",
+  statements: "local",
+};
+
+const DEFAULT_FACTORIES: ProviderFactoryRegistry = {
+  bank: {
+    mock: () => createMockBankProvider(),
+    postgres: () => createPostgresBankProvider(),
+  },
+  kms: {
+    mock: () => createMockKmsProvider(),
+    env: () => createEnvKmsProvider(),
+  },
+  rates: {
+    mock: () => createMockRatesProvider(),
+    static: () => createStaticRatesProvider(),
+  },
+  identity: {
+    mock: () => createMockIdentityProvider(),
+    dev: () => createDevIdentityProvider(),
+  },
+  anomaly: {
+    mock: () => createMockAnomalyProvider(),
+    deterministic: () => createDeterministicAnomalyProvider(),
+  },
+  statements: {
+    mock: () => createMockStatementsProvider(),
+    local: () => createLocalStatementsProvider(),
+  },
+};
+
+const KEY_ALIASES: Record<string, ProviderKey> = {
+  bank: "bank",
+  kms: "kms",
+  rates: "rates",
+  idp: "identity",
+  identity: "identity",
+  anomaly: "anomaly",
+  statements: "statements",
+};
+
+function normalizeKey(key: string): ProviderKey | undefined {
+  return KEY_ALIASES[key.trim().toLowerCase()];
+}
+
+function parseProviderMapping(value: string | undefined): Partial<Record<ProviderKey, string>> {
+  const result: Partial<Record<ProviderKey, string>> = {};
+  if (!value) return result;
+  for (const entry of value.split(/[;\n]/)) {
+    if (!entry.trim()) continue;
+    const [rawKey, rawProvider] = entry.split("=");
+    if (!rawKey || !rawProvider) continue;
+    const key = normalizeKey(rawKey);
+    if (!key) continue;
+    result[key] = rawProvider.trim();
+  }
+  return result;
+}
+
+function parseKillSwitches(value: string | undefined): Set<ProviderKey> {
+  const set = new Set<ProviderKey>();
+  if (!value) return set;
+  for (const entry of value.split(/[,;\n]/)) {
+    const key = normalizeKey(entry);
+    if (key) set.add(key);
+  }
+  return set;
+}
+
+function mergeFactories(
+  defaults: ProviderFactoryRegistry,
+  overrides: Partial<ProviderFactoryRegistry> | undefined
+): ProviderFactoryRegistry {
+  if (!overrides) return defaults;
+  const merged = { ...defaults } as ProviderFactoryRegistry;
+  for (const key of Object.keys(overrides) as ProviderKey[]) {
+    merged[key] = { ...defaults[key], ...overrides[key] };
+  }
+  return merged;
+}
+
+export function loadProviderConfig(env: NodeJS.ProcessEnv = process.env): ProviderConfig {
+  const primary = parseProviderMapping(env.PROVIDERS);
+  const shadow = parseProviderMapping(env.PROVIDERS_SHADOW);
+  const killed = parseKillSwitches(env.PROVIDER_KILL_SWITCHES);
+  return { primary, shadow, killed };
+}
+
+export class ProviderRegistry {
+  private readonly factories: ProviderFactoryRegistry;
+  private readonly cache = new Map<ProviderKey, ProviderTypes[ProviderKey]>();
+  private readonly primaries = new Map<ProviderKey, ProviderTypes[ProviderKey]>();
+  private readonly shadows = new Map<ProviderKey, ProviderTypes[ProviderKey]>();
+
+  constructor(private readonly config: ProviderConfig, factoryOverrides?: Partial<ProviderFactoryRegistry>) {
+    this.factories = mergeFactories(DEFAULT_FACTORIES, factoryOverrides);
+  }
+
+  static fromEnv(factoryOverrides?: Partial<ProviderFactoryRegistry>): ProviderRegistry {
+    return new ProviderRegistry(loadProviderConfig(), factoryOverrides);
+  }
+
+  get<K extends ProviderKey>(key: K): ProviderTypes[K] {
+    const killSwitch = this.config.killed;
+    if (killSwitch.has(key)) {
+      throw new ProviderKillSwitchError(key);
+    }
+    if (!this.cache.has(key)) {
+      const provider = this.createFacade(key);
+      this.cache.set(key, provider);
+    }
+    return this.cache.get(key)! as ProviderTypes[K];
+  }
+
+  private instantiate<K extends ProviderKey>(key: K, name: string): ProviderTypes[K] {
+    const factories = this.factories[key];
+    const factory = factories[name];
+    if (!factory) {
+      const available = Object.keys(factories).join(", ");
+      throw new Error(`No provider factory registered for ${key} named ${name}. Available: ${available}`);
+    }
+    return factory();
+  }
+
+  private resolvePrimaryName(key: ProviderKey): string {
+    return this.config.primary[key] ?? DEFAULT_PROVIDER_SELECTION[key];
+  }
+
+  private resolveShadowName(key: ProviderKey): string | undefined {
+    return this.config.shadow[key];
+  }
+
+  private createFacade<K extends ProviderKey>(key: K): ProviderTypes[K] {
+    const primaryName = this.resolvePrimaryName(key);
+    const primary = this.primaries.get(key) ?? this.instantiate(key, primaryName);
+    this.primaries.set(key, primary);
+
+    const shadowName = this.resolveShadowName(key);
+    const shadow = shadowName
+      ? this.shadows.get(key) ?? this.instantiate(key, shadowName as string)
+      : undefined;
+    if (shadowName && shadow) {
+      this.shadows.set(key, shadow);
+    }
+
+    const registry = this;
+    const handler: ProxyHandler<ProviderTypes[K]> = {
+      get(target, prop, receiver) {
+        const value = Reflect.get(target, prop, receiver);
+        if (typeof value !== "function") {
+          return value;
+        }
+        return async function providerMethod(this: unknown, ...args: any[]) {
+          if (registry.config.killed.has(key)) {
+            throw new ProviderKillSwitchError(key);
+          }
+          const resultPromise = Promise.resolve(value.apply(primary, args));
+          const shadowImpl = shadow && (shadow as any)[prop];
+          if (typeof shadowImpl === "function") {
+            resultPromise
+              .then(
+                (result) => {
+                  Promise.resolve(shadowImpl.apply(shadow, args)).catch((err) => {
+                    console.warn(`[shadow:${String(key)}]`, err);
+                  });
+                  return result;
+                },
+                (err) => {
+                  Promise.resolve(shadowImpl.apply(shadow, args)).catch((shadowErr) => {
+                    console.warn(`[shadow:${String(key)}]`, shadowErr);
+                  });
+                  throw err;
+                }
+              );
+          }
+          return resultPromise;
+        };
+      },
+    };
+
+    return new Proxy(primary, handler);
+  }
+}
+
+export const providerRegistry = ProviderRegistry.fromEnv();

--- a/src/core/providers/anomaly/deterministicAnomalyProvider.ts
+++ b/src/core/providers/anomaly/deterministicAnomalyProvider.ts
@@ -1,0 +1,27 @@
+import { AnomalyEvaluation, AnomalyProvider, AnomalyProviderError, Thresholds } from "@core/ports";
+
+function ensureVector(vector: Partial<Record<keyof Thresholds, number>>): Record<string, number> {
+  return {
+    variance_ratio: vector.variance_ratio ?? 0,
+    dup_rate: vector.dup_rate ?? 0,
+    gap_minutes: vector.gap_minutes ?? 0,
+    delta_vs_baseline: vector.delta_vs_baseline ?? 0,
+  };
+}
+
+export function createDeterministicAnomalyProvider(): AnomalyProvider {
+  return {
+    async evaluate(vector, thresholds = {}): Promise<AnomalyEvaluation> {
+      if (!vector) {
+        throw new AnomalyProviderError("VECTOR_REQUIRED");
+      }
+      const v = ensureVector(vector);
+      const triggers: string[] = [];
+      if (v.variance_ratio > (thresholds.variance_ratio ?? 0.25)) triggers.push("variance_ratio");
+      if (v.dup_rate > (thresholds.dup_rate ?? 0.05)) triggers.push("dup_rate");
+      if (v.gap_minutes > (thresholds.gap_minutes ?? 60)) triggers.push("gap_minutes");
+      if (Math.abs(v.delta_vs_baseline) > (thresholds.delta_vs_baseline ?? 0.1)) triggers.push("delta_vs_baseline");
+      return { anomalous: triggers.length > 0, triggers };
+    },
+  };
+}

--- a/src/core/providers/anomaly/mockAnomalyProvider.ts
+++ b/src/core/providers/anomaly/mockAnomalyProvider.ts
@@ -1,0 +1,9 @@
+import { AnomalyEvaluation, AnomalyProvider } from "@core/ports";
+
+export function createMockAnomalyProvider(): AnomalyProvider {
+  return {
+    async evaluate(vector, thresholds) {
+      return { anomalous: false, triggers: [] } satisfies AnomalyEvaluation;
+    },
+  };
+}

--- a/src/core/providers/bank/mockBankProvider.ts
+++ b/src/core/providers/bank/mockBankProvider.ts
@@ -1,0 +1,42 @@
+import { v4 as uuidv4 } from "uuid";
+import { BankDestination, BankEgressProvider, BankProviderError, BankRail, BankReleaseResult } from "@core/ports";
+
+function destinationKey(abn: string, rail: BankRail, reference: string) {
+  return `${abn}:${rail}:${reference}`;
+}
+
+export interface MockBankProviderOptions {
+  destinations?: BankDestination[];
+}
+
+export function createMockBankProvider(options: MockBankProviderOptions = {}): BankEgressProvider {
+  const destinations = new Map<string, BankDestination>();
+  for (const dest of options.destinations || []) {
+    destinations.set(destinationKey(dest.abn, dest.rail, dest.reference), dest);
+  }
+  const idempotencyKeys = new Set<string>();
+
+  return {
+    async resolveDestination(abn, rail, reference) {
+      const dest = destinations.get(destinationKey(abn, rail, reference));
+      if (!dest) {
+        throw new BankProviderError("DEST_NOT_ALLOW_LISTED");
+      }
+      return dest;
+    },
+    async releasePayment(abn, taxType, periodId, amountCents, rail, reference) {
+      if (amountCents <= 0) {
+        throw new BankProviderError("AMOUNT_MUST_BE_POSITIVE");
+      }
+      const key = `${abn}:${taxType}:${periodId}:${amountCents}:${rail}:${reference}`;
+      if (idempotencyKeys.has(key)) {
+        const transfer_uuid = uuidv4();
+        return { transfer_uuid, bank_receipt_hash: `bank:${transfer_uuid.slice(0, 12)}`, status: "DUPLICATE" };
+      }
+      idempotencyKeys.add(key);
+      const transfer_uuid = uuidv4();
+      const bank_receipt_hash = `bank:${transfer_uuid.slice(0, 12)}`;
+      return { transfer_uuid, bank_receipt_hash, status: "OK" } satisfies BankReleaseResult;
+    },
+  } satisfies BankEgressProvider;
+}

--- a/src/core/providers/bank/postgresBankProvider.ts
+++ b/src/core/providers/bank/postgresBankProvider.ts
@@ -1,0 +1,74 @@
+import { Pool } from "pg";
+import { v4 as uuidv4 } from "uuid";
+import { appendAudit } from "../../../audit/appendOnly";
+import { sha256Hex } from "../../../crypto/merkle";
+import { BankDestination, BankEgressProvider, BankProviderError, BankRail, BankReleaseResult } from "@core/ports";
+
+interface PoolLike {
+  query<T = any>(text: string, params?: any[]): Promise<{ rows: T[]; rowCount: number }>;
+}
+
+export interface PostgresBankProviderOptions {
+  pool?: PoolLike;
+  auditLogger?: typeof appendAudit;
+  uuidFactory?: () => string;
+}
+
+function buildKey(abn: string, taxType: string, periodId: string, amountCents: number, rail: BankRail, reference: string) {
+  return `${abn}:${taxType}:${periodId}:${amountCents}:${rail}:${reference}`;
+}
+
+export function createPostgresBankProvider(options: PostgresBankProviderOptions = {}): BankEgressProvider {
+  const pool: PoolLike = options.pool ?? new Pool();
+  const auditLogger = options.auditLogger ?? appendAudit;
+  const makeUuid = options.uuidFactory ?? uuidv4;
+  const idempotency = new Set<string>();
+
+  return {
+    async resolveDestination(abn, rail, reference) {
+      const { rows } = await pool.query<BankDestination>(
+        "select abn, rail, reference, account_name, account_number, bsb from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
+        [abn, rail, reference]
+      );
+      if (!rows.length) {
+        throw new BankProviderError("DEST_NOT_ALLOW_LISTED");
+      }
+      return rows[0];
+    },
+    async releasePayment(abn, taxType, periodId, amountCents, rail, reference) {
+      if (amountCents <= 0) {
+        throw new BankProviderError("AMOUNT_MUST_BE_POSITIVE");
+      }
+      const key = buildKey(abn, taxType, periodId, amountCents, rail, reference);
+      if (idempotency.has(key)) {
+        const transfer_uuid = makeUuid();
+        return { transfer_uuid, bank_receipt_hash: `bank:${transfer_uuid.slice(0, 12)}`, status: "DUPLICATE" } satisfies BankReleaseResult;
+      }
+      idempotency.add(key);
+      const transfer_uuid = makeUuid();
+      try {
+        await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
+      } catch (err) {
+        return { transfer_uuid, bank_receipt_hash: `bank:${transfer_uuid.slice(0, 12)}`, status: "DUPLICATE" };
+      }
+
+      const bank_receipt_hash = `bank:${transfer_uuid.slice(0, 12)}`;
+      const { rows } = await pool.query<{ balance_after_cents: number; hash_after: string }>(
+        "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+        [abn, taxType, periodId]
+      );
+      const prevBal = rows[0]?.balance_after_cents ?? 0;
+      const prevHash = rows[0]?.hash_after ?? "";
+      const newBal = prevBal - amountCents;
+      const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
+
+      await pool.query(
+        "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+        [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
+      );
+      await auditLogger("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
+      await pool.query("update idempotency_keys set last_status=$1 where key=$2", ["DONE", transfer_uuid]);
+      return { transfer_uuid, bank_receipt_hash, status: "OK" } satisfies BankReleaseResult;
+    },
+  };
+}

--- a/src/core/providers/identity/devIdentityProvider.ts
+++ b/src/core/providers/identity/devIdentityProvider.ts
@@ -1,0 +1,18 @@
+import { IdentityProvider, IdentityProfile, IdentityProviderError } from "@core/ports";
+
+const USERS: Record<string, IdentityProfile> = {
+  "token:admin": { id: "admin", name: "Dev Admin", email: "admin@example.com", scopes: ["read", "write", "admin"] },
+  "token:user": { id: "user", name: "Dev User", email: "user@example.com", scopes: ["read"] },
+};
+
+export function createDevIdentityProvider(): IdentityProvider {
+  return {
+    async verifyToken(token: string): Promise<IdentityProfile> {
+      const profile = USERS[token];
+      if (!profile) {
+        throw new IdentityProviderError("UNAUTHENTICATED");
+      }
+      return profile;
+    },
+  };
+}

--- a/src/core/providers/identity/mockIdentityProvider.ts
+++ b/src/core/providers/identity/mockIdentityProvider.ts
@@ -1,0 +1,12 @@
+import { IdentityProvider, IdentityProfile, IdentityProviderError } from "@core/ports";
+
+export function createMockIdentityProvider(): IdentityProvider {
+  return {
+    async verifyToken(token: string): Promise<IdentityProfile> {
+      if (!token) {
+        throw new IdentityProviderError("TOKEN_REQUIRED");
+      }
+      return { id: token, name: "Mock User", email: "mock@example.com", scopes: ["read"] };
+    },
+  };
+}

--- a/src/core/providers/kms/envKmsProvider.ts
+++ b/src/core/providers/kms/envKmsProvider.ts
@@ -1,0 +1,24 @@
+import nacl from "tweetnacl";
+import { KmsProvider, KmsProviderError, KmsSignature } from "@core/ports";
+
+function getSecret(alias: string): Uint8Array {
+  const envVar = `${alias.toUpperCase()}_BASE64`;
+  const value = process.env[envVar];
+  if (!value) {
+    throw new KmsProviderError(`Missing secret for alias ${alias}`);
+  }
+  return new Uint8Array(Buffer.from(value, "base64"));
+}
+
+export function createEnvKmsProvider(): KmsProvider {
+  return {
+    async getKeyAlias(alias: string) {
+      return { privateKey: getSecret(alias) };
+    },
+    async signEd25519(alias: string, payload: Uint8Array): Promise<KmsSignature> {
+      const secret = getSecret(alias);
+      const signature = nacl.sign.detached(payload, secret);
+      return { signature, algorithm: "ED25519" };
+    },
+  };
+}

--- a/src/core/providers/kms/mockKmsProvider.ts
+++ b/src/core/providers/kms/mockKmsProvider.ts
@@ -1,0 +1,26 @@
+import { randomBytes } from "crypto";
+import nacl from "tweetnacl";
+import { KmsProvider, KmsProviderError, KmsSignature } from "@core/ports";
+
+export interface MockKmsProviderOptions {
+  privateKey?: Uint8Array;
+}
+
+export function createMockKmsProvider(options: MockKmsProviderOptions = {}): KmsProvider {
+  const secret = options.privateKey ?? new Uint8Array(randomBytes(64));
+  return {
+    async getKeyAlias(alias: string) {
+      if (!alias) {
+        throw new KmsProviderError("ALIAS_REQUIRED");
+      }
+      return { privateKey: secret };
+    },
+    async signEd25519(alias: string, payload: Uint8Array): Promise<KmsSignature> {
+      if (!alias) {
+        throw new KmsProviderError("ALIAS_REQUIRED");
+      }
+      const signature = nacl.sign.detached(payload, secret);
+      return { signature, algorithm: "ED25519" };
+    },
+  };
+}

--- a/src/core/providers/rates/mockRatesProvider.ts
+++ b/src/core/providers/rates/mockRatesProvider.ts
@@ -1,0 +1,12 @@
+import { RatesProvider, RateQuote } from "@core/ports";
+
+export function createMockRatesProvider(): RatesProvider {
+  return {
+    async getRate(pair: string): Promise<RateQuote> {
+      return { pair, rate: 1, asOf: new Date(0) };
+    },
+    async listRates(): Promise<RateQuote[]> {
+      return [{ pair: "AUD/USD", rate: 0.65, asOf: new Date(0) }];
+    },
+  };
+}

--- a/src/core/providers/rates/staticRatesProvider.ts
+++ b/src/core/providers/rates/staticRatesProvider.ts
@@ -1,0 +1,22 @@
+import { RatesProvider, RateQuote, RatesProviderError } from "@core/ports";
+
+const STATIC_RATES: Record<string, number> = {
+  "AUD/USD": 0.655,
+  "AUD/EUR": 0.605,
+  "AUD/GBP": 0.515,
+};
+
+export function createStaticRatesProvider(): RatesProvider {
+  return {
+    async getRate(pair: string): Promise<RateQuote> {
+      const rate = STATIC_RATES[pair];
+      if (!rate) {
+        throw new RatesProviderError(`Unknown rate pair ${pair}`);
+      }
+      return { pair, rate, asOf: new Date() };
+    },
+    async listRates(): Promise<RateQuote[]> {
+      return Object.entries(STATIC_RATES).map(([pair, rate]) => ({ pair, rate, asOf: new Date() }));
+    },
+  };
+}

--- a/src/core/providers/statements/localStatementsProvider.ts
+++ b/src/core/providers/statements/localStatementsProvider.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+import { StatementLine, StatementsProvider, StatementsProviderError } from "@core/ports";
+
+export interface LocalStatementsProviderOptions {
+  directory?: string;
+}
+
+export function createLocalStatementsProvider(options: LocalStatementsProviderOptions = {}): StatementsProvider {
+  const baseDir = options.directory ?? path.resolve(process.cwd(), "samples/statements");
+
+  return {
+    async fetchStatements(abn: string, periodId: string) {
+      const fileName = `${abn}_${periodId}.json`;
+      const filePath = path.join(baseDir, fileName);
+      if (!fs.existsSync(filePath)) {
+        throw new StatementsProviderError("STATEMENTS_NOT_FOUND");
+      }
+      const raw = await fs.promises.readFile(filePath, "utf-8");
+      const data = JSON.parse(raw) as Array<Omit<StatementLine, "postedAt"> & { postedAt: string }>;
+      return data.map((line) => ({ ...line, postedAt: new Date(line.postedAt) }));
+    },
+  };
+}

--- a/src/core/providers/statements/mockStatementsProvider.ts
+++ b/src/core/providers/statements/mockStatementsProvider.ts
@@ -1,0 +1,13 @@
+import { StatementsProvider, StatementLine } from "@core/ports";
+
+const SAMPLE: StatementLine[] = [
+  { id: "1", postedAt: new Date(0), description: "Opening Balance", amountCents: 0 },
+];
+
+export function createMockStatementsProvider(): StatementsProvider {
+  return {
+    async fetchStatements(abn: string, periodId: string) {
+      return SAMPLE;
+    },
+  };
+}

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,42 +1,19 @@
-﻿import { Pool } from "pg";
-import { v4 as uuidv4 } from "uuid";
-import { appendAudit } from "../audit/appendOnly";
-import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { providerRegistry } from "@core/providerRegistry";
+import { BankRail } from "@core/ports";
 
-/** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
-  const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
-    [abn, rail, reference]
-  );
-  if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
-  return rows[0];
+export async function resolveDestination(abn: string, rail: BankRail, reference: string) {
+  const provider = providerRegistry.get("bank");
+  return provider.resolveDestination(abn, rail, reference);
 }
 
-/** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
-  const transfer_uuid = uuidv4();
-  try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
-  } catch {
-    return { transfer_uuid, status: "DUPLICATE" };
-  }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
-
-  const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
-  const prevHash = rows[0]?.hash_after ?? "";
-  const newBal = prevBal - amountCents;
-  const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
-
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
-  );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: BankRail,
+  reference: string
+) {
+  const provider = providerRegistry.get("bank");
+  return provider.releasePayment(abn, taxType, periodId, amountCents, rail, reference);
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,65 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
-import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+import { providerRegistry, ProviderKillSwitchError } from "@core/providerRegistry";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr = thresholds || {
+    epsilon_cents: 50,
+    variance_ratio: 0.25,
+    dup_rate: 0.01,
+    gap_minutes: 60,
+    delta_vs_baseline: 0.2,
+  };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: any, res: any) {
+  const { abn, taxType, periodId, rail } = req.body;
+  const pr = await pool.query("select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1", [
+    abn,
+    taxType,
+    periodId,
+  ]);
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
-    await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    const bank = providerRegistry.get("bank");
+    await bank.resolveDestination(abn, rail, payload.reference);
+    const r = await bank.releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
+    await pool.query("update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
+    if (e instanceof ProviderKillSwitchError) {
+      return res.status(503).json({ error: e.message });
+    }
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,60 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
-import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+import { RptPayload } from "../crypto/ed25519";
+import { providerRegistry } from "@core/providerRegistry";
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+const pool = new Pool();
+const DEFAULT_SIGNING_ALIAS = process.env.RPT_SIGNING_KEY_ALIAS || "RPT_ED25519_SECRET";
+
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>
+) {
+  const p = await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
+  const anomalyProvider = providerRegistry.get("anomaly");
+  const kmsProvider = providerRegistry.get("kms");
+
   const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+  const decision = await anomalyProvider.evaluate(v, thresholds);
+  if (decision.anomalous) {
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+
+  const message = new TextEncoder().encode(JSON.stringify(payload));
+  const { signature } = await kmsProvider.signEd25519(DEFAULT_SIGNING_ALIAS, message);
+  const signatureB64 = Buffer.from(signature).toString("base64url");
+
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signatureB64]
+  );
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
+  return { payload, signature: signatureB64 };
 }

--- a/tests/providerContracts.test.ts
+++ b/tests/providerContracts.test.ts
@@ -1,0 +1,350 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ProviderRegistry,
+  ProviderConfig,
+  ProviderFactoryRegistry,
+  ProviderKillSwitchError,
+  ProviderKey,
+} from "@core/providerRegistry";
+import { BankDestination } from "@core/ports";
+import { createMockBankProvider } from "@core/providers/bank/mockBankProvider";
+import { createPostgresBankProvider } from "@core/providers/bank/postgresBankProvider";
+import { createMockKmsProvider } from "@core/providers/kms/mockKmsProvider";
+import { createEnvKmsProvider } from "@core/providers/kms/envKmsProvider";
+import { createMockRatesProvider } from "@core/providers/rates/mockRatesProvider";
+import { createStaticRatesProvider } from "@core/providers/rates/staticRatesProvider";
+import { createMockIdentityProvider } from "@core/providers/identity/mockIdentityProvider";
+import { createDevIdentityProvider } from "@core/providers/identity/devIdentityProvider";
+import { createMockAnomalyProvider } from "@core/providers/anomaly/mockAnomalyProvider";
+import { createDeterministicAnomalyProvider } from "@core/providers/anomaly/deterministicAnomalyProvider";
+import { createMockStatementsProvider } from "@core/providers/statements/mockStatementsProvider";
+import { createLocalStatementsProvider } from "@core/providers/statements/localStatementsProvider";
+
+class FakePool {
+  private destinations = new Map<string, BankDestination>();
+  private idempotency = new Map<string, string>();
+  private ledger: Array<{ balance_after_cents: number; hash_after: string }> = [];
+
+  constructor(destinations: BankDestination[]) {
+    for (const dest of destinations) {
+      this.destinations.set(`${dest.abn}:${dest.rail}:${dest.reference}`, dest);
+    }
+  }
+
+  async query<T = any>(text: string, params: any[] = []): Promise<{ rows: T[]; rowCount: number }> {
+    if (text.includes("from remittance_destinations")) {
+      const [abn, rail, reference] = params;
+      const dest = this.destinations.get(`${abn}:${rail}:${reference}`);
+      if (!dest) return { rows: [], rowCount: 0 };
+      return { rows: [dest] as T[], rowCount: 1 };
+    }
+    if (text.startsWith("insert into idempotency_keys")) {
+      const [key, status] = params;
+      if (this.idempotency.has(key)) {
+        throw new Error("duplicate key value violates unique constraint");
+      }
+      this.idempotency.set(key, status);
+      return { rows: [] as T[], rowCount: 1 };
+    }
+    if (text.includes("from owa_ledger")) {
+      const last = this.ledger[this.ledger.length - 1];
+      if (!last) return { rows: [] as T[], rowCount: 0 };
+      return { rows: [last as T], rowCount: 1 };
+    }
+    if (text.startsWith("insert into owa_ledger")) {
+      const row = { balance_after_cents: params[5], hash_after: params[8] };
+      this.ledger.push(row);
+      return { rows: [] as T[], rowCount: 1 };
+    }
+    if (text.startsWith("update idempotency_keys")) {
+      const [status, key] = params;
+      this.idempotency.set(key, status);
+      return { rows: [] as T[], rowCount: 1 };
+    }
+    throw new Error(`Unsupported query in FakePool: ${text}`);
+  }
+}
+
+const DESTINATION: BankDestination = {
+  abn: "12345678901",
+  rail: "EFT",
+  reference: "PRN123",
+  account_name: "ATO PAYMENTS",
+  account_number: "12345678",
+  bsb: "123-456",
+};
+
+function buildRegistry(
+  primary: Partial<Record<ProviderKey, string>>,
+  overrides?: Partial<ProviderFactoryRegistry>,
+  shadow: Partial<Record<ProviderKey, string>> = {},
+  killed: ProviderKey[] = []
+) {
+  const config: ProviderConfig = { primary, shadow, killed: new Set(killed) };
+  return new ProviderRegistry(config, overrides);
+}
+
+describe("Bank provider contract", () => {
+  const fakePool = new FakePool([DESTINATION]);
+  const overrides: Partial<ProviderFactoryRegistry> = {
+    bank: {
+      mock: () => createMockBankProvider({ destinations: [DESTINATION] }),
+      postgres: () =>
+        createPostgresBankProvider({ pool: fakePool, auditLogger: async () => undefined, uuidFactory: () => "uuid-test" }),
+    },
+    kms: { mock: () => createMockKmsProvider() },
+    rates: { mock: () => createMockRatesProvider() },
+    identity: { mock: () => createMockIdentityProvider() },
+    anomaly: { mock: () => createMockAnomalyProvider() },
+    statements: { mock: () => createMockStatementsProvider() },
+  };
+
+  for (const name of ["mock", "postgres"] as const) {
+    it(`releases payments using ${name}`, async () => {
+      const registry = buildRegistry(
+        { bank: name, kms: "mock", rates: "mock", identity: "mock", anomaly: "mock", statements: "mock" },
+        overrides
+      );
+      const bank = registry.get("bank");
+      const dest = await bank.resolveDestination(DESTINATION.abn, DESTINATION.rail, DESTINATION.reference);
+      assert.equal(dest.account_number, DESTINATION.account_number);
+
+      const release = await bank.releasePayment(DESTINATION.abn, "GST", "2025Q1", 1000, DESTINATION.rail, DESTINATION.reference);
+      assert.equal(release.status, "OK");
+      assert.ok(release.transfer_uuid);
+      assert.ok(release.bank_receipt_hash.startsWith("bank:"));
+
+      await assert.rejects(() => bank.releasePayment(DESTINATION.abn, "GST", "2025Q1", -1, DESTINATION.rail, DESTINATION.reference));
+    });
+  }
+});
+
+describe("KMS provider contract", () => {
+  const payload = new TextEncoder().encode("hello");
+  const secret = Buffer.alloc(64, 7);
+  process.env.RPT_ED25519_SECRET_BASE64 = secret.toString("base64");
+
+  const overrides: Partial<ProviderFactoryRegistry> = {
+    kms: {
+      mock: () => createMockKmsProvider({ privateKey: secret }),
+      env: () => createEnvKmsProvider(),
+    },
+  };
+
+  for (const name of ["mock", "env"] as const) {
+    it(`signs payloads with ${name}`, async () => {
+      const registry = buildRegistry(
+        {
+          bank: "mock",
+          kms: name,
+          rates: "mock",
+          identity: "mock",
+          anomaly: "mock",
+          statements: "mock",
+        },
+        {
+          ...overrides,
+          bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+          rates: { mock: () => createMockRatesProvider() },
+          identity: { mock: () => createMockIdentityProvider() },
+          anomaly: { mock: () => createMockAnomalyProvider() },
+          statements: { mock: () => createMockStatementsProvider() },
+        }
+      );
+      const kms = registry.get("kms");
+      const { signature } = await kms.signEd25519("RPT_ED25519_SECRET", payload);
+      assert.ok(signature.byteLength > 0);
+    });
+  }
+});
+
+describe("Rates provider contract", () => {
+  const overrides: Partial<ProviderFactoryRegistry> = {
+    rates: {
+      mock: () => createMockRatesProvider(),
+      static: () => createStaticRatesProvider(),
+    },
+  };
+  for (const name of ["mock", "static"] as const) {
+    it(`returns rates for ${name}`, async () => {
+      const registry = buildRegistry(
+        { bank: "mock", kms: "mock", rates: name, identity: "mock", anomaly: "mock", statements: "mock" },
+        {
+          ...overrides,
+          bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+          kms: { mock: () => createMockKmsProvider() },
+          identity: { mock: () => createMockIdentityProvider() },
+          anomaly: { mock: () => createMockAnomalyProvider() },
+          statements: { mock: () => createMockStatementsProvider() },
+        }
+      );
+      const rates = registry.get("rates");
+      const quote = await rates.getRate("AUD/USD");
+      assert.equal(quote.pair, "AUD/USD");
+      assert.ok(quote.rate > 0);
+    });
+  }
+});
+
+describe("Identity provider contract", () => {
+  const overrides: Partial<ProviderFactoryRegistry> = {
+    identity: {
+      mock: () => createMockIdentityProvider(),
+      dev: () => createDevIdentityProvider(),
+    },
+  };
+  it("authenticates tokens across providers", async () => {
+    const registry = buildRegistry(
+      { bank: "mock", kms: "mock", rates: "mock", identity: "mock", anomaly: "mock", statements: "mock" },
+      {
+        ...overrides,
+        bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+        kms: { mock: () => createMockKmsProvider() },
+        rates: { mock: () => createMockRatesProvider() },
+        anomaly: { mock: () => createMockAnomalyProvider() },
+        statements: { mock: () => createMockStatementsProvider() },
+      }
+    );
+    const mockProvider = registry.get("identity");
+    const profile = await mockProvider.verifyToken("token:admin");
+    assert.equal(profile.id, "token:admin");
+
+    const devRegistry = buildRegistry(
+      { bank: "mock", kms: "mock", rates: "mock", identity: "dev", anomaly: "mock", statements: "mock" },
+      {
+        ...overrides,
+        bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+        kms: { mock: () => createMockKmsProvider() },
+        rates: { mock: () => createMockRatesProvider() },
+        anomaly: { mock: () => createMockAnomalyProvider() },
+        statements: { mock: () => createMockStatementsProvider() },
+      }
+    );
+    const devProvider = devRegistry.get("identity");
+    const admin = await devProvider.verifyToken("token:admin");
+    assert.equal(admin.id, "admin");
+    await assert.rejects(() => devProvider.verifyToken("token:unknown"));
+  });
+});
+
+describe("Anomaly provider contract", () => {
+  const overrides: Partial<ProviderFactoryRegistry> = {
+    anomaly: {
+      mock: () => createMockAnomalyProvider(),
+      deterministic: () => createDeterministicAnomalyProvider(),
+    },
+  };
+
+  it("evaluates anomaly vectors", async () => {
+    const registry = buildRegistry(
+      { bank: "mock", kms: "mock", rates: "mock", identity: "mock", anomaly: "mock", statements: "mock" },
+      {
+        ...overrides,
+        bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+        kms: { mock: () => createMockKmsProvider() },
+        rates: { mock: () => createMockRatesProvider() },
+        identity: { mock: () => createMockIdentityProvider() },
+        statements: { mock: () => createMockStatementsProvider() },
+      }
+    );
+    const mockProvider = registry.get("anomaly");
+    const result = await mockProvider.evaluate({ variance_ratio: 0.1 });
+    assert.equal(result.anomalous, false);
+
+    const deterministicRegistry = buildRegistry(
+      { bank: "mock", kms: "mock", rates: "mock", identity: "mock", anomaly: "deterministic", statements: "mock" },
+      {
+        ...overrides,
+        bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+        kms: { mock: () => createMockKmsProvider() },
+        rates: { mock: () => createMockRatesProvider() },
+        identity: { mock: () => createMockIdentityProvider() },
+        statements: { mock: () => createMockStatementsProvider() },
+      }
+    );
+    const deterministic = deterministicRegistry.get("anomaly");
+    const flagged = await deterministic.evaluate({ variance_ratio: 0.5 });
+    assert.equal(flagged.anomalous, true);
+    assert.ok(flagged.triggers.includes("variance_ratio"));
+  });
+});
+
+describe("Statements provider contract", () => {
+  const overrides: Partial<ProviderFactoryRegistry> = {
+    statements: {
+      mock: () => createMockStatementsProvider(),
+      local: () => createLocalStatementsProvider({ directory: "samples/statements" }),
+    },
+  };
+
+  for (const name of ["mock", "local"] as const) {
+    it(`fetches statements from ${name}`, async () => {
+      const registry = buildRegistry(
+        { bank: "mock", kms: "mock", rates: "mock", identity: "mock", anomaly: "mock", statements: name },
+        {
+          ...overrides,
+          bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+          kms: { mock: () => createMockKmsProvider() },
+          rates: { mock: () => createMockRatesProvider() },
+          identity: { mock: () => createMockIdentityProvider() },
+          anomaly: { mock: () => createMockAnomalyProvider() },
+        }
+      );
+      const statements = registry.get("statements");
+      const lines = await statements.fetchStatements("12345678901", "2025Q1");
+      assert.ok(Array.isArray(lines));
+    });
+  }
+});
+
+describe("Kill switch and shadow behaviour", () => {
+  it("blocks killed providers", () => {
+    const registry = buildRegistry(
+      { bank: "mock", kms: "mock", rates: "mock", identity: "mock", anomaly: "mock", statements: "mock" },
+      {
+        bank: { mock: () => createMockBankProvider({ destinations: [DESTINATION] }) },
+        kms: { mock: () => createMockKmsProvider() },
+        rates: { mock: () => createMockRatesProvider() },
+        identity: { mock: () => createMockIdentityProvider() },
+        anomaly: { mock: () => createMockAnomalyProvider() },
+        statements: { mock: () => createMockStatementsProvider() },
+      },
+      {},
+      ["bank"]
+    );
+    assert.throws(() => registry.get("bank"), ProviderKillSwitchError);
+  });
+
+  it("invokes shadow providers", async () => {
+    let shadowCalls = 0;
+    const registry = buildRegistry(
+      { bank: "mock", kms: "mock", rates: "mock", identity: "mock", anomaly: "mock", statements: "mock" },
+      {
+        bank: {
+          mock: () => createMockBankProvider({ destinations: [DESTINATION] }),
+          shadow: () => ({
+            async resolveDestination() {
+              shadowCalls += 1;
+              return DESTINATION;
+            },
+            async releasePayment() {
+              shadowCalls += 1;
+              return { transfer_uuid: "shadow", bank_receipt_hash: "shadow", status: "OK" };
+            },
+          }),
+        },
+        kms: { mock: () => createMockKmsProvider() },
+        rates: { mock: () => createMockRatesProvider() },
+        identity: { mock: () => createMockIdentityProvider() },
+        anomaly: { mock: () => createMockAnomalyProvider() },
+        statements: { mock: () => createMockStatementsProvider() },
+      },
+      { bank: "shadow" }
+    );
+    const bank = registry.get("bank");
+    await bank.resolveDestination(DESTINATION.abn, DESTINATION.rail, DESTINATION.reference);
+    await bank.releasePayment(DESTINATION.abn, "GST", "2025Q1", 1000, DESTINATION.rail, DESTINATION.reference);
+    assert.ok(shadowCalls >= 2);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": "src",
+    "paths": {
+      "@core/*": ["core/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add a provider registry with domain interfaces and runtime selection, including kill switches and shadow mode support
- refactor reconciliation and RPT issuance flows to consume provider ports via the registry and expose configuration docs
- add provider contract tests, sample data, and scripts for running the suite

## Testing
- npm run provider:contracts

------
https://chatgpt.com/codex/tasks/task_e_68e24c8c7ee083279f4218be53ff7a04