### PR TITLE
Add payments router and provider registry

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,10 +1,37 @@
-// server/index.ts
-import express from "express";
-import bodyParser from "body-parser";
-import { router as paymentsApi } from "./api/payments";
+import express, { type NextFunction, type Request, type Response } from "express";
 
-const app = express();
-app.use(bodyParser.json());
-app.use("/api/payments", paymentsApi);
+import { router as paymentsRouter } from "../apps/express/api/payments";
+import { describeProviderRegistry } from "@core/providers/registry";
 
-app.listen(8080, () => console.log("App on http://localhost:8080"));
+export const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ ok: true });
+});
+
+app.get("/debug/providers", (_req, res) => {
+  res.json(describeProviderRegistry());
+});
+
+app.use("/api/payments", paymentsRouter);
+
+app.use((req, res) => {
+  res.status(404).json({ error: "not_found", path: req.path });
+});
+
+app.use((error: unknown, _req: Request, res: Response, _next: NextFunction) => {
+  console.error("[api] unhandled error", error);
+  res.status(500).json({ error: "internal_error" });
+});
+
+export function startServer(port: number = Number(process.env.PORT ?? 8080)) {
+  return app.listen(port, () => {
+    console.log(`App on http://localhost:${port}`);
+  });
+}
+
+if (process.env.NODE_ENV !== "test") {
+  startServer();
+}

--- a/apps/express/api/payments/index.ts
+++ b/apps/express/api/payments/index.ts
@@ -1,0 +1,48 @@
+import { Router } from "express";
+import { getFeatureFlags, getProviderRegistry } from "@core/providers/registry";
+import type { PayCommand, RefundCommand } from "@core/ports";
+
+export const router = Router();
+
+router.post("/pay", async (req, res, next) => {
+  try {
+    const flags = getFeatureFlags();
+    if (flags.protoKillSwitch) {
+      return res.status(503).json({ error: "payments_disabled", reason: "PROTO_KILL_SWITCH" });
+    }
+    const { bank } = getProviderRegistry();
+    const payload = (req.body ?? {}) as PayCommand;
+    const receipt = await bank.pay(payload);
+    res.status(202).json(receipt);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.get("/pay/:id", async (req, res, next) => {
+  try {
+    const { bank } = getProviderRegistry();
+    const record = await bank.getPayment(req.params.id);
+    if (!record) {
+      return res.status(404).json({ error: "payment_not_found", id: req.params.id });
+    }
+    res.json(record);
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.post("/refund", async (req, res, next) => {
+  try {
+    const flags = getFeatureFlags();
+    if (flags.protoKillSwitch) {
+      return res.status(503).json({ error: "payments_disabled", reason: "PROTO_KILL_SWITCH" });
+    }
+    const { bank } = getProviderRegistry();
+    const payload = (req.body ?? {}) as RefundCommand;
+    const receipt = await bank.refund(payload);
+    res.status(202).json(receipt);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx --test tests/**/*.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",
@@ -13,6 +14,7 @@
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
+        "@types/supertest": "^6.0.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
@@ -21,6 +23,7 @@
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "supertest": "^7.0.0",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"

--- a/src/core/ports/index.ts
+++ b/src/core/ports/index.ts
@@ -1,0 +1,82 @@
+export interface PayCommand {
+  amount: number;
+  currency: string;
+  reference?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PaymentRecord {
+  id: string;
+  amount: number;
+  currency: string;
+  reference?: string;
+  metadata?: Record<string, unknown>;
+  status: "pending" | "settled" | "refunded" | "failed";
+  provider: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface RefundCommand {
+  paymentId: string;
+  amount?: number;
+  reason?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface RefundReceipt {
+  id: string;
+  paymentId: string;
+  provider: string;
+  status: "accepted" | "rejected";
+  processedAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface BankPort {
+  readonly providerName: string;
+  pay(command: PayCommand): Promise<PaymentRecord>;
+  getPayment(id: string): Promise<PaymentRecord | undefined>;
+  refund(command: RefundCommand): Promise<RefundReceipt>;
+}
+
+export interface KmsPort {
+  readonly providerName: string;
+  getKeyId(): string;
+  sign(payload: string): Promise<string>;
+  verify(payload: string, signature: string): Promise<boolean>;
+}
+
+export interface RatesPort {
+  readonly providerName: string;
+  getRate(code: string): Promise<number>;
+  listRates(): Promise<Record<string, number>>;
+}
+
+export interface StatementsPort {
+  readonly providerName: string;
+  generateStatement(accountId: string, options?: Record<string, unknown>): Promise<{ id: string; provider: string; generatedAt: string; metadata?: Record<string, unknown>; }>;
+}
+
+export interface AnomalyPort {
+  readonly providerName: string;
+  detect(payload: Record<string, unknown>): Promise<{ anomalies: Array<{ message: string; score: number }> }>;
+  mode(): "shadow" | "active";
+}
+
+export interface FeatureFlags {
+  protoKillSwitch: boolean;
+  shadowMode: boolean;
+}
+
+export type ProviderBindings = {
+  bank: BankPort;
+  kms: KmsPort;
+  rates: RatesPort;
+  statements: StatementsPort;
+  anomaly: AnomalyPort;
+};
+
+export type ProviderSelection = {
+  [K in keyof ProviderBindings]: string;
+};

--- a/src/core/providers/registry.ts
+++ b/src/core/providers/registry.ts
@@ -1,0 +1,304 @@
+import { randomUUID } from "crypto";
+import type {
+  AnomalyPort,
+  BankPort,
+  FeatureFlags,
+  KmsPort,
+  PayCommand,
+  PaymentRecord,
+  ProviderBindings,
+  ProviderSelection,
+  RatesPort,
+  RefundCommand,
+  RefundReceipt,
+  StatementsPort,
+} from "@core/ports";
+
+const PROVIDER_KEYS: Array<keyof ProviderBindings> = ["bank", "kms", "rates", "statements", "anomaly"];
+
+function parseBoolean(value: string | undefined): boolean {
+  if (!value) return false;
+  return ["1", "true", "yes", "on", "enabled"].includes(value.trim().toLowerCase());
+}
+
+export function getFeatureFlags(): FeatureFlags {
+  return {
+    protoKillSwitch: parseBoolean(process.env.PROTO_KILL_SWITCH),
+    shadowMode: parseBoolean(process.env.SHADOW_MODE),
+  };
+}
+
+abstract class BaseBankProvider implements BankPort {
+  private readonly store = new Map<string, PaymentRecord>();
+
+  protected constructor(public readonly providerName: string) {}
+
+  async pay(command: PayCommand): Promise<PaymentRecord> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const record: PaymentRecord = {
+      id,
+      amount: command.amount ?? 0,
+      currency: command.currency ?? "AUD",
+      reference: command.reference,
+      metadata: command.metadata,
+      status: "pending",
+      provider: this.providerName,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.store.set(id, record);
+    return { ...record };
+  }
+
+  async getPayment(id: string): Promise<PaymentRecord | undefined> {
+    const record = this.store.get(id);
+    return record ? { ...record } : undefined;
+  }
+
+  async refund(command: RefundCommand): Promise<RefundReceipt> {
+    const now = new Date().toISOString();
+    const existing = this.store.get(command.paymentId);
+    if (existing) {
+      existing.status = "refunded";
+      existing.updatedAt = now;
+      this.store.set(existing.id, existing);
+    }
+    return {
+      id: randomUUID(),
+      paymentId: command.paymentId,
+      provider: this.providerName,
+      status: "accepted",
+      processedAt: now,
+      metadata: command.metadata,
+    };
+  }
+}
+
+class MockBankProvider extends BaseBankProvider {
+  constructor() {
+    super("bank:mock");
+  }
+}
+
+class LiveBankProvider extends BaseBankProvider {
+  constructor() {
+    super("bank:live");
+  }
+}
+
+class BaseKmsProvider implements KmsPort {
+  constructor(public readonly providerName: string, private readonly keyId: string) {}
+
+  getKeyId(): string {
+    return this.keyId;
+  }
+
+  async sign(payload: string): Promise<string> {
+    const material = `${this.keyId}:${this.providerName}:${payload}`;
+    return Buffer.from(material).toString("base64url");
+  }
+
+  async verify(payload: string, signature: string): Promise<boolean> {
+    return signature === (await this.sign(payload));
+  }
+}
+
+class MockKmsProvider extends BaseKmsProvider {
+  constructor() {
+    super("kms:mock", "mock-key");
+  }
+}
+
+class LiveKmsProvider extends BaseKmsProvider {
+  constructor() {
+    super("kms:live", "live-key");
+  }
+}
+
+class BaseRatesProvider implements RatesPort {
+  constructor(public readonly providerName: string, private readonly rates: Record<string, number>) {}
+
+  async getRate(code: string): Promise<number> {
+    const upper = code.toUpperCase();
+    const rate = this.rates[upper];
+    if (typeof rate !== "number") {
+      throw new Error(`Rate not found for ${code}`);
+    }
+    return rate;
+  }
+
+  async listRates(): Promise<Record<string, number>> {
+    return { ...this.rates };
+  }
+}
+
+class MockRatesProvider extends BaseRatesProvider {
+  constructor() {
+    super("rates:mock", { AUD: 1, USD: 0.65, EUR: 0.6 });
+  }
+}
+
+class LiveRatesProvider extends BaseRatesProvider {
+  constructor() {
+    super("rates:live", { AUD: 1, USD: 0.64, EUR: 0.59, GBP: 0.51 });
+  }
+}
+
+class BaseStatementsProvider implements StatementsPort {
+  constructor(public readonly providerName: string) {}
+
+  async generateStatement(accountId: string, options: Record<string, unknown> = {}) {
+    return {
+      id: randomUUID(),
+      provider: this.providerName,
+      generatedAt: new Date().toISOString(),
+      metadata: { accountId, options },
+    };
+  }
+}
+
+class MockStatementsProvider extends BaseStatementsProvider {
+  constructor() {
+    super("statements:mock");
+  }
+}
+
+class LiveStatementsProvider extends BaseStatementsProvider {
+  constructor() {
+    super("statements:live");
+  }
+}
+
+class BaseAnomalyProvider implements AnomalyPort {
+  constructor(public readonly providerName: string) {}
+
+  async detect(_payload: Record<string, unknown>) {
+    return { anomalies: [] as Array<{ message: string; score: number }> };
+  }
+
+  mode(): "shadow" | "active" {
+    return getFeatureFlags().shadowMode ? "shadow" : "active";
+  }
+}
+
+class MockAnomalyProvider extends BaseAnomalyProvider {
+  constructor() {
+    super("anomaly:mock");
+  }
+}
+
+class LiveAnomalyProvider extends BaseAnomalyProvider {
+  constructor() {
+    super("anomaly:live");
+  }
+}
+
+type ProviderFactoryMap = {
+  [K in keyof ProviderBindings]: Record<string, () => ProviderBindings[K]>;
+};
+
+const FACTORIES: ProviderFactoryMap = {
+  bank: {
+    mock: () => new MockBankProvider(),
+    live: () => new LiveBankProvider(),
+  },
+  kms: {
+    mock: () => new MockKmsProvider(),
+    live: () => new LiveKmsProvider(),
+  },
+  rates: {
+    mock: () => new MockRatesProvider(),
+    live: () => new LiveRatesProvider(),
+  },
+  statements: {
+    mock: () => new MockStatementsProvider(),
+    live: () => new LiveStatementsProvider(),
+  },
+  anomaly: {
+    mock: () => new MockAnomalyProvider(),
+    live: () => new LiveAnomalyProvider(),
+  },
+};
+
+const DEFAULT_SELECTION: ProviderSelection = {
+  bank: "mock",
+  kms: "mock",
+  rates: "mock",
+  statements: "mock",
+  anomaly: "mock",
+};
+
+let cachedSignature: string | null = null;
+let cachedBindings: ProviderBindings | null = null;
+let cachedSelection: ProviderSelection | null = null;
+
+function parseProviderEnv(): ProviderSelection {
+  const selection: ProviderSelection = { ...DEFAULT_SELECTION };
+  const raw = process.env.PROVIDERS;
+  if (!raw) {
+    return selection;
+  }
+
+  for (const chunk of raw.split(";")) {
+    const [rawKey, rawValue] = chunk.split("=").map((part) => part?.trim());
+    if (!rawKey || !rawValue) continue;
+    const normalizedKey = rawKey.toLowerCase() as keyof ProviderBindings;
+    if (!PROVIDER_KEYS.includes(normalizedKey)) continue;
+    selection[normalizedKey] = rawValue.toLowerCase();
+  }
+
+  return selection;
+}
+
+function instantiateProviders(selection: ProviderSelection): ProviderBindings {
+  const bindings = {} as ProviderBindings;
+  for (const key of PROVIDER_KEYS) {
+    const desired = selection[key];
+    const bucket = FACTORIES[key];
+    const factory = bucket[desired] ?? bucket[DEFAULT_SELECTION[key]];
+    if (!factory) {
+      throw new Error(`No factory available for provider ${String(key)}:${desired}`);
+    }
+    bindings[key] = factory();
+  }
+  return bindings;
+}
+
+function serializeSelection(selection: ProviderSelection): string {
+  return PROVIDER_KEYS.map((key) => `${key}:${selection[key]}`).join("|");
+}
+
+export function getProviderRegistry(): ProviderBindings {
+  const selection = parseProviderEnv();
+  const signature = serializeSelection(selection);
+  if (!cachedBindings || signature !== cachedSignature) {
+    cachedBindings = instantiateProviders(selection);
+    cachedSelection = selection;
+    cachedSignature = signature;
+  }
+  return cachedBindings;
+}
+
+export function describeProviderRegistry() {
+  const bindings = getProviderRegistry();
+  const selection = cachedSelection ?? DEFAULT_SELECTION;
+  const available = Object.fromEntries(
+    PROVIDER_KEYS.map((key) => [key, Object.keys(FACTORIES[key])])
+  ) as Record<keyof ProviderBindings, string[]>;
+
+  return {
+    bindings: { ...selection },
+    active: Object.fromEntries(
+      PROVIDER_KEYS.map((key) => [key, bindings[key].providerName])
+    ) as Record<keyof ProviderBindings, string>,
+    available,
+    flags: getFeatureFlags(),
+  };
+}
+
+export function resetProviderRegistryCache() {
+  cachedBindings = null;
+  cachedSelection = null;
+  cachedSignature = null;
+}

--- a/tests/api/app.test.ts
+++ b/tests/api/app.test.ts
@@ -1,0 +1,29 @@
+import { before, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+type SupertestFactory = typeof import("../helpers/supertest").default;
+type ApiModule = typeof import("../../api/index");
+
+let request: SupertestFactory;
+let app: ApiModule["app"];
+
+before(async () => {
+  process.env.NODE_ENV = "test";
+  try {
+    request = (await import("supertest")).default as SupertestFactory;
+  } catch {
+    request = (await import("../helpers/supertest")).default;
+  }
+  ({ app } = await import("../../api/index"));
+});
+
+describe("api health", () => {
+  it("returns 200 with ok payload", async () => {
+    const response = await request(app).get("/health").expect(200);
+    assert.equal((response.body as { ok?: boolean }).ok, true);
+  });
+
+  it("returns 404 for unknown routes", async () => {
+    await request(app).get("/nope").expect(404);
+  });
+});

--- a/tests/helpers/supertest.ts
+++ b/tests/helpers/supertest.ts
@@ -1,0 +1,107 @@
+import type { Express } from "express";
+import type { Server } from "http";
+import { once } from "events";
+import { AddressInfo } from "net";
+
+type HttpMethod = "get" | "post" | "put" | "patch" | "delete";
+
+type Headers = Record<string, string>;
+
+export interface TestResponse {
+  status: number;
+  headers: Headers;
+  text: string;
+  body: unknown;
+}
+
+class RequestBuilder {
+  private payload: unknown;
+  private headers: Headers = {};
+
+  constructor(private readonly app: Express, private readonly method: HttpMethod, private readonly path: string) {}
+
+  send(body: unknown) {
+    this.payload = body;
+    return this;
+  }
+
+  set(header: string, value: string) {
+    this.headers[header.toLowerCase()] = value;
+    return this;
+  }
+
+  expect(status: number, body?: unknown): Promise<TestResponse> {
+    return this.execute().then((response) => {
+      if (response.status !== status) {
+        throw new Error(`Expected status ${status} but received ${response.status}`);
+      }
+      if (body !== undefined) {
+        const actual = JSON.stringify(response.body);
+        const expected = JSON.stringify(body);
+        if (actual !== expected) {
+          throw new Error(`Expected body ${expected} but received ${actual}`);
+        }
+      }
+      return response;
+    });
+  }
+
+  private async execute(): Promise<TestResponse> {
+    const server = await this.startServer();
+    try {
+      const address = server.address() as AddressInfo;
+      const url = new URL(this.path, `http://127.0.0.1:${address.port}`);
+      const headers = { ...this.headers };
+      const options: RequestInit = { method: this.method.toUpperCase(), headers };
+
+      if (this.payload !== undefined) {
+        if (typeof this.payload === "string" || this.payload instanceof ArrayBuffer) {
+          options.body = this.payload as BodyInit;
+        } else {
+          headers["content-type"] ??= "application/json";
+          options.body = JSON.stringify(this.payload);
+        }
+      }
+
+      const res = await fetch(url, options);
+      const text = await res.text();
+      const lowerHeaders = Object.fromEntries(Array.from(res.headers.entries()).map(([k, v]) => [k.toLowerCase(), v]));
+      let parsed: unknown = text;
+      const contentType = lowerHeaders["content-type"];
+      if (contentType?.includes("application/json")) {
+        try {
+          parsed = text ? JSON.parse(text) : undefined;
+        } catch {
+          parsed = text;
+        }
+      }
+
+      return {
+        status: res.status,
+        headers: lowerHeaders,
+        text,
+        body: parsed,
+      };
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  private async startServer(): Promise<Server> {
+    const server = this.app.listen(0);
+    await once(server, "listening");
+    return server;
+  }
+}
+
+export default function request(app: Express) {
+  const build = (method: HttpMethod) => (path: string) => new RequestBuilder(app, method, path);
+
+  return {
+    get: build("get"),
+    post: build("post"),
+    put: build("put"),
+    patch: build("patch"),
+    delete: build("delete"),
+  };
+}

--- a/tests/providers/registry.test.ts
+++ b/tests/providers/registry.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  describeProviderRegistry,
+  getFeatureFlags,
+  getProviderRegistry,
+  resetProviderRegistryCache,
+} from "@core/providers/registry";
+
+const ORIGINAL_PROVIDERS = process.env.PROVIDERS;
+const ORIGINAL_KILL = process.env.PROTO_KILL_SWITCH;
+const ORIGINAL_SHADOW = process.env.SHADOW_MODE;
+
+describe("provider registry", () => {
+  beforeEach(() => {
+    resetProviderRegistryCache();
+  });
+
+  afterEach(() => {
+    process.env.PROVIDERS = ORIGINAL_PROVIDERS;
+    process.env.PROTO_KILL_SWITCH = ORIGINAL_KILL;
+    process.env.SHADOW_MODE = ORIGINAL_SHADOW;
+    resetProviderRegistryCache();
+  });
+
+  it("defaults to mock providers", () => {
+    delete process.env.PROVIDERS;
+    const registry = getProviderRegistry();
+    assert.equal(registry.bank.providerName, "bank:mock");
+    assert.equal(registry.kms.providerName, "kms:mock");
+  });
+
+  it("switches providers when env overrides", () => {
+    process.env.PROVIDERS = "bank=live;kms=live;rates=live;statements=live;anomaly=live";
+    const registry = getProviderRegistry();
+    assert.equal(registry.bank.providerName, "bank:live");
+    assert.equal(registry.kms.providerName, "kms:live");
+    const description = describeProviderRegistry();
+    assert.equal(description.bindings.bank, "live");
+    assert.equal(description.active.bank, "bank:live");
+  });
+
+  it("reads feature flags", () => {
+    process.env.PROTO_KILL_SWITCH = "1";
+    process.env.SHADOW_MODE = "true";
+    const flags = getFeatureFlags();
+    assert.equal(flags.protoKillSwitch, true);
+    assert.equal(flags.shadowMode, true);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,14 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@core/ports": ["src/core/ports/index.ts"],
+      "@core/ports/*": ["src/core/ports/*"],
+      "@core/providers/registry": ["src/core/providers/registry.ts"],
+      "@core/providers/*": ["src/core/providers/*"]
+    }
   },
-  "include": ["src"]
+  "include": ["src", "api", "apps", "tests"]
 }


### PR DESCRIPTION
## Summary
- create the express payments router with pay, lookup, and refund stubs and mount it in the API along with health and debug endpoints
- add core port definitions plus a provider registry that reads PROVIDERS/feature flag env vars to swap implementations
- add tests covering the HTTP health surface and provider registry behaviour, with a lightweight supertest fallback for environments without the package

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e25487bbdc832796830a47c1ba38e3