### PR TITLE
Implement patent flow API and tests

### DIFF
--- a/__tests__/server.test.js
+++ b/__tests__/server.test.js
@@ -1,0 +1,368 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const assert = require('assert');
+const { test, before, after } = require('node:test');
+const nacl = require('tweetnacl');
+const { createApp } = require('../server');
+
+const MIGRATIONS = ['001_apgms_core.sql', '002_patent_extensions.sql'];
+
+class FakePool {
+  constructor() {
+    this.periods = [];
+    this.rptTokens = [];
+    this.owaLedger = [];
+    this.periodSeq = 1;
+    this.rptSeq = 1;
+    this.ledgerSeq = 1;
+  }
+
+  async query(sql, params = []) {
+    const trimmed = sql.trim();
+    const cleaned = trimmed.replace(/--.*$/gm, '').trim();
+    if (!cleaned) {
+      return { rows: [], rowCount: 0 };
+    }
+    const normalized = cleaned.replace(/\s+/g, ' ').toLowerCase();
+
+    if (normalized.startsWith('select now()')) {
+      return { rows: [{ ts: new Date() }], rowCount: 1 };
+    }
+
+    if (/^create |^alter |^do \$\$|^create or replace/.test(normalized)) {
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (normalized.startsWith('insert into periods')) {
+      const row = {
+        id: this.periodSeq++,
+        abn: params[0],
+        tax_type: params[1],
+        period_id: params[2],
+        state: params[3] ?? 'OPEN',
+        accrued_cents: params[4] ?? 0,
+        credited_to_owa_cents: params[5] ?? 0,
+        final_liability_cents: params[6] ?? 0,
+        anomaly_vector: typeof params[7] === 'string' ? JSON.parse(params[7]) : params[7] || {},
+        thresholds: typeof params[8] === 'string' ? JSON.parse(params[8]) : params[8] || {},
+        merkle_root: null,
+        running_balance_hash: null
+      };
+      this.periods.push(row);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (normalized.startsWith('select * from periods where')) {
+      const [abn, taxType, periodId] = params;
+      const row = this.periods.find((p) => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      return { rows: row ? [row] : [], rowCount: row ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('select state from periods where')) {
+      const [abn, taxType, periodId] = params;
+      const row = this.periods.find((p) => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      return { rows: row ? [{ state: row.state }] : [], rowCount: row ? 1 : 0 };
+    }
+
+    if (normalized.startsWith("update periods set state='blocked_anomaly'")) {
+      const [id] = params;
+      this._updatePeriodState(id, 'BLOCKED_ANOMALY');
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (normalized.startsWith("update periods set state='blocked_discrepancy'")) {
+      const [id] = params;
+      this._updatePeriodState(id, 'BLOCKED_DISCREPANCY');
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (normalized.startsWith("update periods set state='ready_rpt'")) {
+      const [id] = params;
+      this._updatePeriodState(id, 'READY_RPT');
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (normalized.startsWith("update periods set state='released'")) {
+      const [id] = params;
+      this._updatePeriodState(id, 'RELEASED');
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (normalized.startsWith('insert into rpt_tokens')) {
+      const [abn, taxType, periodId, payload, signature, payloadStr, payloadSha256] = params;
+      const row = {
+        id: this.rptSeq++,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        payload,
+        signature,
+        payload_c14n: payloadStr,
+        payload_sha256: payloadSha256,
+        created_at: new Date()
+      };
+      this.rptTokens.push(row);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (normalized.startsWith('select payload, signature from rpt_tokens')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rptTokens
+        .filter((t) => t.abn === abn && t.tax_type === taxType && t.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .map((t) => ({ payload: t.payload, signature: t.signature }));
+      return { rows: rows.slice(0, 1), rowCount: rows.length ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('select payload, payload_c14n')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rptTokens
+        .filter((t) => t.abn === abn && t.tax_type === taxType && t.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .map((t) => ({
+          payload: t.payload,
+          payload_c14n: t.payload_c14n,
+          payload_sha256: t.payload_sha256,
+          signature: t.signature,
+          created_at: t.created_at
+        }));
+      return { rows: rows.slice(0, 1), rowCount: rows.length ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('select payload_c14n, payload_sha256 from rpt_tokens')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rptTokens
+        .filter((t) => t.abn === abn && t.tax_type === taxType && t.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .map((t) => ({
+          payload_c14n: t.payload_c14n,
+          payload_sha256: t.payload_sha256
+        }));
+      return { rows: rows.slice(0, 1), rowCount: rows.length ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('select balance_after_cents from owa_ledger')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this._ledgerFor(abn, taxType, periodId);
+      const last = rows[rows.length - 1];
+      const value = last ? last.balance_after_cents : null;
+      return { rows: last ? [{ balance_after_cents: value }] : [], rowCount: last ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('select balance_after_cents as bal from owa_ledger')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this._ledgerFor(abn, taxType, periodId);
+      const last = rows[rows.length - 1];
+      const value = last ? last.balance_after_cents : null;
+      return { rows: last ? [{ bal: value }] : [], rowCount: last ? 1 : 0 };
+    }
+
+    if (normalized.startsWith('select id, amount_cents, balance_after_cents')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this._ledgerFor(abn, taxType, periodId).map((r) => ({
+        id: r.id,
+        amount_cents: r.amount_cents,
+        balance_after_cents: r.balance_after_cents,
+        bank_receipt_hash: r.bank_receipt_hash,
+        prev_hash: r.prev_hash,
+        hash_after: r.hash_after,
+        created_at: r.created_at
+      }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (normalized.startsWith('select amount_cents from owa_ledger')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this._ledgerFor(abn, taxType, periodId).map((r) => ({ amount_cents: r.amount_cents }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (normalized.startsWith('select id,') && normalized.includes('from owa_append')) {
+      const [abn, taxType, periodId, amount, bankReceipt] = params;
+      const row = this._appendLedger(abn, taxType, periodId, amount, bankReceipt);
+      return {
+        rows: [{
+          id: row.id,
+          amount_cents: row.amount_cents,
+          balance_after: row.balance_after_cents,
+          bank_receipt_hash: row.bank_receipt_hash,
+          prev_hash: row.prev_hash,
+          hash_after: row.hash_after
+        }],
+        rowCount: 1
+      };
+    }
+
+    if (normalized.startsWith('select periods_sync_totals')) {
+      // no-op for fake implementation
+      return { rows: [], rowCount: 0 };
+    }
+
+    throw new Error(`Unsupported query in fake pool: ${sql}`);
+  }
+
+  _ledgerFor(abn, taxType, periodId) {
+    return this.owaLedger
+      .filter((r) => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+      .sort((a, b) => a.id - b.id);
+  }
+
+  _appendLedger(abn, taxType, periodId, amount, bankReceipt) {
+    if (bankReceipt) {
+      const existing = this.owaLedger.find(
+        (r) => r.abn === abn && r.tax_type === taxType && r.period_id === periodId && r.bank_receipt_hash === bankReceipt
+      );
+      if (existing) {
+        return existing;
+      }
+    }
+
+    const rows = this._ledgerFor(abn, taxType, periodId);
+    const prev = rows[rows.length - 1];
+    const prevBal = prev ? prev.balance_after_cents : 0;
+    const prevHash = prev ? prev.hash_after : '';
+    const newBal = prevBal + amount;
+    const hash = crypto.createHash('sha256')
+      .update((prevHash || '') + (bankReceipt || '') + String(newBal))
+      .digest('hex');
+
+    const row = {
+      id: this.ledgerSeq++,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      amount_cents: amount,
+      balance_after_cents: newBal,
+      bank_receipt_hash: bankReceipt || null,
+      prev_hash: prevHash || '',
+      hash_after: hash,
+      created_at: new Date()
+    };
+    this.owaLedger.push(row);
+    return row;
+  }
+
+  _updatePeriodState(id, state) {
+    const period = this.periods.find((p) => p.id === id);
+    if (period) {
+      period.state = state;
+    }
+  }
+
+  async end() {}
+}
+
+let pool;
+let server;
+let baseUrl;
+
+const abn = '12345678901';
+const taxType = 'GST';
+const periodId = '2025-09';
+
+before(async () => {
+  pool = new FakePool();
+
+  const migrationsDir = path.join(__dirname, '..', 'migrations');
+  for (const file of MIGRATIONS) {
+    const sql = fs.readFileSync(path.join(migrationsDir, file), 'utf8');
+    await pool.query(sql);
+  }
+
+  const keyPair = nacl.sign.keyPair();
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString('base64');
+  process.env.RPT_PUBLIC_BASE64 = Buffer.from(keyPair.publicKey).toString('base64');
+  process.env.ATO_PRN = 'PRN12345';
+
+  const app = createApp({ pool });
+  server = app.listen(0);
+  await new Promise((resolve) => server.once('listening', resolve));
+  const address = server.address();
+  baseUrl = `http://127.0.0.1:${address.port}`;
+
+  await pool.query(
+    'insert into periods(abn,tax_type,period_id,state,accrued_cents,credited_to_owa_cents,final_liability_cents,anomaly_vector,thresholds) values ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb)',
+    [abn, taxType, periodId, 'CLOSING', 10000, 10000, 10000, '{}', '{}']
+  );
+
+  await pool.query(
+    `select id,
+            balance_after as balance_after,
+            hash_after
+       from owa_append($1,$2,$3,$4,$5) as t(
+         id int,
+         balance_after bigint,
+         hash_after text
+       )`,
+    [abn, taxType, periodId, 10000, 'seed-credit']
+  );
+});
+
+after(async () => {
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+test('patent flow endpoints', async () => {
+  const statusResp = await fetch(`${baseUrl}/period/status?abn=${abn}&taxType=${taxType}&periodId=${periodId}`);
+  assert.strictEqual(statusResp.status, 200);
+  const statusBody = await statusResp.json();
+  assert.strictEqual(statusBody.period.state, 'CLOSING');
+
+  const issueResp = await fetch(`${baseUrl}/rpt/issue`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ abn, taxType, periodId })
+  });
+  assert.strictEqual(issueResp.status, 200);
+  const issueBody = await issueResp.json();
+  assert.strictEqual(issueBody.payload.amount_cents, 10000);
+  assert.strictEqual(issueBody.payload_sha256.length, 64);
+  assert.ok(issueBody.signature);
+
+  const tokenRow = await pool.query(
+    'select payload_c14n, payload_sha256 from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1',
+    [abn, taxType, periodId]
+  );
+  assert.strictEqual(tokenRow.rowCount, 1);
+  assert.strictEqual(tokenRow.rows[0].payload_c14n, JSON.stringify(issueBody.payload));
+  assert.strictEqual(tokenRow.rows[0].payload_sha256, issueBody.payload_sha256);
+
+  const periodAfterIssue = await pool.query(
+    'select state from periods where abn=$1 and tax_type=$2 and period_id=$3',
+    [abn, taxType, periodId]
+  );
+  assert.strictEqual(periodAfterIssue.rows[0].state, 'READY_RPT');
+
+  const releaseResp = await fetch(`${baseUrl}/release`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ abn, taxType, periodId })
+  });
+  assert.strictEqual(releaseResp.status, 200);
+  const releaseBody = await releaseResp.json();
+  assert.strictEqual(releaseBody.released, true);
+  assert.ok(/^rpt_debit:/.test(releaseBody.bank_receipt_hash));
+
+  const ledgerEntries = await pool.query(
+    'select amount_cents from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id',
+    [abn, taxType, periodId]
+  );
+  assert.strictEqual(ledgerEntries.rowCount, 2);
+  assert.strictEqual(Number(ledgerEntries.rows[1].amount_cents), -10000);
+
+  const periodAfterRelease = await pool.query(
+    'select state from periods where abn=$1 and tax_type=$2 and period_id=$3',
+    [abn, taxType, periodId]
+  );
+  assert.strictEqual(periodAfterRelease.rows[0].state, 'RELEASED');
+
+  const evidenceResp = await fetch(`${baseUrl}/evidence?abn=${abn}&taxType=${taxType}&periodId=${periodId}`);
+  assert.strictEqual(evidenceResp.status, 200);
+  const evidenceBody = await evidenceResp.json();
+  assert.strictEqual(evidenceBody.rpt.payload_sha256, issueBody.payload_sha256);
+  assert.ok(Array.isArray(evidenceBody.owa_ledger));
+  assert.strictEqual(evidenceBody.owa_ledger.length, 2);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "node --test"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/server.js
+++ b/server.js
@@ -5,211 +5,276 @@ const { Pool } = require('pg');
 const nacl = require('tweetnacl');
 const crypto = require('crypto');
 
-const app = express();
-app.use(bodyParser.json());
+function createPool() {
+  const {
+    PGHOST = '127.0.0.1',
+    PGUSER = 'apgms',
+    PGPASSWORD = 'apgms_pw',
+    PGDATABASE = 'apgms',
+    PGPORT = '5432'
+  } = process.env;
 
-const {
-  PGHOST='127.0.0.1', PGUSER='apgms', PGPASSWORD='apgms_pw', PGDATABASE='apgms', PGPORT='5432',
-  RPT_ED25519_SECRET_BASE64, RPT_PUBLIC_BASE64, ATO_PRN='1234567890'
-} = process.env;
+  return new Pool({
+    host: PGHOST,
+    user: PGUSER,
+    password: PGPASSWORD,
+    database: PGDATABASE,
+    port: Number(PGPORT)
+  });
+}
 
-const pool = new Pool({
-  host: PGHOST, user: PGUSER, password: PGPASSWORD, database: PGDATABASE, port: +PGPORT
-});
+function createApp({ pool }) {
+  const app = express();
+  app.use(bodyParser.json());
 
-// small async handler wrapper
-const ah = fn => (req,res)=>fn(req,res).catch(e=>{
-  console.error(e);
-  if (e.code === '08P01') return res.status(500).json({error:'INTERNAL', message:e.message});
-  res.status(400).json({error: e.message || 'BAD_REQUEST'});
-});
+  const asyncHandler = (fn) => (req, res) => fn(req, res).catch((e) => {
+    console.error(e);
+    if (e.code === '08P01') {
+      return res.status(500).json({ error: 'INTERNAL', message: e.message });
+    }
+    res.status(400).json({ error: e.message || 'BAD_REQUEST' });
+  });
 
-// ---------- HEALTH ----------
-app.get('/health', ah(async (req,res)=>{
-  await pool.query('select now()');
-  res.json(['ok','db', true, 'up']);
-}));
+  app.get('/health', asyncHandler(async (req, res) => {
+    await pool.query('select now() as ts');
+    res.json(['ok', 'db', true, 'up']);
+  }));
 
-// ---------- PERIOD STATUS ----------
-app.get('/period/status', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.query;
-  const r = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (r.rowCount===0) return res.status(404).json({error:'NOT_FOUND'});
-  res.json({ period: r.rows[0] });
-}));
-
-// ---------- RPT ISSUE ----------
-app.post('/rpt/issue', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.body;
-  const pr = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (pr.rowCount===0) throw new Error('PERIOD_NOT_FOUND');
-  const p = pr.rows[0];
-
-  if (p.state !== 'CLOSING') return res.status(409).json({error:'BAD_STATE', state:p.state});
-
-  // simple anomaly thresholds (demo)
-  const thresholds = { epsilon_cents: 0, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
-  const v = p.anomaly_vector || {};
-  const exceeds =
-    (v.variance_ratio || 0) > thresholds.variance_ratio ||
-    (v.dup_rate || 0) > thresholds.dup_rate ||
-    (v.gap_minutes || 0) > thresholds.gap_minutes ||
-    Math.abs((v.delta_vs_baseline || 0)) > thresholds.delta_vs_baseline;
-
-  if (exceeds) {
-    await pool.query(update periods set state='BLOCKED_ANOMALY' where id=, [p.id]);
-    return res.status(409).json({error:'BLOCKED_ANOMALY'});
-  }
-
-  const epsilon = Math.abs(Number(p.final_liability_cents) - Number(p.credited_to_owa_cents));
-  if (epsilon > thresholds.epsilon_cents) {
-    await pool.query(update periods set state='BLOCKED_DISCREPANCY' where id=, [p.id]);
-    return res.status(409).json({error:'BLOCKED_DISCREPANCY', epsilon});
-  }
-
-  // patent-critical: canonical payload string + sha256 saved alongside signature
-  const payload = {
-    entity_id: p.abn,
-    period_id: p.period_id,
-    tax_type: p.tax_type,
-    amount_cents: Number(p.final_liability_cents),
-    merkle_root: p.merkle_root || null,
-    running_balance_hash: p.running_balance_hash || null,
-    anomaly_vector: v,
-    thresholds,
-    rail_id: "EFT",
-    reference: ATO_PRN,
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(),
-    nonce: crypto.randomUUID()
-  };
-
-  const payloadStr = JSON.stringify(payload);
-  const payloadSha256 = crypto.createHash('sha256').update(payloadStr).digest('hex');
-  const msg = new TextEncoder().encode(payloadStr);
-
-  if (!RPT_ED25519_SECRET_BASE64) throw new Error('NO_SK');
-  const skBuf = Buffer.from(RPT_ED25519_SECRET_BASE64, 'base64');
-  const sig = nacl.sign.detached(msg, new Uint8Array(skBuf));
-  const signature = Buffer.from(sig).toString('base64');
-
-  // 7 params insert (payload_c14n + payload_sha256)
-  await pool.query(
-    insert into rpt_tokens(abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256)
-     values (,,,,,,),
-    [abn, taxType, periodId, payload, signature, payloadStr, payloadSha256]
-  );
-
-  await pool.query(update periods set state='READY_RPT' where id=, [p.id]);
-  res.json({ payload, signature, payload_sha256: payloadSha256 });
-}));
-
-// ---------- RELEASE (debit from OWA; uses owa_append OUT cols) ----------
-app.post('/release', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.body;
-
-  const pr = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (pr.rowCount===0) throw new Error('PERIOD_NOT_FOUND');
-  const p = pr.rows[0];
-
-  // need latest token
-  const rr = await pool.query(
-    select payload, signature from rpt_tokens
-     where abn= and tax_type= and period_id=
-     order by id desc limit 1,
-    [abn, taxType, periodId]
-  );
-  if (rr.rowCount===0) return res.status(400).json({error:'NO_RPT'});
-
-  // ensure funds exist
-  const lr = await pool.query(
-    select balance_after_cents from owa_ledger
-       where abn= and tax_type= and period_id=
-       order by id desc limit 1,
-    [abn, taxType, periodId]
-  );
-  const prevBal = lr.rows[0]?.balance_after_cents ?? 0;
-  const amt = Number(p.final_liability_cents);
-  if (prevBal < amt) return res.status(422).json({error:'INSUFFICIENT_OWA', prevBal: String(prevBal), needed: amt});
-
-  // do the debit
-  const synthetic = 'rpt_debit:' + crypto.randomUUID().slice(0,12);
-  const r = await pool.query(select * from owa_append(,,,,),
-    [abn, taxType, periodId, -amt, synthetic]);
-
-  let newBalance = null;
-  if (r.rowCount && r.rows[0] && r.rows[0].out_balance_after != null) {
-    newBalance = r.rows[0].out_balance_after;
-  } else {
-    // fallback: read back most recent balance if no row returned
-    const fr = await pool.query(
-      select balance_after_cents as bal from owa_ledger
-       where abn= and tax_type= and period_id=
-       order by id desc limit 1,
+  app.get('/period/status', asyncHandler(async (req, res) => {
+    const { abn, taxType, periodId } = req.query;
+    const result = await pool.query(
+      'select * from periods where abn=$1 and tax_type=$2 and period_id=$3',
       [abn, taxType, periodId]
     );
-    newBalance = fr.rows[0]?.bal ?? (prevBal - amt);
-  }
+    if (result.rowCount === 0) {
+      return res.status(404).json({ error: 'NOT_FOUND' });
+    }
+    res.json({ period: result.rows[0] });
+  }));
 
-  await pool.query(update periods set state='RELEASED' where id=, [p.id]);
-  res.json({ released: true, bank_receipt_hash: synthetic, new_balance: newBalance });
-}));
+  app.post('/rpt/issue', asyncHandler(async (req, res) => {
+    const { abn, taxType, periodId } = req.body;
+    const periodResult = await pool.query(
+      'select * from periods where abn=$1 and tax_type=$2 and period_id=$3',
+      [abn, taxType, periodId]
+    );
+    if (periodResult.rowCount === 0) {
+      throw new Error('PERIOD_NOT_FOUND');
+    }
+    const period = periodResult.rows[0];
 
-// ---------- EVIDENCE ----------
-app.get('/evidence', ah(async (req,res)=>{
-  const {abn, taxType, periodId} = req.query;
-  const pr = await pool.query(
-    select * from periods where abn= and tax_type= and period_id=,
-    [abn, taxType, periodId]
-  );
-  if (pr.rowCount===0) return res.status(404).json({error:'NOT_FOUND'});
-  const p = pr.rows[0];
+    if (period.state !== 'CLOSING') {
+      return res.status(409).json({ error: 'BAD_STATE', state: period.state });
+    }
 
-  const rr = await pool.query(
-    select payload, payload_c14n, payload_sha256, signature, created_at
-       from rpt_tokens
-      where abn= and tax_type= and period_id=
-      order by id desc limit 1,
-    [abn, taxType, periodId]
-  );
-  const rpt = rr.rows[0] || null;
+    const thresholds = {
+      epsilon_cents: 0,
+      variance_ratio: 0.25,
+      dup_rate: 0.01,
+      gap_minutes: 60,
+      delta_vs_baseline: 0.2
+    };
+    const anomalyVector = period.anomaly_vector || {};
 
-  const lr = await pool.query(
-    select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at
-       from owa_ledger
-      where abn= and tax_type= and period_id=
-      order by id,
-    [abn, taxType, periodId]
-  );
+    const exceedsThreshold =
+      (anomalyVector.variance_ratio || 0) > thresholds.variance_ratio ||
+      (anomalyVector.dup_rate || 0) > thresholds.dup_rate ||
+      (anomalyVector.gap_minutes || 0) > thresholds.gap_minutes ||
+      Math.abs(anomalyVector.delta_vs_baseline || 0) > thresholds.delta_vs_baseline;
 
-  const basLabels = { W1:null, W2:null, "1A":null, "1B":null };
+    if (exceedsThreshold) {
+      await pool.query(
+        "update periods set state='BLOCKED_ANOMALY' where id=$1",
+        [period.id]
+      );
+      return res.status(409).json({ error: 'BLOCKED_ANOMALY' });
+    }
 
-  res.json({
-    meta: { generated_at: new Date().toISOString(), abn, taxType, periodId },
-    period: {
-      state: p.state,
-      accrued_cents: Number(p.accrued_cents||0),
-      credited_to_owa_cents: Number(p.credited_to_owa_cents||0),
-      final_liability_cents: Number(p.final_liability_cents||0),
-      merkle_root: p.merkle_root,
-      running_balance_hash: p.running_balance_hash,
-      anomaly_vector: p.anomaly_vector,
-      thresholds: p.thresholds
-    },
-    rpt,
-    owa_ledger: lr.rows,
-    bas_labels: basLabels,
-    discrepancy_log: []
+    const epsilon = Math.abs(Number(period.final_liability_cents) - Number(period.credited_to_owa_cents));
+    if (epsilon > thresholds.epsilon_cents) {
+      await pool.query(
+        "update periods set state='BLOCKED_DISCREPANCY' where id=$1",
+        [period.id]
+      );
+      return res.status(409).json({ error: 'BLOCKED_DISCREPANCY', epsilon });
+    }
+
+    const {
+      RPT_ED25519_SECRET_BASE64,
+      ATO_PRN = '1234567890'
+    } = process.env;
+
+    if (!RPT_ED25519_SECRET_BASE64) {
+      throw new Error('NO_SK');
+    }
+
+    const payload = {
+      entity_id: period.abn,
+      period_id: period.period_id,
+      tax_type: period.tax_type,
+      amount_cents: Number(period.final_liability_cents),
+      merkle_root: period.merkle_root || null,
+      running_balance_hash: period.running_balance_hash || null,
+      anomaly_vector: anomalyVector,
+      thresholds,
+      rail_id: 'EFT',
+      reference: ATO_PRN,
+      expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      nonce: crypto.randomUUID()
+    };
+
+    const payloadStr = JSON.stringify(payload);
+    const payloadSha256 = crypto.createHash('sha256').update(payloadStr).digest('hex');
+    const msg = new TextEncoder().encode(payloadStr);
+
+    const secretKey = Buffer.from(RPT_ED25519_SECRET_BASE64, 'base64');
+    const signature = Buffer.from(
+      nacl.sign.detached(msg, new Uint8Array(secretKey))
+    ).toString('base64');
+
+    await pool.query(
+      'insert into rpt_tokens(abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256) values ($1,$2,$3,$4,$5,$6,$7)',
+      [abn, taxType, periodId, payload, signature, payloadStr, payloadSha256]
+    );
+
+    await pool.query(
+      "update periods set state='READY_RPT' where id=$1",
+      [period.id]
+    );
+
+    res.json({ payload, signature, payload_sha256: payloadSha256 });
+  }));
+
+  app.post('/release', asyncHandler(async (req, res) => {
+    const { abn, taxType, periodId } = req.body;
+    const periodResult = await pool.query(
+      'select * from periods where abn=$1 and tax_type=$2 and period_id=$3',
+      [abn, taxType, periodId]
+    );
+    if (periodResult.rowCount === 0) {
+      throw new Error('PERIOD_NOT_FOUND');
+    }
+    const period = periodResult.rows[0];
+
+    const rptResult = await pool.query(
+      'select payload, signature from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1',
+      [abn, taxType, periodId]
+    );
+    if (rptResult.rowCount === 0) {
+      return res.status(400).json({ error: 'NO_RPT' });
+    }
+
+    const ledgerResult = await pool.query(
+      'select balance_after_cents from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1',
+      [abn, taxType, periodId]
+    );
+    const previousBalance = ledgerResult.rows[0]?.balance_after_cents ?? 0;
+    const amount = Number(period.final_liability_cents);
+    if (previousBalance < amount) {
+      return res.status(422).json({
+        error: 'INSUFFICIENT_OWA',
+        prevBal: String(previousBalance),
+        needed: amount
+      });
+    }
+
+    const syntheticReceipt = 'rpt_debit:' + crypto.randomUUID().slice(0, 12);
+    const debitQuery = `select id,
+       amount_cents,
+       balance_after as balance_after,
+       bank_receipt_hash,
+       prev_hash,
+       hash_after
+from owa_append($1,$2,$3,$4,$5) as t(
+  id int,
+  amount_cents bigint,
+  balance_after bigint,
+  bank_receipt_hash text,
+  prev_hash text,
+  hash_after text
+)`;
+    const debitResult = await pool.query(
+      debitQuery,
+      [abn, taxType, periodId, -amount, syntheticReceipt]
+    );
+
+    let newBalance = null;
+    if (debitResult.rowCount && debitResult.rows[0] && debitResult.rows[0].balance_after != null) {
+      newBalance = debitResult.rows[0].balance_after;
+    } else {
+      const fallback = await pool.query(
+        'select balance_after_cents as bal from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1',
+        [abn, taxType, periodId]
+      );
+      newBalance = fallback.rows[0]?.bal ?? (previousBalance - amount);
+    }
+
+    await pool.query(
+      "update periods set state='RELEASED' where id=$1",
+      [period.id]
+    );
+
+    res.json({ released: true, bank_receipt_hash: syntheticReceipt, new_balance: newBalance });
+  }));
+
+  app.get('/evidence', asyncHandler(async (req, res) => {
+    const { abn, taxType, periodId } = req.query;
+    const periodResult = await pool.query(
+      'select * from periods where abn=$1 and tax_type=$2 and period_id=$3',
+      [abn, taxType, periodId]
+    );
+    if (periodResult.rowCount === 0) {
+      return res.status(404).json({ error: 'NOT_FOUND' });
+    }
+    const period = periodResult.rows[0];
+
+    const rptResult = await pool.query(
+      'select payload, payload_c14n, payload_sha256, signature, created_at from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1',
+      [abn, taxType, periodId]
+    );
+    const rpt = rptResult.rows[0] || null;
+
+    const ledgerResult = await pool.query(
+      'select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id',
+      [abn, taxType, periodId]
+    );
+
+    const basLabels = { W1: null, W2: null, '1A': null, '1B': null };
+
+    res.json({
+      meta: { generated_at: new Date().toISOString(), abn, taxType, periodId },
+      period: {
+        state: period.state,
+        accrued_cents: Number(period.accrued_cents || 0),
+        credited_to_owa_cents: Number(period.credited_to_owa_cents || 0),
+        final_liability_cents: Number(period.final_liability_cents || 0),
+        merkle_root: period.merkle_root,
+        running_balance_hash: period.running_balance_hash,
+        anomaly_vector: period.anomaly_vector,
+        thresholds: period.thresholds
+      },
+      rpt,
+      owa_ledger: ledgerResult.rows,
+      bas_labels: basLabels,
+      discrepancy_log: []
+    });
+  }));
+
+  return app;
+}
+
+function startServer() {
+  const pool = createPool();
+  const app = createApp({ pool });
+  const port = process.env.PORT ? Number(process.env.PORT) : 8080;
+  const server = app.listen(port, () => {
+    console.log(`APGMS demo API listening on :${port}`);
   });
-}));
+  return { app, pool, server };
+}
 
-const port = process.env.PORT ? +process.env.PORT : 8080;
-app.listen(port, ()=> console.log(APGMS demo API listening on :));
+if (require.main === module) {
+  startServer();
+}
+
+module.exports = { createApp, createPool, startServer };


### PR DESCRIPTION
## Summary
- parameterize all SQL in server.js and restructure the app factory for reuse
- implement the patent flow endpoints to persist canonical payloads and advance period states
- add a node-based test harness that replays the migrations against a fake Postgres and exercises the flow

## Testing
- node --test

------
https://chatgpt.com/codex/tasks/task_e_68e26027b13c832790333ffe22e1f6d5