### PR TITLE
Improve reconciliation flow and bas gate controls

### DIFF
--- a/apps/services/bas-gate/main.py
+++ b/apps/services/bas-gate/main.py
@@ -1,7 +1,13 @@
-﻿# apps/services/bas-gate/main.py
+# apps/services/bas-gate/main.py
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import os, psycopg2, json, time
+import os, json, time
+from typing import Optional, Tuple
+
+try:  # pragma: no cover - exercised in production, not unit tests
+    import psycopg2  # type: ignore
+except ImportError:  # pragma: no cover
+    psycopg2 = None  # type: ignore
 
 app = FastAPI(title="bas-gate")
 
@@ -10,33 +16,100 @@ class TransitionReq(BaseModel):
     target_state: str
     reason_code: str | None = None
 
+ALLOWED_TRANSITIONS = {
+    None: {"Open"},
+    "Open": {"Pending-Close", "Blocked"},
+    "Pending-Close": {"Reconciling", "Blocked"},
+    "Reconciling": {"RPT-Issued", "Blocked"},
+    "RPT-Issued": {"Remitted", "Blocked"},
+    "Blocked": {"Reconciling", "Open"},
+    "Remitted": set(),
+}
+
+REQUIRES_REASON = {"Blocked", "Remitted"}
+
+
 def db():
+    if psycopg2 is None:  # pragma: no cover - ensures explicit failure when driver missing
+        raise RuntimeError("psycopg2 not available")
     return psycopg2.connect(
-        host=os.getenv("PGHOST","127.0.0.1"),
-        user=os.getenv("PGUSER","postgres"),
-        password=os.getenv("PGPASSWORD","postgres"),
-        dbname=os.getenv("PGDATABASE","postgres"),
-        port=int(os.getenv("PGPORT","5432"))
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "postgres"),
+        password=os.getenv("PGPASSWORD", "postgres"),
+        dbname=os.getenv("PGDATABASE", "postgres"),
+        port=int(os.getenv("PGPORT", "5432")),
     )
+
+
+def _validate_transition(prev_state: Optional[str], prev_reason: Optional[str], req: TransitionReq) -> None:
+    allowed = ALLOWED_TRANSITIONS.get(prev_state, set())
+    if req.target_state not in allowed:
+        raise HTTPException(409, "invalid transition")
+    if req.target_state in REQUIRES_REASON and not req.reason_code:
+        raise HTTPException(400, "reason required")
+    if req.target_state == "Remitted":
+        if prev_state != "RPT-Issued":
+            raise HTTPException(409, "invalid transition")
+        if prev_reason and req.reason_code and prev_reason == req.reason_code:
+            raise HTTPException(403, "separation of duties violated")
+
+
+def _load_state(cur, period_id: str) -> Tuple[Optional[str], Optional[str], Optional[str]]:
+    cur.execute(
+        "SELECT state, reason_code, hash_this FROM bas_gate_states WHERE period_id=%s FOR UPDATE",
+        (period_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None, None, None
+    return row[0], row[1], row[2]
+
 
 @app.post("/gate/transition")
 def transition(req: TransitionReq):
-    if req.target_state not in {"Open","Pending-Close","Reconciling","RPT-Issued","Remitted","Blocked"}:
+    if req.target_state not in {"Open", "Pending-Close", "Reconciling", "RPT-Issued", "Remitted", "Blocked"}:
         raise HTTPException(400, "invalid state")
-    conn = db(); cur = conn.cursor()
-    cur.execute("SELECT hash_this FROM bas_gate_states WHERE period_id=%s", (req.period_id,))
-    row = cur.fetchone()
-    prev = row[0] if row else None
-    payload = json.dumps({"period_id": req.period_id, "state": req.target_state, "ts": int(time.time())}, separators=(",",":"))
-    import libs.audit_chain.chain as ch
-    h = ch.link(prev, payload)
-    if row:
-        cur.execute("UPDATE bas_gate_states SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s WHERE period_id=%s",
-                    (req.target_state, req.reason_code, prev, h, req.period_id))
-    else:
-        cur.execute("INSERT INTO bas_gate_states(period_id,state,reason_code,hash_prev,hash_this) VALUES (%s,%s,%s,%s,%s)",
-                    (req.period_id, req.target_state, req.reason_code, prev, h))
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('bas_gate',%s,%s,%s)",
-                (payload, prev, h))
-    conn.commit(); cur.close(); conn.close()
-    return {"ok": True, "hash": h}
+    conn = db()
+    cur = conn.cursor()
+    try:
+        prev_state, prev_reason, prev_hash = _load_state(cur, req.period_id)
+        if prev_state == req.target_state and prev_reason == req.reason_code:
+            return {"ok": True, "hash": prev_hash}
+        _validate_transition(prev_state, prev_reason, req)
+        payload = json.dumps(
+            {
+                "period_id": req.period_id,
+                "state": req.target_state,
+                "reason": req.reason_code,
+                "ts": int(time.time()),
+            },
+            separators=(",", ":"),
+        )
+        import libs.audit_chain.chain as ch
+
+        h = ch.link(prev_hash, payload)
+        if prev_state is None:
+            cur.execute(
+                "INSERT INTO bas_gate_states(period_id,state,reason_code,hash_prev,hash_this) VALUES (%s,%s,%s,%s,%s)",
+                (req.period_id, req.target_state, req.reason_code, prev_hash, h),
+            )
+        else:
+            cur.execute(
+                "UPDATE bas_gate_states SET state=%s, reason_code=%s, updated_at=NOW(), hash_prev=%s, hash_this=%s WHERE period_id=%s",
+                (req.target_state, req.reason_code, prev_hash, h, req.period_id),
+            )
+        cur.execute(
+            "INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('bas_gate',%s,%s,%s)",
+            (payload, prev_hash, h),
+        )
+        conn.commit()
+        return {"ok": True, "hash": h}
+    except HTTPException:
+        conn.rollback()
+        raise
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        cur.close()
+        conn.close()

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -1,15 +1,39 @@
-﻿export type PeriodState = "OPEN"|"CLOSING"|"READY_RPT"|"BLOCKED_DISCREPANCY"|"BLOCKED_ANOMALY"|"RELEASED"|"FINALIZED";
-export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
+export type PeriodState =
+  | "OPEN"
+  | "CLOSING"
+  | "READY_RPT"
+  | "BLOCKED_DISCREPANCY"
+  | "BLOCKED_ANOMALY"
+  | "RELEASED"
+  | "FINALIZED";
+
+export interface Thresholds {
+  epsilon_cents: number;
+  variance_ratio: number;
+  dup_rate: number;
+  gap_minutes: number;
+  delta_vs_baseline?: number;
+}
+
+const transitionMap = new Map<string, PeriodState>([
+  ["OPEN:CLOSE", "CLOSING"],
+  ["OPEN:BLOCK_DISCREPANCY", "BLOCKED_DISCREPANCY"],
+  ["OPEN:BLOCK_ANOMALY", "BLOCKED_ANOMALY"],
+  ["CLOSING:PASS", "READY_RPT"],
+  ["CLOSING:FAIL_DISCREPANCY", "BLOCKED_DISCREPANCY"],
+  ["CLOSING:FAIL_ANOMALY", "BLOCKED_ANOMALY"],
+  ["BLOCKED_DISCREPANCY:REMEDIED", "CLOSING"],
+  ["BLOCKED_DISCREPANCY:RESET", "OPEN"],
+  ["BLOCKED_ANOMALY:REMEDIED", "CLOSING"],
+  ["BLOCKED_ANOMALY:RESET", "OPEN"],
+  ["READY_RPT:RELEASE", "RELEASED"],
+  ["READY_RPT:BLOCK_DISCREPANCY", "BLOCKED_DISCREPANCY"],
+  ["READY_RPT:BLOCK_ANOMALY", "BLOCKED_ANOMALY"],
+  ["READY_RPT:RESET", "OPEN"],
+  ["RELEASED:FINALIZE", "FINALIZED"],
+]);
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
-  }
+  const t = `${current}:${evt}`;
+  return transitionMap.get(t) ?? current;
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,212 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
+import { merkleRootHex, sha256Hex } from "../crypto/merkle";
+import { nextState, PeriodState } from "../recon/stateMachine";
 import { Pool } from "pg";
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
-  try {
-    const rpt = await issueRPT(abn, taxType, periodId, thr);
-    return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+class HttpError extends Error {
+  status: number;
+  body: Record<string, unknown>;
+  constructor(status: number, body: Record<string, unknown>) {
+    super(String(body?.error ?? status));
+    this.status = status;
+    this.body = body;
   }
 }
 
-export async function payAto(req:any, res:any) {
+function normalizeThresholds(input: any): Record<string, number> {
+  const thr = { ...DEFAULT_THRESHOLDS } as Record<string, number>;
+  if (input && typeof input === "object") {
+    for (const [key, value] of Object.entries(input)) {
+      if (typeof value === "number" && Number.isFinite(value)) {
+        thr[key] = value;
+      }
+    }
+  }
+  return thr;
+}
+
+export async function closeAndIssue(req: any, res: any) {
+  const { abn, taxType, periodId } = req.body;
+  const thresholds = normalizeThresholds(req.body?.thresholds);
+
+  const client = await pool.connect();
+  let creditedToOwa = 0;
+  let merkleRoot: string | null = null;
+  let runningBalanceHash: string | null = null;
+  try {
+    await client.query("BEGIN");
+    const periodRes = await client.query(
+      "select * from periods where abn=$1 and tax_type=$2 and period_id=$3 for update",
+      [abn, taxType, periodId]
+    );
+    if (periodRes.rowCount === 0) {
+      throw new HttpError(404, { error: "PERIOD_NOT_FOUND" });
+    }
+    const period = periodRes.rows[0];
+    const currentState = period.state as PeriodState;
+
+    let closingState: PeriodState = currentState;
+    if (currentState !== "CLOSING") {
+      const candidate = nextState(currentState, "CLOSE");
+      if (candidate === currentState) {
+        throw new HttpError(409, { error: "BAD_STATE", state: currentState });
+      }
+      closingState = candidate;
+    }
+
+    const ledgerRes = await client.query(
+      "select id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    );
+
+    let prevHash = "";
+    const leaves: string[] = [];
+    const ledgerUpdates: Array<{ id: number; prev_hash: string; hash_after: string }> = [];
+    for (const row of ledgerRes.rows) {
+      const amount = Number(row.amount_cents || 0);
+      const balanceAfter = Number(row.balance_after_cents || 0);
+      const receipt = row.bank_receipt_hash || "";
+      const expectedHash = sha256Hex(prevHash + receipt + String(balanceAfter));
+      if ((row.prev_hash ?? "") !== prevHash || (row.hash_after ?? "") !== expectedHash) {
+        ledgerUpdates.push({ id: Number(row.id), prev_hash: prevHash, hash_after: expectedHash });
+      }
+      if (amount > 0) creditedToOwa += amount;
+      leaves.push(
+        JSON.stringify({
+          id: Number(row.id),
+          amount_cents: amount,
+          balance_after_cents: balanceAfter,
+          bank_receipt_hash: receipt,
+          hash_after: expectedHash,
+        })
+      );
+      prevHash = expectedHash;
+    }
+
+    for (const upd of ledgerUpdates) {
+      await client.query(
+        "update owa_ledger set prev_hash=$1, hash_after=$2 where id=$3",
+        [upd.prev_hash, upd.hash_after, upd.id]
+      );
+    }
+
+    merkleRoot = leaves.length > 0 ? merkleRootHex(leaves) : null;
+    runningBalanceHash = prevHash || null;
+
+    await client.query(
+      "update periods set state=$1, credited_to_owa_cents=$2, final_liability_cents=$3, merkle_root=$4, running_balance_hash=$5, thresholds=$6 where id=$7",
+      [
+        closingState,
+        creditedToOwa,
+        creditedToOwa,
+        merkleRoot,
+        runningBalanceHash,
+        thresholds,
+        period.id,
+      ]
+    );
+    await client.query("COMMIT");
+  } catch (err: any) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    client.release();
+    if (err instanceof HttpError) {
+      return res.status(err.status).json(err.body);
+    }
+    return res.status(500).json({ error: err?.message || "CLOSE_FAILED" });
+  }
+  client.release();
+
+  try {
+    const rpt = await issueRPT(abn, taxType, periodId, thresholds);
+    return res.json({
+      state: "READY_RPT",
+      rpt,
+      period: {
+        credited_to_owa_cents: creditedToOwa,
+        final_liability_cents: creditedToOwa,
+        merkle_root: merkleRoot,
+        running_balance_hash: runningBalanceHash,
+        thresholds,
+      },
+    });
+  } catch (e: any) {
+    const message = e?.message || "ISSUE_FAILED";
+    const status = message.startsWith("BLOCKED") || message === "BAD_STATE" ? 409 : 400;
+    return res.status(status).json({ error: message });
+  }
+}
+
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
+
+  const periodRes = await pool.query(
+    "select id, state from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
+  if (periodRes.rowCount === 0) {
+    return res.status(404).json({ error: "PERIOD_NOT_FOUND" });
+  }
+  const period = periodRes.rows[0];
+  const next = nextState(period.state as PeriodState, "RELEASE");
+  if (next === period.state) {
+    return res.status(409).json({ error: "BAD_STATE", state: period.state });
+  }
+
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-    return res.json(r);
-  } catch (e:any) {
+    const release = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      payload.reference
+    );
+    const tail = await pool.query(
+      "select hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+      [abn, taxType, periodId]
+    );
+    const runningHash = tail.rows[0]?.hash_after ?? null;
+    await pool.query("update periods set state=$1, running_balance_hash=$2 where id=$3", [next, runningHash, period.id]);
+    return res.json({ ...release, state: next, running_balance_hash: runningHash });
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/tests/test_bas_gate_transitions.py
+++ b/tests/test_bas_gate_transitions.py
@@ -1,0 +1,203 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+MODULE_PATH = ROOT / "apps" / "services" / "bas-gate" / "main.py"
+spec = importlib.util.spec_from_file_location("bas_gate_main", MODULE_PATH)
+assert spec and spec.loader is not None
+bas_gate = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bas_gate)  # type: ignore[attr-defined]
+
+
+class FakeCursor:
+    def __init__(self, store):
+        self.store = store
+        self._queue = []
+
+    def execute(self, sql, params):
+        sql = sql.strip()
+        if sql.startswith("SELECT state"):
+            row = self.store.get("row")
+            if row:
+                self._queue = [(row["state"], row.get("reason_code"), row.get("hash_this"))]
+            else:
+                self._queue = []
+        elif sql.startswith("INSERT INTO bas_gate_states"):
+            period_id, state, reason, hash_prev, hash_this = params
+            self.store["row"] = {
+                "period_id": period_id,
+                "state": state,
+                "reason_code": reason,
+                "hash_prev": hash_prev,
+                "hash_this": hash_this,
+            }
+            self.store.setdefault("history", []).append((hash_prev, hash_this))
+        elif sql.startswith("UPDATE bas_gate_states SET"):
+            state, reason, hash_prev, hash_this, period_id = params
+            row = self.store["row"]
+            assert row["period_id"] == period_id
+            row.update(
+                {
+                    "state": state,
+                    "reason_code": reason,
+                    "hash_prev": hash_prev,
+                    "hash_this": hash_this,
+                }
+            )
+            self.store.setdefault("history", []).append((hash_prev, hash_this))
+        elif sql.startswith("INSERT INTO audit_log"):
+            payload, prev_hash, hash_this = params
+            self.store.setdefault("audit", []).append((payload, prev_hash, hash_this))
+        else:
+            raise AssertionError(f"unexpected SQL: {sql}")
+
+    def fetchone(self):
+        return self._queue.pop(0) if self._queue else None
+
+    def close(self):
+        pass
+
+
+class FakeConn:
+    def __init__(self, store):
+        self.store = store
+        self.cursor_obj = FakeCursor(store)
+        self.committed = False
+        self.rolled_back = False
+        self.closed = False
+
+    def cursor(self):
+        return self.cursor_obj
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        self.closed = True
+
+
+def make_fake_db(store):
+    def _factory():
+        return FakeConn(store)
+
+    return _factory
+
+
+@pytest.mark.parametrize(
+    "prev_state,target_state,prev_reason,new_reason",
+    [
+        (None, "Open", None, None),
+        ("Open", "Pending-Close", None, None),
+        ("Open", "Blocked", None, "ops-block"),
+        ("Pending-Close", "Reconciling", None, None),
+        ("Pending-Close", "Blocked", None, "ops-block"),
+        ("Reconciling", "RPT-Issued", None, "issuer"),
+        ("Reconciling", "Blocked", None, "ops-block"),
+        ("RPT-Issued", "Remitted", "issuer", "remitter"),
+        ("RPT-Issued", "Blocked", "issuer", "ops-block"),
+        ("Blocked", "Reconciling", "ops-block", None),
+        ("Blocked", "Open", "ops-block", None),
+    ],
+)
+def test_allowed_transitions(monkeypatch, prev_state, target_state, prev_reason, new_reason):
+    store = {
+        "row": None
+        if prev_state is None
+        else {
+            "period_id": "2024Q4",
+            "state": prev_state,
+            "reason_code": prev_reason,
+            "hash_prev": "prev",
+            "hash_this": "tail",
+        }
+    }
+    monkeypatch.setattr(bas_gate, "db", make_fake_db(store))
+
+    prior_tail = store["row"]["hash_this"] if store.get("row") else None
+    req = bas_gate.TransitionReq(period_id="2024Q4", target_state=target_state, reason_code=new_reason)
+    result = bas_gate.transition(req)
+
+    assert result["ok"] is True
+    assert "hash" in result
+    assert store["row"]["state"] == target_state
+    history = store.get("history")
+    assert history, "ledger history should be updated"
+    prev_hash, new_hash = history[-1]
+    assert prev_hash == store["row"].get("hash_prev")
+    assert new_hash == store["row"]["hash_this"]
+    if prior_tail is not None:
+        assert prev_hash == prior_tail
+
+
+def test_remitted_requires_different_actor(monkeypatch):
+    store = {
+        "row": {
+            "period_id": "2024Q4",
+            "state": "RPT-Issued",
+            "reason_code": "issuer",
+            "hash_prev": "h0",
+            "hash_this": "h1",
+        }
+    }
+    monkeypatch.setattr(bas_gate, "db", make_fake_db(store))
+
+    req = bas_gate.TransitionReq(period_id="2024Q4", target_state="Remitted", reason_code="issuer")
+    with pytest.raises(HTTPException) as exc:
+        bas_gate.transition(req)
+    assert exc.value.status_code == 403
+    assert store["row"]["state"] == "RPT-Issued"
+
+
+def test_blocked_requires_reason(monkeypatch):
+    store = {
+        "row": {
+            "period_id": "2024Q4",
+            "state": "Open",
+            "reason_code": None,
+            "hash_prev": "h0",
+            "hash_this": "h1",
+        }
+    }
+    monkeypatch.setattr(bas_gate, "db", make_fake_db(store))
+
+    req = bas_gate.TransitionReq(period_id="2024Q4", target_state="Blocked", reason_code=None)
+    with pytest.raises(HTTPException) as exc:
+        bas_gate.transition(req)
+    assert exc.value.status_code == 400
+
+
+def test_invalid_transition(monkeypatch):
+    store = {"row": None}
+    monkeypatch.setattr(bas_gate, "db", make_fake_db(store))
+
+    req = bas_gate.TransitionReq(period_id="2024Q4", target_state="Remitted", reason_code="ops")
+    with pytest.raises(HTTPException) as exc:
+        bas_gate.transition(req)
+    assert exc.value.status_code == 409
+
+
+def test_idempotent_noop(monkeypatch):
+    store = {
+        "row": {
+            "period_id": "2024Q4",
+            "state": "Reconciling",
+            "reason_code": "ops",
+            "hash_prev": "hp",
+            "hash_this": "ht",
+        }
+    }
+    monkeypatch.setattr(bas_gate, "db", make_fake_db(store))
+
+    req = bas_gate.TransitionReq(period_id="2024Q4", target_state="Reconciling", reason_code="ops")
+    result = bas_gate.transition(req)
+    assert result == {"ok": True, "hash": "ht"}
+    assert store.get("history") is None


### PR DESCRIPTION
## Summary
- rewrite the reconciliation state machine to use safe transition tokens and cover anomaly and remittance paths
- implement period closing to recompute liabilities, refresh ledger hashes, and guard release transitions in the reconcile route
- harden the BAS gate transition service with separation-of-duties and hash-chain checks backed by new unit tests

## Testing
- pytest tests/test_bas_gate_transitions.py

------
https://chatgpt.com/codex/tasks/task_e_68e2602ab3b08327a733d4d475bcc27b