### PR TITLE
Add migration runner with checksum enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
+        "migrate": "ts-node --transpile-only scripts/migrate.ts",
         "lint": "echo lint root"
     },
     "version": "0.1.0",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,29 @@
+import { readFileSync, readdirSync } from "fs";
+import { createHash } from "crypto";
+import { getPool } from "../src/db/pool";
+
+async function main() {
+  const db = getPool();
+  await db.query(`
+    create table if not exists schema_migrations(
+      id serial primary key, filename text unique, checksum text, applied_at timestamptz default now()
+    )`);
+  const files = readdirSync("migrations").filter(f => f.endsWith(".sql")).sort();
+  for (const f of files) {
+    const sql = readFileSync(`migrations/${f}`, "utf8");
+    const sum = createHash("sha256").update(sql).digest("hex");
+    const row = await db.query(`select checksum from schema_migrations where filename=$1`, [f]);
+    if (row.rowCount && row.rows[0].checksum !== sum) {
+      throw new Error(`Migration checksum mismatch for ${f}`);
+    }
+    if (row.rowCount === 0) {
+      await db.query("BEGIN");
+      await db.query(sql);
+      await db.query(`insert into schema_migrations (filename, checksum) values ($1,$2)`, [f, sum]);
+      await db.query("COMMIT");
+      console.log("applied", f);
+    }
+  }
+  await db.end();
+}
+main().catch(e=>{ console.error(e); process.exit(1); });

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,10 @@
+import { Pool } from "pg";
+
+let pool: Pool | undefined;
+
+export function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool();
+  }
+  return pool;
+}


### PR DESCRIPTION
## Summary
- add a TypeScript migration runner that hashes migration files, stores checksums, and aborts on drift
- introduce a shared PostgreSQL pool helper used by the migration script
- expose an npm `migrate` script that runs the migrator via ts-node

## Testing
- not run (PostgreSQL connection details are not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2608cc1208327901a6030eaf8a30b