### PR TITLE
Expose runtime metadata in console header and hook calculators to tax engine

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+
+export const api = Router();
+
+api.get("/status", (_req, res) => {
+  res.json({ ok: true });
+});

--- a/src/api/runtime.ts
+++ b/src/api/runtime.ts
@@ -1,0 +1,22 @@
+import { Router } from "express";
+import { runtimeState } from "../runtime/state";
+
+export const runtimeApi = Router();
+
+runtimeApi.get("/runtime/summary", (_req, res) => {
+  res.json(runtimeState.getSummary());
+});
+
+runtimeApi.get("/runtime/queues", (_req, res) => {
+  res.json({ queues: runtimeState.listQueues() });
+});
+
+runtimeApi.post("/runtime/queues/:id/runbook", (req, res) => {
+  const result = runtimeState.runRunbook(req.params.id);
+  if (!result.allowed) {
+    return res.status(result.status).json({ ok: false, message: result.message });
+  }
+  return res
+    .status(result.status)
+    .json({ ok: true, message: result.message, queue: result.queue });
+});

--- a/src/api/taxEngine.ts
+++ b/src/api/taxEngine.ts
@@ -1,0 +1,50 @@
+import { Router } from "express";
+
+const TAX_ENGINE_BASE =
+  process.env.TAX_ENGINE_BASE_URL || "http://localhost:8002";
+
+async function forward(path: string, body: unknown) {
+  const res = await fetch(`${TAX_ENGINE_BASE}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body ?? {}),
+  });
+  const text = await res.text();
+  let json: any = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch (err) {
+    json = { raw: text };
+  }
+  if (!res.ok) {
+    const message = (json && (json.error || json.detail)) || text || "Tax engine error";
+    const error = new Error(String(message));
+    (error as any).status = res.status;
+    throw error;
+  }
+  return json;
+}
+
+export const taxEngineApi = Router();
+
+taxEngineApi.post("/tax/gst", async (req, res) => {
+  try {
+    const data = await forward("/api/gst", req.body);
+    res.json(data);
+  } catch (err: any) {
+    res
+      .status(err?.status || 502)
+      .json({ error: err?.message || "GST calculation failed" });
+  }
+});
+
+taxEngineApi.post("/tax/paygw", async (req, res) => {
+  try {
+    const data = await forward("/api/paygw", req.body);
+    res.json(data);
+  } catch (err: any) {
+    res
+      .status(err?.status || 502)
+      .json({ error: err?.message || "PAYGW calculation failed" });
+  }
+});

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import { fetchJson } from "../utils/api";
+import type { RuntimeSummary, ProviderBinding, FeatureFlag } from "../types/runtime";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -13,13 +15,128 @@ const navLinks = [
   { to: "/help", label: "Help" },
 ];
 
+function formatAgo(iso?: string | null) {
+  if (!iso) return "—";
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "—";
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return `${Math.max(1, Math.round(diff / 1_000))}s ago`;
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return new Date(ts).toLocaleString();
+}
+
+const modeColors: Record<string, string> = {
+  Mock: "#6b7280",
+  Shadow: "#2563eb",
+  Real: "#16a34a",
+};
+
+function ProviderBadge({ provider }: { provider: ProviderBinding }) {
+  return (
+    <div className="provider-chip">
+      <div className="provider-main">
+        <span className="provider-label">{provider.label}</span>
+        <span className="provider-vendor">{provider.vendor}</span>
+      </div>
+      <div className="provider-meta">
+        <span
+          className="provider-mode"
+          style={{ background: `${modeColors[provider.mode] || "#374151"}15`, color: modeColors[provider.mode] || "#374151" }}
+        >
+          {provider.mode}
+        </span>
+        <span className="provider-status">{provider.status}</span>
+        <span className="provider-sync">Last sync {formatAgo(provider.lastSyncIso)}</span>
+      </div>
+    </div>
+  );
+}
+
+function FlagBadge({ flag }: { flag: FeatureFlag }) {
+  return (
+    <div className="flag-chip">
+      <span
+        className="flag-state"
+        style={{ background: flag.enabled ? "#bbf7d0" : "#fee2e2", color: flag.enabled ? "#166534" : "#991b1b" }}
+      >
+        {flag.enabled ? "Enabled" : "Disabled"}
+      </span>
+      <div className="flag-details">
+        <span className="flag-label">{flag.label}</span>
+        {flag.description ? <span className="flag-desc">{flag.description}</span> : null}
+      </div>
+    </div>
+  );
+}
+
 export default function AppLayout() {
+  const [runtime, setRuntime] = React.useState<RuntimeSummary | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    let mounted = true;
+    const load = async () => {
+      try {
+        const data = await fetchJson<RuntimeSummary>("/runtime/summary");
+        if (mounted) {
+          setRuntime(data);
+          setError(null);
+        }
+      } catch (err: any) {
+        if (mounted) {
+          setError(err?.message || "Unable to load runtime summary");
+        }
+      }
+    };
+    load();
+    const id = setInterval(load, 60_000);
+    return () => {
+      mounted = false;
+      clearInterval(id);
+    };
+  }, []);
+
+  const badge = runtime?.badge ?? "Mock";
+  const badgeColor = modeColors[badge] || "#4b5563";
+  const rates = runtime?.rates;
+
   return (
     <div>
       <header className="app-header">
-        <img src={atoLogo} alt="ATO Logo" />
-        <h1>APGMS - Automated PAYGW & GST Management</h1>
-        <p>ATO-Compliant Tax Management System</p>
+        <div className="header-main">
+          <img src={atoLogo} alt="ATO Logo" />
+          <div>
+            <h1>APGMS - Automated PAYGW & GST Management</h1>
+            <p>ATO-Compliant Tax Management System</p>
+            {rates ? (
+              <p className="rates-line">
+                Rates pinned → PAYGW {rates.paygw} • GST {rates.gst}
+              </p>
+            ) : null}
+          </div>
+          <span
+            className="env-badge"
+            style={{ background: `${badgeColor}22`, color: badgeColor, border: `1px solid ${badgeColor}55` }}
+          >
+            {badge} Mode
+          </span>
+        </div>
+        <div className="header-runtime">
+          <div className="providers-block">
+            <h3>Provider Bindings</h3>
+            {runtime?.providers.map((provider) => (
+              <ProviderBadge key={provider.id} provider={provider} />
+            ))}
+          </div>
+          <div className="flags-block">
+            <h3>Feature Flags</h3>
+            {runtime?.feature_flags.map((flag) => (
+              <FlagBadge key={flag.key} flag={flag} />
+            ))}
+            {error ? <div className="runtime-error">{error}</div> : null}
+          </div>
+        </div>
         <nav style={{ marginTop: 16 }}>
           {navLinks.map((link) => (
             <NavLink

--- a/src/components/QueuesPanel.tsx
+++ b/src/components/QueuesPanel.tsx
@@ -1,0 +1,86 @@
+import React from "react";
+import { fetchJson } from "../utils/api";
+import type { QueueState } from "../types/runtime";
+
+type QueuesResponse = { queues: QueueState[] };
+
+const formatAgo = (iso?: string | null) => {
+  if (!iso) return "never";
+  const ts = new Date(iso).getTime();
+  if (Number.isNaN(ts)) return "never";
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return `${Math.max(1, Math.round(diff / 1_000))}s ago`;
+  if (diff < 3_600_000) return `${Math.round(diff / 60_000)}m ago`;
+  if (diff < 86_400_000) return `${Math.round(diff / 3_600_000)}h ago`;
+  return new Date(ts).toLocaleString();
+};
+
+export function QueuesPanel() {
+  const [queues, setQueues] = React.useState<QueueState[]>([]);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [message, setMessage] = React.useState<string | null>(null);
+
+  const loadQueues = React.useCallback(async () => {
+    try {
+      const data = await fetchJson<QueuesResponse>("/runtime/queues");
+      setQueues(data.queues);
+      setError(null);
+    } catch (err: any) {
+      setError(err?.message || "Unable to fetch queues");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  React.useEffect(() => {
+    loadQueues();
+  }, [loadQueues]);
+
+  const runRunbook = async (queueId: string) => {
+    setMessage(null);
+    setError(null);
+    try {
+      const data = await fetchJson<{ ok: boolean; message: string; queue: QueueState }>(
+        `/runtime/queues/${queueId}/runbook`,
+        { method: "POST" }
+      );
+      setQueues((prev) => prev.map((q) => (q.id === queueId ? data.queue : q)));
+      setMessage(data.message || "Runbook executed");
+    } catch (err: any) {
+      setError(err?.message || "Runbook failed");
+    }
+  };
+
+  if (loading) {
+    return <p>Loading queues…</p>;
+  }
+
+  return (
+    <div className="queues-panel">
+      <h2 style={{ marginBottom: 12 }}>Operations Queues</h2>
+      <p style={{ color: "#4b5563", marginTop: 0 }}>
+        Operators can triage anomalies, banking mismatches and DLQ payloads. Overrides are required to execute runbooks.
+      </p>
+      {error ? <div className="queue-error">{error}</div> : null}
+      {message ? <div className="queue-success">{message}</div> : null}
+      <div className="queues-grid">
+        {queues.map((queue) => (
+          <div key={queue.id} className="queue-card">
+            <div className="queue-header">
+              <span className="queue-label">{queue.label}</span>
+              <span className="queue-count">{queue.count}</span>
+            </div>
+            <p className="queue-runbook">{queue.runbook}</p>
+            <p className="queue-last">Last action {formatAgo(queue.lastRunIso)}</p>
+            <button className="button" style={{ marginTop: 12 }} onClick={() => runRunbook(queue.id)}>
+              Run runbook
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default QueuesPanel;

--- a/src/index.css
+++ b/src/index.css
@@ -10,14 +10,27 @@ body {
   background: #00205b;
   color: #fff;
   padding: 28px 0 18px 0;
-  text-align: center;
+  text-align: left;
   border-radius: 0 0 8px 8px;
   margin-bottom: 30px;
+}
+
+.header-main {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  flex-wrap: wrap;
+  padding: 0 32px;
 }
 
 .app-header img {
   max-height: 60px;
   margin-bottom: 10px;
+}
+
+.header-main img {
+  margin-bottom: 0;
 }
 
 .app-header h1 {
@@ -31,6 +44,127 @@ body {
   margin: 0;
   font-size: 1.05rem;
   font-weight: 400;
+}
+
+.rates-line {
+  font-size: 0.95rem;
+  margin-top: 4px;
+  opacity: 0.9;
+}
+
+.env-badge {
+  font-weight: 700;
+  padding: 8px 16px;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.header-runtime {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 20px;
+  margin: 24px 32px 12px 32px;
+}
+
+.providers-block, .flags-block {
+  background: rgba(255,255,255,0.08);
+  border-radius: 16px;
+  padding: 16px;
+  text-align: left;
+}
+
+.providers-block h3, .flags-block h3 {
+  margin-top: 0;
+  font-size: 1rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.8);
+}
+
+.provider-chip, .flag-chip {
+  background: rgba(0,0,0,0.25);
+  border-radius: 12px;
+  padding: 10px 12px;
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.provider-main {
+  display: flex;
+  justify-content: space-between;
+  font-weight: 600;
+}
+
+.provider-label {
+  font-size: 0.95rem;
+}
+
+.provider-vendor {
+  font-size: 0.9rem;
+  opacity: 0.85;
+}
+
+.provider-meta {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  font-size: 0.8rem;
+  align-items: center;
+}
+
+.provider-mode {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+
+.provider-status {
+  text-transform: capitalize;
+}
+
+.provider-sync {
+  opacity: 0.8;
+}
+
+.flag-chip {
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+}
+
+.flag-state {
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.flag-details {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.flag-label {
+  font-weight: 600;
+  font-size: 0.92rem;
+}
+
+.flag-desc {
+  font-size: 0.8rem;
+  opacity: 0.85;
+}
+
+.runtime-error {
+  margin-top: 12px;
+  background: rgba(239,68,68,0.2);
+  color: #fee2e2;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 0.82rem;
 }
 
 .app-footer {
@@ -196,4 +330,70 @@ th {
   background: #f1f6fa;
   font-weight: 600;
   color: #00205b;
+}
+
+.queues-panel {
+  margin-top: 32px;
+}
+
+.queues-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 16px;
+  margin-top: 18px;
+}
+
+.queue-card {
+  background: #ffffff;
+  border-radius: 14px;
+  box-shadow: 0 1px 7px #00205b12;
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+}
+
+.queue-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.queue-label {
+  font-weight: 600;
+  font-size: 1rem;
+  color: #0f172a;
+}
+
+.queue-count {
+  background: #0ea5e9;
+  color: #fff;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-weight: 600;
+}
+
+.queue-runbook {
+  font-size: 0.9rem;
+  color: #475569;
+  min-height: 48px;
+}
+
+.queue-last {
+  font-size: 0.8rem;
+  color: #6b7280;
+}
+
+.queue-error {
+  background: #fee2e2;
+  color: #991b1b;
+  padding: 10px 12px;
+  border-radius: 8px;
+  margin-top: 12px;
+}
+
+.queue-success {
+  background: #dcfce7;
+  color: #166534;
+  padding: 10px 12px;
+  border-radius: 8px;
+  margin-top: 12px;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import dotenv from "dotenv";
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
+import { taxEngineApi } from "./api/taxEngine";
+import { runtimeApi } from "./api/runtime";
 import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
@@ -27,6 +29,8 @@ app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+app.use("/api", taxEngineApi);
+app.use("/api", runtimeApi);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { QueuesPanel } from '../components/QueuesPanel';
 
 export default function Dashboard() {
   const complianceStatus = {
@@ -95,6 +96,8 @@ export default function Dashboard() {
       <div className="mt-4 text-xs text-gray-500 italic">
         Staying compliant helps avoid audits, reduce penalties, and increase access to ATO support programs.
       </div>
+
+      <QueuesPanel />
     </div>
   );
 }

--- a/src/runtime/state.ts
+++ b/src/runtime/state.ts
@@ -1,0 +1,181 @@
+import { randomUUID } from "crypto";
+
+export type ProviderMode = "Mock" | "Shadow" | "Real";
+
+export interface ProviderBinding {
+  id: string;
+  label: string;
+  vendor: string;
+  mode: ProviderMode;
+  status: "connected" | "shadowing" | "disconnected";
+  lastSyncIso: string;
+}
+
+export interface FeatureFlag {
+  key: string;
+  label: string;
+  enabled: boolean;
+  description?: string;
+}
+
+export interface QueueState {
+  id: string;
+  label: string;
+  count: number;
+  runbook: string;
+  lastRunIso?: string | null;
+}
+
+type RunbookResult =
+  | { allowed: false; status: number; message: string }
+  | { allowed: true; status: number; message: string; queue: QueueState };
+
+const env = (key: string, fallback: string): string => {
+  const v = process.env[key];
+  return v == null || v === "" ? fallback : v;
+};
+
+const envBool = (key: string, fallback: boolean): boolean => {
+  const raw = process.env[key];
+  if (raw == null) return fallback;
+  return ["1", "true", "yes", "on"].includes(raw.toLowerCase());
+};
+
+const PAYGW_RATES_VERSION = env("PAYGW_RATES_VERSION", "2024-25");
+const GST_RATES_VERSION = env("GST_RATES_VERSION", "GST-2024-07");
+
+const providerModes: Record<string, ProviderMode> = {
+  payroll: (env("PROVIDER_PAYROLL_MODE", "Shadow") as ProviderMode) || "Shadow",
+  pos: (env("PROVIDER_POS_MODE", "Mock") as ProviderMode) || "Mock",
+  bank: (env("PROVIDER_BANK_MODE", "Real") as ProviderMode) || "Real",
+};
+
+const providerBindings: ProviderBinding[] = [
+  {
+    id: "payroll",
+    label: "Payroll",
+    vendor: env("PROVIDER_PAYROLL_VENDOR", "MYOB Advanced"),
+    mode: providerModes.payroll,
+    status: providerModes.payroll === "Real" ? "connected" : "shadowing",
+    lastSyncIso: new Date(Date.now() - 15 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "pos",
+    label: "Point of Sale",
+    vendor: env("PROVIDER_POS_VENDOR", "Square AU"),
+    mode: providerModes.pos,
+    status: providerModes.pos === "Mock" ? "disconnected" : "connected",
+    lastSyncIso: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  },
+  {
+    id: "bank",
+    label: "Bank Feeds",
+    vendor: env("PROVIDER_BANK_VENDOR", "Basiq Sandbox"),
+    mode: providerModes.bank,
+    status: "connected",
+    lastSyncIso: new Date(Date.now() - 2 * 60 * 1000).toISOString(),
+  },
+];
+
+const featureFlags: FeatureFlag[] = [
+  {
+    key: "shadow_mode",
+    label: "Shadow Settlements",
+    enabled: envBool("FEATURE_SHADOW_MODE", true),
+    description: "Mirror settlements without releasing funds until reviewed.",
+  },
+  {
+    key: "operator_overrides",
+    label: "Operator Overrides",
+    enabled: envBool("FEATURE_OPERATOR_OVERRIDES", false),
+    description: "Allow console operators to force-run guarded actions.",
+  },
+  {
+    key: "auto_release",
+    label: "Auto Release on RPT",
+    enabled: envBool("FEATURE_AUTO_RELEASE", false),
+    description: "Automatically release PAYGW/GST once an RPT is signed.",
+  },
+];
+
+const queues: QueueState[] = [
+  {
+    id: "pending-anomalies",
+    label: "Pending Anomalies",
+    count: 3,
+    runbook: "Review anomaly vectors, attach operator note, then requeue via /ops/anomaly/requeue",
+  },
+  {
+    id: "unreconciled-bank",
+    label: "Unreconciled Bank Lines",
+    count: 5,
+    runbook: "Match bank lines using /ops/bank/reconcile or push to suspense account.",
+  },
+  {
+    id: "dead-letter",
+    label: "DLQ",
+    count: 2,
+    runbook: "Inspect payload, patch root cause, then replay with /ops/dlq/replay?dryRun=false.",
+  },
+];
+
+const badgePriority: ProviderMode[] = ["Real", "Shadow", "Mock"];
+
+const deriveBadge = (): ProviderMode => {
+  for (const mode of badgePriority) {
+    if (providerBindings.some((p) => p.mode === mode)) {
+      return mode;
+    }
+  }
+  return "Mock";
+};
+
+const cloneQueue = (q: QueueState): QueueState => ({ ...q });
+
+export const runtimeState = {
+  getSummary() {
+    return {
+      badge: deriveBadge(),
+      providers: providerBindings.map((p) => ({ ...p })),
+      feature_flags: featureFlags.map((f) => ({ ...f })),
+      overrides_enabled:
+        featureFlags.find((f) => f.key === "operator_overrides")?.enabled ?? false,
+      rates: {
+        paygw: PAYGW_RATES_VERSION,
+        gst: GST_RATES_VERSION,
+      },
+    };
+  },
+  listQueues(): QueueState[] {
+    return queues.map(cloneQueue);
+  },
+  runRunbook(queueId: string): RunbookResult {
+    const queue = queues.find((q) => q.id === queueId);
+    if (!queue) {
+      return { allowed: false, status: 404, message: "Queue not found" };
+    }
+
+    const overridesEnabled =
+      featureFlags.find((f) => f.key === "operator_overrides")?.enabled ?? false;
+
+    if (!overridesEnabled) {
+      return {
+        allowed: false,
+        status: 412,
+        message: "Operator overrides are disabled in this environment",
+      };
+    }
+
+    queue.count = 0;
+    queue.lastRunIso = new Date().toISOString();
+
+    return {
+      allowed: true,
+      status: 200,
+      message: `Runbook executed with override ${randomUUID().slice(0, 8)}`,
+      queue: cloneQueue(queue),
+    };
+  },
+};
+
+export type RuntimeSummary = ReturnType<typeof runtimeState.getSummary>;

--- a/src/types/runtime.ts
+++ b/src/types/runtime.ts
@@ -1,0 +1,36 @@
+export type ProviderMode = "Mock" | "Shadow" | "Real";
+
+export type ProviderBinding = {
+  id: string;
+  label: string;
+  vendor: string;
+  mode: ProviderMode;
+  status: "connected" | "shadowing" | "disconnected";
+  lastSyncIso: string;
+};
+
+export type FeatureFlag = {
+  key: string;
+  label: string;
+  enabled: boolean;
+  description?: string;
+};
+
+export type RuntimeSummary = {
+  badge: ProviderMode;
+  providers: ProviderBinding[];
+  feature_flags: FeatureFlag[];
+  overrides_enabled: boolean;
+  rates: {
+    paygw: string;
+    gst: string;
+  };
+};
+
+export type QueueState = {
+  id: string;
+  label: string;
+  count: number;
+  runbook: string;
+  lastRunIso?: string | null;
+};

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -1,0 +1,35 @@
+export const API_BASE = process.env.REACT_APP_API_BASE_URL || "/api";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+interface FetchOptions {
+  method?: HttpMethod;
+  body?: any;
+  headers?: Record<string, string>;
+}
+
+export async function fetchJson<T>(path: string, options: FetchOptions = {}): Promise<T> {
+  const { method = "GET", body, headers = {} } = options;
+  const res = await fetch(`${API_BASE}${path}`, {
+    method,
+    headers: {
+      ...(body != null ? { "content-type": "application/json" } : {}),
+      ...headers,
+    },
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = null;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch (err) {
+    throw new Error(`Invalid JSON response from ${path}`);
+  }
+  if (!res.ok) {
+    const message = (json && (json.error || json.message || json.detail)) || text || res.statusText;
+    const error = new Error(String(message));
+    (error as any).status = res.status;
+    throw error;
+  }
+  return json as T;
+}


### PR DESCRIPTION
## Summary
- add runtime state module and API endpoints to surface provider bindings, feature flags, queues, and proxy tax engine calculators
- update console header and styling to show environment badge, provider bindings, feature flags, and pinned rate versions
- replace GST and PAYGW calculators to call the tax engine API and add an operations queue panel with runbook actions

## Testing
- npm run lint
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e254bfd6d48327a998ade589e321f3