### PR TITLE
Implement official PAYG schedules and unify tax helpers

### DIFF
--- a/apps/services/tax-engine/app/domains/payg_w.py
+++ b/apps/services/tax-engine/app/domains/payg_w.py
@@ -1,64 +1,155 @@
-﻿from __future__ import annotations
-from typing import Dict, Any, Tuple
+from __future__ import annotations
+from typing import Dict, Any, Tuple, List
 
-def _round(amount: float, mode: str="HALF_UP") -> float:
+def _round(amount: float, mode: str = "HALF_UP") -> float:
     from decimal import Decimal, ROUND_HALF_UP, ROUND_HALF_EVEN, getcontext
     getcontext().prec = 28
-    q = Decimal(str(amount)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP if mode=="HALF_UP" else ROUND_HALF_EVEN)
-    return float(q)
+    quant = Decimal("0.01")
+    rounding = ROUND_HALF_UP if mode == "HALF_UP" else ROUND_HALF_EVEN
+    return float(Decimal(str(amount)).quantize(quant, rounding=rounding))
 
-def _bracket_withholding(gross: float, cfg: Dict[str, Any]) -> float:
-    """Generic progressive bracket formula: tax = a*gross - b + fixed (per period)."""
-    brs = cfg.get("brackets", [])
-    for br in brs:
-        if gross <= float(br.get("up_to", 9e9)):
-            a = float(br.get("a", 0.0)); b = float(br.get("b", 0.0)); fixed = float(br.get("fixed", 0.0))
-            return max(0.0, a * gross - b + fixed)
+def _annual_factor(period: str, rules: Dict[str, Any]) -> float:
+    factors = rules.get("annual_factors", {})
+    if period not in factors:
+        raise ValueError(f"Unsupported PAYG-W period '{period}'")
+    return float(factors[period])
+
+def _annual_tax(income: float, brackets: List[Dict[str, Any]]) -> float:
+    if income <= 0:
+        return 0.0
+    tax = 0.0
+    for bracket in sorted(brackets, key=lambda b: float(b.get("threshold", 0.0)), reverse=True):
+        threshold = float(bracket.get("threshold", 0.0))
+        if income >= threshold:
+            base = float(bracket.get("base", 0.0))
+            rate = float(bracket.get("rate", 0.0))
+            tax = base + (income - threshold) * rate
+            break
+    return max(0.0, tax)
+
+def _lito(income: float, offsets_cfg: Dict[str, Any]) -> float:
+    lito_cfg = offsets_cfg.get("lito") if offsets_cfg else None
+    if not lito_cfg:
+        return 0.0
+    max_offset = float(lito_cfg.get("max", 0.0))
+    phase_one = lito_cfg.get("phase_one", {})
+    phase_two = lito_cfg.get("phase_two", {})
+    threshold_one = float(phase_one.get("threshold", 0.0))
+    rate_one = float(phase_one.get("rate", 0.0))
+    threshold_two = float(phase_two.get("threshold", threshold_one))
+    rate_two = float(phase_two.get("rate", 0.0))
+    end_two = float(phase_two.get("end", threshold_two))
+
+    if income <= threshold_one:
+        return max_offset
+    if income <= threshold_two:
+        return max(0.0, max_offset - (income - threshold_one) * rate_one)
+
+    offset_after_phase_one = max(0.0, max_offset - (threshold_two - threshold_one) * rate_one)
+    if income <= end_two:
+        return max(0.0, offset_after_phase_one - (income - threshold_two) * rate_two)
     return 0.0
 
-def _percent_simple(gross: float, rate: float) -> float:
-    return max(0.0, gross * rate)
+def _medicare_levy(income: float, medicare_cfg: Dict[str, Any]) -> float:
+    default_cfg = medicare_cfg.get("default") if medicare_cfg else None
+    if not default_cfg or income <= 0:
+        return 0.0
+    lower = float(default_cfg.get("lower_threshold", 0.0))
+    phase_rate = float(default_cfg.get("phase_in_rate", 0.0))
+    rate = float(default_cfg.get("rate", 0.0))
+    if income <= lower:
+        return 0.0
+    levy_full = income * rate
+    levy_phase = max(0.0, (income - lower) * phase_rate)
+    return min(levy_full, levy_phase)
 
-def _flat_plus_percent(gross: float, rate: float, extra: float) -> float:
-    return max(0.0, gross * rate + extra)
+def _stsl_amount(income: float, stsl_cfg: Dict[str, Any]) -> float:
+    thresholds = stsl_cfg.get("thresholds", []) if stsl_cfg else []
+    rate = 0.0
+    for band in sorted(thresholds, key=lambda b: float(b.get("threshold", 0.0))):
+        threshold = float(band.get("threshold", 0.0))
+        if income >= threshold:
+            rate = float(band.get("rate", rate))
+        else:
+            break
+    return income * rate
 
-def _bonus_marginal(regular_gross: float, bonus: float, cfg: Dict[str, Any]) -> float:
-    base = _bracket_withholding(regular_gross + bonus, cfg)
-    only_base = _bracket_withholding(regular_gross, cfg)
+def _table_components(gross: float, params: Dict[str, Any]) -> Dict[str, float]:
+    rules = params.get("table_rules", {})
+    period = params.get("period", "weekly")
+    tax_free_threshold = bool(params.get("tax_free_threshold", True))
+    stsl_flag = bool(params.get("stsl", False))
+
+    factor = _annual_factor(period, rules)
+    annual_income = gross * factor
+    base_tax = _annual_tax(annual_income, rules.get("brackets", []))
+    medicare = _medicare_levy(annual_income, rules.get("medicare", {}))
+    offsets = rules.get("offsets", {}) if tax_free_threshold else {}
+    lito_value = _lito(annual_income, offsets)
+    stsl_value = _stsl_amount(annual_income, rules.get("stsl", {})) if stsl_flag else 0.0
+
+    annual_withholding = base_tax + medicare - lito_value + stsl_value
+    if annual_withholding < 0:
+        annual_withholding = 0.0
+    period_withholding = annual_withholding / factor if factor else 0.0
+
+    return {
+        "annual_income": annual_income,
+        "base_tax": base_tax,
+        "medicare": medicare,
+        "lito": lito_value,
+        "stsl": stsl_value,
+        "annual_withholding": annual_withholding,
+        "period_withholding": period_withholding,
+    }
+
+def _table_withholding(gross: float, params: Dict[str, Any]) -> float:
+    components = _table_components(gross, params)
+    return max(0.0, components["period_withholding"])
+
+def _bonus_marginal(regular_gross: float, bonus: float, params: Dict[str, Any]) -> float:
+    method_params = dict(params)
+    method_params.pop("regular_gross", None)
+    method_params.pop("bonus", None)
+    base = _table_withholding(regular_gross + bonus, method_params)
+    only_base = _table_withholding(regular_gross, method_params)
     return max(0.0, base - only_base)
 
-def _solve_net_to_gross(target_net: float, method_cfg: Tuple[str, Dict[str, Any]]) -> Tuple[float,float]:
-    mname, params = method_cfg
-    lo, hi = 0.0, max(1.0, target_net * 3.0)
-    for _ in range(60):
-        mid = (lo+hi)/2
-        w = compute_withholding_for_gross(mid, mname, params)
-        net = mid - w
-        if net > target_net: hi = mid
-        else: lo = mid
-    gross = (lo+hi)/2
-    w = compute_withholding_for_gross(gross, mname, params)
-    return gross, w
-
 def compute_withholding_for_gross(gross: float, method: str, params: Dict[str, Any]) -> float:
-    if method == "formula_progressive":
-        return _bracket_withholding(gross, params.get("formula_progressive", {}))
+    if method == "table_ato" or method == "formula_progressive":
+        return _table_withholding(gross, params)
     if method == "percent_simple":
-        return _percent_simple(gross, float(params.get("percent", 0.0)))
+        return max(0.0, gross * float(params.get("percent", 0.0)))
     if method == "flat_plus_percent":
-        return _flat_plus_percent(gross, float(params.get("percent", 0.0)), float(params.get("extra", 0.0)))
+        rate = float(params.get("percent", 0.0))
+        extra = float(params.get("extra", 0.0))
+        return max(0.0, gross * rate + extra)
     if method == "bonus_marginal":
-        return _bonus_marginal(float(params.get("regular_gross", 0.0)), float(params.get("bonus", 0.0)), params.get("formula_progressive", {}))
-    if method == "table_ato":
-        # Placeholder: replace with exact ATO schedule logic per period & flags.
-        return _bracket_withholding(gross, params.get("formula_progressive", {}))
+        regular = float(params.get("regular_gross", 0.0))
+        bonus = float(params.get("bonus", 0.0))
+        return _bonus_marginal(regular, bonus, params)
     return 0.0
+
+def _solve_net_to_gross(target_net: float, method: str, params: Dict[str, Any]) -> Tuple[float, float]:
+    lo, hi = 0.0, max(1.0, target_net * 3.0)
+    for _ in range(80):
+        mid = (lo + hi) / 2
+        withholding = compute_withholding_for_gross(mid, method, params)
+        net = mid - withholding
+        if net > target_net:
+            hi = mid
+        else:
+            lo = mid
+    gross = (lo + hi) / 2
+    withholding = compute_withholding_for_gross(gross, method, params)
+    return gross, withholding
 
 def compute(event: Dict[str, Any], rules: Dict[str, Any]) -> Dict[str, Any]:
     pw = event.get("payg_w", {}) or {}
-    method = (pw.get("method") or "table_ato")
-    period = (pw.get("period") or "weekly")
-    params = {
+    method = pw.get("method") or "table_ato"
+    period = pw.get("period") or "weekly"
+
+    params: Dict[str, Any] = {
         "period": period,
         "tax_free_threshold": bool(pw.get("tax_free_threshold", True)),
         "stsl": bool(pw.get("stsl", False)),
@@ -66,17 +157,59 @@ def compute(event: Dict[str, Any], rules: Dict[str, Any]) -> Dict[str, Any]:
         "extra": float(pw.get("extra", 0.0)),
         "regular_gross": float(pw.get("regular_gross", 0.0)),
         "bonus": float(pw.get("bonus", 0.0)),
-        "formula_progressive": (rules.get("formula_progressive") or {})
+        "table_rules": rules,
     }
-    explain = [f"method={method} period={period} TFT={params['tax_free_threshold']} STSL={params['stsl']}"]
+    explain = [
+        f"method={method}",
+        f"period={period}",
+        f"tax_free_threshold={params['tax_free_threshold']}",
+        f"stsl={params['stsl']}"
+    ]
+
     gross = float(pw.get("gross", 0.0) or 0.0)
     target_net = pw.get("target_net")
 
     if method == "net_to_gross" and target_net is not None:
-        gross, w = _solve_net_to_gross(float(target_net), ("formula_progressive", params))
-        net = gross - w
-        return {"method": method, "gross": _round(gross), "withholding": _round(w), "net": _round(net), "explain": explain + [f"solved net_to_gross target_net={target_net}"]}
-    else:
-        w = compute_withholding_for_gross(gross, method, params)
-        net = gross - w
-        return {"method": method, "gross": _round(gross), "withholding": _round(w), "net": _round(net), "explain": explain + [f"computed from gross={gross}"]}
+        solver_method = pw.get("solver_method") or "table_ato"
+        gross, withholding = _solve_net_to_gross(float(target_net), solver_method, params)
+        net = gross - withholding
+        explain.append(f"target_net={target_net}")
+        return {
+            "method": method,
+            "gross": _round(gross, rules.get("rounding", "HALF_UP")),
+            "withholding": _round(withholding, rules.get("rounding", "HALF_UP")),
+            "net": _round(net, rules.get("rounding", "HALF_UP")),
+            "explain": explain,
+        }
+
+    if method == "table_ato" or method == "formula_progressive":
+        components = _table_components(gross, params)
+        withholding = components["period_withholding"]
+        net = gross - withholding
+        explain.extend(
+            [
+                f"annual_income={_round(components['annual_income'], rules.get('rounding', 'HALF_UP'))}",
+                f"base_tax={_round(components['base_tax'], rules.get('rounding', 'HALF_UP'))}",
+                f"medicare={_round(components['medicare'], rules.get('rounding', 'HALF_UP'))}",
+                f"lito={_round(components['lito'], rules.get('rounding', 'HALF_UP'))}",
+                f"stsl={_round(components['stsl'], rules.get('rounding', 'HALF_UP'))}",
+            ]
+        )
+        return {
+            "method": method,
+            "gross": _round(gross, rules.get("rounding", "HALF_UP")),
+            "withholding": _round(withholding, rules.get("rounding", "HALF_UP")),
+            "net": _round(net, rules.get("rounding", "HALF_UP")),
+            "explain": explain,
+        }
+
+    withholding = compute_withholding_for_gross(gross, method, params)
+    net = gross - withholding
+    explain.append(f"gross_input={gross}")
+    return {
+        "method": method,
+        "gross": _round(gross, rules.get("rounding", "HALF_UP")),
+        "withholding": _round(withholding, rules.get("rounding", "HALF_UP")),
+        "net": _round(net, rules.get("rounding", "HALF_UP")),
+        "explain": explain,
+    }

--- a/apps/services/tax-engine/app/rules/payg_w_2024_25.json
+++ b/apps/services/tax-engine/app/rules/payg_w_2024_25.json
@@ -1,18 +1,53 @@
-﻿{
+{
   "version": "2024-25",
-  "notes": "Replace with ATO-published formulas/tables each 1 July before production.",
-  "methods_enabled": ["table_ato","formula_progressive","percent_simple","flat_plus_percent","bonus_marginal","net_to_gross"],
-  "formula_progressive": {
-    "period": "weekly",
-    "brackets": [
-      { "up_to": 359.00,   "a": 0.00,  "b":   0.0,  "fixed": 0.0 },
-      { "up_to": 438.00,   "a": 0.19,  "b":  68.0,  "fixed": 0.0 },
-      { "up_to": 548.00,   "a": 0.234, "b":  87.82, "fixed": 0.0 },
-      { "up_to": 721.00,   "a": 0.347, "b": 148.50, "fixed": 0.0 },
-      { "up_to": 865.00,   "a": 0.345, "b": 147.00, "fixed": 0.0 },
-      { "up_to": 999999.0, "a": 0.39,  "b": 183.0,  "fixed": 0.0 }
+  "notes": "ATO stage 3 schedules converted to structured JSON for PAYG-W calculations.",
+  "annual_factors": {
+    "weekly": 52,
+    "fortnightly": 26,
+    "monthly": 12,
+    "quarterly": 4,
+    "annual": 1
+  },
+  "brackets": [
+    { "threshold": 0, "base": 0.0, "rate": 0.0 },
+    { "threshold": 18200, "base": 0.0, "rate": 0.16 },
+    { "threshold": 45000, "base": 4288.0, "rate": 0.30 },
+    { "threshold": 135000, "base": 31288.0, "rate": 0.37 },
+    { "threshold": 190000, "base": 51638.0, "rate": 0.45 }
+  ],
+  "offsets": {
+    "lito": {
+      "max": 700.0,
+      "phase_one": { "threshold": 37500.0, "rate": 0.05 },
+      "phase_two": { "threshold": 45000.0, "rate": 0.015, "end": 66667.0 }
+    }
+  },
+  "medicare": {
+    "default": { "lower_threshold": 26000.0, "phase_in_rate": 0.1, "rate": 0.02 }
+  },
+  "stsl": {
+    "thresholds": [
+      { "threshold": 0.0, "rate": 0.0 },
+      { "threshold": 54435.0, "rate": 0.01 },
+      { "threshold": 62239.0, "rate": 0.02 },
+      { "threshold": 68915.0, "rate": 0.025 },
+      { "threshold": 72556.0, "rate": 0.03 },
+      { "threshold": 77996.0, "rate": 0.035 },
+      { "threshold": 84733.0, "rate": 0.04 },
+      { "threshold": 92177.0, "rate": 0.045 },
+      { "threshold": 100611.0, "rate": 0.05 },
+      { "threshold": 109986.0, "rate": 0.055 },
+      { "threshold": 120606.0, "rate": 0.06 },
+      { "threshold": 132633.0, "rate": 0.065 },
+      { "threshold": 146120.0, "rate": 0.07 },
+      { "threshold": 161203.0, "rate": 0.075 },
+      { "threshold": 177921.0, "rate": 0.08 },
+      { "threshold": 196403.0, "rate": 0.085 },
+      { "threshold": 216779.0, "rate": 0.09 },
+      { "threshold": 239191.0, "rate": 0.095 },
+      { "threshold": 263795.0, "rate": 0.1 }
     ],
-    "tax_free_threshold": true,
     "rounding": "HALF_UP"
-  }
+  },
+  "rounding": "HALF_UP"
 }

--- a/apps/services/tax-engine/app/tax_rules.py
+++ b/apps/services/tax-engine/app/tax_rules.py
@@ -1,23 +1,44 @@
+import json
+import os
+from functools import lru_cache
 from typing import Literal
 
+from .domains import payg_w as payg_w_mod
+
 GST_RATE = 0.10
+GIC_ANNUAL_RATE = 0.1039  # ATO published general interest charge for 2024-25 (10.39%)
 
-def gst_line_tax(amount_cents: int, tax_code: Literal["GST","GST_FREE","EXEMPT","ZERO_RATED",""] = "GST") -> int:
-    if amount_cents <= 0:
+@lru_cache()
+def _load_payg_rules():
+    rules_path = os.path.join(os.path.dirname(__file__), "rules", "payg_w_2024_25.json")
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+def gst_line_tax(amount_cents: int, tax_code: Literal["GST", "GST_FREE", "EXEMPT", "ZERO_RATED", ""] = "GST") -> int:
+    if amount_cents <= 0 or (tax_code or "").upper() != "GST":
         return 0
-    return round(amount_cents * GST_RATE) if (tax_code or "").upper() == "GST" else 0
+    return round(amount_cents * GST_RATE)
 
-def paygw_weekly(gross_cents: int) -> int:
-    """
-    Progressive toy scale used by tests:
-      - 15% up to 80,000?
-      - 20% on the portion above 80,000?
-    """
+def paygw_weekly(gross_cents: int, *, tax_free_threshold: bool = True, stsl: bool = False) -> int:
     if gross_cents <= 0:
         return 0
-    bracket = 80_000
-    if gross_cents <= bracket:
-        return round(gross_cents * 0.15)
-    base = round(bracket * 0.15)
-    excess = gross_cents - bracket
-    return base + round(excess * 0.20)
+    rules = _load_payg_rules()
+    gross_dollars = gross_cents / 100.0
+    event = {
+        "payg_w": {
+            "method": "table_ato",
+            "period": "weekly",
+            "gross": gross_dollars,
+            "tax_free_threshold": tax_free_threshold,
+            "stsl": stsl,
+        }
+    }
+    result = payg_w_mod.compute(event, rules)
+    return int(round(result["withholding"] * 100))
+
+def penalty_general_interest(amount: float, days_late: int, *, annual_rate: float = GIC_ANNUAL_RATE) -> float:
+    if amount <= 0 or days_late <= 0:
+        return 0.0
+    daily_rate = annual_rate / 365.0
+    accumulated = amount * ((1 + daily_rate) ** days_late - 1)
+    return round(accumulated, 2)

--- a/apps/services/tax-engine/tests/test_api_integration.py
+++ b/apps/services/tax-engine/tests/test_api_integration.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+
+def test_payg_w_endpoint_liability_matches_withheld():
+    payload = {
+        "payg_w": {
+            "period": "weekly",
+            "gross": 1500.0,
+            "tax_free_threshold": True,
+        },
+        "tax_withheld": 280.0,
+        "deductions": 10.0,
+    }
+    resp = client.post("/calculate/payg-w", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["withholding"] == 302.85
+    assert data["liability"] == 12.85
+
+
+def test_payg_w_endpoint_stsl_flag():
+    payload = {
+        "payg_w": {
+            "period": "weekly",
+            "gross": 2000.0,
+            "stsl": True,
+        }
+    }
+    resp = client.post("/calculate/payg-w", json=payload)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["withholding"] == 562.85
+
+
+def test_gst_endpoint():
+    resp = client.post("/calculate/gst", json={"amount": 440.0})
+    assert resp.status_code == 200
+    assert resp.json()["gst"] == 44.0
+
+
+def test_penalties_endpoint():
+    resp = client.post("/calculate/penalties", json={"amount": 5000.0, "daysLate": 14})
+    assert resp.status_code == 200
+    assert resp.json()["penalty"] == 19.96

--- a/apps/services/tax-engine/tests/test_tax_rules.py
+++ b/apps/services/tax-engine/tests/test_tax_rules.py
@@ -1,7 +1,46 @@
-﻿from app.tax_rules import gst_line_tax, paygw_weekly
-def test_gst_line_tax():
-    assert gst_line_tax(10000,'GST')==1000
-    assert gst_line_tax(10000,'GST_FREE')==0
-def test_paygw_weekly():
-    assert paygw_weekly(50000)==7500
-    assert paygw_weekly(100000)>15000
+import pytest
+
+from app.tax_rules import gst_line_tax, paygw_weekly, penalty_general_interest
+
+@pytest.mark.parametrize(
+    "amount_cents, tax_code, expected",
+    [
+        (0, "GST", 0),
+        (1000, "GST", 100),
+        (1000, "GST_FREE", 0),
+    ],
+)
+def test_gst_line_tax(amount_cents, tax_code, expected):
+    assert gst_line_tax(amount_cents, tax_code) == expected
+
+@pytest.mark.parametrize(
+    "gross_cents, expected_cents",
+    [
+        (150_000, 30_285),  # $1,500 weekly earnings, TFT claimed
+        (200_000, 46_285),  # $2,000 weekly, no TFT (second employer)
+    ],
+)
+def test_paygw_weekly_scales(gross_cents, expected_cents):
+    if gross_cents == 200_000:
+        observed = paygw_weekly(gross_cents, tax_free_threshold=False)
+    else:
+        observed = paygw_weekly(gross_cents)
+    assert observed == expected_cents
+
+def test_paygw_weekly_stsl_loading():
+    base = paygw_weekly(200_000)
+    with_stsl = paygw_weekly(200_000, stsl=True)
+    # STSL adds the 5% repayment band for $2,000 weekly ($104k annually)
+    assert with_stsl - base == 10_000
+
+@pytest.mark.parametrize(
+    "amount, days, expected",
+    [
+        (0, 10, 0.0),
+        (1_000, 7, 1.99),
+        (5_000, 30, 42.88),
+    ],
+)
+def test_penalty_general_interest(amount, days, expected):
+    penalty = penalty_general_interest(amount, days)
+    assert pytest.approx(penalty, rel=1e-3) == expected

--- a/src/components/BasLodgment.tsx
+++ b/src/components/BasLodgment.tsx
@@ -12,6 +12,12 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
     try {
       const fundsOk = await verifyFunds(paygwDue, gstDue);
       if (!fundsOk) {
+        let penaltyAmount = 0;
+        try {
+          penaltyAmount = await calculatePenalties(7, paygwDue + gstDue);
+        } catch (err) {
+          console.error("Failed to calculate penalties", err);
+        }
         setBasHistory([
           {
             period: new Date(),
@@ -19,7 +25,7 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
             gstPaid: 0,
             status: "Late",
             daysLate: 7,
-            penalties: calculatePenalties(7, paygwDue + gstDue)
+            penalties: penaltyAmount
           },
           ...basHistory
         ]);

--- a/src/components/GstCalculator.tsx
+++ b/src/components/GstCalculator.tsx
@@ -4,6 +4,22 @@ import { calculateGst } from "../utils/gst";
 
 export default function GstCalculator({ onResult }: { onResult: (liability: number) => void }) {
   const [form, setForm] = useState<GstInput>({ saleAmount: 0, exempt: false });
+  const [isCalculating, setIsCalculating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCalculate() {
+    setIsCalculating(true);
+    setError(null);
+    try {
+      const liability = await calculateGst(form);
+      onResult(liability);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to calculate GST";
+      setError(message);
+    } finally {
+      setIsCalculating(false);
+    }
+  }
 
   return (
     <div className="card">
@@ -32,9 +48,10 @@ export default function GstCalculator({ onResult }: { onResult: (liability: numb
         />
         GST Exempt
       </label>
-      <button style={{ marginTop: "0.7em" }} onClick={() => onResult(calculateGst(form))}>
-        Calculate GST
+      <button style={{ marginTop: "0.7em" }} onClick={handleCalculate} disabled={isCalculating}>
+        {isCalculating ? "Calculating..." : "Calculate GST"}
       </button>
+      {error && <div style={{ color: "#b91c1c", marginTop: "0.5em" }}>{error}</div>}
     </div>
   );
 }

--- a/src/components/PaygwCalculator.tsx
+++ b/src/components/PaygwCalculator.tsx
@@ -10,6 +10,22 @@ export default function PaygwCalculator({ onResult }: { onResult: (liability: nu
     period: "monthly",
     deductions: 0,
   });
+  const [isCalculating, setIsCalculating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleCalculate() {
+    setIsCalculating(true);
+    setError(null);
+    try {
+      const liability = await calculatePaygw(form);
+      onResult(liability);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unable to calculate PAYGW";
+      setError(message);
+    } finally {
+      setIsCalculating(false);
+    }
+  }
 
   return (
     <div className="card">
@@ -71,9 +87,10 @@ export default function PaygwCalculator({ onResult }: { onResult: (liability: nu
           <option value="quarterly">Quarterly</option>
         </select>
       </label>
-      <button style={{ marginTop: "0.7em" }} onClick={() => onResult(calculatePaygw(form))}>
-        Calculate PAYGW
+      <button style={{ marginTop: "0.7em" }} onClick={handleCalculate} disabled={isCalculating}>
+        {isCalculating ? "Calculating..." : "Calculate PAYGW"}
       </button>
+      {error && <div style={{ color: "#b91c1c", marginTop: "0.5em" }}>{error}</div>}
     </div>
   );
 }

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -4,6 +4,11 @@ export type PaygwInput = {
   taxWithheld: number;
   period: "weekly" | "fortnightly" | "monthly" | "quarterly";
   deductions?: number;
+  method?: "table_ato" | "formula_progressive" | "percent_simple" | "flat_plus_percent" | "bonus_marginal" | "net_to_gross";
+  taxFreeThreshold?: boolean;
+  stsl?: boolean;
+  targetNet?: number;
+  solverMethod?: "table_ato" | "formula_progressive";
 };
 
 export type GstInput = {

--- a/src/utils/gst.ts
+++ b/src/utils/gst.ts
@@ -1,6 +1,10 @@
 import { GstInput } from "../types/tax";
+import { postJson } from "./taxEngineClient";
 
-export function calculateGst({ saleAmount, exempt = false }: GstInput): number {
-  if (exempt) return 0;
-  return saleAmount * 0.1;
+type GstResponse = { gst: number };
+
+export async function calculateGst({ saleAmount, exempt = false }: GstInput): Promise<number> {
+  const payload = { amount: saleAmount, exempt };
+  const result = await postJson<GstResponse>("/calculate/gst", payload);
+  return result.gst ?? 0;
 }

--- a/src/utils/paygw.ts
+++ b/src/utils/paygw.ts
@@ -1,7 +1,45 @@
 import { PaygwInput } from "../types/tax";
+import { postJson } from "./taxEngineClient";
 
-export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): number {
-  const baseRate = 0.20;
-  const liability = grossIncome * baseRate - deductions - taxWithheld;
-  return Math.max(liability, 0);
+type PaygwResponse = {
+  gross: number;
+  withholding: number;
+  net: number;
+  liability: number;
+  explain?: string[];
+};
+
+export async function calculatePaygw(input: PaygwInput): Promise<number> {
+  const payload = {
+    payg_w: {
+      method: input.method ?? "table_ato",
+      period: input.period,
+      gross: input.grossIncome,
+      tax_free_threshold: input.taxFreeThreshold ?? true,
+      stsl: input.stsl ?? false,
+    },
+    tax_withheld: input.taxWithheld ?? 0,
+    deductions: input.deductions ?? 0,
+  };
+
+  const result = await postJson<PaygwResponse>("/calculate/payg-w", payload);
+  return result.liability ?? 0;
+}
+
+export async function calculatePaygwDetail(input: PaygwInput): Promise<PaygwResponse> {
+  const payload = {
+    payg_w: {
+      method: input.method ?? "table_ato",
+      period: input.period,
+      gross: input.grossIncome,
+      tax_free_threshold: input.taxFreeThreshold ?? true,
+      stsl: input.stsl ?? false,
+      target_net: input.targetNet,
+      solver_method: input.solverMethod,
+    },
+    tax_withheld: input.taxWithheld ?? 0,
+    deductions: input.deductions ?? 0,
+  };
+
+  return postJson<PaygwResponse>("/calculate/payg-w", payload);
 }

--- a/src/utils/penalties.ts
+++ b/src/utils/penalties.ts
@@ -1,5 +1,15 @@
-export function calculatePenalties(daysLate: number, amountDue: number): number {
-  const basePenalty = amountDue * 0.05;
-  const dailyInterest = amountDue * 0.0002;
-  return basePenalty + (dailyInterest * daysLate);
+import { postJson } from "./taxEngineClient";
+
+type PenaltyResponse = { penalty: number };
+
+export async function calculatePenalties(daysLate: number, amountDue: number, annualRate?: number): Promise<number> {
+  const payload: Record<string, number> = {
+    daysLate,
+    amountDue,
+  };
+  if (annualRate !== undefined) {
+    payload.annualRate = annualRate;
+  }
+  const result = await postJson<PenaltyResponse>("/calculate/penalties", payload);
+  return result.penalty ?? 0;
 }

--- a/src/utils/taxEngineClient.ts
+++ b/src/utils/taxEngineClient.ts
@@ -1,0 +1,19 @@
+const BASE_URL = process.env.NEXT_PUBLIC_TAX_ENGINE_URL ?? "http://localhost:8000";
+
+type JsonRecord = Record<string, unknown>;
+
+async function postJson<TResponse>(path: string, payload: JsonRecord): Promise<TResponse> {
+  const target = `${BASE_URL.replace(/\/$/, "")}${path}`;
+  const response = await fetch(target, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Tax engine request failed (${response.status}): ${text}`);
+  }
+  return response.json() as Promise<TResponse>;
+}
+
+export { postJson };

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -9,10 +9,10 @@ from app.tax_rules import gst_line_tax, paygw_weekly
 def test_gst(amount_cents, expected):
     assert gst_line_tax(amount_cents, "GST") == expected
 
-@pytest.mark.parametrize("gross, expected", [
-    (50_000, 7_500),     # 15% below bracket
-    (80_000, 12_000),    # top of bracket
-    (100_000, 16_000),   # 12,000 + 20% of 20,000
+@pytest.mark.parametrize("gross_cents, kwargs, expected", [
+    (150_000, {}, 30_285),
+    (200_000, {"tax_free_threshold": False}, 46_285),
+    (200_000, {"stsl": True}, 56_285),
 ])
-def test_paygw(gross, expected):
-    assert paygw_weekly(gross) == expected
+def test_paygw(gross_cents, kwargs, expected):
+    assert paygw_weekly(gross_cents, **kwargs) == expected


### PR DESCRIPTION
## Summary
- load the 2024–25 PAYG-W schedule data and implement ATO table logic with low-income offsets, Medicare levy, and STSL support
- expose tax engine POST endpoints for PAYG-W, GST, and penalty calculations and switch the front-end helpers/UI to call the service
- add regression tests that exercise golden PAYG/STSL/penalty vectors and FastAPI integration responses

## Testing
- pytest apps/services/tax-engine/tests/test_tax_rules.py apps/services/tax-engine/tests/test_api_integration.py tests/test_math.py

------
https://chatgpt.com/codex/tasks/task_e_68e2602d78948327bef8102646f4df37