### PR TITLE
Add settlement webhook and guard real banking adapter

### DIFF
--- a/apps/services/payments/src/bank/eftBpayAdapter.ts
+++ b/apps/services/payments/src/bank/eftBpayAdapter.ts
@@ -1,10 +1,14 @@
-﻿import pg from "pg";
 import https from "https";
 import axios from "axios";
 import { createHash, randomUUID } from "crypto";
+import type { PoolClient } from "pg";
+import { getPool } from "../db/pool";
+import { FEATURES } from "../config/features";
 
 type Params = {
-  abn: string; taxType: string; periodId: string;
+  abn: string;
+  taxType: string;
+  periodId: string;
   amount_cents: number;
   destination: { bpay_biller?: string; crn?: string; bsb?: string; acct?: string };
   idempotencyKey: string;
@@ -14,26 +18,218 @@ const agent = new https.Agent({
   ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
   cert: process.env.BANK_TLS_CERT ? require("fs").readFileSync(process.env.BANK_TLS_CERT) : undefined,
   key: process.env.BANK_TLS_KEY ? require("fs").readFileSync(process.env.BANK_TLS_KEY) : undefined,
-  rejectUnauthorized: true
+  rejectUnauthorized: true,
 });
 
 const client = axios.create({
   baseURL: process.env.BANK_API_BASE,
   timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
-  httpsAgent: agent
+  httpsAgent: agent,
 });
 
-export async function sendEftOrBpay(p: Params): Promise<{transfer_uuid: string; bank_receipt_hash: string; provider_receipt_id: string}> {
+const pool = getPool();
+
+type ColumnSet = Set<string>;
+let cachedColumns: ColumnSet | null = null;
+
+async function getBankTransferColumns(conn: PoolClient): Promise<ColumnSet> {
+  if (cachedColumns) return cachedColumns;
+  const res = await conn.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = ANY(current_schemas(false))
+        AND table_name = 'bank_transfers'`
+  );
+  cachedColumns = new Set(res.rows.map((r) => r.column_name.toLowerCase()));
+  return cachedColumns;
+}
+
+function addInsertColumn(
+  columns: ColumnSet,
+  inserted: Set<string>,
+  names: string | string[],
+  insertCols: string[],
+  placeholders: string[],
+  values: any[],
+  value: any
+): boolean {
+  const list = Array.isArray(names) ? names : [names];
+  let added = false;
+  for (const name of list) {
+    const lower = name.toLowerCase();
+    if (columns.has(lower) && !inserted.has(lower)) {
+      inserted.add(lower);
+      insertCols.push(lower);
+      values.push(value);
+      placeholders.push(`$${values.length}`);
+      added = true;
+    }
+  }
+  return added;
+}
+
+function addUpdateColumn(
+  columns: ColumnSet,
+  touched: Set<string>,
+  names: string | string[],
+  sets: string[],
+  values: any[],
+  value: any
+): boolean {
+  const list = Array.isArray(names) ? names : [names];
+  let added = false;
+  for (const name of list) {
+    const lower = name.toLowerCase();
+    if (columns.has(lower) && !touched.has(lower)) {
+      touched.add(lower);
+      values.push(value);
+      sets.push(`${lower}=$${values.length}`);
+      added = true;
+    }
+  }
+  return added;
+}
+
+async function recordIntent(p: Params, transfer_uuid: string): Promise<void> {
+  const conn = await pool.connect();
+  try {
+    const columns = await getBankTransferColumns(conn);
+    const inserted = new Set<string>();
+    const insertCols: string[] = [];
+    const placeholders: string[] = [];
+    const values: any[] = [];
+
+    addInsertColumn(columns, inserted, "transfer_uuid", insertCols, placeholders, values, transfer_uuid);
+    addInsertColumn(columns, inserted, "abn", insertCols, placeholders, values, p.abn);
+    addInsertColumn(columns, inserted, "tax_type", insertCols, placeholders, values, p.taxType);
+    addInsertColumn(columns, inserted, "period_id", insertCols, placeholders, values, p.periodId);
+    addInsertColumn(columns, inserted, ["amount_cents", "amount"], insertCols, placeholders, values, p.amount_cents);
+
+    const destination = p.destination ?? {};
+    addInsertColumn(columns, inserted, ["destination", "destination_json", "destination_details"], insertCols, placeholders, values, destination);
+
+    const initialStatus = "INTENT";
+    addInsertColumn(columns, inserted, ["status", "state"], insertCols, placeholders, values, initialStatus);
+
+    const mode = FEATURES.DRY_RUN ? "DRY_RUN" : "LIVE";
+    addInsertColumn(columns, inserted, ["mode", "mode_tag"], insertCols, placeholders, values, mode);
+    addInsertColumn(columns, inserted, ["channel", "rail", "provider"], insertCols, placeholders, values, "EFT_BPAY");
+    addInsertColumn(columns, inserted, ["direction", "flow"], insertCols, placeholders, values, "OUTBOUND");
+
+    addInsertColumn(columns, inserted, "idempotency_key", insertCols, placeholders, values, p.idempotencyKey);
+    addInsertColumn(
+      columns,
+      inserted,
+      "idempotency_hash",
+      insertCols,
+      placeholders,
+      values,
+      createHash("sha256").update(p.idempotencyKey).digest("hex")
+    );
+
+    const now = new Date();
+    addInsertColumn(columns, inserted, "created_at", insertCols, placeholders, values, now);
+    addInsertColumn(columns, inserted, "updated_at", insertCols, placeholders, values, now);
+
+    if (!insertCols.length) {
+      await conn.query(`INSERT INTO bank_transfers (transfer_uuid) VALUES ($1)`, [transfer_uuid]);
+      return;
+    }
+
+    const sql = `INSERT INTO bank_transfers (${insertCols.join(", ")}) VALUES (${placeholders.join(", ")})`;
+    await conn.query(sql, values);
+  } finally {
+    conn.release();
+  }
+}
+
+function formatError(err: any): string {
+  if (!err) return "unknown error";
+  const responseData = err?.response?.data;
+  if (responseData) {
+    if (typeof responseData === "string") return responseData;
+    if (typeof responseData.error === "string") return responseData.error;
+    try {
+      return JSON.stringify(responseData);
+    } catch {
+      /* ignore */
+    }
+  }
+  if (err?.message) return String(err.message);
+  return String(err);
+}
+
+async function updateTransfer(
+  transfer_uuid: string,
+  updates: { status?: string; provider_receipt_id?: string; bank_receipt_hash?: string; failure_reason?: string }
+): Promise<void> {
+  const conn = await pool.connect();
+  try {
+    const columns = await getBankTransferColumns(conn);
+    if (!columns.size) return;
+    const touched = new Set<string>();
+    const sets: string[] = [];
+    const values: any[] = [];
+
+    if (updates.status) {
+      addUpdateColumn(columns, touched, ["status", "state"], sets, values, updates.status);
+      const statusLower = updates.status.toLowerCase();
+      if (statusLower === "completed" || statusLower === "succeeded" || statusLower === "success") {
+        addUpdateColumn(columns, touched, ["completed_at", "succeeded_at"], sets, values, new Date());
+      }
+      if (statusLower === "failed" || statusLower === "error") {
+        addUpdateColumn(columns, touched, ["failed_at", "errored_at"], sets, values, new Date());
+      }
+    }
+    if (updates.provider_receipt_id) {
+      addUpdateColumn(columns, touched, ["provider_receipt_id", "bank_receipt_id"], sets, values, updates.provider_receipt_id);
+    }
+    if (updates.bank_receipt_hash) {
+      addUpdateColumn(columns, touched, ["bank_receipt_hash", "receipt_hash"], sets, values, updates.bank_receipt_hash);
+    }
+    if (updates.failure_reason) {
+      addUpdateColumn(columns, touched, ["failure_reason", "error", "error_message", "failure"], sets, values, updates.failure_reason);
+    }
+    if (!touched.has("updated_at") && columns.has("updated_at")) {
+      sets.push("updated_at=NOW()");
+      touched.add("updated_at");
+    }
+
+    if (!sets.length) return;
+    values.push(transfer_uuid);
+    await conn.query(`UPDATE bank_transfers SET ${sets.join(", ")} WHERE transfer_uuid=$${values.length}`, values);
+  } finally {
+    conn.release();
+  }
+}
+
+export async function sendEftOrBpay(
+  p: Params
+): Promise<{ transfer_uuid: string; bank_receipt_hash: string; provider_receipt_id: string }> {
   const transfer_uuid = randomUUID();
+  await recordIntent(p, transfer_uuid);
+
+  if (FEATURES.DRY_RUN) {
+    const simulatedReceipt = `dry-run-${transfer_uuid}`;
+    const hash = createHash("sha256").update(simulatedReceipt).digest("hex");
+    await updateTransfer(transfer_uuid, {
+      status: "DRY_RUN",
+      provider_receipt_id: simulatedReceipt,
+      bank_receipt_hash: hash,
+    });
+    return { transfer_uuid, bank_receipt_hash: hash, provider_receipt_id: simulatedReceipt };
+  }
+
   const payload = {
     amount_cents: p.amount_cents,
     meta: { abn: p.abn, taxType: p.taxType, periodId: p.periodId, transfer_uuid },
-    destination: p.destination
+    destination: p.destination,
   };
 
   const headers = { "Idempotency-Key": p.idempotencyKey };
   const maxAttempts = 3;
-  let attempt = 0, lastErr: any;
+  let attempt = 0;
+  let lastErr: any;
 
   while (attempt < maxAttempts) {
     attempt++;
@@ -41,11 +237,22 @@ export async function sendEftOrBpay(p: Params): Promise<{transfer_uuid: string; 
       const r = await client.post("/payments/eft-bpay", payload, { headers });
       const receipt = r.data?.receipt_id || "";
       const hash = createHash("sha256").update(receipt).digest("hex");
+      await updateTransfer(transfer_uuid, {
+        status: "COMPLETED",
+        provider_receipt_id: receipt,
+        bank_receipt_hash: hash,
+      });
       return { transfer_uuid, bank_receipt_hash: hash, provider_receipt_id: receipt };
     } catch (e: any) {
       lastErr = e;
-      await new Promise(s => setTimeout(s, attempt * 250));
+      await new Promise((resolve) => setTimeout(resolve, attempt * 250));
     }
   }
-  throw new Error("Bank transfer failed: " + String(lastErr?.message || lastErr));
+
+  const reason = formatError(lastErr);
+  await updateTransfer(transfer_uuid, {
+    status: "FAILED",
+    failure_reason: reason,
+  });
+  throw new Error("Bank transfer failed: " + reason);
 }

--- a/apps/services/payments/src/config/features.ts
+++ b/apps/services/payments/src/config/features.ts
@@ -1,0 +1,1 @@
+export { FEATURES } from "../../../../../src/config/features";

--- a/apps/services/payments/src/db/pool.ts
+++ b/apps/services/payments/src/db/pool.ts
@@ -1,0 +1,29 @@
+import pg from "pg";
+
+const { Pool } = pg;
+
+let pool: pg.Pool | null = null;
+
+function connectionString(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const user = process.env.PGUSER || "postgres";
+  const password = encodeURIComponent(process.env.PGPASSWORD || "");
+  const host = process.env.PGHOST || "127.0.0.1";
+  const port = process.env.PGPORT || "5432";
+  const db = process.env.PGDATABASE || "postgres";
+  return `postgres://${user}:${password}@${host}:${port}/${db}`;
+}
+
+export function getPool(): pg.Pool {
+  if (!pool) {
+    pool = new Pool({ connectionString: connectionString() });
+  }
+  return pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}

--- a/src/api/v1/index.ts
+++ b/src/api/v1/index.ts
@@ -1,0 +1,8 @@
+import { Router } from "express";
+import { router as settlementRouter } from "../../routes/settlement";
+
+export const v1 = Router();
+
+v1.use("/settlement", settlementRouter);
+
+export default v1;

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,29 @@
+const TRUTHY = new Set(["1", "true", "yes", "on"]);
+const FALSY = new Set(["0", "false", "no", "off"]);
+
+function parseFlag(value: string | undefined, fallback: boolean): boolean {
+  if (value == null) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (TRUTHY.has(normalized)) return true;
+  if (FALSY.has(normalized)) return false;
+  return fallback;
+}
+
+export const FEATURES = {
+  /**
+   * When true we avoid calling external banking providers and instead
+   * simulate success locally. This defaults to true so that real side effects
+   * only occur once explicitly enabled.
+   */
+  DRY_RUN: parseFlag(process.env.FEATURE_DRY_RUN ?? process.env.DRY_RUN, true),
+  /** Shadow mode keeps behaviour read-only while still exercising code paths. */
+  SHADOW_ONLY: parseFlag(process.env.FEATURE_SHADOW_ONLY, false),
+  /**
+   * Controls whether settlement webhooks should attempt to link evidence
+   * bundles immediately after recording the settlement payload.
+   */
+  SETTLEMENT_LINK: parseFlag(process.env.FEATURE_SETTLEMENT_LINK, false),
+} as const;
+
+export type FeatureFlags = typeof FEATURES;
+export { parseFlag as parseFeatureFlag };

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,29 @@
+import pg from "pg";
+
+const { Pool } = pg;
+
+let pool: pg.Pool | null = null;
+
+function resolveConnectionString(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const user = process.env.PGUSER || "postgres";
+  const password = encodeURIComponent(process.env.PGPASSWORD || "");
+  const host = process.env.PGHOST || "127.0.0.1";
+  const port = process.env.PGPORT || "5432";
+  const db = process.env.PGDATABASE || "postgres";
+  return `postgres://${user}:${password}@${host}:${port}/${db}`;
+}
+
+export function getPool(): pg.Pool {
+  if (!pool) {
+    pool = new Pool({ connectionString: resolveConnectionString() });
+  }
+  return pool;
+}
+
+export async function closePool(): Promise<void> {
+  if (pool) {
+    await pool.end();
+    pool = null;
+  }
+}

--- a/src/routes/settlement.ts
+++ b/src/routes/settlement.ts
@@ -1,0 +1,41 @@
+import { Router } from "express";
+import { getPool } from "../db/pool";
+import { FEATURES } from "../config/features";
+
+export const router = Router();
+
+router.post("/webhook", async (req, res) => {
+  const { abn, period_id, settlementRef, paidAt, amountCents, channel } = req.body ?? {};
+  if (!abn || !period_id || !settlementRef || !paidAt || amountCents == null) {
+    return res.status(400).json({ error: "missing fields" });
+  }
+
+  const client = await getPool().connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `insert into settlements (abn, period_id, settlement_ref, paid_at, amount_cents, channel, created_at)
+       values ($1,$2,$3,$4,$5,$6, now())`,
+      [abn, period_id, settlementRef, paidAt, amountCents, channel || null]
+    );
+
+    if (!FEATURES.SHADOW_ONLY && FEATURES.SETTLEMENT_LINK) {
+      await client.query(
+        `update evidence_bundles
+           set details = jsonb_set(coalesce(details,'{}'::jsonb), '{settlement}', to_jsonb($1::json))
+         where abn=$2 and period_id=$3
+         order by created_at desc
+         limit 1`,
+        [{ settlementRef, paidAt, amountCents, channel }, abn, period_id]
+      );
+    }
+
+    await client.query("COMMIT");
+    return res.json({ ok: true, linked: !FEATURES.SHADOW_ONLY && FEATURES.SETTLEMENT_LINK });
+  } catch (e: any) {
+    await client.query("ROLLBACK");
+    return res.status(500).json({ error: e.message });
+  } finally {
+    client.release();
+  }
+});


### PR DESCRIPTION
## Summary
- add shared feature flag parsing and pg pool helpers for the v1 API
- expose a /settlement/webhook endpoint that records settlements and links evidence when enabled
- ensure the EFT/BPAY adapter writes intent rows and only contacts the bank when dry-run is disabled

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e259f879c883278c31fa5983c3fffe