### PR TITLE
Add mock bank ingestion tooling and endpoints

### DIFF
--- a/migrations/003_mock_bank.sql
+++ b/migrations/003_mock_bank.sql
@@ -1,0 +1,62 @@
+-- Mock bank ingestion schema
+create table if not exists mock_bank_batches (
+  id bigserial primary key,
+  source text not null default 'manual',
+  raw_csv text not null,
+  ingested_at timestamptz not null default now()
+);
+
+create table if not exists mock_bank_payouts (
+  id bigserial primary key,
+  batch_id bigint references mock_bank_batches(id) on delete set null,
+  rpt_id text not null unique,
+  statement_date date not null,
+  posted_at timestamptz not null,
+  amount_cents bigint not null,
+  parts_count int not null default 1,
+  status text not null default 'PENDING',
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists mock_bank_statement_lines (
+  id bigserial primary key,
+  batch_id bigint references mock_bank_batches(id) on delete cascade,
+  payout_id bigint references mock_bank_payouts(id) on delete cascade,
+  line_id text not null unique,
+  rpt_id text not null,
+  part_no int not null default 1,
+  parts int not null default 1,
+  amount_cents bigint not null,
+  statement_date date not null,
+  posted_at timestamptz not null,
+  raw jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+
+create table if not exists mock_bank_payout_parts (
+  id bigserial primary key,
+  payout_id bigint references mock_bank_payouts(id) on delete cascade,
+  part_no int not null,
+  amount_cents bigint not null,
+  posted_at timestamptz not null,
+  statement_line_id text not null,
+  created_at timestamptz not null default now(),
+  unique (payout_id, part_no)
+);
+
+create index if not exists mock_bank_payouts_status_idx on mock_bank_payouts(status, posted_at);
+create index if not exists mock_bank_payouts_posted_idx on mock_bank_payouts(posted_at);
+
+create or replace function touch_mock_bank_payout_updated_at() returns trigger as $$
+begin
+  new.updated_at := now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists trg_mock_bank_payout_touch on mock_bank_payouts;
+create trigger trg_mock_bank_payout_touch
+  before update on mock_bank_payouts
+  for each row execute function touch_mock_bank_payout_updated_at();

--- a/mocks/bank/gen.py
+++ b/mocks/bank/gen.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Generate mock bank payout CSVs with duplicates, late postings, and split payouts."""
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+from dataclasses import dataclass
+from datetime import datetime, timedelta, time, timezone
+from pathlib import Path
+from typing import Iterable, List
+from uuid import uuid4
+
+UTC = timezone.utc
+
+
+@dataclass
+class PayoutPart:
+    line_id: str
+    rpt_id: str
+    amount_cents: int
+    statement_date: datetime
+    posted_at: datetime
+    description: str
+    part: int
+    parts: int
+    duplicate_of: str | None = None
+
+    def as_row(self) -> dict[str, str]:
+        return {
+            "line_id": self.line_id,
+            "rpt_id": self.rpt_id,
+            "amount_cents": str(self.amount_cents),
+            "statement_date": self.statement_date.date().isoformat(),
+            "posted_at": self.posted_at.isoformat().replace("+00:00", "Z"),
+            "description": self.description,
+            "part": str(self.part),
+            "parts": str(self.parts),
+            "duplicate_of": self.duplicate_of or "",
+        }
+
+
+def _floor_to_business_hours(dt: datetime) -> datetime:
+    """Ensure anything after Friday 17:00 settles on the following Monday 09:00."""
+    if dt.weekday() == 4 and dt.time() >= time(17, 0):
+        # move to Monday 09:00 local time
+        days_until_monday = 7 - dt.weekday()
+        monday = datetime.combine((dt + timedelta(days=days_until_monday)).date(), time(9, 0), tzinfo=dt.tzinfo)
+        return monday
+    return dt
+
+
+def _late_posting(base: datetime) -> datetime:
+    offset_days = random.randint(-2, 2)
+    posted = base + timedelta(days=offset_days, hours=random.randint(0, 6), minutes=random.randint(0, 59))
+    return _floor_to_business_hours(posted)
+
+
+def _split_amount(amount: int, parts: int) -> List[int]:
+    base = amount // parts
+    remainder = amount % parts
+    buckets = [base] * parts
+    for idx in range(remainder):
+        buckets[idx] += 1
+    return buckets
+
+
+def build_rows(count: int, seed: int | None) -> List[PayoutPart]:
+    if seed is not None:
+        random.seed(seed)
+
+    start_date = datetime.now(tz=UTC).replace(hour=10, minute=0, second=0, microsecond=0)
+    rows: List[PayoutPart] = []
+
+    for idx in range(count):
+        rpt_id = f"RPT{idx+1:05d}"
+        amount = random.randint(50_00, 250_00)  # cents
+        base_day = start_date + timedelta(days=idx)
+        statement_date = datetime.combine(base_day.date(), time(0, 0), tzinfo=UTC)
+        posted_at = _late_posting(base_day)
+
+        parts = 1
+        if random.random() < 0.25:
+            parts = random.choice((2, 3))
+        amounts = _split_amount(amount, parts)
+
+        for part_no, part_amount in enumerate(amounts, start=1):
+            line_id = str(uuid4())
+            description = f"RPT payout {rpt_id} part {part_no}/{parts}"
+            rows.append(
+                PayoutPart(
+                    line_id=line_id,
+                    rpt_id=rpt_id,
+                    amount_cents=part_amount,
+                    statement_date=statement_date,
+                    posted_at=posted_at,
+                    description=description,
+                    part=part_no,
+                    parts=parts,
+                )
+            )
+
+    # introduce duplicates (reuse the same line id & rpt) but mark duplicate_of
+    if rows:
+        dup_samples = random.sample(rows, k=max(1, len(rows) // 5))
+        for original in dup_samples:
+            duplicate = PayoutPart(
+                line_id=original.line_id,
+                rpt_id=original.rpt_id,
+                amount_cents=original.amount_cents,
+                statement_date=original.statement_date,
+                posted_at=original.posted_at,
+                description=original.description,
+                part=original.part,
+                parts=original.parts,
+                duplicate_of=original.line_id,
+            )
+            rows.append(duplicate)
+
+    rows.sort(key=lambda p: (p.statement_date, p.rpt_id, p.part, p.duplicate_of is not None))
+    return rows
+
+
+def write_csv(rows: Iterable[PayoutPart], output: Path | None) -> None:
+    fieldnames = [
+        "line_id",
+        "rpt_id",
+        "amount_cents",
+        "statement_date",
+        "posted_at",
+        "description",
+        "part",
+        "parts",
+        "duplicate_of",
+    ]
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        target = output.open("w", newline="")
+        should_close = True
+    else:
+        import sys
+
+        target = sys.stdout
+        should_close = False
+
+    writer = csv.DictWriter(target, fieldnames=fieldnames)
+    writer.writeheader()
+    for row in rows:
+        writer.writerow(row.as_row())
+
+    if should_close:
+        target.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate mock bank payout CSV")
+    parser.add_argument("--count", type=int, default=10, help="Number of distinct payouts to generate")
+    parser.add_argument("--seed", type=int, help="Seed for deterministic output")
+    parser.add_argument("--output", type=Path, help="Optional output file (defaults to stdout)")
+    args = parser.parse_args()
+
+    rows = build_rows(args.count, args.seed)
+    write_csv(rows, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/server.js
+++ b/server.js
@@ -4,14 +4,23 @@ const bodyParser = require('body-parser');
 const { Pool } = require('pg');
 const nacl = require('tweetnacl');
 const crypto = require('crypto');
+const { parse: parseCsv } = require('csv-parse/sync');
 
 const app = express();
+app.use(bodyParser.text({ type: ['text/csv', 'text/plain'] }));
 app.use(bodyParser.json());
 
 const {
   PGHOST='127.0.0.1', PGUSER='apgms', PGPASSWORD='apgms_pw', PGDATABASE='apgms', PGPORT='5432',
-  RPT_ED25519_SECRET_BASE64, RPT_PUBLIC_BASE64, ATO_PRN='1234567890'
+  RPT_ED25519_SECRET_BASE64, RPT_PUBLIC_BASE64, ATO_PRN='1234567890',
+  MOCK_BANK_ENABLED='false', MOCK_BANK_STRAGGLER_DAYS='2'
 } = process.env;
+
+const toBool = (value) => String(value ?? '').toLowerCase() === 'true';
+const mockBankEnabled = toBool(MOCK_BANK_ENABLED);
+const mockBankStragglerDays = Number.isFinite(Number(MOCK_BANK_STRAGGLER_DAYS))
+  ? Number(MOCK_BANK_STRAGGLER_DAYS)
+  : 2;
 
 const pool = new Pool({
   host: PGHOST, user: PGUSER, password: PGPASSWORD, database: PGDATABASE, port: +PGPORT
@@ -23,6 +32,228 @@ const ah = fn => (req,res)=>fn(req,res).catch(e=>{
   if (e.code === '08P01') return res.status(500).json({error:'INTERNAL', message:e.message});
   res.status(400).json({error: e.message || 'BAD_REQUEST'});
 });
+
+// ---------- MOCK BANK (PROTOTYPE) ----------
+app.post('/mock/bank/ingest', ah(async (req,res)=>{
+  if (!mockBankEnabled) return res.status(404).json({error:'DISABLED'});
+
+  const csvPayload = typeof req.body === 'string' ? req.body : req.body?.csv;
+  if (!csvPayload || !String(csvPayload).trim()) throw new Error('CSV_REQUIRED');
+
+  let rows;
+  try {
+    rows = parseCsv(csvPayload, { columns: true, skip_empty_lines: true, trim: true });
+  } catch (err) {
+    console.error('mock bank csv parse error', err);
+    throw new Error('CSV_PARSE_ERROR');
+  }
+
+  if (!Array.isArray(rows) || rows.length === 0) {
+    return res.json({ batch_id: null, inserted: 0, duplicates: 0, payouts: [] });
+  }
+
+  const source = typeof req.body === 'object' && req.body !== null && req.body.source
+    ? String(req.body.source)
+    : 'manual';
+
+  const client = await pool.connect();
+  const summary = new Map();
+  let insertedLines = 0;
+  let duplicateLines = 0;
+
+  try {
+    await client.query('begin');
+    const batch = await client.query(
+      'insert into mock_bank_batches(source, raw_csv) values($1,$2) returning id',
+      [source, csvPayload]
+    );
+    const batchId = batch.rows[0].id;
+
+    for (const rawRow of rows) {
+      const lineId = String(rawRow.line_id || '').trim();
+      if (!lineId) throw new Error('LINE_ID_REQUIRED');
+
+      const rptId = String(rawRow.rpt_id || '').trim();
+      if (!rptId) throw new Error('RPT_ID_REQUIRED');
+
+      const amountRaw = String(rawRow.amount_cents ?? '').replace(/[,\s]/g, '');
+      if (!/^[-+]?\d+$/.test(amountRaw)) throw new Error(`INVALID_AMOUNT:${lineId}`);
+      const amount = Number.parseInt(amountRaw, 10);
+      if (!Number.isSafeInteger(amount)) throw new Error(`INVALID_AMOUNT:${lineId}`);
+
+      const statementDateStr = String(rawRow.statement_date || '').trim();
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(statementDateStr)) throw new Error(`INVALID_STATEMENT_DATE:${lineId}`);
+
+      let postedAtIso;
+      try {
+        const posted = new Date(rawRow.posted_at);
+        if (Number.isNaN(posted.getTime())) throw new Error('bad');
+        postedAtIso = posted.toISOString();
+      } catch (err) {
+        console.error('mock bank invalid posted_at', err);
+        throw new Error(`INVALID_POSTED_AT:${lineId}`);
+      }
+
+      const part = Number.parseInt(String(rawRow.part ?? '1'), 10);
+      const parts = Number.parseInt(String(rawRow.parts ?? '1'), 10);
+      if (!Number.isInteger(part) || part < 1) throw new Error(`INVALID_PART:${lineId}`);
+      if (!Number.isInteger(parts) || parts < part) throw new Error(`INVALID_PARTS:${lineId}`);
+
+      const description = String(rawRow.description || '').trim() || null;
+      const normalized = {
+        line_id: lineId,
+        rpt_id: rptId,
+        amount_cents: amount,
+        statement_date: statementDateStr,
+        posted_at: postedAtIso,
+        description,
+        part,
+        parts,
+        duplicate_of: rawRow.duplicate_of || null
+      };
+
+      const inserted = await client.query(
+        `insert into mock_bank_statement_lines
+           (batch_id, line_id, rpt_id, part_no, parts, amount_cents, statement_date, posted_at, raw)
+         values ($1,$2,$3,$4,$5,$6,$7::date,$8::timestamptz,$9::jsonb)
+         on conflict (line_id) do nothing
+         returning id`,
+        [batchId, lineId, rptId, part, parts, amount, statementDateStr, postedAtIso, JSON.stringify(normalized)]
+      );
+
+      if (inserted.rowCount === 0) {
+        duplicateLines += 1;
+        continue;
+      }
+
+      insertedLines += 1;
+
+      const payout = await client.query(
+        `insert into mock_bank_payouts
+           (batch_id, rpt_id, statement_date, posted_at, amount_cents, parts_count, metadata)
+         values ($1,$2,$3::date,$4::timestamptz,$5,$6,
+           jsonb_build_object('last_line_id',$7::text,'last_description',$8::text))
+         on conflict (rpt_id) do update
+           set amount_cents = mock_bank_payouts.amount_cents + excluded.amount_cents,
+               posted_at = greatest(mock_bank_payouts.posted_at, excluded.posted_at),
+               statement_date = least(mock_bank_payouts.statement_date, excluded.statement_date),
+               parts_count = greatest(mock_bank_payouts.parts_count, excluded.parts_count),
+               batch_id = excluded.batch_id,
+               metadata = jsonb_set(
+                 jsonb_set(coalesce(mock_bank_payouts.metadata,'{}'::jsonb), '{last_line_id}', to_jsonb($7::text), true),
+                 '{last_description}', to_jsonb($8::text), true
+               ),
+               updated_at = now()
+         returning id, amount_cents, parts_count, posted_at`,
+        [batchId, rptId, statementDateStr, postedAtIso, amount, parts, lineId, description]
+      );
+
+      const payoutId = payout.rows[0].id;
+      const statementLineId = inserted.rows[0].id;
+
+      await client.query(
+        'update mock_bank_statement_lines set payout_id=$1 where id=$2',
+        [payoutId, statementLineId]
+      );
+
+      await client.query(
+        `insert into mock_bank_payout_parts (payout_id, part_no, amount_cents, posted_at, statement_line_id)
+         values ($1,$2,$3,$4::timestamptz,$5)
+         on conflict (payout_id, part_no) do update
+           set amount_cents = excluded.amount_cents,
+               posted_at = excluded.posted_at,
+               statement_line_id = excluded.statement_line_id`,
+        [payoutId, part, amount, postedAtIso, lineId]
+      );
+
+      const existing = summary.get(rptId) || {
+        amount_cents: 0,
+        received_parts: 0,
+        expected_parts: parts,
+        latest_posted_at: postedAtIso
+      };
+      existing.amount_cents += amount;
+      existing.received_parts += 1;
+      existing.expected_parts = Math.max(existing.expected_parts, parts);
+      if (new Date(postedAtIso) > new Date(existing.latest_posted_at)) {
+        existing.latest_posted_at = postedAtIso;
+      }
+      summary.set(rptId, existing);
+    }
+
+    await client.query('commit');
+
+    res.json({
+      batch_id: batchId,
+      inserted: insertedLines,
+      duplicates: duplicateLines,
+      payouts: Array.from(summary.entries()).map(([rptId, info]) => ({
+        rpt_id: rptId,
+        amount_cents: String(info.amount_cents),
+        received_parts: info.received_parts,
+        expected_parts: info.expected_parts,
+        latest_posted_at: info.latest_posted_at
+      }))
+    });
+  } catch (err) {
+    await client.query('rollback');
+    throw err;
+  } finally {
+    client.release();
+  }
+}));
+
+app.get('/mock/bank/unreconciled', ah(async (req,res)=>{
+  if (!mockBankEnabled) return res.status(404).json({error:'DISABLED'});
+
+  const statuses = req.query.status
+    ? String(req.query.status).split(',').map(s => s.trim().toUpperCase()).filter(Boolean)
+    : [];
+
+  const whereClause = statuses.length ? 'where p.status = any($1)' : "where p.status <> 'SETTLED'";
+  const params = statuses.length ? [statuses] : [];
+
+  const rows = await pool.query(
+    `select p.rpt_id, p.amount_cents, p.statement_date, p.posted_at, p.parts_count, p.status,
+            coalesce(json_agg(json_build_object(
+              'part_no', pr.part_no,
+              'amount_cents', pr.amount_cents,
+              'posted_at', pr.posted_at,
+              'statement_line_id', pr.statement_line_id
+            ) order by pr.part_no) filter (where pr.id is not null), '[]'::json) as parts
+       from mock_bank_payouts p
+       left join mock_bank_payout_parts pr on pr.payout_id = p.id
+       ${whereClause}
+       group by p.id
+       order by p.posted_at asc`,
+    params
+  );
+
+  const now = Date.now();
+  const stragglerMs = Number.isFinite(mockBankStragglerDays) && mockBankStragglerDays > 0
+    ? mockBankStragglerDays * 24 * 60 * 60 * 1000
+    : null;
+
+  const payload = rows.rows.map(row => {
+    const postedAt = new Date(row.posted_at);
+    const ageMs = now - postedAt.getTime();
+    const parts = Array.isArray(row.parts) ? row.parts : [];
+    return {
+      rpt_id: row.rpt_id,
+      status: row.status,
+      amount_cents: row.amount_cents,
+      statement_date: row.statement_date,
+      posted_at: row.posted_at,
+      expected_parts: row.parts_count,
+      received_parts: parts.length,
+      parts,
+      age_hours: Math.round((ageMs / 36e5) * 100) / 100,
+      is_straggler: stragglerMs ? ageMs > stragglerMs : false
+    };
+  });
+
+  res.json({ unreconciled: payload });
+}));
 
 // ---------- HEALTH ----------
 app.get('/health', ah(async (req,res)=>{


### PR DESCRIPTION
## Summary
- add a mock bank CSV generator that creates duplicates, late postings, and split payouts for prototype workflows
- introduce database tables to persist mock bank batches, statement lines, and payout aggregates with updated-at trigger
- expose POST /mock/bank/ingest and GET /mock/bank/unreconciled endpoints gated behind MOCK_BANK_* flags

## Testing
- python mocks/bank/gen.py --count 2 --seed 42 | head


------
https://chatgpt.com/codex/tasks/task_e_68e25498d8e48327814c5829b011af1a