### PR TITLE
Add versioned API routing

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,7 @@
+import { Router } from "express";
+import { v1 } from "./v1";
+import { v2 } from "./v2";
+import { FEATURES } from "../config/features";
+export const api = Router();
+api.use("/v1", v1);
+if (FEATURES.API_V2) api.use("/v2", v2);

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,0 +1,10 @@
+import { Router } from "express";
+import { router as balanceRouter } from "../../routes/balance";
+import { router as reconcileRouter } from "../../routes/reconcile";
+import { router as evidenceRouter } from "../../routes/evidence";
+import { router as depositRouter } from "../../routes/deposit";
+export const v1 = Router();
+v1.use("/balance", balanceRouter);
+v1.use("/reconcile", reconcileRouter);
+v1.use("/evidence", evidenceRouter);
+v1.use("/deposit", depositRouter);

--- a/src/api/v2/index.ts
+++ b/src/api/v2/index.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+export const v2 = Router();
+// add new/rewritten endpoints here behind FEATURE_API_V2

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,6 @@
+const flag = String(process.env.FEATURE_API_V2 || "").toLowerCase();
+const truthy = new Set(["1", "true", "on", "yes"]);
+
+export const FEATURES = {
+  API_V2: truthy.has(flag),
+} as const;

--- a/src/events/topics.ts
+++ b/src/events/topics.ts
@@ -1,0 +1,4 @@
+export const topics = {
+  tax: { v1: { payroll: "tax.v1.payroll", pos: "tax.v1.pos" }, v2: { payroll: "tax.v2.payroll", pos: "tax.v2.pos" } },
+  recon: { v1: { result: "recon.v1.result" }, v2: { result: "recon.v2.result" } },
+};

--- a/src/routes/balance.ts
+++ b/src/routes/balance.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import { Pool } from "pg";
+
+const pool = new Pool();
+
+export async function balance(req: any, res: any) {
+  try {
+    const { abn, taxType, periodId } = req.query as Record<string, string>;
+    if (!abn || !taxType || !periodId) {
+      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+    }
+
+    const query = `
+      SELECT
+        COALESCE(SUM(amount_cents), 0)::bigint AS balance_cents,
+        BOOL_OR(amount_cents < 0) AS has_release
+      FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+    `;
+    const { rows } = await pool.query(query, [abn, taxType, periodId]);
+    const row = rows[0] || { balance_cents: 0, has_release: false };
+
+    return res.json({
+      abn,
+      taxType,
+      periodId,
+      balance_cents: Number(row.balance_cents),
+      has_release: Boolean(row.has_release),
+    });
+  } catch (e: any) {
+    return res.status(500).json({ error: "balance query failed", detail: String(e?.message || e) });
+  }
+}
+
+export const router = Router();
+router.get("/", balance);

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,4 +1,4 @@
-﻿import { Request, Response } from "express";
+import { Request, Response, Router } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
 
@@ -52,3 +52,6 @@ export async function deposit(req: Request, res: Response) {
     return res.status(500).json({ error: "Deposit error", detail: String(e.message || e) });
   }
 }
+
+export const router = Router();
+router.post("/", deposit);

--- a/src/routes/evidence.ts
+++ b/src/routes/evidence.ts
@@ -1,0 +1,5 @@
+import { Router } from "express";
+import { evidence } from "./reconcile";
+
+export const router = Router();
+router.get("/", evidence);


### PR DESCRIPTION
## Summary
- add API router that mounts existing endpoints under /api/v1 and gates /api/v2 behind FEATURE_API_V2
- expose shared topic strings for v1/v2 event routing
- wrap existing balance/reconcile/evidence/deposit handlers in routers for reuse

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e259e24d5483278232cd6ad36a995b