### PR TITLE
Add CI workflow with Postgres migrations and secret scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env: { POSTGRES_USER: apgms, POSTGRES_PASSWORD: apgms, POSTGRES_DB: apgms }
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd="pg_isready -U apgms" --health-interval=5s --health-timeout=5s --health-retries=10
+    env:
+      DATABASE_URL: postgres://apgms:apgms@localhost:5432/apgms
+      NODE_ENV: test
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - run: psql "$DATABASE_URL" -f migrations/001_apgms_core.sql
+      - run: for f in migrations/*.sql; do [ "$f" = "migrations/001_apgms_core.sql" ] || psql "$DATABASE_URL" -f "$f"; done
+      - run: npm run build
+      - run: npm test --workspaces=false --if-present
+      - name: Secret scan
+        uses: zricethezav/gitleaks-action@v2
+        with: { config: gitleaks.toml }

--- a/gitleaks.toml
+++ b/gitleaks.toml
@@ -1,0 +1,5 @@
+title = "apgms"
+[[rules]]
+description = "Generic API key"
+regex = '''(?i)(api[_-]?key|token)["']?\s*[:=]\s*["'][a-z0-9_\-]{16,}["']'''
+tags = ["apikey"]


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that provisions Postgres, installs dependencies, runs migrations, builds, and tests
- configure gitleaks to fail the workflow when generic API keys are detected

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e260796dd883279f1efe4d26ba0da0