### PR TITLE
chore: add eslint guard against direct Pool instantiation

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  parser: "@typescript-eslint/parser",
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  rules: {
+    "no-restricted-syntax": [
+      "error",
+      { selector: "NewExpression[callee.name='Pool']", message: "Use getPool() from src/db/pool.ts" }
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
+        "@typescript-eslint/eslint-plugin": "^8.13.0",
+        "@typescript-eslint/parser": "^8.13.0",
+        "eslint": "^9.14.0",
+        "husky": "^9.1.7",
+        "lint-staged": "^15.2.10",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
@@ -24,5 +29,13 @@
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
+    },
+    "husky": {
+        "hooks": {
+            "pre-commit": "lint-staged"
+        }
+    },
+    "lint-staged": {
+        "*.{ts,tsx,js}": "eslint --fix"
     }
 }


### PR DESCRIPTION
## Summary
- add an ESLint configuration that forbids constructing new Pool instances directly
- configure husky and lint-staged to run ESLint with auto-fix on staged JS/TS files
- declare the lint tooling in devDependencies so the rule is available locally

## Testing
- npm i -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin husky lint-staged *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2607fc3908327ba7ba1d582610a10