### PR TITLE
Enrich evidence bundle and audit trail exports

### DIFF
--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -1,6 +1,9 @@
-﻿# apps/services/audit/main.py
+# apps/services/audit/main.py
 from fastapi import FastAPI
 import os, psycopg2, json
+from psycopg2.extras import RealDictCursor
+from datetime import datetime
+from libs.audit_chain.chain import link
 
 app = FastAPI(title="audit")
 
@@ -15,10 +18,66 @@ def db():
 
 @app.get("/audit/bundle/{period_id}")
 def bundle(period_id: str):
-    conn = db(); cur = conn.cursor()
-    cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
-    rpt = cur.fetchone()
-    cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
-    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []
-    cur.close(); conn.close()
-    return {"period_id": period_id, "rpt": rpt[0] if rpt else None, "audit": logs}
+    conn = db(); cur = conn.cursor(cursor_factory=RealDictCursor)
+    try:
+        cur.execute(
+            """
+            SELECT rpt_json, rpt_sig, issued_at
+              FROM rpt_store
+             WHERE period_id=%s
+             ORDER BY issued_at DESC
+             LIMIT 1
+            """,
+            (period_id,)
+        )
+        rpt_row = cur.fetchone()
+        rpt = None
+        if rpt_row:
+            rpt = {
+                "payload": rpt_row["rpt_json"],
+                "signature": rpt_row["rpt_sig"],
+                "issued_at": rpt_row["issued_at"].isoformat() if isinstance(rpt_row["issued_at"], datetime) else rpt_row["issued_at"],
+            }
+
+        pattern = f'%"period_id":"{period_id}"%'
+        cur.execute(
+            """
+            SELECT id, event_time, category, message, hash_prev, hash_this
+              FROM audit_log
+             WHERE category IN ('bas_gate','egress')
+               AND message LIKE %s
+             ORDER BY event_time ASC, id ASC
+            """,
+            (pattern,)
+        )
+        rows = cur.fetchall()
+        prev_hash: str | None = None
+        audit_trail = []
+        for row in rows:
+            raw_message = row["message"] or ""
+            try:
+                parsed_message = json.loads(raw_message)
+            except Exception:
+                parsed_message = raw_message
+            computed_hash = link(prev_hash, raw_message)
+            audit_trail.append({
+                "id": row["id"],
+                "event_time": row["event_time"].isoformat() if isinstance(row["event_time"], datetime) else str(row["event_time"]),
+                "category": row["category"],
+                "message": parsed_message,
+                "hash_prev": row["hash_prev"],
+                "hash_this": row["hash_this"],
+                "hash_computed": computed_hash,
+                "trace_id": computed_hash,
+                "hash_match": (row["hash_this"] == computed_hash)
+            })
+            prev_hash = computed_hash
+
+        return {
+            "period_id": period_id,
+            "rpt": rpt,
+            "audit_trail": audit_trail,
+            "chain_root": audit_trail[-1]["hash_computed"] if audit_trail else None
+        }
+    finally:
+        cur.close(); conn.close()

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
+        "test": "tsx --test tests/node/evidence.test.ts",
         "lint": "echo lint root"
     },
     "version": "0.1.0",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const api = Router();

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,321 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { Pool, PoolClient } from "pg";
+import { sha256Hex } from "../crypto/merkle.js";
+
+type BasLabels = { W1: number | null; W2: number | null; "1A": number | null; "1B": number | null };
+type BasSummary = { w1: number; w2: number; a1: number; b1: number };
+type DiscrepancyEntry = {
+  type: string;
+  severity: "INFO" | "WARN" | "CRITICAL";
+  trace_id: string;
+  [key: string]: unknown;
+};
+
+type LedgerSnapshot = {
+  credited_cents: number;
+  net_cents: number;
+};
+
+type PoolLike = { connect: () => Promise<PoolClient> };
+
+let pool: PoolLike = new Pool();
+
+export function setEvidencePool(mock: PoolLike) {
+  pool = mock;
+}
+
+function coerceNumber(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "bigint") return Number(value);
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  if (value instanceof Date) return value.getTime();
+  return Number(value ?? 0);
+}
+
+function asIsoString(value: unknown): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") {
+    const d = new Date(value);
+    if (!Number.isNaN(d.getTime())) return d.toISOString();
+    return value;
+  }
+  return null;
+}
+
+function parseJson<T>(value: unknown, fallback: T): T {
+  if (value == null) return fallback;
+  if (typeof value === "object") return value as T;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return fallback;
+    }
+  }
+  return fallback;
+}
+
+function sortedJsonString(entry: Record<string, unknown>): string {
+  const keys = Object.keys(entry).sort();
+  const sorted: Record<string, unknown> = {};
+  for (const key of keys) sorted[key] = entry[key];
+  return JSON.stringify(sorted);
+}
+
+async function regclassExists(client: PoolClient, qualified: string): Promise<boolean> {
+  const { rows } = await client.query<{ reg: string | null }>(
+    "SELECT to_regclass($1) AS reg",
+    [qualified]
+  );
+  return Boolean(rows[0]?.reg);
+}
+
+async function getColumns(client: PoolClient, tableName: string): Promise<Set<string>> {
+  const { rows } = await client.query<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns WHERE table_schema='public' AND table_name=$1`,
+    [tableName]
+  );
+  return new Set(rows.map(r => r.column_name));
+}
+
+function pickColumn(columns: Set<string>, candidates: string[]): string | null {
+  for (const candidate of candidates) {
+    if (columns.has(candidate)) return candidate;
+  }
+  return null;
+}
+
+async function loadBasSummary(
+  client: PoolClient,
+  abn: string,
+  taxType: string,
+  periodId: string
+): Promise<BasSummary | null> {
+  const tableName = "period_tax_summaries";
+  if (!(await regclassExists(client, `public.${tableName}`))) return null;
+
+  const columns = await getColumns(client, tableName);
+  const w1Col = pickColumn(columns, ["w1_cents", "paygw_gross_cents", "gross_wages_cents"]);
+  const w2Col = pickColumn(columns, ["w2_cents", "paygw_withheld_cents", "withheld_cents"]);
+  const a1Col = pickColumn(columns, ["gst_on_sales_cents", "gst_collected_cents", "label_1a_cents"]);
+  const b1Col = pickColumn(columns, ["gst_on_purchases_cents", "gst_credits_cents", "label_1b_cents", "gst_input_tax_credits_cents"]);
+  if (!w1Col || !w2Col || !a1Col || !b1Col) return null;
+
+  const hasTaxType = columns.has("tax_type");
+  const hasComputedAt = columns.has("computed_at");
+  const tableIdent = `public."${tableName}"`;
+  const selectSql = [
+    `SELECT "${w1Col}" AS w1, "${w2Col}" AS w2, "${a1Col}" AS a1, "${b1Col}" AS b1`,
+    `FROM ${tableIdent}`,
+    `WHERE abn=$1 AND period_id=$2${hasTaxType ? " AND tax_type=$3" : ""}`,
+    hasComputedAt ? "ORDER BY computed_at DESC" : "",
+    "LIMIT 1"
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const params: string[] = [abn, periodId];
+  if (hasTaxType) params.push(taxType);
+  const { rows } = await client.query(selectSql, params);
+  if (!rows[0]) return null;
+  return {
+    w1: coerceNumber(rows[0].w1),
+    w2: coerceNumber(rows[0].w2),
+    a1: coerceNumber(rows[0].a1),
+    b1: coerceNumber(rows[0].b1)
+  };
+}
+
+function addDiscrepancy(log: DiscrepancyEntry[], entry: Omit<DiscrepancyEntry, "trace_id">) {
+  const payload = sortedJsonString(entry as Record<string, unknown>);
+  log.push({ ...entry, trace_id: sha256Hex(payload) });
+}
+
+async function loadReconciledTotals(
+  client: PoolClient,
+  abn: string,
+  taxType: string,
+  periodId: string,
+  ledgerFallback: LedgerSnapshot
+): Promise<LedgerSnapshot> {
+  if (await regclassExists(client, "public.v_period_balances")) {
+    const { rows } = await client.query<LedgerSnapshot>(
+      `SELECT COALESCE(credited_cents,0) AS credited_cents, COALESCE(net_cents,0) AS net_cents
+       FROM v_period_balances
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    if (rows[0]) {
+      return {
+        credited_cents: coerceNumber(rows[0].credited_cents),
+        net_cents: coerceNumber(rows[0].net_cents)
+      };
+    }
+  }
+  return ledgerFallback;
+}
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
-  };
-  return bundle;
+  const client = await pool.connect();
+  try {
+    const periodRes = await client.query(
+      `SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents,
+              merkle_root, running_balance_hash, anomaly_vector, thresholds
+         FROM periods
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    if (periodRes.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+    const periodRow = periodRes.rows[0];
+
+    const anomalyVector = parseJson<Record<string, number>>(periodRow.anomaly_vector, {});
+    const thresholds = parseJson<Record<string, number>>(periodRow.thresholds, {});
+
+    const rptRes = await client.query(
+      `SELECT payload, payload_c14n, payload_sha256, signature, created_at
+         FROM rpt_tokens
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const rptRow = rptRes.rows[0] ?? null;
+
+    const ledgerRes = await client.query(
+      `SELECT id, transfer_uuid, amount_cents, balance_after_cents,
+              bank_receipt_hash, prev_hash, hash_after, created_at
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    );
+
+    let lastReceipt: string | null = null;
+    const ledgerEntries = ledgerRes.rows.map(row => {
+      if (row.bank_receipt_hash) lastReceipt = row.bank_receipt_hash;
+      return {
+        id: Number(row.id),
+        transfer_uuid: row.transfer_uuid ?? null,
+        amount_cents: coerceNumber(row.amount_cents),
+        balance_after_cents: coerceNumber(row.balance_after_cents),
+        bank_receipt_hash: row.bank_receipt_hash ?? null,
+        prev_hash: row.prev_hash ?? null,
+        hash_after: row.hash_after ?? null,
+        created_at: asIsoString(row.created_at)
+      };
+    });
+
+    const ledgerSnapshot = ledgerEntries.reduce<LedgerSnapshot & { lastReceipt: string | null }>(
+      (acc, entry) => {
+        if (entry.amount_cents >= 0) acc.credited_cents += entry.amount_cents;
+        acc.net_cents += entry.amount_cents;
+        if (entry.bank_receipt_hash) acc.lastReceipt = entry.bank_receipt_hash;
+        return acc;
+      },
+      { credited_cents: 0, net_cents: 0, lastReceipt: lastReceipt }
+    );
+
+    const reconciledTotals = await loadReconciledTotals(
+      client,
+      abn,
+      taxType,
+      periodId,
+      { credited_cents: ledgerSnapshot.credited_cents, net_cents: ledgerSnapshot.net_cents }
+    );
+
+    const basSummary = await loadBasSummary(client, abn, taxType, periodId);
+    const basLabels: BasLabels = {
+      W1: basSummary?.w1 ?? null,
+      W2: basSummary?.w2 ?? null,
+      "1A": basSummary?.a1 ?? null,
+      "1B": basSummary?.b1 ?? null
+    };
+
+    const discrepancyLog: DiscrepancyEntry[] = [];
+
+    for (const [metric, value] of Object.entries(anomalyVector)) {
+      const actual = Number(value);
+      const threshold = thresholds[metric];
+      if (threshold !== undefined && Math.abs(actual) > Number(threshold)) {
+        addDiscrepancy(discrepancyLog, {
+          type: "ANOMALY_THRESHOLD",
+          severity: "CRITICAL",
+          metric,
+          actual,
+          threshold: Number(threshold)
+        });
+      }
+    }
+
+    const finalLiability = coerceNumber(periodRow.final_liability_cents ?? 0);
+    const ledgerDelta = reconciledTotals.net_cents - finalLiability;
+    if (Math.abs(ledgerDelta) > 1) {
+      addDiscrepancy(discrepancyLog, {
+        type: "LEDGER_FINAL_VARIANCE",
+        severity: "WARN",
+        expected_cents: finalLiability,
+        actual_cents: reconciledTotals.net_cents,
+        delta_cents: ledgerDelta
+      });
+    }
+
+    if (basSummary) {
+      const expected = taxType === "PAYGW" ? basSummary.w2 : basSummary.a1;
+      const label = taxType === "PAYGW" ? "W2" : "1A";
+      const variance = reconciledTotals.credited_cents - expected;
+      if (Math.abs(variance) > 1) {
+        addDiscrepancy(discrepancyLog, {
+          type: "LEDGER_SUMMARY_VARIANCE",
+          severity: "WARN",
+          label,
+          expected_cents: expected,
+          actual_cents: reconciledTotals.credited_cents,
+          delta_cents: variance
+        });
+      }
+    }
+
+    const rptPayload = rptRow ? parseJson<any>(rptRow.payload, {}) : null;
+    const payloadC14n = rptRow?.payload_c14n ?? null;
+    const payloadSha = rptRow?.payload_sha256 ?? (payloadC14n ? sha256Hex(payloadC14n) : null);
+
+    return {
+      meta: {
+        generated_at: new Date().toISOString(),
+        abn,
+        taxType,
+        periodId
+      },
+      period: {
+        state: periodRow.state,
+        accrued_cents: coerceNumber(periodRow.accrued_cents ?? 0),
+        credited_to_owa_cents: coerceNumber(periodRow.credited_to_owa_cents ?? 0),
+        final_liability_cents: finalLiability,
+        merkle_root: periodRow.merkle_root ?? null,
+        running_balance_hash: periodRow.running_balance_hash ?? null,
+        anomaly_vector: anomalyVector,
+        thresholds
+      },
+      rpt: rptRow
+        ? {
+            payload: rptPayload,
+            payload_c14n: payloadC14n,
+            payload_sha256: payloadSha,
+            signature: rptRow.signature,
+            created_at: asIsoString(rptRow.created_at)
+          }
+        : null,
+      owa_ledger: ledgerEntries,
+      owa_reconciled_totals: reconciledTotals,
+      bas_labels: basLabels,
+      bank_receipt_hash: ledgerSnapshot.lastReceipt ?? lastReceipt,
+      anomaly_thresholds: thresholds,
+      discrepancy_log: discrepancyLog
+    };
+  } finally {
+    client.release();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-﻿// src/index.ts
+// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
 
@@ -9,7 +9,7 @@ import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
 
-const app = express();
+export const app = express();
 app.use(express.json({ limit: "2mb" }));
 
 // (optional) quick request logger
@@ -34,5 +34,9 @@ app.use("/api", api);
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));
 
-const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+if (process.env.NODE_ENV !== "test") {
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => console.log("APGMS server listening on", port));
+}
+
+export default app;

--- a/tests/node/evidence.test.ts
+++ b/tests/node/evidence.test.ts
@@ -1,0 +1,353 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { AddressInfo } from "node:net";
+import type { Express } from "express";
+
+process.env.NODE_ENV = "test";
+
+type PeriodRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  accrued_cents: number;
+  credited_to_owa_cents: number;
+  final_liability_cents: number;
+  merkle_root: string;
+  running_balance_hash: string;
+  anomaly_vector: Record<string, number>;
+  thresholds: Record<string, number>;
+};
+
+type RptRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  payload: any;
+  payload_c14n: string;
+  payload_sha256: string;
+  signature: string;
+  created_at: string;
+};
+
+type LedgerRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  transfer_uuid: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string | null;
+  prev_hash: string | null;
+  hash_after: string;
+  created_at: string;
+};
+
+type PeriodSummary = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  paygw_gross_cents: number;
+  paygw_withheld_cents: number;
+  gst_on_sales_cents: number;
+  gst_on_purchases_cents: number;
+  computed_at: string;
+};
+
+type ReconciledRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  credited_cents: number;
+  net_cents: number;
+};
+
+type MockData = {
+  periods: PeriodRow[];
+  rpt_tokens: RptRow[];
+  owa_ledger: LedgerRow[];
+  v_period_balances: ReconciledRow[];
+  period_tax_summaries: PeriodSummary[];
+};
+
+type PoolLike = { connect: () => Promise<MockClient> };
+
+class MockClient {
+  constructor(private readonly data: MockData) {}
+
+  async query(text: string, params: readonly unknown[]) {
+    if (text.startsWith("SELECT to_regclass")) {
+      const name = params[0];
+      const reg =
+        name === "public.v_period_balances" || name === "public.period_tax_summaries"
+          ? String(name)
+          : null;
+      return { rows: [{ reg }], rowCount: 1 };
+    }
+
+    if (text.includes("information_schema.columns")) {
+      const table = String(params[0]);
+      if (table === "period_tax_summaries") {
+        return {
+          rows: [
+            { column_name: "abn" },
+            { column_name: "tax_type" },
+            { column_name: "period_id" },
+            { column_name: "paygw_gross_cents" },
+            { column_name: "paygw_withheld_cents" },
+            { column_name: "gst_on_sales_cents" },
+            { column_name: "gst_on_purchases_cents" },
+            { column_name: "computed_at" }
+          ],
+          rowCount: 8
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+
+    if (text.includes("FROM periods")) {
+      const [abn, taxType, periodId] = params as string[];
+      const rows = this.data.periods.filter(
+        row => row.abn === abn && row.tax_type === taxType && row.period_id === periodId
+      );
+      return { rows, rowCount: rows.length };
+    }
+
+    if (text.includes("FROM rpt_tokens")) {
+      const [abn, taxType, periodId] = params as string[];
+      const rows = this.data.rpt_tokens
+        .filter(row => row.abn === abn && row.tax_type === taxType && row.period_id === periodId)
+        .sort((a, b) => Date.parse(b.created_at) - Date.parse(a.created_at))
+        .slice(0, 1);
+      return { rows, rowCount: rows.length };
+    }
+
+    if (text.includes("FROM owa_ledger")) {
+      const [abn, taxType, periodId] = params as string[];
+      const rows = this.data.owa_ledger
+        .filter(row => row.abn === abn && row.tax_type === taxType && row.period_id === periodId)
+        .sort((a, b) => a.id - b.id);
+      return { rows, rowCount: rows.length };
+    }
+
+    if (text.includes("FROM v_period_balances")) {
+      const [abn, taxType, periodId] = params as string[];
+      const rows = this.data.v_period_balances.filter(
+        row => row.abn === abn && row.tax_type === taxType && row.period_id === periodId
+      );
+      return { rows, rowCount: rows.length };
+    }
+
+    if (text.includes("period_tax_summaries")) {
+      const abn = String(params[0]);
+      const periodId = String(params[1]);
+      const taxType = params.length > 2 ? String(params[2]) : null;
+      const rows = this.data.period_tax_summaries
+        .filter(row => row.abn === abn && row.period_id === periodId && (!taxType || row.tax_type === taxType))
+        .sort((a, b) => Date.parse(b.computed_at) - Date.parse(a.computed_at))
+        .slice(0, 1)
+        .map(row => ({
+          w1: row.paygw_gross_cents,
+          w2: row.paygw_withheld_cents,
+          a1: row.gst_on_sales_cents,
+          b1: row.gst_on_purchases_cents
+        }));
+      return { rows, rowCount: rows.length };
+    }
+
+    throw new Error(`Unhandled query: ${text}`);
+  }
+
+  release() {}
+}
+
+const abn = "12345678901";
+const taxType = "GST";
+const periodId = "2025-09";
+
+const mockData: MockData = {
+  periods: [
+    {
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      state: "READY_RPT",
+      accrued_cents: 150000,
+      credited_to_owa_cents: 150000,
+      final_liability_cents: 140000,
+      merkle_root: "merkle-demo-root",
+      running_balance_hash: "running-hash-demo",
+      anomaly_vector: { variance_ratio: 0.35 },
+      thresholds: { variance_ratio: 0.25 }
+    }
+  ],
+  rpt_tokens: [
+    {
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      payload: {
+        entity_id: abn,
+        period_id: periodId,
+        tax_type: taxType,
+        amount_cents: 140000,
+        merkle_root: "merkle-demo-root",
+        running_balance_hash: "running-hash-demo",
+        anomaly_vector: { variance_ratio: 0.35 },
+        thresholds: { variance_ratio: 0.25 },
+        rail_id: "EFT",
+        reference: "PRN-123",
+        expiry_ts: new Date("2025-10-04T20:56:42.000Z").toISOString(),
+        nonce: "nonce-demo"
+      },
+      payload_c14n: JSON.stringify({
+        entity_id: abn,
+        period_id: periodId,
+        tax_type: taxType,
+        amount_cents: 140000,
+        merkle_root: "merkle-demo-root",
+        running_balance_hash: "running-hash-demo",
+        anomaly_vector: { variance_ratio: 0.35 },
+        thresholds: { variance_ratio: 0.25 },
+        rail_id: "EFT",
+        reference: "PRN-123",
+        expiry_ts: new Date("2025-10-04T20:56:42.000Z").toISOString(),
+        nonce: "nonce-demo"
+      }),
+      payload_sha256: "a3ae54f7b19996e4fcc8d0f0a1c0c35b5748e6d8f3f9f035bcd844ebf5a0f566",
+      signature: "sig-demo",
+      created_at: "2025-10-04T20:41:42.879Z"
+    }
+  ],
+  owa_ledger: [
+    {
+      id: 1,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      transfer_uuid: "00000000-0000-0000-0000-000000000001",
+      amount_cents: 90000,
+      balance_after_cents: 90000,
+      bank_receipt_hash: "rcpt:001",
+      prev_hash: null,
+      hash_after: "hash-1",
+      created_at: "2025-10-04T20:41:31.000Z"
+    },
+    {
+      id: 2,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      transfer_uuid: "00000000-0000-0000-0000-000000000002",
+      amount_cents: 60000,
+      balance_after_cents: 150000,
+      bank_receipt_hash: "rcpt:002",
+      prev_hash: "hash-1",
+      hash_after: "hash-2",
+      created_at: "2025-10-04T20:41:32.000Z"
+    },
+    {
+      id: 3,
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      transfer_uuid: "00000000-0000-0000-0000-000000000003",
+      amount_cents: -10000,
+      balance_after_cents: 140000,
+      bank_receipt_hash: "bank:remit-demo",
+      prev_hash: "hash-2",
+      hash_after: "hash-3",
+      created_at: "2025-10-04T20:41:42.905Z"
+    }
+  ],
+  v_period_balances: [
+    { abn, tax_type: taxType, period_id: periodId, credited_cents: 150000, net_cents: 140000 }
+  ],
+  period_tax_summaries: [
+    {
+      abn,
+      tax_type: taxType,
+      period_id: periodId,
+      paygw_gross_cents: 310000,
+      paygw_withheld_cents: 47000,
+      gst_on_sales_cents: 160000,
+      gst_on_purchases_cents: 20000,
+      computed_at: "2025-10-04T21:00:00.000Z"
+    }
+  ]
+};
+
+const mockPool: PoolLike = {
+  async connect() {
+    return new MockClient(mockData);
+  }
+};
+
+const appPromise = (async () => {
+  const { setEvidencePool } = await import("../../src/evidence/bundle.ts");
+  setEvidencePool(mockPool);
+  const mod = await import("../../src/index.ts");
+  return mod.app;
+})();
+
+function startServer(app: Express) {
+  return new Promise<import("node:http").Server>((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+async function stopServer(server: import("node:http").Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.close(err => (err ? reject(err) : resolve()));
+  });
+}
+
+const requestUrl = new URL("/api/evidence", "http://127.0.0.1");
+requestUrl.searchParams.set("abn", abn);
+requestUrl.searchParams.set("taxType", taxType);
+requestUrl.searchParams.set("periodId", periodId);
+
+test("evidence bundle exposes BAS labels, hashes, and discrepancy trace IDs", async () => {
+  const app = await appPromise;
+  const server = await startServer(app);
+  const port = (server.address() as AddressInfo).port;
+  const url = new URL(requestUrl.pathname + requestUrl.search, `http://127.0.0.1:${port}`);
+
+  const response = await fetch(url);
+  const raw = await response.text();
+  assert.equal(response.status, 200, raw);
+  const body = JSON.parse(raw);
+
+  await stopServer(server);
+
+  assert.equal(body.meta.abn, abn);
+  assert.equal(body.meta.periodId, periodId);
+  assert.equal(body.period.merkle_root, "merkle-demo-root");
+  assert.equal(body.bank_receipt_hash, "bank:remit-demo");
+
+  assert.deepEqual(body.bas_labels, {
+    W1: 310000,
+    W2: 47000,
+    "1A": 160000,
+    "1B": 20000
+  });
+
+  assert.ok(Array.isArray(body.discrepancy_log));
+  assert.ok(body.discrepancy_log.length >= 1);
+  for (const entry of body.discrepancy_log) {
+    assert.equal(typeof entry.trace_id, "string");
+    assert.equal(entry.trace_id.length, 64);
+  }
+
+  const anomalyEntry = body.discrepancy_log.find((entry: any) => entry.type === "ANOMALY_THRESHOLD");
+  assert.ok(anomalyEntry);
+  assert.equal(anomalyEntry.metric, "variance_ratio");
+
+  const ledgerVariance = body.discrepancy_log.find((entry: any) => entry.type === "LEDGER_SUMMARY_VARIANCE");
+  assert.ok(ledgerVariance);
+  assert.equal(ledgerVariance.label, "1A");
+
+  assert.equal(body.rpt.payload_sha256.length, 64);
+  assert.equal(body.owa_reconciled_totals.net_cents, 140000);
+});


### PR DESCRIPTION
## Summary
- expand the evidence bundle builder to hydrate BAS labels, compute discrepancy traces, and surface reconciled ledger totals
- expose the express app for testing, add an API router stub, and wire audit trail export of canonical RPT payloads plus gate/egress logs
- provide a node-based integration test covering the evidence endpoint and update package scripts to run it

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68e2602b997083279ee06c3a057eaf80