### PR TITLE
Add JWT auth and security middleware to API

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,18 @@
         "typescript": "^5.9.3"
     },
     "dependencies": {
+        "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
+        "helmet": "^7.2.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
+        "pino": "^9.5.0",
+        "pino-http": "^9.0.0",
         "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "^3.23.8"
     }
 }

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { v1 } from "./v1";
+
+export const api = Router();
+
+api.use("/v1", v1);

--- a/src/api/v1/evidence.ts
+++ b/src/api/v1/evidence.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { evidence as evidenceHandler } from "../../routes/reconcile";
+
+export const evidenceRouter = Router();
+
+evidenceRouter.get("/", evidenceHandler);

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,0 +1,17 @@
+import { Router } from "express";
+import { auth } from "../../http/auth";
+import { reconcileRouter } from "./reconcile";
+import { evidenceRouter } from "./evidence";
+import { settlementRouter } from "./settlement";
+
+export const v1 = Router();
+
+v1.use("/reconcile", auth(["accountant", "admin"]), reconcileRouter);
+v1.use(
+  "/evidence",
+  auth(["auditor", "accountant", "admin"]),
+  evidenceRouter
+);
+v1.use("/settlement", auth(["accountant", "admin"]), settlementRouter);
+
+export { reconcileRouter, evidenceRouter, settlementRouter };

--- a/src/api/v1/reconcile.ts
+++ b/src/api/v1/reconcile.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { idempotency } from "../../middleware/idempotency";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+} from "../../routes/reconcile";
+
+export const reconcileRouter = Router();
+
+reconcileRouter.post("/pay", idempotency(), payAto);
+reconcileRouter.post("/close-issue", closeAndIssue);
+reconcileRouter.post("/payto/sweep", paytoSweep);

--- a/src/api/v1/settlement.ts
+++ b/src/api/v1/settlement.ts
@@ -1,0 +1,6 @@
+import { Router } from "express";
+import { settlementWebhook } from "../../routes/reconcile";
+
+export const settlementRouter = Router();
+
+settlementRouter.post("/webhook", settlementWebhook);

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction } from "express";
+import jwt from "jsonwebtoken";
+
+const SECRET = process.env.API_JWT_SECRET || "dev-secret-change-me";
+
+export type Role = "auditor" | "accountant" | "admin";
+
+export function auth(required?: Role[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const t = (req.headers.authorization || "").replace(/^Bearer /, "");
+    if (!t) return res.status(401).json({ error: "unauthorized" });
+    try {
+      const p = jwt.verify(t, SECRET) as { sub: string; roles?: Role[] };
+      (req as any).user = p;
+      if (
+        required &&
+        required.length &&
+        !(p.roles || []).some((r) => required.includes(r))
+      ) {
+        return res.status(403).json({ error: "forbidden" });
+      }
+      next();
+    } catch {
+      res.status(401).json({ error: "unauthorized" });
+    }
+  };
+}

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,22 @@
+import { AnyZodObject, ZodError } from "zod";
+import { Request, Response, NextFunction } from "express";
+
+export function validate(s: {
+  body?: AnyZodObject;
+  params?: AnyZodObject;
+  query?: AnyZodObject;
+}) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      if (s.body) req.body = s.body.parse(req.body);
+      if (s.params) req.params = s.params.parse(req.params);
+      if (s.query) req.query = s.query.parse(req.query);
+      next();
+    } catch (e) {
+      const ze = e as ZodError;
+      res
+        .status(400)
+        .json({ error: "validation_failed", issues: ze.issues });
+    }
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,72 @@
 ﻿// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
+import rateLimit from "express-rate-limit";
+import helmet from "helmet";
+import cors from "cors";
+import pino from "pino";
+import pinoHttp from "pino-http";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { closeAndIssue, payAto, paytoSweep } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { api } from "./api"; // your existing API router(s)
+import { auth } from "./http/auth";
+import {
+  evidenceRouter,
+  reconcileRouter,
+  settlementRouter,
+} from "./api/v1";
 
 dotenv.config();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
 
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+const corsOrigins = (process.env.CORS_ORIGINS || "")
+  .split(",")
+  .filter(Boolean);
+app.use(
+  cors({ origin: corsOrigins.length ? corsOrigins : undefined, credentials: true })
+);
+app.use(helmet({ crossOriginResourcePolicy: { policy: "same-site" } }));
+app.use(rateLimit({ windowMs: 60_000, max: 120 }));
+const logger = pino({ level: process.env.LOG_LEVEL || "info" });
+app.use(pinoHttp({ logger }));
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+app.post(
+  "/api/pay",
+  auth(["accountant", "admin"]),
+  idempotency(),
+  payAto
+);
+app.post(
+  "/api/close-issue",
+  auth(["accountant", "admin"]),
+  closeAndIssue
+);
+app.post(
+  "/api/payto/sweep",
+  auth(["accountant", "admin"]),
+  paytoSweep
+);
+
+// Router aliases (protected) for structured mounts
+app.use("/api/reconcile", auth(["accountant", "admin"]), reconcileRouter);
+app.use(
+  "/api/evidence",
+  auth(["auditor", "accountant", "admin"]),
+  evidenceRouter
+);
+app.use(
+  "/api/settlement",
+  auth(["accountant", "admin"]),
+  settlementRouter
+);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);


### PR DESCRIPTION
## Summary
- add reusable JWT auth middleware and a Zod-based request validator
- protect reconcile, evidence, and settlement routers via the new v1 API while keeping legacy endpoints secured
- enable CORS, Helmet, rate limiting, and structured logging on the Express server and add the required dependencies

## Testing
- npx tsc --noEmit *(fails: pre-existing syntax error in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e25a0c553483279b20e63323c84dac