### PR TITLE
Implement blue/green deployment workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,20 @@ ps:
 
 fmt:
 	@echo "No formatter configured; add ruff/black if desired."
+
+# ---------- Blue/Green deployment orchestration ----------
+deploy-blue:
+	@./ops/deploy/blue_green.py deploy blue
+
+deploy-green:
+	@./ops/deploy/blue_green.py deploy green
+
+mark-ready:
+	@test -n "$(COLOR)" || (echo "COLOR is required (e.g. make mark-ready COLOR=green)" && exit 1)
+	@./ops/deploy/blue_green.py mark-ready $(COLOR)
+
+gate:
+	@./ops/deploy/blue_green.py gate $(if $(STATUS_URL),--status-url $(STATUS_URL),)
+
+rollback:
+	@./ops/deploy/blue_green.py rollback

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,6 +76,8 @@ services:
   portal-api:
     build:
       context: ./portal-api
+    env_file:
+      - ops/deploy/active.env
     environment:
       NORMALIZER_URL: http://normalizer:8001
     ports:

--- a/docs/runbooks/rollback.md
+++ b/docs/runbooks/rollback.md
@@ -1,0 +1,68 @@
+# Blue/Green Rollback Runbook
+
+This runbook covers the exact commands to execute when rolling back a
+blue/green deployment of the portal stack.
+
+## Preconditions
+
+* The deployment state files in `ops/deploy/` are up to date. In
+  particular `state.json` should show the current `active_color` and the
+  `previous_color` that was just replaced.
+* The blue/green helper script and Make targets have been committed.
+
+## Steps
+
+1. **Confirm current state** (optional but recommended):
+
+   ```bash
+   ./ops/deploy/blue_green.py status
+   ```
+
+   Verify that `previous_color` points to the color you intend to roll
+   back to.
+
+2. **Flip traffic and provider bindings back in one step**:
+
+   ```bash
+   make rollback
+   ```
+
+   This command performs the following actions atomically:
+
+   * Restores `ops/deploy/active.env` from the recorded `previous_color`
+     template so the provider bindings and `DEPLOY_COLOR` match the prior
+     release.
+   * Rewrites `ops/deploy/proxy/active.conf` to point the proxy at the
+     previous color.
+   * Updates `ops/deploy/state.json` so `active_color`, `proxy_color`, and
+     `previous_color` reflect the rollback.
+   * Marks the capability matrix in
+     `portal-api/capability_state.json` as `ready` for the restored color
+     and `rolled back` for the color that was removed.
+
+3. **Validate** the system after rollback by checking the deployment
+   status endpoint. Point the request at the stack that should now be
+   live (for example, the blue pool):
+
+   ```bash
+   curl -s https://portal.example.internal/deploy/status | jq .
+   ```
+
+4. **(Optional) Clean up** any failed pending deployment metadata:
+
+   ```bash
+   rm -f ops/deploy/pending.env
+   ```
+
+   The rollback command already deletes stale pending data, so this is
+   only necessary if additional files were created outside the helper
+   script.
+
+## Notes
+
+* `make rollback` will exit non-zero if there is no recorded
+  `previous_color`. Ensure `make gate` (or `./ops/deploy/blue_green.py
+  gate`) was executed before attempting to roll back.
+* The runbook assumes the portal API is reachable at
+  `https://portal.example.internal`. Adjust the validation command to the
+  correct host as needed.

--- a/ops/deploy/active.env
+++ b/ops/deploy/active.env
@@ -1,0 +1,5 @@
+DEPLOY_COLOR=blue
+AUTH_PROVIDER_ENDPOINT=https://auth-blue.apgms.internal
+BANKING_PROVIDER_ENDPOINT=https://bank-blue.apgms.internal
+LEDGER_PROVIDER_ENDPOINT=https://ledger-blue.apgms.internal
+CAPABILITY_MATRIX_READY=true

--- a/ops/deploy/blue_green.py
+++ b/ops/deploy/blue_green.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+"""Blue/green deployment orchestrator helpers.
+
+This script keeps the repo-local state files in sync so that deploy
+pipelines can source provider bindings, capability state, and proxy
+selection from a single place.  It is intentionally file-based so it can
+run in CI without extra dependencies.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+from urllib import error, request
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+ROOT = SCRIPT_DIR.parent.parent
+STATE_PATH = SCRIPT_DIR / "state.json"
+ENV_DIR = SCRIPT_DIR / "env"
+ACTIVE_ENV_PATH = SCRIPT_DIR / "active.env"
+PENDING_ENV_PATH = SCRIPT_DIR / "pending.env"
+PREVIOUS_ENV_PATH = SCRIPT_DIR / "previous.env"
+PROXY_DIR = SCRIPT_DIR / "proxy"
+ACTIVE_PROXY_PATH = PROXY_DIR / "active.conf"
+PORTAL_BINDINGS_PATH = ROOT / "portal-api" / "provider_bindings.json"
+CAPABILITY_STATE_PATH = ROOT / "portal-api" / "capability_state.json"
+
+
+def load_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def write_json(path: Path, data: Dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+
+
+def load_state() -> Dict[str, Any]:
+    if not STATE_PATH.exists():
+        raise SystemExit(f"State file missing at {STATE_PATH}")
+    return load_json(STATE_PATH)
+
+
+def save_state(state: Dict[str, Any]) -> None:
+    write_json(STATE_PATH, state)
+
+
+def available_colors() -> Dict[str, Any]:
+    bindings = load_json(PORTAL_BINDINGS_PATH)
+    return {c.lower(): cfg for c, cfg in bindings.items()}
+
+
+def env_template(color: str) -> Path:
+    path = ENV_DIR / f"{color}.env"
+    if not path.exists():
+        raise SystemExit(f"Missing env template for color '{color}' at {path}")
+    return path
+
+
+def proxy_template(color: str) -> Path:
+    path = PROXY_DIR / f"{color}.conf"
+    if not path.exists():
+        raise SystemExit(f"Missing proxy template for color '{color}' at {path}")
+    return path
+
+
+def update_capability(color: str, ready: bool, note: Optional[str] = None) -> None:
+    state = load_json(CAPABILITY_STATE_PATH)
+    entry = state.setdefault(color, {"checks": {}, "ready": False, "lastUpdated": None})
+    entry["ready"] = ready
+    entry["lastUpdated"] = time.time()
+    if note:
+        entry["note"] = note
+    checks = entry.setdefault("checks", {})
+    if ready:
+        for check in ("api", "normalizer", "reporting"):
+            checks[check] = "ready"
+    else:
+        for check in ("api", "normalizer", "reporting"):
+            checks[check] = "provisioning"
+    write_json(CAPABILITY_STATE_PATH, state)
+
+
+def fetch_status(url: str) -> Dict[str, Any]:
+    req = request.Request(url, headers={"Accept": "application/json"})
+    with request.urlopen(req) as resp:  # type: ignore[arg-type]
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def handle_deploy(args: argparse.Namespace) -> None:
+    colors = available_colors()
+    color = args.color.lower()
+    if color not in colors:
+        raise SystemExit(f"Unknown deploy color '{args.color}'. Known: {', '.join(colors)}")
+
+    state = load_state()
+    active_color = state.get("active_color")
+    if active_color == color:
+        raise SystemExit("Color already active; nothing to deploy")
+
+    PENDING_ENV_PATH.unlink(missing_ok=True)
+    shutil.copyfile(env_template(color), PENDING_ENV_PATH)
+    state["previous_color"] = active_color
+    state["pending_color"] = color
+    save_state(state)
+
+    update_capability(color, ready=False, note="Deployment initiated")
+    print(f"Prepared deployment config for '{color}'. Pending color set.")
+    print(f"Pending env -> {PENDING_ENV_PATH}")
+    print("Run health checks, then mark-ready and gate when complete.")
+
+
+def handle_mark_ready(args: argparse.Namespace) -> None:
+    color = args.color.lower()
+    colors = available_colors()
+    if color not in colors:
+        raise SystemExit(f"Unknown deploy color '{args.color}'.")
+    update_capability(color, ready=True, note=args.note)
+    print(f"Capability matrix for '{color}' marked ready.")
+
+
+def handle_gate(args: argparse.Namespace) -> None:
+    state = load_state()
+    color = state.get("pending_color")
+    if not color:
+        raise SystemExit("No pending color to gate. Run deploy first.")
+
+    if args.status_url:
+        status_url = args.status_url.rstrip("/") + "/deploy/status"
+        try:
+            payload = fetch_status(status_url)
+        except error.URLError as exc:
+            raise SystemExit(f"Failed to reach status endpoint: {exc}")
+        if payload.get("activeColor") != color:
+            raise SystemExit(
+                f"Status endpoint reports activeColor={payload.get('activeColor')} (expected {color})."
+            )
+        capability = payload.get("capabilityMatrix", {})
+        if not capability or not capability.get("ready"):
+            raise SystemExit("Capability matrix not ready per service response.")
+
+    if not PENDING_ENV_PATH.exists():
+        raise SystemExit(f"Pending env file missing at {PENDING_ENV_PATH}; run deploy first.")
+
+    # promote pending env to active
+    if ACTIVE_ENV_PATH.exists():
+        shutil.copyfile(ACTIVE_ENV_PATH, PREVIOUS_ENV_PATH)
+    shutil.copyfile(PENDING_ENV_PATH, ACTIVE_ENV_PATH)
+    PENDING_ENV_PATH.unlink(missing_ok=True)
+
+    # update proxy
+    shutil.copyfile(proxy_template(color), ACTIVE_PROXY_PATH)
+
+    previous = state.get("active_color")
+    state["active_color"] = color
+    state["proxy_color"] = color
+    state["pending_color"] = None
+    state["previous_color"] = previous
+    save_state(state)
+
+    update_capability(color, ready=True, note="Traffic gated to color")
+    print(f"Traffic flipped to '{color}'. Previous color was '{previous}'.")
+
+
+def handle_rollback(_: argparse.Namespace) -> None:
+    state = load_state()
+    previous = state.get("previous_color")
+    if not previous:
+        raise SystemExit("No previous color recorded for rollback.")
+    current = state.get("active_color")
+    if current == previous:
+        raise SystemExit("Previous color matches current; rollback would be a no-op.")
+
+    shutil.copyfile(env_template(previous), ACTIVE_ENV_PATH)
+    shutil.copyfile(proxy_template(previous), ACTIVE_PROXY_PATH)
+
+    state["pending_color"] = None
+    state["proxy_color"] = previous
+    state["active_color"] = previous
+    state["previous_color"] = current
+    save_state(state)
+
+    PENDING_ENV_PATH.unlink(missing_ok=True)
+
+    update_capability(previous, ready=True, note="Rollback executed")
+    if current:
+        update_capability(current, ready=False, note="Rolled back")
+    print(f"Rollback complete. Active color restored to '{previous}'.")
+
+
+def handle_status(_: argparse.Namespace) -> None:
+    state = load_state()
+    print(json.dumps(state, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Blue/green deployment helper")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    deploy = sub.add_parser("deploy", help="Prepare a color for deployment")
+    deploy.add_argument("color", help="Color to deploy (blue/green)")
+    deploy.set_defaults(func=handle_deploy)
+
+    mark = sub.add_parser("mark-ready", help="Mark a color's capability matrix ready")
+    mark.add_argument("color", help="Color to update")
+    mark.add_argument("--note", help="Optional note for the capability matrix entry")
+    mark.set_defaults(func=handle_mark_ready)
+
+    gate = sub.add_parser("gate", help="Flip traffic once readiness is confirmed")
+    gate.add_argument("--status-url", help="Portal API base URL to validate readiness")
+    gate.set_defaults(func=handle_gate)
+
+    rollback = sub.add_parser("rollback", help="Rollback to the previous active color")
+    rollback.set_defaults(func=handle_rollback)
+
+    status = sub.add_parser("status", help="Show current deployment state")
+    status.set_defaults(func=handle_status)
+
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ops/deploy/env/blue.env
+++ b/ops/deploy/env/blue.env
@@ -1,0 +1,5 @@
+DEPLOY_COLOR=blue
+AUTH_PROVIDER_ENDPOINT=https://auth-blue.apgms.internal
+BANKING_PROVIDER_ENDPOINT=https://bank-blue.apgms.internal
+LEDGER_PROVIDER_ENDPOINT=https://ledger-blue.apgms.internal
+CAPABILITY_MATRIX_READY=true

--- a/ops/deploy/env/green.env
+++ b/ops/deploy/env/green.env
@@ -1,0 +1,5 @@
+DEPLOY_COLOR=green
+AUTH_PROVIDER_ENDPOINT=https://auth-green.apgms.internal
+BANKING_PROVIDER_ENDPOINT=https://bank-green.apgms.internal
+LEDGER_PROVIDER_ENDPOINT=https://ledger-green.apgms.internal
+CAPABILITY_MATRIX_READY=false

--- a/ops/deploy/proxy/active.conf
+++ b/ops/deploy/proxy/active.conf
@@ -1,0 +1,4 @@
+# Auto-generated upstream for blue deployment
+upstream portal_api_active {
+    server portal-api-blue.internal:8000;
+}

--- a/ops/deploy/proxy/blue.conf
+++ b/ops/deploy/proxy/blue.conf
@@ -1,0 +1,4 @@
+# Auto-generated upstream for blue deployment
+upstream portal_api_active {
+    server portal-api-blue.internal:8000;
+}

--- a/ops/deploy/proxy/green.conf
+++ b/ops/deploy/proxy/green.conf
@@ -1,0 +1,4 @@
+# Auto-generated upstream for green deployment
+upstream portal_api_active {
+    server portal-api-green.internal:8000;
+}

--- a/ops/deploy/state.json
+++ b/ops/deploy/state.json
@@ -1,0 +1,6 @@
+{
+  "active_color": "blue",
+  "previous_color": null,
+  "pending_color": null,
+  "proxy_color": "blue"
+}

--- a/portal-api/Dockerfile
+++ b/portal-api/Dockerfile
@@ -3,5 +3,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 COPY app.py .
+COPY provider_bindings.json ./provider_bindings.json
+COPY capability_state.json ./capability_state.json
 EXPOSE 8000
 CMD ["uvicorn","app:app","--host","0.0.0.0","--port","8000"]

--- a/portal-api/app.py
+++ b/portal-api/app.py
@@ -1,12 +1,133 @@
-from fastapi import FastAPI, Query
-from pydantic import BaseModel
-from typing import List, Dict, Any
+import copy
+import json
+import os
 import time
+from pathlib import Path
+from typing import Any, Dict, List
+
+from fastapi import FastAPI, HTTPException, Query
+from pydantic import BaseModel
 
 app = FastAPI(title="APGMS Portal API", version="0.1.0")
 
+BASE_DIR = Path(__file__).resolve().parent
+BINDINGS_PATH = BASE_DIR / "provider_bindings.json"
+CAPABILITY_STATE_PATH = BASE_DIR / "capability_state.json"
+
+
+def _load_provider_bindings() -> Dict[str, Dict[str, Any]]:
+    if not BINDINGS_PATH.exists():
+        raise RuntimeError(f"Missing provider bindings file at {BINDINGS_PATH}")
+    with BINDINGS_PATH.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise RuntimeError("Provider bindings must be a JSON object keyed by deploy color")
+    normalized: Dict[str, Dict[str, Any]] = {}
+    for key, value in data.items():
+        normalized[key.lower()] = value
+    return normalized
+
+
+def _load_capability_state() -> Dict[str, Any]:
+    if not CAPABILITY_STATE_PATH.exists():
+        # initialize with defaults derived from bindings
+        bindings = _load_provider_bindings()
+        default_state = {
+            color: {
+                "ready": color == "blue",  # blue live by default
+                "checks": {
+                    "api": "ready" if color == "blue" else "provisioning",
+                    "normalizer": "ready" if color == "blue" else "provisioning",
+                    "reporting": "ready" if color == "blue" else "provisioning",
+                },
+                "lastUpdated": None,
+            }
+            for color in bindings.keys()
+        }
+        CAPABILITY_STATE_PATH.write_text(json.dumps(default_state, indent=2), encoding="utf-8")
+    with CAPABILITY_STATE_PATH.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    normalized: Dict[str, Any] = {}
+    for color, details in data.items():
+        normalized[color.lower()] = details
+    return normalized
+
+
+def _write_capability_state(state: Dict[str, Any]) -> None:
+    CAPABILITY_STATE_PATH.write_text(json.dumps(state, indent=2) + "\n", encoding="utf-8")
+
+
+PROVIDER_BINDINGS = _load_provider_bindings()
+PROVIDER_ENV_KEYS = {
+    "auth": "AUTH_PROVIDER_ENDPOINT",
+    "banking": "BANKING_PROVIDER_ENDPOINT",
+    "ledger": "LEDGER_PROVIDER_ENDPOINT",
+}
+
+
+def _get_color_from_env() -> str:
+    color = os.getenv("DEPLOY_COLOR", "blue").lower()
+    if color not in PROVIDER_BINDINGS:
+        raise RuntimeError(
+            f"DEPLOY_COLOR='{color}' is not defined in provider_bindings.json"
+        )
+    return color
+
 @app.get("/readyz")
 def readyz(): return {"ok": True, "ts": time.time()}
+
+
+@app.get("/deploy/status")
+def deploy_status():
+    color = _get_color_from_env()
+    state = _load_capability_state()
+    capability = state.get(color, {})
+    bindings = _bindings_for_color(color)
+    return {
+        "activeColor": color,
+        "bindings": bindings,
+        "capabilityMatrix": capability,
+    }
+
+
+class CapabilityUpdate(BaseModel):
+    color: str
+    ready: bool
+    checks: Dict[str, str] | None = None
+    note: str | None = None
+
+
+@app.post("/deploy/capability-matrix")
+def update_capability_matrix(update: CapabilityUpdate):
+    color = update.color.lower()
+    if color not in PROVIDER_BINDINGS:
+        raise HTTPException(status_code=400, detail=f"Unknown deploy color '{update.color}'")
+
+    state = _load_capability_state()
+    entry = state.setdefault(color, {"checks": {}, "ready": False, "lastUpdated": None})
+    if update.checks is not None:
+        entry["checks"] = update.checks
+    entry["ready"] = update.ready
+    entry["lastUpdated"] = time.time()
+    if update.note:
+        entry["note"] = update.note
+    _write_capability_state(state)
+    return {"ok": True, "color": color, "ready": entry["ready"]}
+
+
+def _bindings_for_color(color: str) -> Dict[str, Any]:
+    base = PROVIDER_BINDINGS[color]
+    bindings: Dict[str, Any] = copy.deepcopy(base)
+    providers = bindings.setdefault("providers", {})
+    overrides: Dict[str, str] = {}
+    for logical_name, env_key in PROVIDER_ENV_KEYS.items():
+        val = os.getenv(env_key)
+        if val:
+            overrides[logical_name] = val
+    if overrides:
+        providers.update(overrides)
+        bindings["overrides"] = sorted(overrides.keys())
+    return bindings
 
 @app.get("/metrics", response_class=None)
 def metrics():
@@ -35,8 +156,14 @@ def list_connections(): return _connections
 
 @app.post("/connections/start")
 def start_conn(req: ConnStart):
-    url = f"https://example-auth/{req.provider}/authorize?state=fake"
-    return {"url": url}
+    color = _get_color_from_env()
+    bindings = _bindings_for_color(color)
+    providers = bindings.get("providers", {})
+    if req.provider not in providers:
+        raise HTTPException(status_code=400, detail=f"Provider '{req.provider}' not bound for {color}")
+    base_url = providers[req.provider]
+    url = f"{base_url.rstrip('/')}/authorize?state=fake"
+    return {"url": url, "color": color}
 
 @app.delete("/connections/{conn_id}")
 def delete_conn(conn_id: int):

--- a/portal-api/capability_state.json
+++ b/portal-api/capability_state.json
@@ -1,0 +1,20 @@
+{
+  "blue": {
+    "ready": true,
+    "checks": {
+      "api": "ready",
+      "normalizer": "ready",
+      "reporting": "ready"
+    },
+    "lastUpdated": null
+  },
+  "green": {
+    "ready": false,
+    "checks": {
+      "api": "provisioning",
+      "normalizer": "provisioning",
+      "reporting": "provisioning"
+    },
+    "lastUpdated": null
+  }
+}

--- a/portal-api/provider_bindings.json
+++ b/portal-api/provider_bindings.json
@@ -1,0 +1,16 @@
+{
+  "blue": {
+    "providers": {
+      "auth": "https://auth-blue.apgms.internal",
+      "banking": "https://bank-blue.apgms.internal",
+      "ledger": "https://ledger-blue.apgms.internal"
+    }
+  },
+  "green": {
+    "providers": {
+      "auth": "https://auth-green.apgms.internal",
+      "banking": "https://bank-green.apgms.internal",
+      "ledger": "https://ledger-green.apgms.internal"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a file-based blue/green deployment helper with make targets, env templates, and proxy configs
- expose deployment status, capability matrix updates, and provider binding selection in the portal API
- document the rollback procedure and capture default provider bindings/capability state

## Testing
- python -m compileall portal-api/app.py ops/deploy/blue_green.py

------
https://chatgpt.com/codex/tasks/task_e_68e24d08b8fc8327a93488fcc992b7fc