### PR TITLE
Add OpenTelemetry tracing bootstrap and request ID propagation

### DIFF
--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -1,4 +1,6 @@
 // libs/paymentsClient.ts
+import { withRequestId } from "../src/http/outbound";
+
 type Common = { abn: string; taxType: string; periodId: string };
 export type DepositArgs = Common & { amountCents: number };   // > 0
 export type ReleaseArgs = Common & { amountCents: number };   // < 0
@@ -8,6 +10,15 @@ const BASE =
   process.env.NEXT_PUBLIC_PAYMENTS_BASE_URL ||
   process.env.PAYMENTS_BASE_URL ||
   "http://localhost:3001";
+
+type RequestContext = { req?: Parameters<typeof withRequestId>[0] };
+
+function withOutboundContext<T extends { headers?: Record<string, string> }>(
+  ctx: RequestContext | undefined,
+  init: T,
+) {
+  return withRequestId(ctx?.req, init);
+}
 
 async function handle(res: Response) {
   const text = await res.text();
@@ -21,32 +32,36 @@ async function handle(res: Response) {
 }
 
 export const Payments = {
-  async deposit(args: DepositArgs) {
-    const res = await fetch(`${BASE}/deposit`, {
+  async deposit(args: DepositArgs, ctx?: RequestContext) {
+    const init = withOutboundContext(ctx, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(args),
     });
+    const res = await fetch(`${BASE}/deposit`, init);
     return handle(res);
   },
-  async payAto(args: ReleaseArgs) {
-    const res = await fetch(`${BASE}/payAto`, {
+  async payAto(args: ReleaseArgs, ctx?: RequestContext) {
+    const init = withOutboundContext(ctx, {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify(args),
     });
+    const res = await fetch(`${BASE}/payAto`, init);
     return handle(res);
   },
-  async balance(q: Common) {
+  async balance(q: Common, ctx?: RequestContext) {
     const u = new URL(`${BASE}/balance`);
     Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
-    const res = await fetch(u);
+    const init = withOutboundContext(ctx, {});
+    const res = await fetch(u, init);
     return handle(res);
   },
-  async ledger(q: Common) {
+  async ledger(q: Common, ctx?: RequestContext) {
     const u = new URL(`${BASE}/ledger`);
     Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
-    const res = await fetch(u);
+    const init = withOutboundContext(ctx, {});
+    const res = await fetch(u, init);
     return handle(res);
   },
 };

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
         "express": "^5.1.0",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/sdk-node": "^0.54.1",
+        "@opentelemetry/auto-instrumentations-node": "^0.47.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.54.1"
     }
 }

--- a/pages/api/balance/index.ts
+++ b/pages/api/balance/index.ts
@@ -11,7 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
-    const data = await Payments.balance({ abn, taxType, periodId });
+    const data = await Payments.balance({ abn, taxType, periodId }, { req });
     return res.status(200).json(data);
   } catch (err: any) {
     return res.status(500).json({ error: err?.message || "Balance failed" });

--- a/pages/api/deposit/index.ts
+++ b/pages/api/deposit/index.ts
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (amountCents <= 0) {
       return res.status(400).json({ error: "Deposit must be positive" });
     }
-    const data = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const data = await Payments.deposit({ abn, taxType, periodId, amountCents }, { req });
     return res.status(200).json(data);
   } catch (err: any) {
     return res.status(400).json({ error: err?.message || "Deposit failed" });

--- a/pages/api/ledger/index.ts
+++ b/pages/api/ledger/index.ts
@@ -11,7 +11,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
-    const data = await Payments.ledger({ abn, taxType, periodId });
+    const data = await Payments.ledger({ abn, taxType, periodId }, { req });
     return res.status(200).json(data);
   } catch (err: any) {
     return res.status(500).json({ error: err?.message || "Ledger failed" });

--- a/pages/api/payments.ts
+++ b/pages/api/payments.ts
@@ -13,7 +13,7 @@ router.post("/deposit", async (req, res) => {
     if (amountCents <= 0) {
       return res.status(400).json({ error: "Deposit must be positive" });
     }
-    const result = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const result = await Payments.deposit({ abn, taxType, periodId, amountCents }, { req });
     res.json(result);
   } catch (err: any) {
     // Payments client throws Error with message from the service on 4xx
@@ -30,7 +30,7 @@ router.post("/release", async (req, res) => {
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
-    const result = await Payments.payAto({ abn, taxType, periodId, amountCents });
+    const result = await Payments.payAto({ abn, taxType, periodId, amountCents }, { req });
     res.json(result);
   } catch (err: any) {
     res.status(400).json({ error: err.message || "Release failed" });

--- a/pages/api/payments/deposit.ts
+++ b/pages/api/payments/deposit.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { abn, taxType, periodId, amountCents } = await req.json();
     if (amountCents <= 0) return NextResponse.json({ error: "Deposit must be positive" }, { status: 400 });
-    const out = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const out = await Payments.deposit({ abn, taxType, periodId, amountCents }, { req });
     return NextResponse.json(out);
   } catch (err: any) {
     return NextResponse.json({ error: err.message || "Deposit failed" }, { status: 400 });

--- a/pages/api/payments/release.ts
+++ b/pages/api/payments/release.ts
@@ -6,7 +6,7 @@ export async function POST(req: Request) {
   try {
     const { abn, taxType, periodId, amountCents } = await req.json();
     if (amountCents <= 0) return NextResponse.json({ error: "Deposit must be positive" }, { status: 400 });
-    const out = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const out = await Payments.deposit({ abn, taxType, periodId, amountCents }, { req });
     return NextResponse.json(out);
   } catch (err: any) {
     return NextResponse.json({ error: err.message || "Deposit failed" }, { status: 400 });

--- a/pages/api/release/index.ts
+++ b/pages/api/release/index.ts
@@ -14,7 +14,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
-    const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
+    const data = await Payments.payAto({ abn, taxType, periodId, amountCents }, { req });
     return res.status(200).json(data);
   } catch (err: any) {
     return res.status(400).json({ error: err?.message || "Release failed" });

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -11,7 +11,7 @@ paymentsApi.get("/balance", async (req, res) => {
     if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
-    const data = await Payments.balance({ abn, taxType, periodId });
+    const data = await Payments.balance({ abn, taxType, periodId }, { req });
     res.json(data);
   } catch (err: any) {
     res.status(500).json({ error: err?.message || "Balance failed" });
@@ -25,7 +25,7 @@ paymentsApi.get("/ledger", async (req, res) => {
     if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
-    const data = await Payments.ledger({ abn, taxType, periodId });
+    const data = await Payments.ledger({ abn, taxType, periodId }, { req });
     res.json(data);
   } catch (err: any) {
     res.status(500).json({ error: err?.message || "Ledger failed" });
@@ -42,7 +42,7 @@ paymentsApi.post("/deposit", async (req, res) => {
     if (amountCents <= 0) {
       return res.status(400).json({ error: "Deposit must be positive" });
     }
-    const data = await Payments.deposit({ abn, taxType, periodId, amountCents });
+    const data = await Payments.deposit({ abn, taxType, periodId, amountCents }, { req });
     res.json(data);
   } catch (err: any) {
     res.status(400).json({ error: err?.message || "Deposit failed" });
@@ -59,7 +59,7 @@ paymentsApi.post("/release", async (req, res) => {
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
-    const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
+    const data = await Payments.payAto({ abn, taxType, periodId, amountCents }, { req });
     res.json(data);
   } catch (err: any) {
     res.status(400).json({ error: err?.message || "Release failed" });

--- a/src/http/outbound.ts
+++ b/src/http/outbound.ts
@@ -1,0 +1,61 @@
+import type { IncomingHttpHeaders } from "http";
+
+type HeaderCarrier = { headers: IncomingHttpHeaders | Headers } | undefined;
+
+type HeaderMap = Record<string, string>;
+
+type WithHeaders<T> = T & { headers?: HeadersInit };
+
+function extractRequestId(req: HeaderCarrier): string | undefined {
+  if (!req) {
+    return undefined;
+  }
+  const { headers } = req;
+  if (headers instanceof Headers) {
+    return headers.get("x-request-id") ?? undefined;
+  }
+  const header = headers["x-request-id"];
+  if (Array.isArray(header)) {
+    return header[0];
+  }
+  return header;
+}
+
+function normalizeHeaders(headers?: HeadersInit): HeaderMap {
+  if (!headers) {
+    return {};
+  }
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  if (Array.isArray(headers)) {
+    return headers.reduce<HeaderMap>((acc, [key, value]) => {
+      acc[key] = Array.isArray(value) ? value[0] : String(value);
+      return acc;
+    }, {});
+  }
+  return Object.entries(headers).reduce<HeaderMap>((acc, [key, value]) => {
+    if (Array.isArray(value)) {
+      acc[key] = value[0];
+    } else if (typeof value !== "undefined") {
+      acc[key] = String(value);
+    }
+    return acc;
+  }, {});
+}
+
+export function withRequestId<T extends object>(req: HeaderCarrier, init: WithHeaders<T>): WithHeaders<T> {
+  const requestId = extractRequestId(req);
+  if (!requestId) {
+    return init;
+  }
+
+  const headers = normalizeHeaders(init.headers);
+  return {
+    ...init,
+    headers: {
+      ...headers,
+      "x-request-id": requestId,
+    },
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,29 @@
 ﻿// src/index.ts
+import { otel } from "./otel";
 import express from "express";
 import dotenv from "dotenv";
+import { randomUUID } from "crypto";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
+await otel.start();
+process.on("SIGTERM", async () => {
+  await otel.shutdown();
+  process.exit(0);
+});
+
 dotenv.config();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
+
+app.use((req, _res, next) => {
+  req.headers["x-request-id"] ||= randomUUID();
+  next();
+});
 
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });

--- a/src/otel.ts
+++ b/src/otel.ts
@@ -1,0 +1,12 @@
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+
+const exporter = new OTLPTraceExporter({
+  url: process.env.OTEL_EXPORTER_OTLP_ENDPOINT || "http://localhost:4318/v1/traces",
+});
+
+export const otel = new NodeSDK({
+  traceExporter: exporter,
+  instrumentations: [getNodeAutoInstrumentations()],
+});


### PR DESCRIPTION
## Summary
- initialize the OpenTelemetry Node SDK before starting the Express application and add graceful shutdown handling
- add middleware and outbound helpers to propagate x-request-id headers through inbound and outbound requests
- update payments client and related API routes to apply the outbound helper when calling downstream services

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e26065a7288327a7a417415ff39857