### PR TITLE
feat(console): scaffold console app shell

### DIFF
--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -12,7 +12,10 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@tanstack/react-query": "^5.51.0"
+    "@tanstack/react-query": "^5.51.0",
+    "react-router-dom": "^6.26.2",
+    "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-popover": "^1.1.2"
   },
   "devDependencies": {
     "typescript": "^5.6.2",

--- a/apps/web/console/src/App.tsx
+++ b/apps/web/console/src/App.tsx
@@ -1,0 +1,38 @@
+import { QueryClientProvider } from "@tanstack/react-query";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { queryClient } from "./api/client";
+import PageShell from "./layouts/PageShell";
+
+function Dashboard() {
+  return (
+    <div style={{ display: "grid", gap: "1rem" }}>
+      <section>
+        <h2 style={{ marginBottom: "0.25rem" }}>Status Tiles</h2>
+        <p style={{ margin: 0, color: "#475569" }}>
+          Live system status cards will be placed here, summarising the posture of APGMS
+          services.
+        </p>
+      </section>
+      <section>
+        <h2 style={{ marginBottom: "0.25rem" }}>Upcoming Work</h2>
+        <p style={{ margin: 0, color: "#475569" }}>
+          Planned releases, automation runs, and RPT widgets mount within this workspace.
+        </p>
+      </section>
+    </div>
+  );
+}
+
+export default function App() {
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<PageShell />}>
+            <Route index element={<Dashboard />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
+    </QueryClientProvider>
+  );
+}

--- a/apps/web/console/src/api/client.ts
+++ b/apps/web/console/src/api/client.ts
@@ -1,0 +1,85 @@
+import { QueryClient, useQuery } from "@tanstack/react-query";
+
+type CapabilityStatus = "online" | "degraded" | "offline";
+
+export interface CapabilityDescriptor {
+  id: string;
+  name: string;
+  status: CapabilityStatus;
+  summary: string;
+}
+
+export interface ConsoleMode {
+  label: string;
+  tone: "operational" | "maintenance" | "emergency";
+  description: string;
+}
+
+export interface KillSwitchState {
+  active: boolean;
+  message?: string;
+  activatedAt?: string;
+}
+
+export interface ConsoleData {
+  mode: ConsoleMode;
+  killSwitch: KillSwitchState;
+  capabilityMatrix: CapabilityDescriptor[];
+  lastUpdated: string;
+}
+
+export const queryClient = new QueryClient();
+
+async function fetchConsoleData(): Promise<ConsoleData> {
+  // In lieu of a live backend, mock the values with a short async boundary so
+  // React Query behaves as it would with a remote request.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  return {
+    mode: {
+      label: "Operations",
+      tone: "operational",
+      description: "Live production data with automatic safeguards enabled.",
+    },
+    killSwitch: {
+      active: false,
+      message: undefined,
+      activatedAt: undefined,
+    },
+    capabilityMatrix: [
+      {
+        id: "alerts",
+        name: "Alerting",
+        status: "online",
+        summary: "Pipeline and escalation policies are functioning normally.",
+      },
+      {
+        id: "reporting",
+        name: "Reporting",
+        status: "degraded",
+        summary: "Scheduled exports are delayed ~15 minutes while caches warm.",
+      },
+      {
+        id: "workflows",
+        name: "Workflows",
+        status: "online",
+        summary: "Automation rules are executing across all tenants.",
+      },
+      {
+        id: "integrations",
+        name: "Integrations",
+        status: "offline",
+        summary: "Third-party CRM syncs are paused pending credential rotation.",
+      },
+    ],
+    lastUpdated: new Date().toISOString(),
+  };
+}
+
+export function useConsoleData() {
+  return useQuery({
+    queryKey: ["console", "status"],
+    queryFn: fetchConsoleData,
+    staleTime: 30_000,
+  });
+}

--- a/apps/web/console/src/components/CapabilityMatrixPanel.tsx
+++ b/apps/web/console/src/components/CapabilityMatrixPanel.tsx
@@ -1,0 +1,141 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { useState, type CSSProperties } from "react";
+import { useConsoleData } from "../api/client";
+
+const overlayStyle: CSSProperties = {
+  backgroundColor: "rgba(15, 23, 42, 0.45)",
+  position: "fixed",
+  inset: 0,
+};
+
+const contentStyle: CSSProperties = {
+  backgroundColor: "#ffffff",
+  borderRadius: "0.75rem",
+  boxShadow: "0 30px 60px rgba(15, 23, 42, 0.25)",
+  position: "fixed",
+  top: "50%",
+  left: "50%",
+  transform: "translate(-50%, -50%)",
+  width: "min(680px, 90vw)",
+  maxHeight: "80vh",
+  padding: "1.5rem",
+  overflowY: "auto",
+};
+
+const statusColorMap: Record<string, string> = {
+  online: "#0f766e",
+  degraded: "#b45309",
+  offline: "#b91c1c",
+};
+
+export default function CapabilityMatrixPanel() {
+  const [open, setOpen] = useState(false);
+  const { data, isLoading } = useConsoleData();
+
+  return (
+    <Dialog.Root open={open} onOpenChange={setOpen}>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          style={{
+            display: "inline-flex",
+            alignItems: "center",
+            gap: "0.5rem",
+            padding: "0.45rem 0.9rem",
+            borderRadius: "0.5rem",
+            border: "1px solid #cbd5f5",
+            backgroundColor: "white",
+            color: "#1d4ed8",
+            fontWeight: 600,
+            cursor: "pointer",
+            transition: "background-color 0.15s ease",
+            boxShadow: open ? "0 0 0 2px rgba(59,130,246,0.2)" : "none",
+          }}
+        >
+          ⓘ Capability Matrix
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay style={overlayStyle} />
+        <Dialog.Content style={contentStyle}>
+          <div style={{ display: "flex", justifyContent: "space-between", gap: "1rem" }}>
+            <Dialog.Title style={{ fontSize: "1.5rem", fontWeight: 700 }}>
+              Capability Matrix
+            </Dialog.Title>
+            <Dialog.Close
+              aria-label="Close capability matrix"
+              style={{
+                border: "none",
+                background: "transparent",
+                fontSize: "1.25rem",
+                cursor: "pointer",
+                color: "#64748b",
+              }}
+            >
+              ×
+            </Dialog.Close>
+          </div>
+          <p style={{ marginTop: "0.5rem", color: "#475569" }}>
+            Consolidated view of operational capabilities across the APGMS platform.
+          </p>
+
+          <div style={{ marginTop: "1.5rem", display: "grid", gap: "1rem" }}>
+            {isLoading && <div>Loading capability status…</div>}
+            {!isLoading && data?.capabilityMatrix.map((capability) => (
+              <div
+                key={capability.id}
+                style={{
+                  border: "1px solid #e2e8f0",
+                  borderRadius: "0.75rem",
+                  padding: "1rem",
+                  display: "flex",
+                  flexDirection: "column",
+                  gap: "0.5rem",
+                }}
+              >
+                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                  <div style={{ fontWeight: 600, fontSize: "1.05rem" }}>{capability.name}</div>
+                  <span
+                    style={{
+                      display: "inline-flex",
+                      alignItems: "center",
+                      gap: "0.35rem",
+                      padding: "0.25rem 0.65rem",
+                      borderRadius: "999px",
+                      fontSize: "0.8rem",
+                      fontWeight: 600,
+                      color: "white",
+                      backgroundColor: statusColorMap[capability.status] ?? "#475569",
+                    }}
+                  >
+                    <span
+                      style={{
+                        display: "inline-block",
+                        width: "0.5rem",
+                        height: "0.5rem",
+                        borderRadius: "999px",
+                        backgroundColor: "white",
+                        opacity: 0.8,
+                      }}
+                    />
+                    {capability.status.toUpperCase()}
+                  </span>
+                </div>
+                <p style={{ margin: 0, color: "#475569", lineHeight: 1.4 }}>{capability.summary}</p>
+              </div>
+            ))}
+            {!isLoading && !data?.capabilityMatrix.length && (
+              <div style={{ color: "#94a3b8" }}>No capability data is available right now.</div>
+            )}
+          </div>
+
+          {data?.lastUpdated ? (
+            <footer style={{ marginTop: "1.5rem", fontSize: "0.75rem", color: "#94a3b8" }}>
+              Last refreshed {new Date(data.lastUpdated).toLocaleString()}
+            </footer>
+          ) : null}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/web/console/src/components/KillSwitchBanner.tsx
+++ b/apps/web/console/src/components/KillSwitchBanner.tsx
@@ -1,0 +1,49 @@
+import { useConsoleData } from "../api/client";
+
+export default function KillSwitchBanner() {
+  const { data, isLoading } = useConsoleData();
+
+  if (isLoading) {
+    return (
+      <div
+        role="status"
+        style={{
+          backgroundColor: "#fff3cd",
+          border: "1px solid #ffe69c",
+          color: "#664d03",
+          padding: "0.75rem 1rem",
+          borderRadius: "0.5rem",
+          marginBottom: "1rem",
+        }}
+      >
+        Checking safeguards…
+      </div>
+    );
+  }
+
+  if (!data?.killSwitch.active) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      style={{
+        backgroundColor: "#f8d7da",
+        border: "1px solid #f5c2c7",
+        color: "#842029",
+        padding: "0.75rem 1rem",
+        borderRadius: "0.5rem",
+        marginBottom: "1rem",
+      }}
+    >
+      <strong>Kill Switch Engaged.</strong>
+      <div>{data.killSwitch.message ?? "All outbound operations are halted."}</div>
+      {data.killSwitch.activatedAt ? (
+        <div style={{ fontSize: "0.8rem", opacity: 0.8, marginTop: "0.25rem" }}>
+          Activated at {new Date(data.killSwitch.activatedAt).toLocaleString()}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/console/src/components/ModePill.tsx
+++ b/apps/web/console/src/components/ModePill.tsx
@@ -1,0 +1,49 @@
+import { useMemo } from "react";
+import { useConsoleData } from "../api/client";
+
+type ToneColor = {
+  background: string;
+  color: string;
+  border: string;
+};
+
+function toneToColors(tone: string): ToneColor {
+  switch (tone) {
+    case "maintenance":
+      return { background: "#fff8e1", color: "#8a6100", border: "#f5d47a" };
+    case "emergency":
+      return { background: "#fde4e4", color: "#a30d0d", border: "#f4b3b3" };
+    default:
+      return { background: "#e8f5e9", color: "#1b5e20", border: "#c8e6c9" };
+  }
+}
+
+export default function ModePill() {
+  const { data, isLoading } = useConsoleData();
+
+  const { background, color, border } = useMemo(() => {
+    const tone = data?.mode.tone ?? "operational";
+    return toneToColors(tone);
+  }, [data?.mode.tone]);
+
+  return (
+    <span
+      aria-live="polite"
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "0.35rem 0.75rem",
+        borderRadius: "9999px",
+        fontSize: "0.85rem",
+        fontWeight: 600,
+        backgroundColor: background,
+        color,
+        border: `1px solid ${border}`,
+        minWidth: "7rem",
+        justifyContent: "center",
+      }}
+    >
+      {isLoading ? "Loading…" : data?.mode.label ?? "Unknown"}
+    </span>
+  );
+}

--- a/apps/web/console/src/layouts/PageShell.tsx
+++ b/apps/web/console/src/layouts/PageShell.tsx
@@ -1,0 +1,95 @@
+import { NavLink, Outlet } from "react-router-dom";
+import CapabilityMatrixPanel from "../components/CapabilityMatrixPanel";
+import KillSwitchBanner from "../components/KillSwitchBanner";
+import ModePill from "../components/ModePill";
+
+const navigationItems = [
+  { label: "Overview", path: "/" },
+  { label: "Reports", path: "/reports" },
+  { label: "Workflows", path: "/workflows" },
+  { label: "Integrations", path: "/integrations" },
+  { label: "Settings", path: "/settings" },
+];
+
+export default function PageShell() {
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "240px 1fr", minHeight: "100vh" }}>
+      <aside
+        style={{
+          backgroundColor: "#0f172a",
+          color: "#e2e8f0",
+          padding: "1.5rem 1rem",
+          display: "flex",
+          flexDirection: "column",
+          gap: "2rem",
+        }}
+      >
+        <div>
+          <div style={{ fontSize: "1.25rem", fontWeight: 700 }}>APGMS</div>
+          <div style={{ fontSize: "0.85rem", opacity: 0.7 }}>Operations Console</div>
+        </div>
+
+        <nav style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+          {navigationItems.map((item) => (
+            <NavLink
+              key={item.path}
+              to={item.path}
+              style={({ isActive }) => ({
+                color: "inherit",
+                textDecoration: "none",
+                padding: "0.6rem 0.75rem",
+                borderRadius: "0.5rem",
+                backgroundColor: isActive ? "rgba(148, 163, 184, 0.25)" : "transparent",
+                transition: "background-color 0.15s ease",
+              })}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+        </nav>
+
+        <footer style={{ fontSize: "0.75rem", opacity: 0.6 }}>
+          &copy; {new Date().getFullYear()} APGMS Platform
+        </footer>
+      </aside>
+
+      <main style={{ backgroundColor: "#f8fafc", padding: "2rem 2.5rem" }}>
+        <header
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "1rem",
+            marginBottom: "1.5rem",
+          }}
+        >
+          <div>
+            <h1 style={{ margin: 0, fontSize: "1.75rem" }}>Console Overview</h1>
+            <p style={{ margin: 0, color: "#475569" }}>
+              Real-time visibility across platform health, workflows, and integrations.
+            </p>
+          </div>
+
+          <div style={{ display: "flex", alignItems: "center", gap: "0.75rem" }}>
+            <ModePill />
+            <CapabilityMatrixPanel />
+          </div>
+        </header>
+
+        <KillSwitchBanner />
+
+        <section
+          style={{
+            backgroundColor: "white",
+            borderRadius: "1rem",
+            padding: "1.5rem",
+            boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+            minHeight: "60vh",
+          }}
+        >
+          <Outlet />
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,15 @@
-﻿import React from "react";
+import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import App from "./App";
 
-function App() {
-  return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
-    </div>
-  );
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Failed to find root element");
 }
-createRoot(document.getElementById("root")!).render(<App />);
+
+createRoot(container).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);


### PR DESCRIPTION
## Summary
- add routing and query client providers to the console application entry point
- implement the shared PageShell layout with navigation, mode indicator, kill switch banner, and capability matrix dialog
- centralize console data fetching behind a React Query client and shared UI components

## Testing
- npm --prefix apps/web/console run lint

------
https://chatgpt.com/codex/tasks/task_e_68e26443cac0832795654fe34ffc7196