### PR TITLE
feat: scaffold console shell with gates and audit viewer

### DIFF
--- a/apps/web/console/jest.config.ts
+++ b/apps/web/console/jest.config.ts
@@ -1,0 +1,20 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest/presets/default-esm",
+  testEnvironment: "jsdom",
+  roots: ["<rootDir>/src"],
+  moduleNameMapper: {
+    "^.+\\.(css|scss|sass)$": "identity-obj-proxy",
+  },
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  extensionsToTreatAsEsm: [".ts", ".tsx"],
+  globals: {
+    "ts-jest": {
+      useESM: true,
+      tsconfig: "<rootDir>/tsconfig.json",
+    },
+  },
+};
+
+export default config;

--- a/apps/web/console/jest.setup.ts
+++ b/apps/web/console/jest.setup.ts
@@ -1,0 +1,2 @@
+import "@testing-library/jest-dom";
+import "whatwg-fetch";

--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "@apgms/console",
   "version": "0.1.0",
   "private": true,
@@ -7,17 +7,34 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 5173",
-    "lint": "echo lint web"
+    "lint": "echo lint web",
+    "test": "jest"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.51.0",
+    "clsx": "^2.1.0",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "@tanstack/react-query": "^5.51.0"
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^22.7.5",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.3",
+    "autoprefixer": "^10.4.20",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "postcss": "^8.4.47",
+    "tailwindcss": "^3.4.13",
+    "ts-jest": "^29.2.5",
+    "ts-node": "^10.9.2",
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
-    "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0"
+    "whatwg-fetch": "^3.6.20"
   }
 }

--- a/apps/web/console/postcss.config.cjs
+++ b/apps/web/console/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/console/src/App.tsx
+++ b/apps/web/console/src/App.tsx
@@ -1,0 +1,137 @@
+import { useMemo, useState } from "react";
+import { useMutationState } from "@tanstack/react-query";
+import { FeatureGate } from "./constants/featureGates";
+import {
+  getGateState,
+  useBasTotals,
+  useFeatureGates,
+  useIssueRptMutation,
+  usePaymentsQueue,
+  useReconQueue,
+  useRptEvidence,
+} from "./api/hooks";
+import { ModePill } from "./components/ModePill";
+import { KillSwitchBanner } from "./components/KillSwitchBanner";
+import { BasTotalsCard } from "./components/BasTotalsCard";
+import { IssueRptButton } from "./components/IssueRptButton";
+import { QueuePane } from "./components/QueuePane";
+import { EvidenceDrawer } from "./components/EvidenceDrawer";
+import { AuditViewer } from "./components/AuditViewer";
+
+export default function App() {
+  const { data: gates, isLoading: isLoadingGates } = useFeatureGates();
+  const { data: basTotals, isLoading: isLoadingBasTotals } = useBasTotals();
+  const { data: paymentsQueue, isLoading: isLoadingPayments } = usePaymentsQueue();
+  const { data: reconQueue, isLoading: isLoadingRecon } = useReconQueue();
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const issueRptMutation = useIssueRptMutation();
+  const isIssuing = issueRptMutation.isPending;
+
+  const killSwitchGate = useMemo(
+    () => gates?.find((gate) => gate.gate === FeatureGate.KillSwitchActive),
+    [gates]
+  );
+
+  const rptEnabled = getGateState(gates, FeatureGate.RptIssuanceEnabled, false);
+  const killSwitchActive = getGateState(gates, FeatureGate.KillSwitchActive, false);
+
+  const { data: evidence, isLoading: isEvidenceLoading } = useRptEvidence(drawerOpen);
+
+  const disabled = !rptEnabled || killSwitchActive;
+  const disabledReason = !rptEnabled
+    ? "Issuance disabled by gate RPT_ISSUANCE_ENABLED."
+    : killSwitchActive
+      ? "Kill switch is active. Clear KILL_SWITCH_ACTIVE before issuing."
+      : undefined;
+
+  const latestRatesVersion = basTotals?.ratesVersion ?? "latest";
+
+  const outstandingMutations = useMutationState({
+    filters: { mutationKey: ["issue-rpt"] },
+    select: (mutation) => mutation.state.status,
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col gap-6 bg-gradient-to-b from-slate-950 via-slate-950 to-slate-900 px-8 py-6">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-white">APGMS Console</h1>
+          <p className="text-sm text-slate-400">
+            Monitor BAS performance, manage RPT issuance, and track operational queues.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <ModePill gates={gates} />
+          {isLoadingGates && <span className="text-xs text-slate-500">Syncing gates…</span>}
+        </div>
+      </header>
+
+      <KillSwitchBanner
+        active={killSwitchActive}
+        updatedAt={killSwitchGate?.updatedAt}
+        updatedBy={killSwitchGate?.updatedBy}
+      />
+
+      <main className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <div className="xl:col-span-2 space-y-6">
+          <BasTotalsCard data={basTotals} isLoading={isLoadingBasTotals} />
+          <section className="rounded-2xl bg-slate-900/70 p-6 shadow ring-1 ring-white/5">
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-white">RPT Controls</h2>
+                <p className="text-xs text-slate-400">
+                  Issue reports with rates version {latestRatesVersion}. Feature flags ensure gate parity with the
+                  backend.
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                <IssueRptButton
+                  disabled={disabled}
+                  disabledReason={disabledReason}
+                  onIssue={() => {
+                    issueRptMutation.mutate(
+                      { ratesVersion: latestRatesVersion },
+                      {
+                        onSuccess: () => {
+                          setDrawerOpen(true);
+                        },
+                      }
+                    );
+                  }}
+                  isSubmitting={isIssuing}
+                />
+                <button
+                  type="button"
+                  onClick={() => setDrawerOpen(true)}
+                  className="rounded-md border border-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-200 hover:bg-slate-800/60"
+                >
+                  Review Evidence
+                </button>
+              </div>
+            </header>
+            {outstandingMutations.length > 0 && (
+              <p className="mt-3 text-xs text-slate-400">
+                RPT issuance is processing. You can continue to monitor queues while we confirm delivery.
+              </p>
+            )}
+          </section>
+
+          <section className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+            <QueuePane title="Payments Queue" items={paymentsQueue} isLoading={isLoadingPayments} />
+            <QueuePane title="Reconciliation Queue" items={reconQueue} isLoading={isLoadingRecon} />
+          </section>
+        </div>
+        <div className="flex flex-col gap-6">
+          <AuditViewer />
+        </div>
+      </main>
+
+      <EvidenceDrawer
+        isOpen={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        evidence={evidence}
+        isLoading={isEvidenceLoading}
+      />
+    </div>
+  );
+}

--- a/apps/web/console/src/__tests__/EvidenceDrawer.test.tsx
+++ b/apps/web/console/src/__tests__/EvidenceDrawer.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EvidenceDrawer } from "../components/EvidenceDrawer";
+
+function createToken(payload: Record<string, unknown>) {
+  const header = { alg: "EdDSA", typ: "JWT" };
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${encode(header)}.${encode(payload)}.signature-fragment`;
+}
+
+describe("EvidenceDrawer", () => {
+  it("renders decoded payload and closes", async () => {
+    const token = createToken({ rptId: "rpt-42", totals: 12345 });
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <EvidenceDrawer
+        isOpen
+        onClose={onClose}
+        isLoading={false}
+        evidence={{ rptId: "rpt-42", evidenceToken: token }}
+      />
+    );
+
+    expect(screen.getByText(/RPT rpt-42/i)).toBeInTheDocument();
+    expect(screen.getByText(/"totals": 12345/)).toBeInTheDocument();
+    const closeButton = screen.getByRole("button", { name: /close/i });
+    await user.click(closeButton);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/console/src/__tests__/IssueRptButton.test.tsx
+++ b/apps/web/console/src/__tests__/IssueRptButton.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { IssueRptButton } from "../components/IssueRptButton";
+
+describe("IssueRptButton", () => {
+  it("shows disabled reason when gates block issuance", async () => {
+    render(
+      <IssueRptButton
+        disabled
+        disabledReason="Kill switch is active"
+        isSubmitting={false}
+        onIssue={() => {}}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: /issue rpt/i });
+    expect(button).toBeDisabled();
+    expect(screen.getByTestId("issue-rpt-disabled-reason")).toHaveTextContent("Kill switch is active");
+  });
+
+  it("invokes callback when enabled", async () => {
+    const user = userEvent.setup();
+    const onIssue = jest.fn();
+    render(
+      <IssueRptButton
+        disabled={false}
+        isSubmitting={false}
+        disabledReason=""
+        onIssue={onIssue}
+      />
+    );
+
+    const button = screen.getByRole("button", { name: /issue rpt/i });
+    expect(button).toBeEnabled();
+    await user.click(button);
+    expect(onIssue).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/console/src/api/client.ts
+++ b/apps/web/console/src/api/client.ts
@@ -1,0 +1,117 @@
+import { FeatureGate } from "../constants/featureGates";
+import type {
+  AuditEntry,
+  BasTotalsResponse,
+  FeatureGateState,
+  QueueItem,
+  RptEvidenceResponse,
+} from "./schema";
+
+const API_BASE = "/api";
+
+async function parseJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+  return (await response.json()) as T;
+}
+
+export async function getFeatureGates(): Promise<FeatureGateState[]> {
+  const response = await fetch(`${API_BASE}/feature-gates`);
+  return parseJson<FeatureGateState[]>(response);
+}
+
+export async function getBasTotals(): Promise<BasTotalsResponse> {
+  const response = await fetch(`${API_BASE}/bas/totals`);
+  return parseJson<BasTotalsResponse>(response);
+}
+
+export interface IssueRptPayload {
+  ratesVersion: string;
+}
+
+export interface IssueRptResponse {
+  rptId: string;
+  issuedAt: string;
+}
+
+export async function issueRpt(payload: IssueRptPayload): Promise<IssueRptResponse> {
+  const response = await fetch(`${API_BASE}/rpt/issue`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  return parseJson<IssueRptResponse>(response);
+}
+
+export async function getPaymentsQueue(): Promise<QueueItem[]> {
+  const response = await fetch(`${API_BASE}/queues/payments`);
+  return parseJson<QueueItem[]>(response);
+}
+
+export async function getReconciliationQueue(): Promise<QueueItem[]> {
+  const response = await fetch(`${API_BASE}/queues/reconciliation`);
+  return parseJson<QueueItem[]>(response);
+}
+
+export async function getRptEvidence(): Promise<RptEvidenceResponse> {
+  const response = await fetch(`${API_BASE}/rpt/evidence/latest`);
+  return parseJson<RptEvidenceResponse>(response);
+}
+
+export async function streamAuditLog(
+  signal: AbortSignal,
+  onEntry: (entry: AuditEntry) => void
+): Promise<void> {
+  const response = await fetch(`${API_BASE}/audit/stream`, {
+    headers: { Accept: "application/jsonl" },
+    signal,
+  });
+
+  if (!response.body) {
+    throw new Error("Audit stream is not supported in this environment.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let remainder = "";
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) {
+      break;
+    }
+    remainder += decoder.decode(value, { stream: true });
+    let newlineIndex = remainder.indexOf("\n");
+    while (newlineIndex >= 0) {
+      const line = remainder.slice(0, newlineIndex).trim();
+      remainder = remainder.slice(newlineIndex + 1);
+      if (line.length > 0) {
+        try {
+          const parsed = JSON.parse(line) as AuditEntry;
+          onEntry(parsed);
+        } catch (error) {
+          console.error("Failed to parse audit entry", error);
+        }
+      }
+      newlineIndex = remainder.indexOf("\n");
+    }
+  }
+
+  if (remainder.trim().length > 0) {
+    try {
+      const parsed = JSON.parse(remainder.trim()) as AuditEntry;
+      onEntry(parsed);
+    } catch (error) {
+      console.error("Failed to parse trailing audit entry", error);
+    }
+  }
+}
+
+export function mapGatesByKey(gates: FeatureGateState[]): Record<FeatureGate, FeatureGateState> {
+  return gates.reduce<Record<FeatureGate, FeatureGateState>>((acc, gate) => {
+    acc[gate.gate] = gate;
+    return acc;
+  }, {} as Record<FeatureGate, FeatureGateState>);
+}

--- a/apps/web/console/src/api/hooks.ts
+++ b/apps/web/console/src/api/hooks.ts
@@ -1,0 +1,79 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { FeatureGate } from "../constants/featureGates";
+import type { FeatureGateState } from "./schema";
+import {
+  getBasTotals,
+  getFeatureGates,
+  getPaymentsQueue,
+  getReconciliationQueue,
+  getRptEvidence,
+  issueRpt,
+  mapGatesByKey,
+} from "./client";
+import type { IssueRptPayload, IssueRptResponse } from "./client";
+
+export const featureGatesQueryKey = ["feature-gates"] as const;
+export const basTotalsQueryKey = ["bas-totals"] as const;
+export const paymentsQueueQueryKey = ["payments-queue"] as const;
+export const reconQueueQueryKey = ["recon-queue"] as const;
+export const rptEvidenceQueryKey = ["rpt-evidence"] as const;
+
+export function useFeatureGates() {
+  return useQuery({
+    queryKey: featureGatesQueryKey,
+    queryFn: getFeatureGates,
+  });
+}
+
+export function useBasTotals() {
+  return useQuery({
+    queryKey: basTotalsQueryKey,
+    queryFn: getBasTotals,
+  });
+}
+
+export function usePaymentsQueue() {
+  return useQuery({
+    queryKey: paymentsQueueQueryKey,
+    queryFn: getPaymentsQueue,
+  });
+}
+
+export function useReconQueue() {
+  return useQuery({
+    queryKey: reconQueueQueryKey,
+    queryFn: getReconciliationQueue,
+  });
+}
+
+export function useRptEvidence(enabled: boolean) {
+  return useQuery({
+    queryKey: rptEvidenceQueryKey,
+    queryFn: getRptEvidence,
+    enabled,
+    staleTime: 0,
+  });
+}
+
+export function useIssueRptMutation() {
+  const client = useQueryClient();
+  return useMutation<IssueRptResponse, Error, IssueRptPayload>({
+    mutationKey: ["issue-rpt"],
+    mutationFn: issueRpt,
+    onSuccess: () => {
+      void client.invalidateQueries({ queryKey: paymentsQueueQueryKey });
+      void client.invalidateQueries({ queryKey: reconQueueQueryKey });
+      void client.invalidateQueries({ queryKey: rptEvidenceQueryKey });
+    },
+  });
+}
+
+export function getGateState(
+  gates: FeatureGateState[] | undefined,
+  gate: FeatureGate,
+  fallback = false
+): boolean {
+  if (!gates) return fallback;
+  const map = mapGatesByKey(gates);
+  return map[gate]?.enabled ?? fallback;
+}

--- a/apps/web/console/src/api/schema.ts
+++ b/apps/web/console/src/api/schema.ts
@@ -1,0 +1,40 @@
+import { FeatureGate } from "../constants/featureGates";
+
+export interface FeatureGateState {
+  gate: FeatureGate;
+  enabled: boolean;
+  updatedAt: string;
+  updatedBy?: string;
+}
+
+export interface BasTotalsResponse {
+  ratesVersion: string;
+  totals: Array<{
+    segment: string;
+    submitted: number;
+    reconciled: number;
+    delta: number;
+  }>;
+}
+
+export interface QueueItem {
+  id: string;
+  payer: string;
+  amount: number;
+  currency: string;
+  status: "pending" | "in_progress" | "complete" | "blocked";
+  createdAt: string;
+}
+
+export interface RptEvidenceResponse {
+  rptId: string;
+  evidenceToken: string;
+}
+
+export interface AuditEntry {
+  id: string;
+  occurredAt: string;
+  actor: string;
+  action: string;
+  payload: Record<string, unknown>;
+}

--- a/apps/web/console/src/components/AuditViewer.tsx
+++ b/apps/web/console/src/components/AuditViewer.tsx
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import { useAuditStream } from "../lib/useAuditStream";
+
+export function AuditViewer() {
+  const [enabled, setEnabled] = useState(true);
+  const { entries, isStreaming, error } = useAuditStream(enabled);
+
+  return (
+    <section className="flex h-full flex-col gap-4 rounded-2xl bg-slate-900/70 p-6 shadow ring-1 ring-white/5">
+      <header className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-white">Audit Viewer</h3>
+          <p className="text-xs text-slate-400">Live feed of `/api/audit/stream`</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setEnabled((prev) => !prev)}
+          className="rounded-md border border-white/10 px-3 py-1 text-xs uppercase tracking-wide text-slate-300 hover:bg-slate-800/60"
+        >
+          {enabled ? "Pause" : "Resume"}
+        </button>
+      </header>
+      {error && <p className="text-xs text-rose-300">{error}</p>}
+      <div className="flex-1 overflow-y-auto rounded-xl bg-slate-950/40 p-3 text-[11px] text-slate-100">
+        {entries.length === 0 && (
+          <p className="text-xs text-slate-500">
+            {isStreaming ? "Awaiting audit entries…" : "No audit events captured."}
+          </p>
+        )}
+        <ul className="space-y-3">
+          {entries.map((entry) => (
+            <li key={entry.id} className="space-y-1 rounded-lg bg-slate-900/80 p-3">
+              <div className="flex items-center justify-between text-[10px] uppercase tracking-wide text-slate-400">
+                <span>{new Date(entry.occurredAt).toLocaleString()}</span>
+                <span>{entry.actor}</span>
+              </div>
+              <p className="text-xs font-semibold text-slate-200">{entry.action}</p>
+              <pre className="overflow-x-auto whitespace-pre-wrap text-[11px]">
+                {JSON.stringify(entry.payload, null, 2)}
+              </pre>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/console/src/components/BasTotalsCard.tsx
+++ b/apps/web/console/src/components/BasTotalsCard.tsx
@@ -1,0 +1,45 @@
+import type { BasTotalsResponse } from "../api/schema";
+
+interface BasTotalsCardProps {
+  data?: BasTotalsResponse;
+  isLoading: boolean;
+}
+
+export function BasTotalsCard({ data, isLoading }: BasTotalsCardProps) {
+  return (
+    <section className="rounded-2xl bg-slate-900/70 p-6 shadow-lg ring-1 ring-white/5">
+      <header className="flex items-center justify-between">
+        <div>
+          <h2 className="text-lg font-semibold text-white">BAS Totals</h2>
+          <p className="text-xs text-slate-300">Rates Version {data?.ratesVersion ?? "—"}</p>
+        </div>
+        {isLoading && <span className="text-xs text-slate-400">Loading…</span>}
+      </header>
+      <div className="mt-6 grid gap-3 text-sm">
+        {(data?.totals ?? []).map((row) => (
+          <div key={row.segment} className="grid grid-cols-4 gap-4 rounded-lg bg-slate-800/60 px-4 py-3">
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-400">Segment</p>
+              <p className="font-medium text-slate-100">{row.segment}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-400">Submitted</p>
+              <p className="font-mono text-slate-100">{row.submitted.toLocaleString()}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-400">Reconciled</p>
+              <p className="font-mono text-emerald-200">{row.reconciled.toLocaleString()}</p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-wide text-slate-400">Delta</p>
+              <p className="font-mono text-amber-200">{row.delta.toLocaleString(undefined, { maximumFractionDigits: 2 })}</p>
+            </div>
+          </div>
+        ))}
+        {!isLoading && (data?.totals?.length ?? 0) === 0 && (
+          <p className="text-sm text-slate-400">No BAS totals available for the selected rate set.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/console/src/components/EvidenceDrawer.tsx
+++ b/apps/web/console/src/components/EvidenceDrawer.tsx
@@ -1,0 +1,82 @@
+import { clsx } from "clsx";
+import type { RptEvidenceResponse } from "../api/schema";
+import { decodeJws } from "../lib/jws";
+
+interface EvidenceDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+  evidence?: RptEvidenceResponse;
+  isLoading: boolean;
+}
+
+export function EvidenceDrawer({ isOpen, onClose, evidence, isLoading }: EvidenceDrawerProps) {
+  const decoded = (() => {
+    if (!evidence) return null;
+    try {
+      return decodeJws(evidence.evidenceToken);
+    } catch (error) {
+      console.error("Failed to decode RPT evidence", error);
+      return null;
+    }
+  })();
+
+  return (
+    <div
+      className={clsx(
+        "pointer-events-none fixed inset-0 z-40 flex justify-end bg-slate-950/50 backdrop-blur transition",
+        isOpen ? "opacity-100" : "opacity-0"
+      )}
+      aria-hidden={!isOpen}
+    >
+      <aside
+        className={clsx(
+          "pointer-events-auto flex h-full w-full max-w-xl flex-col gap-4 border-l border-white/10 bg-slate-900/95 p-6 shadow-xl transition-transform",
+          isOpen ? "translate-x-0" : "translate-x-full"
+        )}
+        role="dialog"
+        aria-modal="true"
+        aria-label="RPT Evidence"
+      >
+        <header className="flex items-center justify-between">
+          <div>
+            <h3 className="text-lg font-semibold text-white">RPT Evidence</h3>
+            <p className="text-xs text-slate-400">RPT {evidence?.rptId ?? "—"}</p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-white/10 px-3 py-1 text-xs uppercase tracking-wide text-slate-300 hover:bg-slate-800/60"
+          >
+            Close
+          </button>
+        </header>
+        {isLoading && <p className="text-sm text-slate-300">Loading latest evidence…</p>}
+        {!isLoading && decoded && (
+          <div className="flex flex-col gap-4 overflow-y-auto text-xs text-slate-100">
+            <section>
+              <h4 className="font-semibold uppercase tracking-wide text-slate-400">Header</h4>
+              <pre className="mt-2 max-h-48 overflow-auto rounded-lg bg-slate-950/60 p-3 text-[11px]">
+                {JSON.stringify(decoded.header, null, 2)}
+              </pre>
+            </section>
+            <section>
+              <h4 className="font-semibold uppercase tracking-wide text-slate-400">Payload</h4>
+              <pre className="mt-2 max-h-64 overflow-auto rounded-lg bg-slate-950/60 p-3 text-[11px]">
+                {JSON.stringify(decoded.payload, null, 2)}
+              </pre>
+            </section>
+            <section>
+              <h4 className="font-semibold uppercase tracking-wide text-slate-400">Signature</h4>
+              <code className="mt-2 block break-all rounded-lg bg-slate-950/60 p-3 text-[11px]">
+                {decoded.signature}
+              </code>
+            </section>
+          </div>
+        )}
+        {!isLoading && !decoded && (
+          <p className="text-sm text-rose-200">Unable to decode the evidence payload.</p>
+        )}
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/console/src/components/IssueRptButton.tsx
+++ b/apps/web/console/src/components/IssueRptButton.tsx
@@ -1,0 +1,33 @@
+import { clsx } from "clsx";
+import type { MouseEventHandler } from "react";
+
+interface IssueRptButtonProps {
+  disabled: boolean;
+  disabledReason?: string;
+  onIssue: MouseEventHandler<HTMLButtonElement>;
+  isSubmitting: boolean;
+}
+
+export function IssueRptButton({ disabled, disabledReason, onIssue, isSubmitting }: IssueRptButtonProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={onIssue}
+        disabled={disabled || isSubmitting}
+        className={clsx(
+          "inline-flex items-center justify-center rounded-lg px-5 py-2 text-sm font-semibold transition",
+          "bg-brand-primary/20 text-sky-100 ring-1 ring-brand-primary/40 hover:bg-brand-primary/30",
+          "disabled:cursor-not-allowed disabled:bg-slate-800 disabled:text-slate-500 disabled:ring-slate-700"
+        )}
+      >
+        {isSubmitting ? "Issuing…" : "Issue RPT"}
+      </button>
+      {(disabled || isSubmitting) && disabledReason && (
+        <p className="text-xs text-slate-400" data-testid="issue-rpt-disabled-reason">
+          {disabledReason}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/console/src/components/KillSwitchBanner.tsx
+++ b/apps/web/console/src/components/KillSwitchBanner.tsx
@@ -1,0 +1,25 @@
+interface KillSwitchBannerProps {
+  active: boolean;
+  updatedAt?: string;
+  updatedBy?: string;
+}
+
+export function KillSwitchBanner({ active, updatedAt, updatedBy }: KillSwitchBannerProps) {
+  if (!active) return null;
+
+  return (
+    <div className="bg-red-600/20 border border-red-500/40 rounded-lg px-4 py-3 text-sm text-red-200">
+      <div className="font-semibold uppercase tracking-wide">Kill Switch Active</div>
+      <p className="mt-1 text-red-100/80">
+        RPT issuance and queue processing are suspended. Override gates must be cleared before
+        resuming operations.
+      </p>
+      {(updatedAt || updatedBy) && (
+        <p className="mt-2 text-xs text-red-100/60">
+          {updatedBy ? `Last toggled by ${updatedBy}` : "Kill switch updated"}
+          {updatedAt ? ` on ${new Date(updatedAt).toLocaleString()}` : ""}.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/console/src/components/ModePill.tsx
+++ b/apps/web/console/src/components/ModePill.tsx
@@ -1,0 +1,42 @@
+import { clsx } from "clsx";
+import { FeatureGate } from "../constants/featureGates";
+import type { FeatureGateState } from "../api/schema";
+
+interface ModePillProps {
+  gates?: FeatureGateState[];
+}
+
+function resolveMode(gates?: FeatureGateState[]): { label: string; tone: "live" | "shadow" | "override" } {
+  const enabled = new Map<FeatureGate, boolean>();
+  gates?.forEach((gate) => enabled.set(gate.gate, gate.enabled));
+
+  if (enabled.get(FeatureGate.ShadowMode)) {
+    return { label: "Shadow", tone: "shadow" };
+  }
+
+  if (enabled.get(FeatureGate.ProtoAllowOverrides)) {
+    return { label: "Override", tone: "override" };
+  }
+
+  return { label: "Live", tone: "live" };
+}
+
+export function ModePill({ gates }: ModePillProps) {
+  const mode = resolveMode(gates);
+  return (
+    <span
+      data-testid="mode-pill"
+      className={clsx(
+        "inline-flex items-center gap-2 rounded-full px-4 py-1 text-sm font-medium",
+        {
+          "bg-emerald-500/10 text-emerald-300 ring-1 ring-emerald-500/40": mode.tone === "live",
+          "bg-sky-500/10 text-sky-300 ring-1 ring-sky-500/40": mode.tone === "shadow",
+          "bg-amber-500/10 text-amber-300 ring-1 ring-amber-500/40": mode.tone === "override",
+        }
+      )}
+    >
+      <span className="size-2 rounded-full bg-current" aria-hidden />
+      <span className="uppercase tracking-wide">{mode.label} Mode</span>
+    </span>
+  );
+}

--- a/apps/web/console/src/components/QueuePane.tsx
+++ b/apps/web/console/src/components/QueuePane.tsx
@@ -1,0 +1,49 @@
+import type { QueueItem } from "../api/schema";
+
+interface QueuePaneProps {
+  title: string;
+  items?: QueueItem[];
+  isLoading: boolean;
+}
+
+const statusClasses: Record<QueueItem["status"], string> = {
+  pending: "bg-amber-500/20 text-amber-200",
+  in_progress: "bg-sky-500/20 text-sky-200",
+  complete: "bg-emerald-500/20 text-emerald-200",
+  blocked: "bg-rose-500/20 text-rose-200",
+};
+
+export function QueuePane({ title, items, isLoading }: QueuePaneProps) {
+  return (
+    <section className="flex flex-col gap-4 rounded-2xl bg-slate-900/70 p-6 shadow ring-1 ring-white/5">
+      <header className="flex items-center justify-between">
+        <h3 className="text-base font-semibold text-white">{title}</h3>
+        {isLoading && <span className="text-xs text-slate-400">Loading…</span>}
+      </header>
+      <div className="flex-1 space-y-3 text-sm">
+        {(items ?? []).map((item) => (
+          <article
+            key={item.id}
+            className="rounded-xl border border-white/5 bg-slate-800/60 px-4 py-3 shadow-sm"
+          >
+            <header className="flex items-center justify-between text-xs text-slate-400">
+              <span className="font-medium text-slate-200">{item.payer}</span>
+              <span>{new Date(item.createdAt).toLocaleString()}</span>
+            </header>
+            <div className="mt-2 flex items-center justify-between">
+              <span className="font-mono text-lg text-slate-100">
+                {item.currency} {item.amount.toLocaleString(undefined, { minimumFractionDigits: 2 })}
+              </span>
+              <span className={`rounded-full px-3 py-1 text-xs font-medium ${statusClasses[item.status]}`}>
+                {item.status.replace(/_/g, " ")}
+              </span>
+            </div>
+          </article>
+        ))}
+        {!isLoading && (items?.length ?? 0) === 0 && (
+          <p className="text-sm text-slate-400">Queue is clear.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/console/src/constants/featureGates.ts
+++ b/apps/web/console/src/constants/featureGates.ts
@@ -1,0 +1,13 @@
+export enum FeatureGate {
+  ProtoAllowOverrides = "PROTO_ALLOW_OVERRIDES",
+  ShadowMode = "SHADOW_MODE",
+  KillSwitchActive = "KILL_SWITCH_ACTIVE",
+  RptIssuanceEnabled = "RPT_ISSUANCE_ENABLED",
+}
+
+export const FEATURE_GATE_LABELS: Record<FeatureGate, string> = {
+  [FeatureGate.ProtoAllowOverrides]: "Proto Overrides",
+  [FeatureGate.ShadowMode]: "Shadow Mode",
+  [FeatureGate.KillSwitchActive]: "Kill Switch",
+  [FeatureGate.RptIssuanceEnabled]: "Issue RPT",
+};

--- a/apps/web/console/src/index.css
+++ b/apps/web/console/src/index.css
@@ -1,0 +1,16 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+#root {
+  min-height: 100vh;
+}

--- a/apps/web/console/src/lib/jws.ts
+++ b/apps/web/console/src/lib/jws.ts
@@ -1,0 +1,22 @@
+export interface DecodedJws<TPayload = unknown, THeader = unknown> {
+  header: THeader;
+  payload: TPayload;
+  signature: string;
+}
+
+function decodeBase64Url(value: string): string {
+  const padded = value.padEnd(value.length + ((4 - (value.length % 4)) % 4), "=");
+  const converted = padded.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(converted, "base64").toString("utf8");
+}
+
+export function decodeJws<TPayload = unknown, THeader = unknown>(token: string): DecodedJws<TPayload, THeader> {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("Invalid JWS token");
+  }
+  const [headerSegment, payloadSegment, signature] = segments;
+  const header = JSON.parse(decodeBase64Url(headerSegment)) as THeader;
+  const payload = JSON.parse(decodeBase64Url(payloadSegment)) as TPayload;
+  return { header, payload, signature };
+}

--- a/apps/web/console/src/lib/useAuditStream.ts
+++ b/apps/web/console/src/lib/useAuditStream.ts
@@ -1,0 +1,42 @@
+import { useEffect, useRef, useState } from "react";
+import { streamAuditLog } from "../api/client";
+import type { AuditEntry } from "../api/schema";
+
+export function useAuditStream(enabled: boolean) {
+  const [entries, setEntries] = useState<AuditEntry[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      abortControllerRef.current?.abort();
+      setIsStreaming(false);
+      return;
+    }
+
+    const abortController = new AbortController();
+    abortControllerRef.current = abortController;
+    setIsStreaming(true);
+    setError(null);
+
+    streamAuditLog(abortController.signal, (entry) => {
+      setEntries((prev) => [entry, ...prev].slice(0, 100));
+    })
+      .catch((err) => {
+        if (abortController.signal.aborted) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (!abortController.signal.aborted) {
+          setIsStreaming(false);
+        }
+      });
+
+    return () => {
+      abortController.abort();
+    };
+  }, [enabled]);
+
+  return { entries, isStreaming, error };
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,22 @@
-﻿import React from "react";
-import { createRoot } from "react-dom/client";
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import "./index.css";
 
-function App() {
-  return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
-    </div>
-  );
-}
-createRoot(document.getElementById("root")!).render(<App />);
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 30_000,
+    },
+  },
+});
+
+ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/apps/web/console/tailwind.config.ts
+++ b/apps/web/console/tailwind.config.ts
@@ -1,0 +1,18 @@
+import type { Config } from "tailwindcss";
+
+export default {
+  darkMode: "class",
+  content: ["./index.html", "./src/**/*.{ts,tsx,js,jsx}"],
+  theme: {
+    extend: {
+      colors: {
+        brand: {
+          primary: "#38bdf8",
+          muted: "#1e293b",
+          accent: "#facc15",
+        },
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config;

--- a/apps/web/console/tsconfig.json
+++ b/apps/web/console/tsconfig.json
@@ -1,13 +1,22 @@
-﻿{
+{
   "compilerOptions": {
     "target": "ES2022",
-    "lib": ["ES2022", "DOM"],
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
     "jsx": "react-jsx",
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "types": []
+    "types": [
+      "node"
+    ]
   },
-  "include": ["src"]
+  "include": [
+    "src",
+    "jest.setup.ts",
+    "jest.config.ts"
+  ]
 }

--- a/apps/web/console/vite.config.ts
+++ b/apps/web/console/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      "/api": {
+        target: "http://localhost:3000",
+        changeOrigin: true,
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.12.3",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + Tailwind console shell with mode pill, kill-switch banner, BAS totals, queue panes, and audit viewer
- wire TanStack Query to the generated API client for BAS, RPT, evidence, queues, and audit streaming with feature-gate awareness
- add Jest + Testing Library coverage for disabled Issue RPT states and evidence drawer interactions

## Testing
- npm test *(fails: jest binary unavailable because dependencies could not be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2602eccbc8327aefa60e86056296e