### PR TITLE
Add ports and composition for banking, payroll, and schedules

### DIFF
--- a/src/adapters/mock/banking.mock.ts
+++ b/src/adapters/mock/banking.mock.ts
@@ -1,0 +1,21 @@
+import crypto from "crypto";
+import { BankingPort, Tx } from "../../ports/banking";
+
+export class MockBanking implements BankingPort {
+  private mk(abn: string, amountCents: number, channel: Tx["channel"], reference?: string): Tx {
+    return { id: crypto.randomUUID(), abn, amountCents, channel, reference, status: "PENDING" };
+  }
+
+  async eft(abn: string, amountCents: number, reference?: string) {
+    return this.mk(abn, amountCents, "EFT", reference);
+  }
+
+  async bpay(abn: string, amountCents: number, reference?: string) {
+    return this.mk(abn, amountCents, "BPAY", reference);
+  }
+
+  async payToSweep(_mandateId: string, amountCents: number, ref: string) {
+    const abn = "mock-abn";
+    return this.mk(abn, amountCents, "PayTo", ref);
+  }
+}

--- a/src/adapters/mock/payroll.mock.ts
+++ b/src/adapters/mock/payroll.mock.ts
@@ -1,0 +1,7 @@
+import { PayrollPort } from "../../ports/payroll";
+
+export class MockPayroll implements PayrollPort {
+  async ingest(_abn: string, _grossCents: number, _paygCents: number, _occurredAtISO: string) {
+    /* no-op */
+  }
+}

--- a/src/adapters/mock/schedules.mock.ts
+++ b/src/adapters/mock/schedules.mock.ts
@@ -1,0 +1,11 @@
+import { SchedulesPort } from "../../ports/schedules";
+
+export class PlaceholderSchedules implements SchedulesPort {
+  paygw(taxableCents: number) {
+    return Math.round(taxableCents * 0.2);
+  }
+
+  gst(taxableCents: number) {
+    return Math.round(taxableCents / 11);
+  }
+}

--- a/src/adapters/real/banking.real.ts
+++ b/src/adapters/real/banking.real.ts
@@ -1,0 +1,34 @@
+import crypto from "crypto";
+import { BankingPort, Tx } from "../../ports/banking";
+import { FEATURES } from "../../config/features";
+import { getPool } from "../../db/pool";
+
+export class RealBanking implements BankingPort {
+  private async persist(
+    abn: string,
+    amountCents: number,
+    channel: Tx["channel"],
+    reference?: string
+  ): Promise<Tx> {
+    const id = crypto.randomUUID();
+    await getPool().query(
+      `insert into bank_transfers (id, abn, amount_cents, channel, reference, status, created_at)
+       values ($1,$2,$3,$4,$5,$6, now())`,
+      [id, abn, amountCents, channel, reference || null, FEATURES.DRY_RUN ? "PENDING" : "PENDING"]
+    );
+    return { id, abn, amountCents, channel, reference, status: "PENDING" };
+  }
+
+  async eft(abn: string, amountCents: number, reference?: string) {
+    return this.persist(abn, amountCents, "EFT", reference);
+  }
+
+  async bpay(abn: string, amountCents: number, reference?: string) {
+    return this.persist(abn, amountCents, "BPAY", reference);
+  }
+
+  async payToSweep(_mandateId: string, amountCents: number, ref: string) {
+    const abn = "unresolved-abn";
+    return this.persist(abn, amountCents, "PayTo", ref);
+  }
+}

--- a/src/adapters/real/payroll.real.ts
+++ b/src/adapters/real/payroll.real.ts
@@ -1,0 +1,12 @@
+import { PayrollPort } from "../../ports/payroll";
+import { getPool } from "../../db/pool";
+
+export class RealPayroll implements PayrollPort {
+  async ingest(abn: string, grossCents: number, paygCents: number, occurredAtISO: string) {
+    await getPool().query(
+      `insert into payroll_events (id, abn, gross_cents, payg_cents, occurred_at)
+       values (gen_random_uuid(), $1, $2, $3, $4)`,
+      [abn, grossCents, paygCents, occurredAtISO]
+    );
+  }
+}

--- a/src/adapters/real/schedules.real.ts
+++ b/src/adapters/real/schedules.real.ts
@@ -1,0 +1,14 @@
+import { SchedulesPort } from "../../ports/schedules";
+
+export class ATOSchedules implements SchedulesPort {
+  // NOTE: replace with actual ATO schedule tables later
+  paygw(taxableCents: number, frequency: "weekly" | "fortnightly" | "monthly" = "monthly") {
+    const annual = taxableCents * (frequency === "weekly" ? 52 : frequency === "fortnightly" ? 26 : 12);
+    const taxAnnual = annual <= 1_820_000 ? 0 : Math.round((annual - 1_820_000) * 0.19);
+    return Math.round(taxAnnual / (frequency === "weekly" ? 52 : frequency === "fortnightly" ? 26 : 12));
+  }
+
+  gst(taxableCents: number) {
+    return Math.round(taxableCents / 11);
+  }
+}

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -1,0 +1,14 @@
+import { MockBanking } from "./adapters/mock/banking.mock";
+import { MockPayroll } from "./adapters/mock/payroll.mock";
+import { PlaceholderSchedules } from "./adapters/mock/schedules.mock";
+import { RealBanking } from "./adapters/real/banking.real";
+import { RealPayroll } from "./adapters/real/payroll.real";
+import { ATOSchedules } from "./adapters/real/schedules.real";
+import { FEATURES } from "./config/features";
+import { BankingPort } from "./ports/banking";
+import { PayrollPort } from "./ports/payroll";
+import { SchedulesPort } from "./ports/schedules";
+
+export const banking: BankingPort = FEATURES.BANKING ? new RealBanking() : new MockBanking();
+export const payroll: PayrollPort = FEATURES.STP ? new RealPayroll() : new MockPayroll();
+export const schedules: SchedulesPort = FEATURES.ATO_TABLES ? new ATOSchedules() : new PlaceholderSchedules();

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,11 @@
+const flag = (value: string | undefined) => {
+  if (!value) return false;
+  return ["1", "true", "yes", "on"].includes(value.toLowerCase());
+};
+
+export const FEATURES = {
+  DRY_RUN: flag(process.env.FEATURE_DRY_RUN),
+  BANKING: flag(process.env.FEATURE_BANKING),
+  STP: flag(process.env.FEATURE_STP),
+  ATO_TABLES: flag(process.env.FEATURE_ATO_TABLES),
+};

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,31 @@
+import { Pool, PoolConfig } from "pg";
+
+let pool: Pool | undefined;
+
+export function getPool(): Pool {
+  if (!pool) {
+    const {
+      DATABASE_URL,
+      PGHOST,
+      PGUSER,
+      PGPASSWORD,
+      PGDATABASE,
+      PGPORT,
+    } = process.env;
+
+    const config: PoolConfig = {};
+    if (DATABASE_URL) {
+      config.connectionString = DATABASE_URL;
+    } else {
+      if (PGHOST) config.host = PGHOST;
+      if (PGUSER) config.user = PGUSER;
+      if (PGPASSWORD) config.password = PGPASSWORD;
+      if (PGDATABASE) config.database = PGDATABASE;
+      if (PGPORT) config.port = Number(PGPORT);
+    }
+
+    pool = new Pool(config);
+  }
+
+  return pool;
+}

--- a/src/ports/banking.ts
+++ b/src/ports/banking.ts
@@ -1,0 +1,14 @@
+export type Tx = {
+  id: string;
+  abn: string;
+  amountCents: number;
+  channel: "EFT" | "BPAY" | "PayTo";
+  reference?: string;
+  status: "PENDING" | "SETTLED" | "FAILED";
+};
+
+export interface BankingPort {
+  eft(abn: string, amountCents: number, reference?: string): Promise<Tx>;
+  bpay(abn: string, amountCents: number, reference?: string): Promise<Tx>;
+  payToSweep(mandateId: string, amountCents: number, ref: string): Promise<Tx>;
+}

--- a/src/ports/payroll.ts
+++ b/src/ports/payroll.ts
@@ -1,0 +1,8 @@
+export interface PayrollPort {
+  ingest(
+    abn: string,
+    grossCents: number,
+    paygCents: number,
+    occurredAtISO: string
+  ): Promise<void>;
+}

--- a/src/ports/schedules.ts
+++ b/src/ports/schedules.ts
@@ -1,0 +1,7 @@
+export interface SchedulesPort {
+  paygw(
+    taxableCents: number,
+    frequency: "weekly" | "fortnightly" | "monthly"
+  ): number;
+  gst(taxableCents: number): number;
+}

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,5 +1,5 @@
 ﻿import { Request, Response } from "express";
-import { pool } from "../index.js";
+import { getPool } from "../db/pool";
 import { randomUUID } from "node:crypto";
 
 export async function deposit(req: Request, res: Response) {
@@ -13,7 +13,7 @@ export async function deposit(req: Request, res: Response) {
       return res.status(400).json({ error: "amountCents must be positive for a deposit" });
     }
 
-    const client = await pool.connect();
+    const client = await getPool().connect();
     try {
       await client.query("BEGIN");
 

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,85 @@
-﻿import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
-import { releasePayment, resolveDestination } from "../rails/adapter";
-import { debit as paytoDebit } from "../payto/adapter";
+import { banking } from "../composition";
+import { getPool } from "../db/pool";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { releasePayment, resolveDestination } from "../rails/adapter";
+import { Tx } from "../ports/banking";
+import { issueRPT } from "../rpt/issuer";
 
-export async function closeAndIssue(req:any, res:any) {
+const pool = getPool();
+
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr = thresholds || {
+    epsilon_cents: 50,
+    variance_ratio: 0.25,
+    dup_rate: 0.01,
+    gap_minutes: 60,
+    delta_vs_baseline: 0.2,
+  };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
+    const bankTx: Tx = rail === "BPAY"
+      ? await banking.bpay(abn, payload.amount_cents, payload.reference)
+      : await banking.eft(abn, payload.amount_cents, payload.reference);
+    const r = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      payload.reference
+    );
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-    return res.json(r);
-  } catch (e:any) {
+    return res.json({ ...r, bank_tx: bankTx });
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
-  const { abn, amount_cents, reference } = req.body;
-  const r = await paytoDebit(abn, amount_cents, reference);
-  return res.json(r);
+export async function paytoSweep(req: any, res: any) {
+  const { mandateId, abn, amount_cents, amountCents, reference } = req.body || {};
+  const amt = typeof amountCents === "number" ? amountCents : Number(amount_cents);
+  if (!Number.isFinite(amt) || amt <= 0) {
+    return res.status(400).json({ error: "INVALID_AMOUNT" });
+  }
+  const sweepMandate = typeof mandateId === "string" && mandateId.length > 0
+    ? mandateId
+    : typeof abn === "string" && abn.length > 0
+      ? abn
+      : undefined;
+  if (!sweepMandate) {
+    return res.status(400).json({ error: "MANDATE_ID_REQUIRED" });
+  }
+  const tx = await banking.payToSweep(sweepMandate, amt, reference ?? "");
+  return res.json(tx);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }


### PR DESCRIPTION
## Summary
- introduce ports for banking, payroll, and schedules along with mock and real adapters
- add feature flag driven composition along with shared pool helper and update routes to depend on the new interfaces

## Testing
- npx tsc --noEmit *(fails: existing syntax errors in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e259d2e9d8832799c2c9b77301eb4f