### PR TITLE
Add helmet middleware for security headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "csv-parse": "^6.1.0",
+        "helmet": "^7.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "pg": "^8.16.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 ﻿// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
+import helmet from "helmet";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
@@ -11,6 +12,20 @@ dotenv.config();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
+app.use(helmet({
+  contentSecurityPolicy: {
+    useDefaults: true,
+    directives: {
+      "default-src": ["'self'"],
+      "script-src": ["'self'"],
+      "object-src": ["'none'"],
+      "frame-ancestors": ["'none'"]
+    }
+  },
+  referrerPolicy: { policy: "no-referrer" },
+  frameguard: { action: "deny" },
+  hsts: { maxAge: 15552000, includeSubDomains: true, preload: false }
+}));
 
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });


### PR DESCRIPTION
## Summary
- add the helmet dependency to the server package configuration
- apply helmet middleware with CSP, referrer policy, frameguard, and HSTS settings

## Testing
- not run (network restrictions prevented installing new npm packages)

------
https://chatgpt.com/codex/tasks/task_e_68e260a798948327a560a2da98a1ba31