### PR TITLE
Add fixture recording middleware and replay CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 dist/
 .next/
 coverage/
+/fixtures/
 
 # OS noise
 Thumbs.db

--- a/README.md
+++ b/README.md
@@ -89,3 +89,12 @@ For demonstration and prototyping only—real-world deployments require further 
 Contributing
 Pull requests are welcome!
 For major changes, please open an issue first to discuss what you’d like to change.
+
+Record & Replay Fixtures
+To capture HTTP interactions for parity testing, services emit JSONL fixtures under `fixtures/<port>/<YYYYMMDD>/`. Use the `tools/replay` CLI to compare a recorded provider with its opposite implementation:
+
+```
+tools/replay --port bank --fixture 20251005
+```
+
+Provide environment variables `REPLAY_BASE_<PORT>_PRIMARY` and `REPLAY_BASE_<PORT>_SECONDARY` so the CLI knows where to send replay traffic. Semantic comparison paths can be customised per port with `fixtures/<port>/semantic-fields.json` (JSON array of dot paths).

--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -1,8 +1,10 @@
 ﻿# apps/services/audit/main.py
 from fastapi import FastAPI
+from libs.fixtures import attach_fixture_recorder
 import os, psycopg2, json
 
 app = FastAPI(title="audit")
+attach_fixture_recorder(app)
 
 def db():
     return psycopg2.connect(

--- a/apps/services/bank-egress/main.py
+++ b/apps/services/bank-egress/main.py
@@ -1,10 +1,12 @@
 ﻿# apps/services/bank-egress/main.py
 from fastapi import FastAPI, HTTPException
+from libs.fixtures import attach_fixture_recorder
 from pydantic import BaseModel
 import os, psycopg2, json
 from libs.rpt.rpt import verify
 
 app = FastAPI(title="bank-egress")
+attach_fixture_recorder(app, port_label="bank")
 
 class EgressReq(BaseModel):
     period_id: str

--- a/apps/services/bas-gate/main.py
+++ b/apps/services/bas-gate/main.py
@@ -1,9 +1,11 @@
 ﻿# apps/services/bas-gate/main.py
 from fastapi import FastAPI, HTTPException
+from libs.fixtures import attach_fixture_recorder
 from pydantic import BaseModel
 import os, psycopg2, json, time
 
 app = FastAPI(title="bas-gate")
+attach_fixture_recorder(app)
 
 class TransitionReq(BaseModel):
     period_id: str

--- a/apps/services/event-normalizer/app/main.py
+++ b/apps/services/event-normalizer/app/main.py
@@ -1,10 +1,12 @@
-﻿from fastapi import FastAPI, Response
+from fastapi import FastAPI, Response
 from fastapi.responses import PlainTextResponse
 from typing import Optional
 from prometheus_client import REGISTRY, Gauge, generate_latest, CONTENT_TYPE_LATEST
+from libs.fixtures import attach_fixture_recorder
 
 APP_NAME = "event-normalizer"
 app = FastAPI(title=APP_NAME)
+attach_fixture_recorder(app, port_label="event-normalizer")
 
 def _get_or_make_results_gauge() -> Gauge:
     name = "normalizer_tax_results_total"

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -5,6 +5,7 @@ import './loadEnv.js'; // ensures .env.local is loaded when running with tsx
 import express from 'express';
 import pg from 'pg'; const { Pool } = pg;
 
+import { createFixtureRecorder } from './middleware/fixtureRecorder.js';
 import { rptGate } from './middleware/rptGate.js';
 import { payAtoRelease } from './routes/payAto.js';
 import { deposit } from './routes/deposit';
@@ -25,6 +26,7 @@ export const pool = new Pool({ connectionString });
 
 const app = express();
 app.use(express.json());
+app.use(createFixtureRecorder({ portLabel: 'payments' }));
 
 // Health check
 app.get('/health', (_req, res) => res.json({ ok: true }));

--- a/apps/services/payments/src/middleware/fixtureRecorder.ts
+++ b/apps/services/payments/src/middleware/fixtureRecorder.ts
@@ -1,0 +1,220 @@
+// apps/services/payments/src/middleware/fixtureRecorder.ts
+import type { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+import { promises as fs, existsSync } from 'fs';
+import path from 'path';
+
+interface RecorderOptions {
+  portLabel?: string;
+  provider?: string;
+}
+
+interface FixtureEntry {
+  id: string;
+  ts: string;
+  duration_ms: number;
+  port: string;
+  provider: string;
+  request: {
+    method: string;
+    path: string;
+    query?: Record<string, unknown>;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+  response: {
+    status: number;
+    headers: Record<string, string>;
+    body: unknown;
+  };
+}
+
+const repoRoot = findRepoRoot();
+const fixturesRoot = path.resolve(process.env.FIXTURES_ROOT ?? path.join(repoRoot, 'fixtures'));
+const sessionId = process.env.FIXTURE_SESSION ?? `${formatTimeStamp(new Date())}-${process.pid}-${randomUUID().slice(0, 8)}`;
+
+export function createFixtureRecorder(options: RecorderOptions = {}) {
+  const portLabel = slugify(options.portLabel ?? process.env.PORT_LABEL ?? process.env.PORT_NAME ?? 'payments');
+  const provider = (options.provider ?? process.env.FIXTURE_PROVIDER ?? process.env.PORT_PROVIDER ?? 'primary').toLowerCase();
+
+  return function fixtureRecorder(req: Request, res: Response, next: NextFunction) {
+    const start = Date.now();
+    const requestBody = cloneBody((req as any).body);
+    const requestHeaders = sanitizeHeaders(req.headers ?? {});
+    const responseHeaders: Record<string, string> = {};
+    let responseBody: unknown;
+    const responseChunks: Buffer[] = [];
+
+    const originalJson = res.json.bind(res);
+    res.json = ((body?: unknown) => {
+      responseBody = body;
+      return originalJson(body as any);
+    }) as typeof res.json;
+
+    const originalSend = res.send.bind(res);
+    res.send = ((body?: unknown) => {
+      responseBody = body;
+      return originalSend(body as any);
+    }) as typeof res.send;
+
+    const originalWrite = res.write.bind(res);
+    res.write = function (chunk: any, encoding?: BufferEncoding | Function, cb?: Function): boolean {
+      captureChunk(responseChunks, chunk, encoding);
+      return originalWrite(chunk, encoding as any, cb as any);
+    } as typeof res.write;
+
+    const originalEnd = res.end.bind(res);
+    res.end = function (chunk?: any, encoding?: BufferEncoding | Function, cb?: Function): Response {
+      captureChunk(responseChunks, chunk, encoding);
+      return originalEnd(chunk, encoding as any, cb as any) as any;
+    } as typeof res.end;
+
+    res.on('finish', () => {
+      try {
+        const elapsed = Date.now() - start;
+        const combinedBody = responseBody !== undefined ? responseBody : mergeChunks(responseChunks);
+        const headersObject = sanitizeHeaders(res.getHeaders());
+        Object.assign(responseHeaders, headersObject);
+
+        const entry: FixtureEntry = {
+          id: randomUUID(),
+          ts: new Date().toISOString(),
+          duration_ms: elapsed,
+          port: portLabel,
+          provider,
+          request: {
+            method: req.method,
+            path: req.originalUrl || req.url,
+            query: Object.keys(req.query || {}).length ? req.query : undefined,
+            headers: requestHeaders,
+            body: requestBody,
+          },
+          response: {
+            status: res.statusCode,
+            headers: responseHeaders,
+            body: decodeBody(combinedBody, headersObject['content-type']),
+          },
+        };
+
+        writeEntry(portLabel, entry).catch((err) => {
+          console.error('[fixture-recorder] write failed', err);
+        });
+      } catch (err) {
+        console.error('[fixture-recorder] unexpected error', err);
+      }
+    });
+
+    next();
+  };
+}
+
+function sanitizeHeaders(headers: Record<string, any>): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (value === undefined || value === null) continue;
+    const lower = key.toLowerCase();
+    if (lower === 'authorization' || lower === 'proxy-authorization') {
+      result[key] = '***';
+      continue;
+    }
+    if (Array.isArray(value)) {
+      result[key] = value.join(',');
+    } else {
+      result[key] = String(value);
+    }
+  }
+  delete result['content-length'];
+  delete result['Content-Length'];
+  delete result['host'];
+  delete result['Host'];
+  return result;
+}
+
+function captureChunk(chunks: Buffer[], chunk?: any, encoding?: BufferEncoding | Function) {
+  if (!chunk) return;
+  let buf: Buffer;
+  if (Buffer.isBuffer(chunk)) {
+    buf = chunk;
+  } else if (typeof chunk === 'string') {
+    const enc = typeof encoding === 'string' ? encoding : 'utf8';
+    buf = Buffer.from(chunk, enc);
+  } else {
+    return;
+  }
+  chunks.push(buf);
+}
+
+function mergeChunks(chunks: Buffer[]): string | undefined {
+  if (!chunks.length) return undefined;
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+function decodeBody(body: unknown, contentType?: string | string[]): unknown {
+  if (body === undefined || body === null) return null;
+  const type = Array.isArray(contentType) ? contentType.join(',') : contentType;
+  if (typeof body === 'object' && !Buffer.isBuffer(body) && !Array.isArray(body)) {
+    return body;
+  }
+  const text = Buffer.isBuffer(body) ? body.toString('utf8') : String(body);
+  if (type && type.includes('application/json')) {
+    try {
+      return JSON.parse(text);
+    } catch (err) {
+      return text;
+    }
+  }
+  if (text.length === 0) return null;
+  return text;
+}
+
+function cloneBody(body: unknown): unknown {
+  if (body === undefined || body === null) return null;
+  if (Buffer.isBuffer(body)) return body.toString('base64');
+  if (typeof body === 'object') {
+    try {
+      return JSON.parse(JSON.stringify(body));
+    } catch (err) {
+      return String(body);
+    }
+  }
+  return body;
+}
+
+async function writeEntry(portLabel: string, entry: FixtureEntry) {
+  const dateDir = formatDate(new Date());
+  const dir = path.join(fixturesRoot, portLabel, dateDir);
+  if (!existsSync(dir)) {
+    await fs.mkdir(dir, { recursive: true });
+  }
+  const file = path.join(dir, `${sessionId}.jsonl`);
+  await fs.appendFile(file, JSON.stringify(entry) + '\n');
+}
+
+function findRepoRoot(): string {
+  let current = process.cwd();
+  while (true) {
+    if (existsSync(path.join(current, '.git'))) return current;
+    const parent = path.dirname(current);
+    if (!parent || parent === current) return process.cwd();
+    current = parent;
+  }
+}
+
+function slugify(input: string): string {
+  const slug = input.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  return slug || 'port';
+}
+
+function formatDate(d: Date): string {
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(d.getUTCDate()).padStart(2, '0');
+  return `${y}${m}${day}`;
+}
+
+function formatTimeStamp(d: Date): string {
+  const h = String(d.getUTCHours()).padStart(2, '0');
+  const m = String(d.getUTCMinutes()).padStart(2, '0');
+  const s = String(d.getUTCSeconds()).padStart(2, '0');
+  return `${formatDate(d)}-${h}${m}${s}`;
+}

--- a/apps/services/recon/main.py
+++ b/apps/services/recon/main.py
@@ -1,9 +1,11 @@
 ﻿# apps/services/recon/main.py
 from fastapi import FastAPI
+from libs.fixtures import attach_fixture_recorder
 from pydantic import BaseModel
 import os, psycopg2, json, math
 
 app = FastAPI(title="recon")
+attach_fixture_recorder(app)
 
 class ReconReq(BaseModel):
     period_id: str

--- a/apps/services/rpt-verify/main.py
+++ b/apps/services/rpt-verify/main.py
@@ -1,8 +1,10 @@
 from fastapi import FastAPI, HTTPException
+from libs.fixtures import attach_fixture_recorder
 from pydantic import BaseModel
 import nacl.signing, nacl.encoding, hashlib
 
 app = FastAPI()
+attach_fixture_recorder(app, port_label="rpt-verify")
 
 class VerifyIn(BaseModel):
     kid: str

--- a/apps/services/tax-engine/app/main.py
+++ b/apps/services/tax-engine/app/main.py
@@ -1,6 +1,7 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 from fastapi import FastAPI, Response
 from prometheus_client import Counter, generate_latest, CONTENT_TYPE_LATEST
+from libs.fixtures import attach_fixture_recorder
 
 app = FastAPI(title="APGMS Tax Engine")
 
@@ -37,6 +38,8 @@ try:
     app  # reuse if exists
 except NameError:
     app = FastAPI(title="tax-engine")
+
+attach_fixture_recorder(app, port_label="tax-engine")
 
 NATS_URL = os.getenv("NATS_URL", "nats://nats:4222")
 SUBJECT_INPUT = os.getenv("SUBJECT_INPUT", "apgms.normalized.v1")

--- a/libs/fixtures/__init__.py
+++ b/libs/fixtures/__init__.py
@@ -1,0 +1,4 @@
+"""Fixture recording utilities."""
+from .recorder import attach_fixture_recorder
+
+__all__ = ["attach_fixture_recorder"]

--- a/libs/fixtures/recorder.py
+++ b/libs/fixtures/recorder.py
@@ -1,0 +1,188 @@
+"""Fixture recording middleware helpers for FastAPI services."""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Iterable, Mapping, MutableMapping
+
+from fastapi import FastAPI, Request
+from starlette.responses import Response
+
+
+@dataclass
+class RecorderConfig:
+    port_label: str
+    provider: str
+    fixtures_root: Path
+    session_id: str
+
+
+def attach_fixture_recorder(app: FastAPI, *, port_label: str | None = None, provider: str | None = None) -> None:
+    """Attach recording middleware to a FastAPI app."""
+    cfg = _build_config(app, port_label=port_label, provider=provider)
+    recorder = _FixtureRecorder(cfg)
+
+    @app.middleware("http")
+    async def _middleware(  # type: ignore[misc]
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        return await recorder(request, call_next)
+
+
+class _FixtureRecorder:
+    def __init__(self, config: RecorderConfig) -> None:
+        self._cfg = config
+
+    async def __call__(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        start = datetime.now(timezone.utc)
+        body_bytes = await request.body()
+        request._body = body_bytes  # cache for downstream handlers
+
+        response = await call_next(request)
+
+        payload = b""
+        async for chunk in response.body_iterator:  # type: ignore[attr-defined]
+            payload += chunk
+
+        duration_ms = int((datetime.now(timezone.utc) - start).total_seconds() * 1000)
+
+        response_headers = _sanitize_headers(dict(response.headers))
+        response_headers.pop("content-length", None)
+
+        entry = {
+            "id": str(uuid.uuid4()),
+            "ts": start.isoformat(),
+            "duration_ms": duration_ms,
+            "port": self._cfg.port_label,
+            "provider": self._cfg.provider,
+            "request": {
+                "method": request.method,
+                "path": _compose_path(request),
+                "headers": _sanitize_headers(dict(request.headers)),
+                "body": _decode_body(body_bytes, request.headers.get("content-type")),
+            },
+            "response": {
+                "status": response.status_code,
+                "headers": response_headers,
+                "body": _decode_body(payload, response.headers.get("content-type")),
+            },
+        }
+
+        await _write_entry(self._cfg, entry)
+
+        return Response(
+            content=payload,
+            status_code=response.status_code,
+            headers=response_headers,
+            media_type=response.media_type,
+            background=response.background,
+        )
+
+
+async def _write_entry(cfg: RecorderConfig, entry: Mapping[str, Any]) -> None:
+    day_dir = cfg.fixtures_root / cfg.port_label / datetime.now(timezone.utc).strftime("%Y%m%d")
+    day_dir.mkdir(parents=True, exist_ok=True)
+    file_path = day_dir / f"{cfg.session_id}.jsonl"
+
+    line = json.dumps(entry, default=_json_default) + "\n"
+    await asyncio.to_thread(_append_line, file_path, line)
+
+
+def _append_line(file_path: Path, line: str) -> None:
+    with file_path.open("a", encoding="utf-8") as fh:
+        fh.write(line)
+
+
+def _json_default(obj: Any) -> Any:
+    if isinstance(obj, datetime):
+        return obj.isoformat()
+    if isinstance(obj, bytes):
+        return obj.decode("utf-8", errors="replace")
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
+
+
+def _build_config(app: FastAPI, *, port_label: str | None, provider: str | None) -> RecorderConfig:
+    port = _slugify(port_label or getattr(app, "title", None) or os.getenv("PORT_LABEL") or "service")
+    provider_name = (provider or os.getenv("FIXTURE_PROVIDER") or os.getenv("PORT_PROVIDER") or "primary").lower()
+
+    fixtures_root = Path(os.getenv("FIXTURES_ROOT") or _discover_root() / "fixtures").resolve()
+    session = os.getenv("FIXTURE_SESSION")
+    if not session:
+        ts = datetime.now(timezone.utc)
+        session = f"{ts.strftime('%Y%m%d-%H%M%S')}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+
+    return RecorderConfig(port_label=port, provider=provider_name, fixtures_root=fixtures_root, session_id=session)
+
+
+def _discover_root() -> Path:
+    current = Path.cwd().resolve()
+    for candidate in [current, *current.parents]:
+        if (candidate / ".git").exists():
+            return candidate
+    return current
+
+
+def _compose_path(request: Request) -> str:
+    path = request.url.path
+    if request.url.query:
+        path = f"{path}?{request.url.query}"
+    return path
+
+
+def _sanitize_headers(headers: MutableMapping[str, Any]) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for key, value in headers.items():
+        if value is None:
+            continue
+        lower = key.lower()
+        if lower in {"authorization", "proxy-authorization"}:
+            result[key] = "***"
+            continue
+        if isinstance(value, str):
+            result[key] = value
+        elif isinstance(value, Iterable):
+            result[key] = ",".join(str(v) for v in value)
+        else:
+            result[key] = str(value)
+    result.pop("host", None)
+    return result
+
+
+def _decode_body(payload: bytes | str | None, content_type: str | None) -> Any:
+    if payload in (None, b"", ""):
+        return None
+    if isinstance(payload, bytes):
+        text = payload.decode("utf-8", errors="replace")
+    else:
+        text = str(payload)
+
+    if content_type and "application/json" in content_type.lower():
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            return text
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return text
+
+
+def _slugify(value: str) -> str:
+    lowered = value.lower()
+    stripped = "-".join(filter(None, [segment for segment in lowered.replace("_", "-").split("-") if segment.strip("-")]))
+    cleaned = "".join(ch if ch.isalnum() or ch == "-" else "-" for ch in stripped)
+    cleaned = cleaned.strip("-")
+    return cleaned or "port"
+
+
+__all__ = ["attach_fixture_recorder"]

--- a/tools/replay
+++ b/tools/replay
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+/* tools/replay.js - Replay recorded fixtures against alternate providers. */
+
+const fs = require('fs');
+const path = require('path');
+const process = require('process');
+
+if (typeof fetch !== 'function') {
+  console.error('Global fetch is required (Node.js 18+).');
+  process.exit(1);
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (!args.port || !args.fixture) {
+    usage('Missing --port or --fixture');
+    process.exit(1);
+  }
+
+  const repoRoot = findRepoRoot(process.cwd());
+  const fixtureDir = path.join(repoRoot, 'fixtures', args.port, args.fixture);
+  if (!fs.existsSync(fixtureDir) || !fs.statSync(fixtureDir).isDirectory()) {
+    console.error(`Fixture directory not found: ${fixtureDir}`);
+    process.exit(1);
+  }
+
+  const files = fs.readdirSync(fixtureDir).filter((f) => f.endsWith('.jsonl')).sort();
+  if (files.length === 0) {
+    console.error(`No .jsonl files found in ${fixtureDir}`);
+    process.exit(1);
+  }
+
+  const selectors = await loadSelectors(repoRoot, args.port);
+  const diffs = [];
+  let total = 0;
+
+  for (const file of files) {
+    const filePath = path.join(fixtureDir, file);
+    const lines = fs.readFileSync(filePath, 'utf8').split(/\r?\n/).filter(Boolean);
+    for (const line of lines) {
+      total += 1;
+      let entry;
+      try {
+        entry = JSON.parse(line);
+      } catch (err) {
+        diffs.push({ type: 'parse-error', file: file, detail: err.message });
+        continue;
+      }
+      const diff = await replayEntry(args.port, entry, selectors);
+      if (diff) {
+        diffs.push({ file, entryId: entry.id, ...diff });
+      }
+    }
+  }
+
+  if (diffs.length === 0) {
+    console.log(`✅  Replayed ${total} interactions for port '${args.port}' without diffs.`);
+    return;
+  }
+
+  console.error(`❌  Found ${diffs.length} diffs out of ${total} interactions:`);
+  for (const d of diffs.slice(0, 10)) {
+    console.error(JSON.stringify(d, null, 2));
+  }
+  if (diffs.length > 10) {
+    console.error(`... and ${diffs.length - 10} more`);
+  }
+  process.exit(2);
+}
+
+function usage(msg) {
+  if (msg) console.error(msg);
+  console.error('Usage: tools/replay --port <name> --fixture <YYYYMMDD>');
+  console.error('Environment: set REPLAY_BASE_<PORT>_<ROLE> to target URLs (ROLE = PRIMARY|SECONDARY).');
+}
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--port' && argv[i + 1]) {
+      out.port = argv[++i];
+    } else if (arg === '--fixture' && argv[i + 1]) {
+      out.fixture = argv[++i];
+    } else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      usage();
+      process.exit(1);
+    }
+  }
+  return out;
+}
+
+async function replayEntry(port, entry, selectors) {
+  const recordedProvider = (entry.provider || 'primary').toLowerCase();
+  const targetProvider = recordedProvider === 'primary' ? 'secondary' : 'primary';
+  const base = resolveReplayBase(port, targetProvider);
+  if (!base) {
+    return { type: 'config', message: `Missing REPLAY_BASE_${port.toUpperCase()}_${targetProvider.toUpperCase()}` };
+  }
+
+  const url = new URL(entry.request?.path || '/', base);
+  const method = (entry.request?.method || 'GET').toUpperCase();
+  const headers = Object.assign({}, entry.request?.headers || {});
+  delete headers['content-length'];
+  delete headers['Content-Length'];
+  delete headers['host'];
+  delete headers['Host'];
+
+  let body = undefined;
+  if (!['GET', 'HEAD'].includes(method)) {
+    body = prepareBody(entry.request?.body, headers);
+  }
+
+  let response;
+  let text;
+  try {
+    response = await fetch(url, { method, headers, body });
+    text = await response.text();
+  } catch (err) {
+    return { type: 'network', message: err.message, url: url.toString() };
+  }
+
+  const replayBody = safeParseJson(text);
+  const recordedSemantic = selectSemantic(entry.response?.body, selectors);
+  const replaySemantic = selectSemantic(replayBody, selectors);
+
+  const statusDiff = entry.response?.status !== response.status;
+  const bodyDiff = !deepEqual(recordedSemantic, replaySemantic);
+  if (!statusDiff && !bodyDiff) {
+    return null;
+  }
+
+  return {
+    type: 'mismatch',
+    url: url.toString(),
+    status_recorded: entry.response?.status,
+    status_replay: response.status,
+    semantic_recorded: recordedSemantic,
+    semantic_replay: replaySemantic,
+  };
+}
+
+function resolveReplayBase(port, providerRole) {
+  const key = `REPLAY_BASE_${port.toUpperCase()}_${providerRole.toUpperCase()}`;
+  return process.env[key] || null;
+}
+
+async function loadSelectors(repoRoot, port) {
+  const perPort = path.join(repoRoot, 'fixtures', port, 'semantic-fields.json');
+  if (fs.existsSync(perPort)) {
+    try {
+      const raw = fs.readFileSync(perPort, 'utf8');
+      const data = JSON.parse(raw);
+      if (Array.isArray(data)) return data;
+    } catch (err) {
+      console.warn(`Warning: unable to parse semantic fields for ${port}: ${err.message}`);
+    }
+  }
+  return [];
+}
+
+function selectSemantic(body, selectors) {
+  if (!selectors || selectors.length === 0) {
+    return body;
+  }
+  const result = {};
+  for (const selector of selectors) {
+    result[selector] = getByPath(body, selector);
+  }
+  return result;
+}
+
+function getByPath(obj, selector) {
+  if (!selector) return obj;
+  const parts = selector.split('.');
+  let current = obj;
+  for (const part of parts) {
+    if (current && typeof current === 'object' && part in current) {
+      current = current[part];
+    } else {
+      return undefined;
+    }
+  }
+  return current;
+}
+
+function prepareBody(body, headers) {
+  if (body === null || body === undefined) return undefined;
+  if (typeof body === 'string') {
+    return body;
+  }
+  if (Buffer.isBuffer(body)) {
+    return body;
+  }
+  if (typeof body === 'object') {
+    headers['content-type'] = headers['content-type'] || 'application/json';
+    return JSON.stringify(body);
+  }
+  return String(body);
+}
+
+function safeParseJson(text) {
+  if (text === '') return null;
+  try {
+    return JSON.parse(text);
+  } catch (_err) {
+    return text;
+  }
+}
+
+function deepEqual(a, b) {
+  return JSON.stringify(normalize(a)) === JSON.stringify(normalize(b));
+}
+
+function normalize(value) {
+  if (Array.isArray(value)) {
+    return value.map((item) => normalize(item));
+  }
+  if (value && typeof value === 'object') {
+    const sorted = Object.keys(value).sort();
+    const out = {};
+    for (const key of sorted) {
+      out[key] = normalize(value[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+function findRepoRoot(startDir) {
+  let current = path.resolve(startDir);
+  while (true) {
+    if (fs.existsSync(path.join(current, '.git'))) return current;
+    const parent = path.dirname(current);
+    if (!parent || parent === current) break;
+    current = parent;
+  }
+  return path.resolve(startDir);
+}
+
+if (require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- add express middleware that logs payments port traffic into daily fixture jsonl files
- add shared FastAPI recorder and hook it into each service port so inbound calls are captured
- provide a fixtures replay CLI plus documentation and gitignore entry for generated recordings

## Testing
- npm --prefix apps/services/payments run build *(fails: existing TypeScript config lacks module compatibility and type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e24ceba9308327ab70c46cfd5c8393