### PR TITLE
Add feature toggle configuration with prototype defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+APP_MODE=prototype
+FEATURE_TAX_ENGINE=false
+FEATURE_ATO_TABLES=false
+FEATURE_BANKING=false
+FEATURE_STP=false
+FEATURE_SECURITY_MIN=true
+FEATURE_SETTLEMENT_LINK=false
+FEATURE_API_V2=false
+DRY_RUN=true
+SHADOW_ONLY=true
+
+# Networking
+PORT=8080
+CORS_ORIGINS=http://localhost:3000
+
+# Postgres
+DATABASE_URL=postgres://apgms:apgms@127.0.0.1:5432/apgms
+PG_POOL_MAX=10
+
+# Security (dev defaults; change for real)
+API_JWT_SECRET=dev-only-change-me
+RPT_ED25519_SECRET_BASE64=ZGV2LXNlY3JldC10ZXN0Cg==
+ALLOWLIST_ABNS=11122233344
+
+# mTLS (real only)
+MTLS_CERT=
+MTLS_KEY=
+MTLS_CA=

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,13 @@
+export const FEATURES = {
+  MODE: process.env.APP_MODE ?? "prototype", // prototype | real
+  TAX_ENGINE: process.env.FEATURE_TAX_ENGINE === "true",
+  ATO_TABLES: process.env.FEATURE_ATO_TABLES === "true",
+  BANKING: process.env.FEATURE_BANKING === "true",
+  STP: process.env.FEATURE_STP === "true",
+  SECURITY_MIN: process.env.FEATURE_SECURITY_MIN !== "false", // default on
+  SETTLEMENT_LINK: process.env.FEATURE_SETTLEMENT_LINK === "true",
+  DRY_RUN: process.env.DRY_RUN === "true",
+  SHADOW_ONLY: process.env.SHADOW_ONLY === "true",
+  API_V2: process.env.FEATURE_API_V2 === "true",
+};
+export const IS_REAL = FEATURES.MODE === "real";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,14 @@
-﻿// src/index.ts
+// src/index.ts
+import "dotenv/config";
 import express from "express";
-import dotenv from "dotenv";
 
+import { FEATURES } from "./config/features";
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
-dotenv.config();
+console.log("[features]", FEATURES);
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));


### PR DESCRIPTION
## Summary
- add a central feature flag config with `FEATURES`/`IS_REAL` helpers
- log the active feature flags at server boot for visibility
- document prototype-safe defaults in a new `.env.example`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e259b6f9708327bfcfe933c98ae8de