### PR TITLE
Add Vitest setup and console UI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,17 +29,21 @@ cd apgms
 
 Install Dependencies
 
-npm install
+pnpm install
 
 Run the Development Server
 
-npm start
+pnpm --filter @apgms/console dev
 
 The app will start on http://localhost:3000
 
 Build for Production
 
-npm run build
+pnpm --filter @apgms/console build
+
+Testing
+
+pnpm --filter @apgms/console test
 
 Project Structure
 apgms/

--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 5173",
-    "lint": "echo lint web"
+    "lint": "echo lint web",
+    "test": "vitest run"
   },
   "dependencies": {
     "react": "^18.3.1",
@@ -17,6 +18,16 @@
   "devDependencies": {
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
+    "vitest": "^2.1.2",
+    "jsdom": "^25.0.1",
+    "@vitejs/plugin-react": "^4.3.2",
+    "@testing-library/react": "^16.0.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@testing-library/jest-dom": "^6.5.1",
+    "@types/testing-library__jest-dom": "^6.2.0",
+    "tailwindcss": "^3.4.13",
+    "postcss": "^8.4.47",
+    "autoprefixer": "^10.4.20",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0"
   }

--- a/apps/web/console/postcss.config.cjs
+++ b/apps/web/console/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/console/src/App.tsx
+++ b/apps/web/console/src/App.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo, useState } from "react";
+
+import { KillSwitchBanner } from "./components/KillSwitchBanner";
+import { ModePill } from "./components/ModePill";
+import { QueueTable } from "./components/QueueTable";
+
+type ConsoleMode = "AUTO" | "MANUAL";
+
+type QueueItem = {
+  id: string;
+  label: string;
+  pendingCount: number;
+  summary: string;
+  details: string[];
+  issueRptDisabledReason?: string;
+};
+
+const INITIAL_QUEUE: QueueItem[] = [
+  {
+    id: "queue-paygw",
+    label: "PAYGW Lodgments",
+    pendingCount: 3,
+    summary: "PAYGW settlements ready for overnight batching.",
+    details: [
+      "3 payments reconciled against the PAYGW holding account.",
+      "ATO settlement window opens at 18:00 AEST.",
+    ],
+  },
+  {
+    id: "queue-gst",
+    label: "GST Adjustments",
+    pendingCount: 1,
+    summary: "Manual override required before issuing an RPT.",
+    details: [
+      "Adjustment flagged by compliance rules.",
+      "CFO approval pending for variance greater than 10%.",
+    ],
+    issueRptDisabledReason: "Awaiting CFO approval before issuing the RPT.",
+  },
+];
+
+export function App(): React.ReactElement {
+  const [mode, setMode] = useState<ConsoleMode>("AUTO");
+  const [killSwitchActive, setKillSwitchActive] = useState(false);
+
+  const queueItems = useMemo(() => INITIAL_QUEUE, []);
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-5xl items-center justify-between gap-4 px-6 py-4">
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+              APGMS Console
+            </p>
+            <h1 className="text-2xl font-semibold text-slate-900">Realtime lodgment oversight</h1>
+          </div>
+          <div className="flex items-center gap-3">
+            <ModePill
+              mode={mode}
+              onToggle={() => setMode((current) => (current === "AUTO" ? "MANUAL" : "AUTO"))}
+            />
+            <button
+              type="button"
+              role="switch"
+              aria-checked={killSwitchActive}
+              aria-label={`Kill switch is ${killSwitchActive ? "active" : "inactive"}. Toggle kill switch.`}
+              onClick={() => setKillSwitchActive((value) => !value)}
+              className="flex items-center gap-2 rounded-full border border-red-200 px-4 py-2 text-sm font-medium text-red-600 transition-colors hover:border-red-300 hover:bg-red-50"
+            >
+              <span className="inline-flex h-2.5 w-2.5 rounded-full bg-red-500" aria-hidden="true" />
+              Kill switch
+            </button>
+          </div>
+        </div>
+      </header>
+      <main className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-8">
+        <KillSwitchBanner active={killSwitchActive} />
+        <QueueTable killSwitchActive={killSwitchActive} items={queueItems} />
+      </main>
+    </div>
+  );
+}
+
+export type { QueueItem, ConsoleMode };

--- a/apps/web/console/src/__tests__/app.test.tsx
+++ b/apps/web/console/src/__tests__/app.test.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { App } from "../App";
+
+describe("Console experience", () => {
+  it("allows operators to toggle the mode pill", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const modeSwitch = screen.getByRole("switch", { name: /console mode/i });
+    expect(modeSwitch).toHaveAttribute("aria-checked", "true");
+    expect(within(modeSwitch).getByTestId("mode-pill-label")).toHaveTextContent("Auto");
+
+    await user.click(modeSwitch);
+
+    expect(modeSwitch).toHaveAttribute("aria-checked", "false");
+    expect(within(modeSwitch).getByTestId("mode-pill-label")).toHaveTextContent("Manual");
+  });
+
+  it("reveals the kill-switch banner when the switch is enabled", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(screen.queryByTestId("kill-switch-banner")).not.toBeInTheDocument();
+
+    const killSwitchToggle = screen.getByRole("switch", { name: /kill switch/i });
+    await user.click(killSwitchToggle);
+
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/kill switch active/i);
+
+    await user.click(killSwitchToggle);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("disables Issue RPT with a visible reason when the queue is blocked", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const gstQueueToggle = screen.getByRole("button", { name: /gst adjustments/i });
+    await user.click(gstQueueToggle);
+
+    const issueRptButton = screen.getByRole("button", { name: /issue rpt for gst adjustments/i });
+    expect(issueRptButton).toBeDisabled();
+    expect(screen.getByRole("note", { name: /awaiting cfo approval/i })).toBeInTheDocument();
+  });
+
+  it("expands and collapses queue drawers for contextual detail", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    const paygwToggle = screen.getByRole("button", { name: /paygw lodgments/i });
+    expect(screen.queryByTestId("queue-paygw-drawer")).not.toBeInTheDocument();
+
+    await user.click(paygwToggle);
+    const drawer = screen.getByTestId("queue-paygw-drawer");
+    expect(drawer).toBeVisible();
+    expect(within(drawer).getByText(/ATO settlement window/i)).toBeInTheDocument();
+
+    await user.click(paygwToggle);
+    expect(screen.queryByTestId("queue-paygw-drawer")).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/console/src/components/KillSwitchBanner.tsx
+++ b/apps/web/console/src/components/KillSwitchBanner.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface KillSwitchBannerProps {
+  active: boolean;
+}
+
+export function KillSwitchBanner({ active }: KillSwitchBannerProps): React.ReactElement | null {
+  if (!active) {
+    return null;
+  }
+
+  return (
+    <div
+      role="alert"
+      className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-red-700 shadow-sm"
+      data-testid="kill-switch-banner"
+    >
+      <p className="font-semibold">Kill switch active</p>
+      <p className="text-sm">
+        All automated lodgments are paused. Manual review is required before issuing new RPTs.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/console/src/components/ModePill.tsx
+++ b/apps/web/console/src/components/ModePill.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+import type { ConsoleMode } from "../App";
+
+interface ModePillProps {
+  mode: ConsoleMode;
+  onToggle: () => void;
+}
+
+export function ModePill({ mode, onToggle }: ModePillProps): React.ReactElement {
+  const isAuto = mode === "AUTO";
+  const label = isAuto ? "Auto" : "Manual";
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={isAuto}
+      aria-label={`Console mode is ${label.toLowerCase()}. Toggle mode.`}
+      onClick={onToggle}
+      data-testid="mode-pill"
+      className="flex items-center gap-2 rounded-full border border-slate-200 bg-slate-900 px-4 py-2 text-slate-100 shadow-sm transition-colors hover:bg-slate-800"
+    >
+      <span className="text-xs font-semibold uppercase tracking-wide text-slate-300">Mode</span>
+      <span className="text-sm font-medium" data-testid="mode-pill-label">
+        {label}
+      </span>
+    </button>
+  );
+}

--- a/apps/web/console/src/components/QueueTable.tsx
+++ b/apps/web/console/src/components/QueueTable.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+import type { QueueItem } from "../App";
+import { QueueTableRow } from "./QueueTableRow";
+
+interface QueueTableProps {
+  items: QueueItem[];
+  killSwitchActive: boolean;
+}
+
+export function QueueTable({ items, killSwitchActive }: QueueTableProps): React.ReactElement {
+  return (
+    <section aria-label="Lodgment queues" className="space-y-3">
+      <header className="flex items-baseline justify-between">
+        <h2 className="text-lg font-semibold text-slate-900">Queues</h2>
+        <p className="text-sm text-slate-500">{items.length} active monitoring lanes</p>
+      </header>
+      <div className="space-y-3">
+        {items.map((item) => (
+          <QueueTableRow key={item.id} item={item} killSwitchActive={killSwitchActive} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/console/src/components/QueueTableRow.tsx
+++ b/apps/web/console/src/components/QueueTableRow.tsx
@@ -1,0 +1,57 @@
+import React, { useId, useState } from "react";
+
+import type { QueueItem } from "../App";
+import { IssueRptButton } from "./buttons/IssueRptButton";
+
+interface QueueTableRowProps {
+  item: QueueItem;
+  killSwitchActive: boolean;
+}
+
+export function QueueTableRow({ item, killSwitchActive }: QueueTableRowProps): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const drawerId = useId();
+
+  const killSwitchReason = killSwitchActive
+    ? "Kill switch active: Issue RPT actions are temporarily disabled."
+    : undefined;
+
+  const disabledReason = killSwitchReason ?? item.issueRptDisabledReason;
+
+  return (
+    <article className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm" data-testid={`${item.id}-card`}>
+      <button
+        type="button"
+        aria-expanded={open}
+        aria-controls={drawerId}
+        onClick={() => setOpen((value) => !value)}
+        className="flex w-full items-start justify-between gap-4 px-4 py-3 text-left transition-colors hover:bg-slate-50"
+      >
+        <div>
+          <p className="text-base font-semibold text-slate-900">{item.label}</p>
+          <p className="text-sm text-slate-500">{item.summary}</p>
+        </div>
+        <div className="flex items-center gap-3 text-sm">
+          <span className="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 font-medium text-slate-600">
+            {item.pendingCount} pending
+          </span>
+          <span className="text-slate-500">{open ? "Hide details" : "View details"}</span>
+        </div>
+      </button>
+      {open ? (
+        <div id={drawerId} role="region" aria-live="polite" className="border-t border-slate-200 bg-slate-50 px-4 py-4" data-testid={`${item.id}-drawer`}>
+          <ul className="mb-4 list-disc space-y-1 pl-5 text-sm text-slate-600">
+            {item.details.map((detail) => (
+              <li key={detail}>{detail}</li>
+            ))}
+          </ul>
+          <IssueRptButton
+            queueId={item.id}
+            queueLabel={item.label}
+            disabledReason={disabledReason}
+          />
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/apps/web/console/src/components/buttons/IssueRptButton.tsx
+++ b/apps/web/console/src/components/buttons/IssueRptButton.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+
+interface IssueRptButtonProps {
+  queueId: string;
+  queueLabel: string;
+  disabledReason?: string;
+}
+
+const slugify = (value: string): string =>
+  value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+
+export function IssueRptButton({ queueId, queueLabel, disabledReason }: IssueRptButtonProps): React.ReactElement {
+  const reasonId = disabledReason ? `${slugify(queueId)}-issue-rpt-reason` : undefined;
+
+  return (
+    <div className="space-y-2" data-testid={`${queueId}-issue-rpt`}>
+      <button
+        type="button"
+        className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:bg-emerald-200 disabled:text-emerald-700"
+        aria-label={`Issue RPT for ${queueLabel}`}
+        aria-describedby={reasonId}
+        disabled={Boolean(disabledReason)}
+      >
+        Issue RPT
+      </button>
+      {disabledReason ? (
+        <p id={reasonId} role="note" className="text-sm text-emerald-900">
+          {disabledReason}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/console/src/index.css
+++ b/apps/web/console/src/index.css
@@ -1,0 +1,18 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background-color: rgb(248 250 252);
+  color: rgb(15 23 42);
+}
+
+a {
+  color: inherit;
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,14 @@
-﻿import React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
 
-function App() {
-  return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
-    </div>
-  );
+import { App } from "./App";
+import "./index.css";
+
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Root element #root was not found in the document");
 }
-createRoot(document.getElementById("root")!).render(<App />);
+
+const root = createRoot(container);
+root.render(<App />);

--- a/apps/web/console/src/test/setup.ts
+++ b/apps/web/console/src/test/setup.ts
@@ -1,0 +1,2 @@
+import "@testing-library/jest-dom/vitest";
+import "../index.css";

--- a/apps/web/console/tsconfig.json
+++ b/apps/web/console/tsconfig.json
@@ -7,7 +7,7 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "types": []
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }

--- a/apps/web/console/tsconfig.vitest.json
+++ b/apps/web/console/tsconfig.vitest.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals", "@testing-library/jest-dom", "vite/client"]
+  },
+  "include": ["src", "src/__tests__"],
+  "exclude": []
+}

--- a/apps/web/console/vite.config.ts
+++ b/apps/web/console/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  css: {
+    postcss: "./postcss.config.cjs",
+  },
+});

--- a/apps/web/console/vitest.config.ts
+++ b/apps/web/console/vitest.config.ts
@@ -1,0 +1,19 @@
+import { mergeConfig, defineConfig } from "vite";
+import viteConfig from "./vite.config";
+
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      globals: true,
+      environment: "jsdom",
+      setupFiles: "./src/test/setup.ts",
+      css: true,
+      reporters: "default",
+      include: ["src/__tests__/**/*.test.{ts,tsx}"],
+      typecheck: {
+        tsconfig: "./tsconfig.vitest.json",
+      },
+    },
+  }),
+);

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "pnpm --filter @apgms/console test"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.12.0",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [],
+  content: [
+    "./apps/web/console/index.html",
+    "./apps/web/console/src/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- add Vitest, Testing Library, Tailwind tooling, and a test script to the console package
- build console UI scaffolding for the mode pill, kill switch banner, Issue RPT control, and queue drawers
- document the pnpm filter commands and surface a repo-level test script for CI consumption

## Testing
- pnpm --filter @apgms/console test *(fails: pnpm download blocked by registry proxy in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26445c56c832798ce2b5eaf4f4db2