### PR TITLE
Embed payments router in API entrypoint

### DIFF
--- a/api/index.test.ts
+++ b/api/index.test.ts
@@ -1,0 +1,20 @@
+import { once } from "node:events";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+if (!process.env.RPT_PUBLIC_BASE64 && !process.env.ED25519_PUBLIC_KEY_PEM) {
+  process.env.RPT_PUBLIC_BASE64 = Buffer.alloc(32).toString("base64");
+}
+
+test("payments api server boots", async () => {
+  const { createApp } = await import("./index");
+  const app = createApp();
+  const server = app.listen(0);
+  await once(server, "listening");
+
+  const address = server.address();
+  assert.ok(address && typeof address === "object" && address.port > 0);
+
+  server.close();
+  await once(server, "close");
+});

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,10 +1,17 @@
-// server/index.ts
 import express from "express";
-import bodyParser from "body-parser";
-import { router as paymentsApi } from "./api/payments";
 
-const app = express();
-app.use(bodyParser.json());
-app.use("/api/payments", paymentsApi);
+import { router as paymentsApi } from "./payments";
 
-app.listen(8080, () => console.log("App on http://localhost:8080"));
+export function createApp() {
+  const app = express();
+  app.use("/api/payments", paymentsApi);
+  return app;
+}
+
+if (require.main === module) {
+  const port = Number(process.env.PORT ?? 8080);
+  const app = createApp();
+  app.listen(port, () => {
+    console.log(`App on http://localhost:${port}`);
+  });
+}

--- a/api/payments.ts
+++ b/api/payments.ts
@@ -1,0 +1,3 @@
+import { createPaymentsRouter } from "../apps/services/payments/src/index";
+
+export const router = createPaymentsRouter();


### PR DESCRIPTION
## Summary
- export a reusable payments router from the payments service and guard the standalone bootstrap
- wire the API entrypoint to the shared router and expose a factory for consumers/tests
- add a smoke test that boots the API server to verify the wiring

## Testing
- npx tsx --test api/index.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2569f40c883279c774aa54197601d