### PR TITLE
Implement tax engine event pipeline through recon and RPT

### DIFF
--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -14,12 +14,11 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
 
-    // Accept pending/active. Order by created_at so newest wins.
+    // Always inspect latest token; ensure it has been issued.
     const q = `
       SELECT id as rpt_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce
       FROM rpt_tokens
       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
-        AND status IN ('pending','active')
       ORDER BY created_at DESC
       LIMIT 1
     `;
@@ -27,6 +26,10 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
     if (!rows.length) return res.status(403).json({ error: "No active RPT for period" });
 
     const r = rows[0];
+    const status = String(r.status || "").toUpperCase();
+    if (!["ISSUED", "ACTIVE"].includes(status)) {
+      return res.status(403).json({ error: "RPT not yet issued" });
+    }
     if (r.expires_at && new Date() > new Date(r.expires_at)) {
       return res.status(403).json({ error: "RPT expired" });
     }
@@ -37,13 +40,35 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
       return res.status(403).json({ error: "Payload hash mismatch" });
     }
 
+    let parsed: any;
+    try {
+      parsed = JSON.parse(r.payload_c14n);
+    } catch (err) {
+      return res.status(500).json({ error: "RPT payload malformed" });
+    }
+
+    if (parsed?.period_id && parsed.period_id !== periodId) {
+      return res.status(403).json({ error: "RPT period mismatch" });
+    }
+    if (parsed?.tax_type && parsed.tax_type !== taxType) {
+      return res.status(403).json({ error: "RPT tax type mismatch" });
+    }
+    if (parsed?.entity_id && parsed.entity_id !== abn) {
+      return res.status(403).json({ error: "RPT entity mismatch" });
+    }
+
     // Signature verify (signature is stored as base64 text in your seed)
     const payload = Buffer.from(r.payload_c14n);
     const sig = Buffer.from(r.signature, "base64");
     const ok = await kms.verify(payload, sig);
     if (!ok) return res.status(403).json({ error: "RPT signature invalid" });
 
-    (req as any).rpt = { rpt_id: r.rpt_id, nonce: r.nonce, payload_sha256: r.payload_sha256 };
+    (req as any).rpt = {
+      rpt_id: r.rpt_id,
+      nonce: r.nonce,
+      payload_sha256: r.payload_sha256,
+      payload: parsed,
+    };
     return next();
   } catch (e: any) {
     return res.status(500).json({ error: "RPT verification error", detail: String(e?.message || e) });

--- a/apps/services/tax-engine/app/main.py
+++ b/apps/services/tax-engine/app/main.py
@@ -25,8 +25,12 @@ def metrics():
 
 # --- BEGIN TAX_ENGINE_CORE_APP ---
 import asyncio
+import hashlib
+import json
+import logging
 import os
-from typing import Optional
+import time
+from typing import Any, Dict, Optional
 
 from fastapi import FastAPI, Response, status
 from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
@@ -37,6 +41,8 @@ try:
     app  # reuse if exists
 except NameError:
     app = FastAPI(title="tax-engine")
+
+LOGGER = logging.getLogger("tax-engine")
 
 NATS_URL = os.getenv("NATS_URL", "nats://nats:4222")
 SUBJECT_INPUT = os.getenv("SUBJECT_INPUT", "apgms.normalized.v1")
@@ -50,6 +56,130 @@ TAX_REQS = Counter("tax_requests_total", "Total tax requests consumed")
 TAX_OUT = Counter("tax_results_total", "Total tax results produced")
 NATS_CONNECTED = Gauge("taxengine_nats_connected", "1 if connected to NATS else 0")
 CALC_LAT = Histogram("taxengine_calc_seconds", "Calculate latency")
+
+_PAYGW_RULES: Optional[Dict[str, Any]] = None
+
+
+def _rules_path() -> str:
+    return os.path.join(os.path.dirname(__file__), "rules", "payg_w_2024_25.json")
+
+
+def _load_paygw_rules() -> Dict[str, Any]:
+    global _PAYGW_RULES
+    if _PAYGW_RULES is None:
+        with open(_rules_path(), "r", encoding="utf-8-sig") as fh:
+            _PAYGW_RULES = json.load(fh)
+    return _PAYGW_RULES
+
+
+def _line_amount_cents(line: Dict[str, Any]) -> int:
+    if "amount_cents" in line and line["amount_cents"] is not None:
+        return int(round(float(line["amount_cents"])))
+    if "total_cents" in line and line["total_cents"] is not None:
+        return int(round(float(line["total_cents"])))
+    qty = int(line.get("qty") or 0)
+    unit = int(line.get("unit_price_cents") or 0)
+    if qty and unit:
+        return qty * unit
+    if "amount" in line and line["amount"] is not None:
+        return int(round(float(line["amount"]) * 100))
+    return 0
+
+
+def _hash_source(payload: Any) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()
+
+
+def process_normalized_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Transform a normalized tax event into aggregated totals for downstream services."""
+
+    from .domains import payg_w as payg_w_mod  # local import to avoid circulars during startup
+    from .tax_rules import gst_line_tax
+
+    payg_section = event.get("payg_w") or {}
+    rules = _load_paygw_rules() if payg_section else {}
+    payg_result: Dict[str, Any] = {}
+
+    gross_cents = 0
+    paygw_cents = 0
+
+    if payg_section:
+        payg_result = payg_w_mod.compute({"payg_w": payg_section}, rules)
+        gross_val = payg_section.get("gross")
+        gross_cents = int(round(float(gross_val) * 100)) if gross_val is not None else int(
+            round(float(payg_section.get("gross_cents", 0)))
+        )
+        gross_cents = max(gross_cents, int(round(float(payg_result.get("gross", 0.0)) * 100)))
+        paygw_cents = int(round(float(payg_result.get("withholding", 0.0)) * 100))
+    else:
+        gross_val = event.get("gross") or event.get("gross_cents", 0)
+        if gross_val:
+            if "gross_cents" in event:
+                gross_cents = int(round(float(event.get("gross_cents", 0))))
+            else:
+                gross_cents = int(round(float(gross_val) * 100))
+
+    lines = event.get("lines") or []
+    taxable_cents = 0
+    gst_cents = 0
+    for line in lines:
+        amount = _line_amount_cents(line)
+        taxable_cents += max(0, amount)
+        gst_cents += gst_line_tax(amount, (line.get("tax_code") or "GST").upper())
+
+    paygw_total = round(paygw_cents / 100, 2)
+    gst_total = round(gst_cents / 100, 2)
+
+    gross_total = round(gross_cents / 100, 2)
+    taxable_total = round(taxable_cents / 100, 2)
+
+    expected_paygw_ratio = 0.2
+    expected_gst_ratio = 0.1
+
+    paygw_ratio = paygw_total / gross_total if gross_total else 0.0
+    gst_ratio = gst_total / taxable_total if taxable_total else 0.0
+
+    delta_paygw = abs(paygw_ratio - expected_paygw_ratio)
+    delta_gst = abs(gst_ratio - expected_gst_ratio)
+    anomaly_score = round(min(1.0, delta_paygw + delta_gst), 6)
+    variance_ratio = max(
+        (delta_paygw / expected_paygw_ratio) if expected_paygw_ratio else 0.0,
+        (delta_gst / expected_gst_ratio) if expected_gst_ratio else 0.0,
+    )
+
+    metrics = {
+        "paygw_ratio": round(paygw_ratio, 6),
+        "gst_ratio": round(gst_ratio, 6),
+        "delta_paygw_ratio": round(delta_paygw, 6),
+        "delta_gst_ratio": round(delta_gst, 6),
+        "variance_ratio": round(variance_ratio, 6),
+    }
+
+    source_digests: Dict[str, str] = {}
+    if payg_section:
+        source_digests["payroll"] = _hash_source(payg_section)
+    if lines:
+        source_digests["pos"] = _hash_source(lines)
+    if not source_digests:
+        source_digests["event"] = _hash_source(event)
+
+    return {
+        "id": event.get("id"),
+        "entity": event.get("entity"),
+        "period": event.get("period"),
+        "processed_at": int(time.time()),
+        "paygw_total": paygw_total,
+        "gst_total": gst_total,
+        "gross_paygw": gross_total,
+        "taxable_sales_total": taxable_total,
+        "paygw_details": payg_result,
+        "anomaly": {
+            "score": anomaly_score,
+            "metrics": metrics,
+        },
+        "source_digests": source_digests,
+    }
 
 @app.get("/metrics")
 def metrics():
@@ -85,9 +215,14 @@ async def _subscribe_and_run(nc: NATS):
         with CALC_LAT.time():
             TAX_REQS.inc()
             data = msg.data or b"{}"
-            # TODO: real calc -> publish real result
-            await nc.publish(SUBJECT_OUTPUT, data)
-            TAX_OUT.inc()
+            try:
+                event = json.loads(data.decode("utf-8"))
+                result = process_normalized_event(event)
+                payload = json.dumps(result, separators=(",", ":")).encode("utf-8")
+                await nc.publish(SUBJECT_OUTPUT, payload)
+                TAX_OUT.inc()
+            except Exception as exc:
+                LOGGER.exception("Failed to process tax event: %s", exc)
     await nc.subscribe(SUBJECT_INPUT, cb=_on_msg)
     _ready.set()
 
@@ -143,41 +278,46 @@ except Exception:
 # --- END READINESS_METRICS (tax-engine) ---
 
 # --- BEGIN MINI_UI ---
-from fastapi import Request
-from fastapi.templating import Jinja2Templates
-from fastapi.staticfiles import StaticFiles
-from .domains import payg_w as payg_w_mod
-import os, json
+try:
+    from fastapi import Request
+    from fastapi.templating import Jinja2Templates
+    from fastapi.staticfiles import StaticFiles
+    from .domains import payg_w as payg_w_mod
+    import os, json
 
-TEMPLATES = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), "templates"))
-app.mount("/static", StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")
+    _templates_dir = os.path.join(os.path.dirname(__file__), "templates")
+    TEMPLATES = Jinja2Templates(directory=_templates_dir)
+    app.mount("/static", StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")
 
-@app.get("/ui")
-def ui_index(request: Request):
-    return TEMPLATES.TemplateResponse("index.html", {"request": request, "title": "PAYG-W Calculator", "badge":"demo"})
+    @app.get("/ui")
+    def ui_index(request: Request):
+        return TEMPLATES.TemplateResponse("index.html", {"request": request, "title": "PAYG-W Calculator", "badge":"demo"})
 
-@app.post("/ui/calc")
-async def ui_calc(request: Request):
-    form = await request.form()
-    pw = {
-        "method": form.get("method"),
-        "period": form.get("period"),
-        "gross": float(form.get("gross") or 0),
-        "percent": float(form.get("percent") or 0),
-        "extra": float(form.get("extra") or 0),
-        "regular_gross": float(form.get("gross") or 0),
-        "bonus": float(form.get("bonus") or 0),
-        "tax_free_threshold": form.get("tft") == "true",
-        "stsl": form.get("stsl") == "true",
-        "target_net": float(form.get("target_net")) if form.get("target_net") else None
-    }
-    with open(os.path.join(os.path.dirname(__file__), "rules", "payg_w_2024_25.json"), "r", encoding="utf-8") as f:
-        rules = json.load(f)
-    res = payg_w_mod.compute({"payg_w": pw}, rules)
-    return TEMPLATES.TemplateResponse("index.html", {"request": request, "title": "PAYG-W Calculator", "result": res, "badge":"demo"})
+    @app.post("/ui/calc")
+    async def ui_calc(request: Request):
+        form = await request.form()
+        pw = {
+            "method": form.get("method"),
+            "period": form.get("period"),
+            "gross": float(form.get("gross") or 0),
+            "percent": float(form.get("percent") or 0),
+            "extra": float(form.get("extra") or 0),
+            "regular_gross": float(form.get("gross") or 0),
+            "bonus": float(form.get("bonus") or 0),
+            "tax_free_threshold": form.get("tft") == "true",
+            "stsl": form.get("stsl") == "true",
+            "target_net": float(form.get("target_net")) if form.get("target_net") else None
+        }
+        with open(os.path.join(os.path.dirname(__file__), "rules", "payg_w_2024_25.json"), "r", encoding="utf-8") as f:
+            rules = json.load(f)
+        res = payg_w_mod.compute({"payg_w": pw}, rules)
+        return TEMPLATES.TemplateResponse("index.html", {"request": request, "title": "PAYG-W Calculator", "result": res, "badge":"demo"})
 
-@app.get("/ui/help")
-def ui_help(request: Request):
-    return TEMPLATES.TemplateResponse("help.html", {"request": request, "title": "Help", "badge":"demo"})
+    @app.get("/ui/help")
+    def ui_help(request: Request):
+        return TEMPLATES.TemplateResponse("help.html", {"request": request, "title": "Help", "badge":"demo"})
+except AssertionError:
+    # Optional UI dependency (jinja2) is not installed in test envs.
+    TEMPLATES = None
 # --- END MINI_UI ---
 

--- a/libs/rpt/rpt.py
+++ b/libs/rpt/rpt.py
@@ -22,6 +22,7 @@ def build(period_id: str,
           gst_total: float,
           source_digests: Dict[str,str],
           anomaly_score: float,
+          anomaly_metrics: Dict[str, float] | None = None,
           ttl_seconds: int = 3600) -> Dict[str, Any]:
     rpt = {
         "period_id": period_id,
@@ -29,6 +30,7 @@ def build(period_id: str,
         "gst_total": round(gst_total,2),
         "source_digests": source_digests,
         "anomaly_score": anomaly_score,
+        "anomaly_metrics": anomaly_metrics or {},
         "expires_at": int(time.time()) + ttl_seconds,
         "nonce": os.urandom(8).hex()
     }

--- a/tests/integration/test_tax_pipeline.py
+++ b/tests/integration/test_tax_pipeline.py
@@ -1,0 +1,107 @@
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from app.main import process_normalized_event
+from app.domains import payg_w as payg_w_mod
+from apps.services.recon.main import TaxSummary, OwaSnapshot, ReconReq, evaluate_recon
+from libs.rpt import rpt
+
+
+def _load_paygw_rules():
+    rules_path = "apps/services/tax-engine/app/rules/payg_w_2024_25.json"
+    with open(rules_path, "r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def paygw_rules():
+    return _load_paygw_rules()
+
+
+@pytest.fixture
+def sample_event():
+    return {
+        "id": "evt-001",
+        "entity": "12345678901",
+        "period": "2025-09",
+        "payg_w": {
+            "method": "formula_progressive",
+            "period": "weekly",
+            "gross": 2000.0,
+            "tax_free_threshold": True,
+        },
+        "lines": [
+            {"sku": "POS-1", "qty": 10, "unit_price_cents": 5000, "tax_code": "GST"},
+            {"sku": "POS-2", "qty": 4, "unit_price_cents": 2500, "tax_code": "GST_FREE"},
+        ],
+    }
+
+
+@pytest.fixture
+def expected_payg(paygw_rules, sample_event):
+    result = payg_w_mod.compute({"payg_w": sample_event["payg_w"]}, paygw_rules)
+    return float(result["withholding"])
+
+
+def test_pipeline_produces_authoritative_totals(sample_event, expected_payg):
+    tax_out = process_normalized_event(sample_event)
+
+    assert pytest.approx(tax_out["paygw_total"], rel=1e-6) == round(expected_payg, 2)
+
+    gst_lines = sample_event["lines"][0]
+    taxable_sales = (gst_lines["qty"] * gst_lines["unit_price_cents"]) / 100
+    assert pytest.approx(tax_out["gst_total"], rel=1e-6) == round(taxable_sales * 0.10, 2)
+
+    assert tax_out["source_digests"].keys() >= {"payroll", "pos"}
+    assert 0.0 <= tax_out["anomaly"]["score"] <= 1.0
+
+    recon_req = ReconReq(
+        period_id=sample_event["period"],
+        tax=TaxSummary(
+            paygw_total=tax_out["paygw_total"],
+            gst_total=tax_out["gst_total"],
+            anomaly_score=tax_out["anomaly"]["score"],
+            metrics=tax_out["anomaly"]["metrics"],
+        ),
+        owa=OwaSnapshot(paygw=tax_out["paygw_total"], gst=tax_out["gst_total"]),
+    )
+    recon = evaluate_recon(recon_req)
+    assert recon["pass"] is True
+    assert recon["reason_code"] is None
+    assert recon["next_state"] == "RPT-Issued"
+    assert recon["metrics"] == tax_out["anomaly"]["metrics"]
+
+    rpt_token = rpt.build(
+        sample_event["period"],
+        tax_out["paygw_total"],
+        tax_out["gst_total"],
+        tax_out["source_digests"],
+        tax_out["anomaly"]["score"],
+        tax_out["anomaly"]["metrics"],
+    )
+    payload = {k: v for k, v in rpt_token.items() if k != "signature"}
+    assert rpt.verify(payload, rpt_token["signature"]) is True
+    assert payload["anomaly_metrics"] == tax_out["anomaly"]["metrics"]
+
+
+def test_recon_reason_codes_when_mismatched(sample_event):
+    tax_summary = TaxSummary(
+        paygw_total=200.0,
+        gst_total=50.0,
+        anomaly_score=0.95,
+        metrics={"paygw_ratio": 0.1},
+    )
+    owa = OwaSnapshot(paygw=150.0, gst=60.0)
+    recon = evaluate_recon(ReconReq(period_id="2025-09", tax=tax_summary, owa=owa))
+    assert recon["pass"] is False
+    assert recon["next_state"] == "Blocked"
+    assert "ANOMALY_BREACH" in recon["reason_code"]
+    assert "PAYGW_EXCESS" in recon["reason_code"]
+    assert "GST_SHORTFALL" in recon["reason_code"]


### PR DESCRIPTION
## Summary
- compute PAYGW/GST totals and anomaly metrics in the tax-engine NATS consumer and publish structured tax events
- enhance the recon service to evaluate tax outputs alongside OWA balances and emit reasoned next states
- require payments release and evidence generation to rely on issued RPT payloads and include anomaly context, with integration coverage tying the flow together

## Testing
- pytest tests/integration/test_tax_pipeline.py tests/test_math.py

------
https://chatgpt.com/codex/tasks/task_e_68e256a276548327be98fe6282e2248c