### PR TITLE
Add indexes for key tables

### DIFF
--- a/migrations/009_indexes.sql
+++ b/migrations/009_indexes.sql
@@ -1,0 +1,5 @@
+create index if not exists ix_ledger_abn_period on ledger (abn, period_id);
+create index if not exists ix_evidence_abn_period on evidence_bundles (abn, period_id);
+create index if not exists ix_periods_abn on periods (abn);
+create index if not exists ix_idempotency_key on idempotency (key);
+create index if not exists ix_payroll_events_abn on payroll_events (abn);


### PR DESCRIPTION
## Summary
- add database indexes to support frequent lookups on ledger, evidence bundles, periods, idempotency keys, and payroll events

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e260b714c883279d0336d25d342d02