### PR TITLE
Add RPT rates version metadata across persistence and API

### DIFF
--- a/apps/services/payments/openapi.json
+++ b/apps/services/payments/openapi.json
@@ -1,0 +1,81 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Payments Service",
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/payAto": {
+      "post": {
+        "summary": "Release funds to the ATO once an RPT has been verified",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["abn", "taxType", "periodId", "amountCents"],
+                "properties": {
+                  "abn": { "type": "string" },
+                  "taxType": { "type": "string" },
+                  "periodId": { "type": "string" },
+                  "amountCents": { "type": "integer" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Release created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "ok",
+                    "ledger_id",
+                    "transfer_uuid",
+                    "release_uuid",
+                    "balance_after_cents",
+                    "rpt_ref"
+                  ],
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "ledger_id": { "type": "integer" },
+                    "transfer_uuid": { "type": "string", "format": "uuid" },
+                    "release_uuid": { "type": "string", "format": "uuid" },
+                    "balance_after_cents": { "type": "integer" },
+                    "rpt_ref": {
+                      "$ref": "#/components/schemas/RptReference"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or business rule rejection"
+          },
+          "403": {
+            "description": "RPT missing or failed verification"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "RptReference": {
+        "type": "object",
+        "required": ["rpt_id", "payload_sha256", "rates_version"],
+        "properties": {
+          "rpt_id": { "type": "integer" },
+          "kid": { "type": ["string", "null"] },
+          "payload_sha256": { "type": "string" },
+          "rates_version": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apps/services/payments/src/evidence/evidenceBundle.ts
+++ b/apps/services/payments/src/evidence/evidenceBundle.ts
@@ -12,7 +12,7 @@ type BuildParams = {
 
 export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
   const rpt = await client.query(
-    "SELECT rpt_id, payload_c14n, payload_sha256, signature FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED' ORDER BY created_at DESC LIMIT 1",
+    "SELECT rpt_id, payload_c14n, payload_sha256, signature, rates_version FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED' ORDER BY created_at DESC LIMIT 1",
     [p.abn, p.taxType, p.periodId]
   );
   if (!rpt.rows.length) throw new Error("Missing RPT for bundle");
@@ -56,5 +56,8 @@ export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
     canonicalJson(p.bankReceipts), canonicalJson(p.atoReceipts), canonicalJson(p.operatorOverrides)
   ];
   const out = await client.query(ins, vals);
-  return out.rows[0].bundle_id as number;
+  return {
+    bundleId: out.rows[0].bundle_id as number,
+    ratesVersion: r.rates_version as string,
+  };
 }

--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -16,7 +16,7 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
 
     // Accept pending/active. Order by created_at so newest wins.
     const q = `
-      SELECT id as rpt_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce
+      SELECT id as rpt_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce, rates_version
       FROM rpt_tokens
       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
         AND status IN ('pending','active')
@@ -43,7 +43,12 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
     const ok = await kms.verify(payload, sig);
     if (!ok) return res.status(403).json({ error: "RPT signature invalid" });
 
-    (req as any).rpt = { rpt_id: r.rpt_id, nonce: r.nonce, payload_sha256: r.payload_sha256 };
+    (req as any).rpt = {
+      rpt_id: r.rpt_id,
+      nonce: r.nonce,
+      payload_sha256: r.payload_sha256,
+      rates_version: r.rates_version,
+    };
     return next();
   } catch (e: any) {
     return res.status(500).json({ error: "RPT verification error", detail: String(e?.message || e) });

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -81,7 +81,12 @@ export async function payAtoRelease(req: Request, res: Response) {
       transfer_uuid,
       release_uuid,
       balance_after_cents: ins[0].balance_after_cents,
-      rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
+      rpt_ref: {
+        rpt_id: rpt.rpt_id,
+        kid: rpt.kid,
+        payload_sha256: rpt.payload_sha256,
+        rates_version: rpt.rates_version,
+      },
     });
   } catch (e: any) {
     await client.query('ROLLBACK');

--- a/migrations/001_apgms_core.sql
+++ b/migrations/001_apgms_core.sql
@@ -40,6 +40,7 @@ create table if not exists rpt_tokens (
   period_id text not null,
   payload jsonb not null,
   signature text not null,
+  rates_version text not null,
   status text not null default 'ISSUED',
   created_at timestamptz default now()
 );

--- a/migrations/003_add_rates_version_to_rpt_tokens.sql
+++ b/migrations/003_add_rates_version_to_rpt_tokens.sql
@@ -1,0 +1,15 @@
+-- 003_add_rates_version_to_rpt_tokens.sql
+-- Adds rates_version column and backfills existing tokens so downstream services
+-- can rely on the metadata.
+BEGIN;
+
+ALTER TABLE rpt_tokens
+  ADD COLUMN IF NOT EXISTS rates_version TEXT;
+
+UPDATE rpt_tokens
+SET rates_version = COALESCE(rates_version, '2024-10-ATO-v1');
+
+ALTER TABLE rpt_tokens
+  ALTER COLUMN rates_version SET NOT NULL;
+
+COMMIT;

--- a/scripts/doctor.ps1
+++ b/scripts/doctor.ps1
@@ -204,10 +204,10 @@ if ($chkActive.ok -and $chkActive.value -ne "") {
   Say "No active/pending RPT found for release period — copying latest ACTIVE…" "Yellow"
   $copySql = @"
 INSERT INTO rpt_tokens
-  (abn, tax_type, period_id, payload, signature, status, created_at,
+  (abn, tax_type, period_id, payload, signature, rates_version, status, created_at,
    payload_c14n, payload_sha256, nonce, expires_at)
 SELECT
-  abn, tax_type, '$PeriodRelease', payload, signature, 'active', now(),
+  abn, tax_type, '$PeriodRelease', payload, signature, rates_version, 'active', now(),
   payload_c14n, payload_sha256, nonce || '-doctor', now() + interval '7 days'
 FROM rpt_tokens
 WHERE abn='$ABN' AND tax_type='$TaxType' AND status='active'

--- a/scripts/run_all_tests.ps1
+++ b/scripts/run_all_tests.ps1
@@ -216,10 +216,10 @@ if ($haveRpt.ok -and $haveRpt.value -ne "") {
   Say "No ACTIVE/PENDING RPT — copying latest ACTIVE to target period…" "Yellow"
   $ins = Psql -Sql @"
 INSERT INTO rpt_tokens
-  (abn, tax_type, period_id, payload, signature, status, created_at,
+  (abn, tax_type, period_id, payload, signature, rates_version, status, created_at,
    payload_c14n, payload_sha256, nonce, expires_at)
 SELECT
-  abn, tax_type, '$ReleasePeriod', payload, signature, 'active', now(),
+  abn, tax_type, '$ReleasePeriod', payload, signature, rates_version, 'active', now(),
   payload_c14n, payload_sha256, nonce || '-e2e', now() + interval '7 days'
 FROM rpt_tokens
 WHERE abn='$ABN' AND tax_type='$TaxType' AND status='active'

--- a/scripts/seed_rpt.ts
+++ b/scripts/seed_rpt.ts
@@ -21,6 +21,7 @@ function hexToBuf(hex: string) { return Buffer.from(hex, "hex"); }
   const taxType = "PAYG";
   const periodId = "2024Q4";
   const kid = "dev-ed25519-kms-001"; // mirrors KMS key id in prod
+  const ratesVersion = process.env.RPT_RATES_VERSION || "2024-10-ATO-v1";
 
   const payload = {
     abn, taxType, periodId,
@@ -28,7 +29,8 @@ function hexToBuf(hex: string) { return Buffer.from(hex, "hex"); }
     issuedAt: new Date().toISOString(),
     expiresAt: new Date(Date.now() + 24*3600*1000).toISOString(),
     nonce: crypto.randomBytes(16).toString("hex"),
-    kid
+    kid,
+    ratesVersion
   };
 
   const c14n = canonicalize(payload);
@@ -43,12 +45,13 @@ function hexToBuf(hex: string) { return Buffer.from(hex, "hex"); }
   const res = await client.query(
     `
     INSERT INTO rpt_tokens
-      (abn, tax_type, period_id, key_id, payload_json, payload_c14n, payload_sha256, sig_ed25519, nonce, expires_at, status)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'active')
+      (abn, tax_type, period_id, key_id, payload_json, rates_version, payload_c14n, payload_sha256, sig_ed25519, nonce, expires_at, status)
+    VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'active')
     ON CONFLICT (abn, tax_type, period_id) WHERE status IN ('pending','active')
     DO UPDATE SET
       key_id = EXCLUDED.key_id,
       payload_json = EXCLUDED.payload_json,
+      rates_version = EXCLUDED.rates_version,
       payload_c14n = EXCLUDED.payload_c14n,
       payload_sha256 = EXCLUDED.payload_sha256,
       sig_ed25519 = EXCLUDED.sig_ed25519,
@@ -61,6 +64,7 @@ function hexToBuf(hex: string) { return Buffer.from(hex, "hex"); }
       abn, taxType, periodId,
       kid,
       payload,
+      ratesVersion,
       c14n,
       sha,          // BYTEA
       sig,          // BYTEA

--- a/setup_and_migrate.ps1
+++ b/setup_and_migrate.ps1
@@ -106,6 +106,7 @@ CREATE TABLE IF NOT EXISTS rpt_tokens (
   period_id        TEXT        NOT NULL,
   key_id           TEXT        NOT NULL,
   payload_json     JSONB       NOT NULL,
+  rates_version    TEXT        NOT NULL,
   payload_sha256   BYTEA       NOT NULL,
   sig_ed25519      BYTEA       NOT NULL,
   nonce            TEXT        NOT NULL,
@@ -113,6 +114,15 @@ CREATE TABLE IF NOT EXISTS rpt_tokens (
   created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   status           TEXT        NOT NULL CHECK (status IN ('pending','active','revoked','expired'))
 );
+
+ALTER TABLE rpt_tokens
+  ADD COLUMN IF NOT EXISTS rates_version TEXT;
+
+UPDATE rpt_tokens
+SET rates_version = COALESCE(rates_version, '2024-10-ATO-v1');
+
+ALTER TABLE rpt_tokens
+  ALTER COLUMN rates_version SET NOT NULL;
 
 CREATE UNIQUE INDEX IF NOT EXISTS ux_rpt_tokens_unique_pending_active
   ON rpt_tokens (abn, tax_type, period_id)


### PR DESCRIPTION
## Summary
- add a rates_version column to rpt_tokens via schema changes and backfill migration
- update RPT seeding scripts and operational tooling to capture and copy the rates version
- surface the stored rates_version through payments middleware, routes, evidence helpers, and OpenAPI documentation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e26045e3288327a0392e160d23f163