### PR TITLE
Add console routes and shared UI primitives

### DIFF
--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -10,9 +10,11 @@
     "lint": "echo lint web"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.51.0",
+    "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@tanstack/react-query": "^5.51.0"
+    "react-router-dom": "^6.26.2"
   },
   "devDependencies": {
     "typescript": "^5.6.2",

--- a/apps/web/console/src/App.tsx
+++ b/apps/web/console/src/App.tsx
@@ -1,0 +1,89 @@
+import { useQuery } from "@tanstack/react-query";
+import { NavLink, Navigate, Route, Routes } from "react-router-dom";
+import { api } from "./api";
+import { AuditPage, BasPage, DashboardPage, QueuesPage, RptsPage, SettingsPage } from "./pages";
+
+const navigation = [
+  { label: "Dashboard", to: "/dashboard" },
+  { label: "BAS", to: "/bas" },
+  { label: "RPTs", to: "/rpts" },
+  { label: "Queues", to: "/queues" },
+  { label: "Audit", to: "/audit" },
+  { label: "Settings", to: "/settings" },
+];
+
+export default function App() {
+  const { data: basStatus } = useQuery({
+    queryKey: ["bas-status"],
+    queryFn: () => api.getBasStatus(),
+    staleTime: 30_000,
+  });
+
+  return (
+    <div className="min-h-screen bg-slate-100 text-slate-900">
+      <a href="#main" className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:rounded-md focus:bg-white focus:px-4 focus:py-2 focus:text-sm focus:shadow-lg">
+        Skip to content
+      </a>
+      <div className="flex">
+        <aside className="hidden w-60 shrink-0 border-r border-slate-200 bg-white/90 backdrop-blur sm:block">
+          <div className="border-b border-slate-200 px-6 py-5">
+            <span className="text-lg font-semibold">APGMS Console</span>
+            <p className="text-xs text-slate-500">Operational control plane</p>
+          </div>
+          <nav className="px-4 py-6" aria-label="Primary">
+            <ul className="space-y-1">
+              {navigation.map((item) => (
+                <li key={item.to}>
+                  <NavLink
+                    to={item.to}
+                    className={({ isActive }) =>
+                      `flex items-center rounded-md px-3 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60 ${
+                        isActive ? "bg-blue-50 text-blue-700" : "text-slate-700 hover:bg-slate-100"
+                      }`
+                    }
+                  >
+                    {item.label}
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
+        <div className="flex-1">
+          <header className="flex items-center justify-between border-b border-slate-200 bg-white px-6 py-4 shadow-sm">
+            <div className="sm:hidden">
+              <span className="text-lg font-semibold text-slate-900">APGMS Console</span>
+            </div>
+            <div className="flex items-center gap-3 text-xs text-slate-500">
+              <span>Rates pinned</span>
+              <span className="inline-flex items-center rounded-full bg-slate-200 px-2 py-1 font-semibold text-slate-700">
+                {basStatus ? `v${basStatus.pinnedRatesVersion}` : "—"}
+              </span>
+            </div>
+          </header>
+          <main id="main" className="px-4 py-6 sm:px-8">
+            <Routes>
+              <Route path="/dashboard" element={<DashboardPage />} />
+              <Route path="/bas" element={<BasPage />} />
+              <Route path="/rpts" element={<RptsPage />} />
+              <Route path="/queues" element={<QueuesPage />} />
+              <Route path="/audit" element={<AuditPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </main>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NotFound() {
+  return (
+    <div className="rounded-lg border border-amber-200 bg-amber-50 p-6 text-sm text-amber-900">
+      <p className="font-semibold">Page not found</p>
+      <p className="mt-2">Select a destination from the navigation to get back on track.</p>
+    </div>
+  );
+}

--- a/apps/web/console/src/api.ts
+++ b/apps/web/console/src/api.ts
@@ -1,0 +1,270 @@
+export interface BasCountdown {
+  nextSubmissionUtc: string;
+  secondsRemaining: number;
+  ratesVersion: string;
+}
+
+export interface DashboardSummary {
+  basCountdown: BasCountdown;
+  todaysRpts: {
+    total: number;
+    issued: number;
+    pending: number;
+  };
+  unreconciledCounts: {
+    anomalies: number;
+    unreconciled: number;
+    dlq: number;
+  };
+  anomalyBlocks: Array<{
+    id: string;
+    name: string;
+    severity: "info" | "warning" | "critical";
+    description: string;
+    updatedAt: string;
+  }>;
+}
+
+export interface BasTotals {
+  currency: string;
+  collected: number;
+  remitted: number;
+  outstanding: number;
+}
+
+export interface BasStatus {
+  countdown: BasCountdown;
+  totals: BasTotals;
+  issueDisabledReason?: string;
+  lastIssuedAt?: string;
+  latestTraceId?: string;
+  dryRunAvailable: boolean;
+  canUndo: boolean;
+  pinnedRatesVersion: string;
+}
+
+export interface BasEvidence {
+  traceId: string;
+  merkleRoot: string;
+  compactJws: string;
+  payload: Record<string, unknown>;
+}
+
+export interface BasIssueRequest {
+  dryRun?: boolean;
+  disableReason?: string;
+}
+
+export interface BasIssueResponse {
+  message: string;
+  status: BasStatus;
+  evidence?: BasEvidence;
+}
+
+export interface BasUndoResponse {
+  message: string;
+  status: BasStatus;
+}
+
+export interface QueueItem {
+  id: string;
+  type: "anomaly" | "unreconciled" | "dlq";
+  severity: "info" | "low" | "medium" | "high" | "critical";
+  title: string;
+  summary: string;
+  updatedAt: string;
+  traceId?: string;
+  payload?: Record<string, unknown>;
+  status?: string;
+}
+
+export interface QueueFilters {
+  queue: "anomalies" | "unreconciled" | "dlq";
+  page: number;
+  pageSize: number;
+  status?: string;
+  search?: string;
+}
+
+export interface QueueResponse {
+  items: QueueItem[];
+  page: number;
+  totalPages: number;
+  totalItems: number;
+}
+
+export interface RptRecord {
+  id: string;
+  period: string;
+  status: "draft" | "pending" | "issued" | "failed";
+  issuedAt?: string;
+  total: number;
+  currency: string;
+  ratesVersion: string;
+}
+
+export interface RptListResponse {
+  items: RptRecord[];
+}
+
+export interface AuditFilters {
+  level?: string;
+  traceId?: string;
+  queue?: string;
+}
+
+export interface AuditEvent {
+  timestamp: string;
+  level: string;
+  message: string;
+  traceId?: string;
+  context?: Record<string, unknown>;
+}
+
+const API_BASE = "/api";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE}${path}`, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const message = await safeParseError(response);
+    throw new Error(message);
+  }
+
+  if (response.status === 204) {
+    return undefined as unknown as T;
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (contentType?.includes("application/json")) {
+    return (await response.json()) as T;
+  }
+
+  return (await response.text()) as unknown as T;
+}
+
+async function safeParseError(response: Response): Promise<string> {
+  try {
+    const data = await response.json();
+    if (typeof data?.message === "string") {
+      return data.message;
+    }
+  } catch (error) {
+    // ignored
+  }
+  return `${response.status} ${response.statusText}`;
+}
+
+function encodeQuery(params: Record<string, string | number | boolean | undefined>): string {
+  const query = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== "")
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join("&");
+  return query ? `?${query}` : "";
+}
+
+export const api = {
+  getDashboardSummary(): Promise<DashboardSummary> {
+    return request<DashboardSummary>("/dashboard");
+  },
+
+  getBasStatus(): Promise<BasStatus> {
+    return request<BasStatus>("/bas/status");
+  },
+
+  issueBasRpt(payload: BasIssueRequest): Promise<BasIssueResponse> {
+    return request<BasIssueResponse>("/bas/issue", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+  },
+
+  undoBasRpt(): Promise<BasUndoResponse> {
+    return request<BasUndoResponse>("/bas/undo", {
+      method: "POST",
+    });
+  },
+
+  getQueueItems(filters: QueueFilters): Promise<QueueResponse> {
+    const query = encodeQuery({
+      queue: filters.queue,
+      page: filters.page,
+      pageSize: filters.pageSize,
+      status: filters.status,
+      search: filters.search,
+    });
+    return request<QueueResponse>(`/queues${query}`);
+  },
+
+  getEvidence(traceId: string): Promise<BasEvidence> {
+    return request<BasEvidence>(`/evidence/${encodeURIComponent(traceId)}`);
+  },
+
+  getRptSchedule(): Promise<RptListResponse> {
+    return request<RptListResponse>("/rpts");
+  },
+
+  async *streamAuditEvents(filters: AuditFilters, signal?: AbortSignal): AsyncGenerator<AuditEvent> {
+    const query = encodeQuery({
+      level: filters.level,
+      traceId: filters.traceId,
+      queue: filters.queue,
+    });
+    const response = await fetch(`${API_BASE}/audit/stream${query}`, {
+      method: "GET",
+      signal,
+    });
+
+    if (!response.ok || !response.body) {
+      const message = await safeParseError(response);
+      throw new Error(message);
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let remainder = "";
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+          break;
+        }
+        remainder += decoder.decode(value, { stream: true });
+        let newlineIndex = remainder.indexOf("\n");
+        while (newlineIndex !== -1) {
+          const line = remainder.slice(0, newlineIndex).trim();
+          remainder = remainder.slice(newlineIndex + 1);
+          if (line) {
+            yield JSON.parse(line) as AuditEvent;
+          }
+          newlineIndex = remainder.indexOf("\n");
+        }
+      }
+      const finalLine = remainder.trim();
+      if (finalLine) {
+        yield JSON.parse(finalLine) as AuditEvent;
+      }
+    } finally {
+      reader.releaseLock();
+    }
+  },
+};
+
+export function decodeCompactJwsPayload(compactJws: string): Record<string, unknown> {
+  const parts = compactJws.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Invalid JWS format");
+  }
+  const payload = parts[1];
+  const normalized = payload.replace(/-/g, "+").replace(/_/g, "/");
+  const padded = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), "=");
+  const json = atob(padded);
+  return JSON.parse(json) as Record<string, unknown>;
+}

--- a/apps/web/console/src/components/ConfirmModal.tsx
+++ b/apps/web/console/src/components/ConfirmModal.tsx
@@ -1,0 +1,80 @@
+import { ReactNode, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+export interface ConfirmModalProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  danger?: boolean;
+  children?: ReactNode;
+}
+
+export function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  onCancel,
+  danger,
+  children,
+}: ConfirmModalProps) {
+  const confirmRef = useRef<HTMLButtonElement | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      confirmRef.current?.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-4"
+      role="presentation"
+      onClick={onCancel}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+        className="w-full max-w-lg rounded-xl bg-white shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="border-b border-slate-200 px-6 py-4">
+          <h2 id="confirm-modal-title" className="text-lg font-semibold text-slate-900">
+            {title}
+          </h2>
+          {description && <p className="mt-2 text-sm text-slate-600">{description}</p>}
+        </header>
+        {children && <div className="px-6 py-4 text-sm text-slate-700">{children}</div>}
+        <footer className="flex items-center justify-end gap-3 border-t border-slate-200 bg-slate-50 px-6 py-4">
+          <button
+            type="button"
+            className="inline-flex items-center rounded-md border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60"
+            onClick={onCancel}
+          >
+            {cancelLabel}
+          </button>
+          <button
+            ref={confirmRef}
+            type="button"
+            className={`inline-flex items-center rounded-md px-4 py-2 text-sm font-semibold text-white focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60 ${
+              danger ? "bg-rose-600 hover:bg-rose-700" : "bg-blue-600 hover:bg-blue-700"
+            }`}
+            onClick={onConfirm}
+          >
+            {confirmLabel}
+          </button>
+        </footer>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/console/src/components/CopyToClipboard.tsx
+++ b/apps/web/console/src/components/CopyToClipboard.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { useToast } from "./ToastProvider";
+
+export interface CopyToClipboardProps {
+  value: string;
+  label?: string;
+  className?: string;
+}
+
+export function CopyToClipboard({ value, label = "Copy", className }: CopyToClipboardProps) {
+  const { pushToast } = useToast();
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      if (!navigator.clipboard) {
+        throw new Error("Clipboard API unavailable");
+      }
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      pushToast({ title: "Copied", description: "Value copied to clipboard", tone: "success" });
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      pushToast({ title: "Clipboard error", description: "Unable to copy to clipboard", tone: "danger" });
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      className={
+        className ??
+        "inline-flex items-center rounded-md border border-slate-200 bg-white px-3 py-1.5 text-xs font-medium text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60"
+      }
+      onClick={handleCopy}
+      aria-live="polite"
+      aria-label={`Copy ${label}`}
+    >
+      {copied ? "Copied" : label}
+    </button>
+  );
+}

--- a/apps/web/console/src/components/DataGrid.tsx
+++ b/apps/web/console/src/components/DataGrid.tsx
@@ -1,0 +1,108 @@
+import clsx from "clsx";
+import { ReactNode } from "react";
+
+type Alignment = "left" | "center" | "right";
+
+export interface DataGridColumn<T> {
+  key: string;
+  header: ReactNode;
+  render?: (item: T) => ReactNode;
+  align?: Alignment;
+  className?: string;
+  headerClassName?: string;
+  cellLabel?: (item: T) => string;
+}
+
+export interface DataGridProps<T> {
+  data: T[];
+  columns: Array<DataGridColumn<T>>;
+  getRowId: (item: T) => string;
+  caption?: string;
+  footer?: ReactNode;
+  emptyState?: ReactNode;
+  onRowClick?: (item: T) => void;
+}
+
+export function DataGrid<T>({
+  data,
+  columns,
+  getRowId,
+  caption,
+  footer,
+  emptyState,
+  onRowClick,
+}: DataGridProps<T>) {
+  const showEmptyState = data.length === 0 && emptyState;
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full divide-y divide-slate-200" role="grid">
+        {caption && <caption className="sr-only">{caption}</caption>}
+        <thead className="bg-slate-50">
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                scope="col"
+                className={clsx(
+                  "px-4 py-3 text-left text-sm font-semibold text-slate-700",
+                  column.align === "center" && "text-center",
+                  column.align === "right" && "text-right",
+                  column.headerClassName,
+                )}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-200 bg-white" role="rowgroup">
+          {data.map((item) => {
+            const id = getRowId(item);
+            return (
+              <tr
+                key={id}
+                className={clsx(
+                  "transition hover:bg-slate-50 focus-within:bg-slate-100",
+                  onRowClick && "cursor-pointer",
+                )}
+                tabIndex={onRowClick ? 0 : undefined}
+                onClick={() => onRowClick?.(item)}
+                onKeyDown={(event) => {
+                  if (!onRowClick) return;
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    onRowClick(item);
+                  }
+                }}
+              >
+                {columns.map((column) => (
+                  <td
+                    key={column.key}
+                    className={clsx(
+                      "whitespace-nowrap px-4 py-3 text-sm text-slate-700",
+                      column.align === "center" && "text-center",
+                      column.align === "right" && "text-right",
+                      column.className,
+                    )}
+                    aria-label={column.cellLabel?.(item)}
+                  >
+                    {column.render ? column.render(item) : (item as Record<string, unknown>)[column.key]}
+                  </td>
+                ))}
+              </tr>
+            );
+          })}
+          {showEmptyState && (
+            <tr>
+              <td colSpan={columns.length} className="px-4 py-6 text-center text-sm text-slate-600">
+                {emptyState}
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      {footer && <div className="border-t border-slate-200 bg-slate-50 p-3">{footer}</div>}
+    </div>
+  );
+}

--- a/apps/web/console/src/components/Drawer.tsx
+++ b/apps/web/console/src/components/Drawer.tsx
@@ -1,0 +1,113 @@
+import { ReactNode, useEffect, useRef } from "react";
+import { createPortal } from "react-dom";
+
+export interface DrawerProps {
+  open: boolean;
+  title: string;
+  description?: string;
+  onClose: () => void;
+  children: ReactNode;
+  footer?: ReactNode;
+  ariaLabel?: string;
+}
+
+export function Drawer({ open, title, description, onClose, children, footer, ariaLabel }: DrawerProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocused = useRef<Element | null>(null);
+
+  useEffect(() => {
+    if (open) {
+      previouslyFocused.current = document.activeElement;
+      const container = containerRef.current;
+      const focusable = container?.querySelector<HTMLElement>("button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])");
+      focusable?.focus();
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+      if (previouslyFocused.current instanceof HTMLElement) {
+        previouslyFocused.current.focus();
+      }
+    }
+
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!open) return;
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+      if (event.key === "Tab" && containerRef.current) {
+        const focusableElements = Array.from(
+          containerRef.current.querySelectorAll<HTMLElement>(
+            "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])",
+          ),
+        ).filter((element) => !element.hasAttribute("disabled"));
+        if (focusableElements.length === 0) {
+          event.preventDefault();
+          return;
+        }
+        const first = focusableElements[0];
+        const last = focusableElements[focusableElements.length - 1];
+        if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        } else if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return createPortal(
+    <div
+      role="presentation"
+      className="fixed inset-0 z-50 flex items-start justify-end bg-slate-900/30 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <aside
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="drawer-title"
+        aria-label={ariaLabel}
+        className="h-full w-full max-w-3xl transform bg-white shadow-xl transition focus:outline-none sm:rounded-l-2xl"
+        onClick={(event) => event.stopPropagation()}
+        ref={containerRef}
+      >
+        <header className="border-b border-slate-200 px-6 py-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 id="drawer-title" className="text-lg font-semibold text-slate-900">
+                {title}
+              </h2>
+              {description && <p className="mt-1 text-sm text-slate-600">{description}</p>}
+            </div>
+            <button
+              type="button"
+              className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-transparent text-slate-500 transition hover:bg-slate-100 hover:text-slate-700 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60"
+              onClick={onClose}
+              aria-label="Close drawer"
+            >
+              ×
+            </button>
+          </div>
+        </header>
+        <div className="flex h-[calc(100%-4rem)] flex-col">
+          <div className="flex-1 overflow-y-auto px-6 py-4 text-sm text-slate-700">{children}</div>
+          {footer && <footer className="border-t border-slate-200 px-6 py-4">{footer}</footer>}
+        </div>
+      </aside>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/console/src/components/JsonViewer.tsx
+++ b/apps/web/console/src/components/JsonViewer.tsx
@@ -1,0 +1,27 @@
+import { ReactNode, useMemo } from "react";
+
+export interface JsonViewerProps {
+  value: unknown;
+  title?: string;
+  footer?: ReactNode;
+  maxHeight?: number;
+}
+
+export function JsonViewer({ value, title, footer, maxHeight = 320 }: JsonViewerProps) {
+  const formatted = useMemo(() => JSON.stringify(value, null, 2), [value]);
+
+  return (
+    <div className="flex flex-col overflow-hidden rounded-lg border border-slate-200 bg-slate-950/90 text-slate-100">
+      {title && <div className="border-b border-slate-800 px-4 py-2 text-xs font-semibold uppercase tracking-wider">{title}</div>}
+      <pre
+        className="flex-1 overflow-auto px-4 py-3 text-xs leading-relaxed"
+        style={{ maxHeight }}
+        role="log"
+        aria-live="polite"
+      >
+        {formatted}
+      </pre>
+      {footer && <div className="border-t border-slate-800 bg-slate-900/80 px-4 py-2 text-xs text-slate-400">{footer}</div>}
+    </div>
+  );
+}

--- a/apps/web/console/src/components/Tag.tsx
+++ b/apps/web/console/src/components/Tag.tsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import { ReactNode } from "react";
+
+type TagTone = "default" | "success" | "warning" | "danger" | "info";
+
+const toneClasses: Record<TagTone, string> = {
+  default: "bg-slate-100 text-slate-800 ring-slate-200",
+  success: "bg-emerald-100 text-emerald-800 ring-emerald-200",
+  warning: "bg-amber-100 text-amber-800 ring-amber-200",
+  danger: "bg-rose-100 text-rose-800 ring-rose-200",
+  info: "bg-blue-100 text-blue-800 ring-blue-200",
+};
+
+export interface TagProps {
+  tone?: TagTone;
+  children: ReactNode;
+  className?: string;
+  title?: string;
+}
+
+export function Tag({ tone = "default", children, className, title }: TagProps) {
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-xs font-semibold ring-1 ring-inset",
+        toneClasses[tone],
+        className,
+      )}
+      role="status"
+      aria-label={typeof children === "string" ? children : title}
+      title={title}
+    >
+      {children}
+    </span>
+  );
+}

--- a/apps/web/console/src/components/ToastProvider.tsx
+++ b/apps/web/console/src/components/ToastProvider.tsx
@@ -1,0 +1,123 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { createPortal } from "react-dom";
+import clsx from "clsx";
+
+type ToastTone = "neutral" | "success" | "danger" | "warning" | "info";
+
+export interface ToastOptions {
+  title: string;
+  description?: string;
+  tone?: ToastTone;
+  durationMs?: number;
+}
+
+interface ToastInternal extends ToastOptions {
+  id: string;
+}
+
+interface ToastContextValue {
+  pushToast: (options: ToastOptions) => void;
+  dismissToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+const toneClasses: Record<ToastTone, string> = {
+  neutral: "border-slate-200 bg-white text-slate-900",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-900",
+  danger: "border-rose-200 bg-rose-50 text-rose-900",
+  warning: "border-amber-200 bg-amber-50 text-amber-900",
+  info: "border-blue-200 bg-blue-50 text-blue-900",
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<ToastInternal[]>([]);
+  const toastId = useRef(0);
+
+  const pushToast = useCallback((options: ToastOptions) => {
+    setToasts((current) => {
+      const id = `toast-${toastId.current++}`;
+      const tone = options.tone ?? "neutral";
+      const toast: ToastInternal = {
+        ...options,
+        id,
+        tone,
+        durationMs: options.durationMs ?? 5000,
+      };
+      return [...current, toast];
+    });
+  }, []);
+
+  const dismissToast = useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const value = useMemo(() => ({ pushToast, dismissToast }), [pushToast, dismissToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      {createPortal(
+        <div
+          className="pointer-events-none fixed inset-x-0 top-4 z-50 flex flex-col items-center gap-3"
+          role="status"
+          aria-live="polite"
+        >
+          {toasts.map((toast) => (
+            <ToastItem key={toast.id} toast={toast} onDismiss={dismissToast} />
+          ))}
+        </div>,
+        document.body,
+      )}
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within a ToastProvider");
+  }
+  return context;
+}
+
+function ToastItem({ toast, onDismiss }: { toast: ToastInternal; onDismiss: (id: string) => void }) {
+  useEffect(() => {
+    const timeout = window.setTimeout(() => onDismiss(toast.id), toast.durationMs);
+    return () => window.clearTimeout(timeout);
+  }, [onDismiss, toast.durationMs, toast.id]);
+
+  return (
+    <div
+      className={clsx(
+        "pointer-events-auto w-full max-w-sm overflow-hidden rounded-lg border px-4 py-3 shadow-lg",
+        toneClasses[toast.tone ?? "neutral"],
+      )}
+      role="alert"
+    >
+      <div className="flex items-start gap-3">
+        <div className="flex-1">
+          <p className="text-sm font-semibold">{toast.title}</p>
+          {toast.description && <p className="mt-1 text-xs text-slate-700">{toast.description}</p>}
+        </div>
+        <button
+          type="button"
+          className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-white/60 text-xs font-semibold text-slate-700 transition hover:bg-white"
+          onClick={() => onDismiss(toast.id)}
+          aria-label="Dismiss notification"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/console/src/components/index.ts
+++ b/apps/web/console/src/components/index.ts
@@ -1,0 +1,7 @@
+export * from "./ConfirmModal";
+export * from "./CopyToClipboard";
+export * from "./DataGrid";
+export * from "./Drawer";
+export * from "./JsonViewer";
+export * from "./Tag";
+export * from "./ToastProvider";

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,25 @@
-﻿import React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import App from "./App";
+import { ToastProvider } from "./components";
 
-function App() {
-  return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
-    </div>
-  );
+const queryClient = new QueryClient();
+
+const rootElement = document.getElementById("root");
+if (!rootElement) {
+  throw new Error("Root element not found");
 }
-createRoot(document.getElementById("root")!).render(<App />);
+
+createRoot(rootElement).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <ToastProvider>
+          <App />
+        </ToastProvider>
+      </BrowserRouter>
+    </QueryClientProvider>
+  </React.StrictMode>,
+);

--- a/apps/web/console/src/pages/Audit.tsx
+++ b/apps/web/console/src/pages/Audit.tsx
@@ -1,0 +1,177 @@
+import { FormEvent, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
+import { api, AuditEvent } from "../api";
+import { CopyToClipboard, JsonViewer, Tag } from "../components";
+import { formatDateTime } from "../utils/format";
+
+const levelTone: Record<string, "info" | "warning" | "danger" | "success"> = {
+  info: "info",
+  debug: "info",
+  warn: "warning",
+  error: "danger",
+  critical: "danger",
+  success: "success",
+};
+
+export function AuditPage() {
+  const [events, setEvents] = useState<AuditEvent[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [filters, setFilters] = useState({ level: "", traceId: "", queue: "" });
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+    async function load() {
+      setIsStreaming(true);
+      setError(null);
+      setEvents([]);
+      try {
+        for await (const event of api.streamAuditEvents(filters, controller.signal)) {
+          if (cancelled) break;
+          setEvents((current) => [...current, event]);
+        }
+      } catch (streamError) {
+        if (!cancelled) {
+          const message = streamError instanceof Error ? streamError.message : "Unable to read audit stream";
+          setError(message);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsStreaming(false);
+        }
+      }
+    }
+    load();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [filters]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const level = formData.get("level");
+    const traceId = formData.get("traceId");
+    const queue = formData.get("queue");
+    setFilters({
+      level: typeof level === "string" ? level : "",
+      traceId: typeof traceId === "string" ? traceId : "",
+      queue: typeof queue === "string" ? queue : "",
+    });
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Audit explorer</h1>
+          <p className="text-sm text-slate-600">
+            Streaming JSONL records directly from the server. Use filters to scope by severity, queue, or trace.
+          </p>
+        </div>
+        <div className="rounded-full bg-slate-100 px-4 py-1 text-xs font-semibold text-slate-600">
+          {isStreaming ? "Streaming" : "Idle"}
+        </div>
+      </header>
+
+      <form className="grid gap-3 sm:grid-cols-4" onSubmit={handleSubmit} role="search">
+        <label className="flex flex-col text-xs font-semibold text-slate-600">
+          Level
+          <select
+            name="level"
+            defaultValue={filters.level}
+            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500/30"
+          >
+            <option value="">All</option>
+            <option value="info">Info</option>
+            <option value="warn">Warning</option>
+            <option value="error">Error</option>
+            <option value="critical">Critical</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-xs font-semibold text-slate-600">
+          Queue
+          <select
+            name="queue"
+            defaultValue={filters.queue}
+            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500/30"
+          >
+            <option value="">All</option>
+            <option value="anomalies">Anomalies</option>
+            <option value="unreconciled">Unreconciled</option>
+            <option value="dlq">DLQ</option>
+          </select>
+        </label>
+        <label className="flex flex-col text-xs font-semibold text-slate-600">
+          Trace ID
+          <input
+            name="traceId"
+            defaultValue={filters.traceId}
+            placeholder="trace_01F…"
+            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500/30"
+          />
+        </label>
+        <div className="flex items-end">
+          <button
+            type="submit"
+            className="inline-flex w-full items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60"
+          >
+            Apply filters
+          </button>
+        </div>
+      </form>
+
+      {error && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900" role="alert">
+          {error}
+        </p>
+      )}
+
+      <section className="space-y-4">
+        <header className="flex items-center justify-between text-xs text-slate-500">
+          <span>{events.length} records</span>
+          {isStreaming && <span className="text-blue-600">Streaming in progress…</span>}
+        </header>
+        <div className="max-h-[480px] overflow-y-auto rounded-lg border border-slate-200 bg-slate-950 text-slate-100">
+          <ol className="divide-y divide-slate-800" aria-live="polite">
+            {events.map((event, index) => (
+              <li key={`${event.timestamp}-${index}`} className="p-4">
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="flex items-center gap-3">
+                    <Tag tone={levelTone[event.level] ?? "info"}>{event.level.toUpperCase()}</Tag>
+                    <span className="text-xs text-slate-400">{formatDateTime(event.timestamp)}</span>
+                  </div>
+                  {event.traceId && (
+                    <div className="flex items-center gap-2 text-xs">
+                      <Link
+                        to={{ pathname: "/queues", search: `?trace=${encodeURIComponent(event.traceId)}` }}
+                        className="text-blue-300 underline"
+                      >
+                        View trace
+                      </Link>
+                      <CopyToClipboard value={event.traceId} label="Copy" />
+                    </div>
+                  )}
+                </div>
+                <p className="mt-2 text-sm text-slate-100">{event.message}</p>
+                {event.context && (
+                  <details className="mt-3 text-xs text-slate-300">
+                    <summary className="cursor-pointer text-slate-200">Context</summary>
+                    <div className="mt-2">
+                      <JsonViewer value={event.context} maxHeight={240} />
+                    </div>
+                  </details>
+                )}
+              </li>
+            ))}
+            {events.length === 0 && !isStreaming && (
+              <li className="p-4 text-sm text-slate-400">No audit records match the current filters.</li>
+            )}
+          </ol>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/console/src/pages/Bas.tsx
+++ b/apps/web/console/src/pages/Bas.tsx
@@ -1,0 +1,244 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { api, BasEvidence, decodeCompactJwsPayload } from "../api";
+import { ConfirmModal, Drawer, JsonViewer, Tag, useToast } from "../components";
+import { formatCurrency, formatDateTime, formatRelativeSeconds } from "../utils/format";
+
+export function BasPage() {
+  const queryClient = useQueryClient();
+  const { pushToast } = useToast();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [confirmDryRun, setConfirmDryRun] = useState(false);
+  const [evidenceDrawer, setEvidenceDrawer] = useState<{ open: boolean; evidence?: BasEvidence; loading: boolean }>(
+    { open: false, evidence: undefined, loading: false },
+  );
+
+  const { data: status, isLoading, error } = useQuery({
+    queryKey: ["bas-status"],
+    queryFn: () => api.getBasStatus(),
+    staleTime: 30_000,
+  });
+
+  const issueMutation = useMutation({
+    mutationFn: ({ dryRun }: { dryRun: boolean }) => api.issueBasRpt({ dryRun }),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ["bas-status"] });
+      if (response.evidence) {
+        setEvidenceDrawer({ open: true, evidence: response.evidence, loading: false });
+      }
+      pushToast({
+        title: response.message,
+        description: response.status.canUndo ? "Undo is now available." : undefined,
+        tone: "success",
+      });
+    },
+    onError: (mutationError: unknown) => {
+      const message = mutationError instanceof Error ? mutationError.message : "Unable to issue RPT";
+      pushToast({ title: "Issue failed", description: message, tone: "danger" });
+    },
+  });
+
+  const undoMutation = useMutation({
+    mutationFn: () => api.undoBasRpt(),
+    onSuccess: (response) => {
+      queryClient.invalidateQueries({ queryKey: ["bas-status"] });
+      pushToast({ title: response.message, tone: "info" });
+    },
+    onError: (mutationError: unknown) => {
+      const message = mutationError instanceof Error ? mutationError.message : "Unable to undo";
+      pushToast({ title: "Undo failed", description: message, tone: "danger" });
+    },
+  });
+
+  const totals = status?.totals;
+  const decodedEvidence = useMemo(() => {
+    if (!evidenceDrawer.evidence) return undefined;
+    try {
+      const decoded = decodeCompactJwsPayload(evidenceDrawer.evidence.compactJws);
+      return { ...decoded, merkleRoot: evidenceDrawer.evidence.merkleRoot, traceId: evidenceDrawer.evidence.traceId };
+    } catch (decodeError) {
+      pushToast({
+        title: "Unable to decode evidence",
+        description: decodeError instanceof Error ? decodeError.message : "Invalid payload",
+        tone: "danger",
+      });
+      return undefined;
+    }
+  }, [evidenceDrawer.evidence, pushToast]);
+
+  async function openEvidence(traceId: string) {
+    setEvidenceDrawer({ open: true, loading: true, evidence: undefined });
+    try {
+      const evidence = await api.getEvidence(traceId);
+      setEvidenceDrawer({ open: true, evidence, loading: false });
+    } catch (fetchError) {
+      pushToast({
+        title: "Evidence unavailable",
+        description: fetchError instanceof Error ? fetchError.message : "Unable to load evidence",
+        tone: "danger",
+      });
+      setEvidenceDrawer({ open: false, evidence: undefined, loading: false });
+    }
+  }
+
+  function handleIssue(dryRun: boolean) {
+    setConfirmDryRun(dryRun);
+    setShowConfirm(true);
+  }
+
+  function confirmIssue() {
+    issueMutation.mutate({ dryRun: confirmDryRun });
+    setShowConfirm(false);
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex flex-wrap items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h1 className="text-xl font-semibold text-slate-900">Business Activity Statement</h1>
+            <p className="text-sm text-slate-600">
+              Rates pinned to <strong>v{status?.pinnedRatesVersion ?? "—"}</strong>
+            </p>
+            {status && (
+              <div className="flex flex-wrap items-center gap-3 text-xs text-slate-500">
+                <span>
+                  Next submission in {formatRelativeSeconds(status.countdown.secondsRemaining)}
+                </span>
+                <span>Scheduled {formatDateTime(status.countdown.nextSubmissionUtc)}</span>
+                {status.lastIssuedAt && <span>Last issued {formatDateTime(status.lastIssuedAt)}</span>}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col items-stretch gap-3">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60 disabled:cursor-not-allowed disabled:bg-slate-200 disabled:text-slate-500"
+              disabled={Boolean(status?.issueDisabledReason) || issueMutation.isPending || isLoading}
+              onClick={() => handleIssue(false)}
+              aria-disabled={Boolean(status?.issueDisabledReason)}
+              aria-describedby={status?.issueDisabledReason ? "issue-disabled-reason" : undefined}
+            >
+              Issue RPT
+            </button>
+            {status?.issueDisabledReason && (
+              <span id="issue-disabled-reason" className="text-xs text-rose-600">
+                {status.issueDisabledReason}
+              </span>
+            )}
+            {status?.dryRunAvailable && (
+              <button
+                type="button"
+                className="inline-flex items-center justify-center rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60"
+                onClick={() => handleIssue(true)}
+                disabled={issueMutation.isPending}
+              >
+                Dry-run
+              </button>
+            )}
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-100 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60 disabled:cursor-not-allowed disabled:text-slate-400"
+              onClick={() => undoMutation.mutate()}
+              disabled={!status?.canUndo || undoMutation.isPending}
+            >
+              Undo last issue
+            </button>
+          </div>
+        </div>
+      </header>
+
+      <section className="grid gap-4 lg:grid-cols-3">
+        <TotalsCard title="Collected" value={totals ? formatCurrency(totals.collected, totals.currency) : "—"} />
+        <TotalsCard title="Remitted" value={totals ? formatCurrency(totals.remitted, totals.currency) : "—"} />
+        <TotalsCard title="Outstanding" value={totals ? formatCurrency(totals.outstanding, totals.currency) : "—"} />
+      </section>
+
+      {status?.canUndo && (
+        <div className="rounded-lg border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+          <p className="font-medium">Latest submission is awaiting confirmation.</p>
+          <p>
+            Trace evidence is available for review. Use undo if submission was triggered in error.
+          </p>
+          {status.latestTraceId && (
+            <button
+              type="button"
+              className="mt-3 inline-flex items-center gap-2 rounded-md border border-blue-300 px-3 py-1.5 text-xs font-semibold text-blue-800 hover:bg-blue-100"
+              onClick={() => openEvidence(status.latestTraceId!)}
+            >
+              View evidence
+            </button>
+          )}
+        </div>
+      )}
+
+      {isLoading && <p className="text-sm text-slate-600">Fetching BAS totals…</p>}
+      {error && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
+          Unable to load BAS status.
+        </p>
+      )}
+
+      <ConfirmModal
+        open={showConfirm}
+        title={confirmDryRun ? "Confirm BAS dry-run" : "Confirm BAS submission"}
+        description={
+          confirmDryRun
+            ? "A dry-run will validate totals and evidence without issuing the RPT."
+            : "Issuing will submit totals using the pinned rates version."
+        }
+        confirmLabel={confirmDryRun ? "Run dry-run" : "Issue RPT"}
+        onCancel={() => setShowConfirm(false)}
+        onConfirm={confirmIssue}
+        danger={!confirmDryRun}
+      >
+        <p>
+          Totals are calculated with <Tag tone="info">Rates v{status?.pinnedRatesVersion ?? "?"}</Tag>.
+        </p>
+        <p className="mt-2 text-slate-600">
+          Ensure supporting documents are ready. Evidence will be generated upon completion.
+        </p>
+      </ConfirmModal>
+
+      <Drawer
+        open={evidenceDrawer.open}
+        onClose={() => setEvidenceDrawer({ open: false, evidence: undefined, loading: false })}
+        title="Submission evidence"
+        description="Decoded payload from the compact JWS"
+      >
+        {evidenceDrawer.loading && <p className="text-sm text-slate-600">Loading evidence…</p>}
+        {!evidenceDrawer.loading && evidenceDrawer.evidence && (
+          <div className="space-y-4">
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+              <dl className="grid grid-cols-1 gap-2 text-xs sm:grid-cols-2">
+                <div>
+                  <dt className="font-semibold text-slate-600">Trace ID</dt>
+                  <dd className="break-all">{evidenceDrawer.evidence.traceId}</dd>
+                </div>
+                <div>
+                  <dt className="font-semibold text-slate-600">Merkle root</dt>
+                  <dd className="break-all">{evidenceDrawer.evidence.merkleRoot}</dd>
+                </div>
+              </dl>
+            </div>
+            {decodedEvidence && (
+              <JsonViewer value={decodedEvidence} title="Decoded payload" maxHeight={360} />
+            )}
+          </div>
+        )}
+        {!evidenceDrawer.loading && !evidenceDrawer.evidence && (
+          <p className="text-sm text-slate-600">No evidence payload available.</p>
+        )}
+      </Drawer>
+    </div>
+  );
+}
+
+function TotalsCard({ title, value }: { title: string; value: string }) {
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-5 shadow-sm" aria-live="polite">
+      <h3 className="text-sm font-semibold text-slate-600">{title}</h3>
+      <p className="mt-2 text-2xl font-semibold text-slate-900">{value}</p>
+    </article>
+  );
+}

--- a/apps/web/console/src/pages/Dashboard.tsx
+++ b/apps/web/console/src/pages/Dashboard.tsx
@@ -1,0 +1,106 @@
+import { ReactNode } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
+import { Tag } from "../components";
+import { formatDateTime, formatRelativeSeconds } from "../utils/format";
+
+const severityTone: Record<string, "info" | "warning" | "danger"> = {
+  info: "info",
+  warning: "warning",
+  critical: "danger",
+};
+
+export function DashboardPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["dashboard"],
+    queryFn: () => api.getDashboardSummary(),
+    staleTime: 30_000,
+  });
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-600">Loading dashboard…</p>;
+  }
+
+  if (error || !data) {
+    return (
+      <div className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
+        Unable to load dashboard data.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+        <DashboardCard title="Next BAS submission" description={`Rates v${data.basCountdown.ratesVersion}`}>
+          <p className="text-3xl font-semibold text-slate-900" aria-live="polite">
+            {formatRelativeSeconds(data.basCountdown.secondsRemaining)}
+          </p>
+          <p className="mt-2 text-sm text-slate-600">
+            Scheduled for {formatDateTime(data.basCountdown.nextSubmissionUtc)}
+          </p>
+        </DashboardCard>
+        <DashboardCard title="Today's RPTs" description="Issued / Pending / Total">
+          <p className="text-3xl font-semibold text-slate-900">
+            {data.todaysRpts.issued} / {data.todaysRpts.pending} / {data.todaysRpts.total}
+          </p>
+        </DashboardCard>
+        <DashboardCard title="Unreconciled" description="Anomalies / Unreconciled / DLQ">
+          <p className="text-3xl font-semibold text-slate-900">
+            {data.unreconciledCounts.anomalies} / {data.unreconciledCounts.unreconciled} / {data.unreconciledCounts.dlq}
+          </p>
+        </DashboardCard>
+        <DashboardCard title="Anomaly blocks" description="Highest severity signals">
+          <p className="text-3xl font-semibold text-slate-900">{data.anomalyBlocks.length}</p>
+        </DashboardCard>
+      </div>
+
+      <section aria-labelledby="anomaly-blocks" className="space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 id="anomaly-blocks" className="text-base font-semibold text-slate-900">
+            Active anomaly blocks
+          </h2>
+          <p className="text-xs text-slate-500">Last updated {formatDateTime(new Date().toISOString())}</p>
+        </div>
+        <div className="grid gap-4 lg:grid-cols-2">
+          {data.anomalyBlocks.map((block) => (
+            <article key={block.id} className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-sm font-semibold text-slate-900">{block.name}</h3>
+                  <p className="mt-1 text-sm text-slate-600">{block.description}</p>
+                </div>
+                <Tag tone={severityTone[block.severity] ?? "warning"}>{block.severity.toUpperCase()}</Tag>
+              </div>
+              <dl className="mt-3 flex flex-wrap gap-6 text-xs text-slate-500">
+                <div>
+                  <dt className="font-medium text-slate-700">Updated</dt>
+                  <dd>{formatDateTime(block.updatedAt)}</dd>
+                </div>
+                <div>
+                  <dt className="font-medium text-slate-700">Queue</dt>
+                  <dd>{block.id}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+          {data.anomalyBlocks.length === 0 && (
+            <p className="col-span-full rounded-lg border border-slate-200 bg-slate-50 p-6 text-center text-sm text-slate-600">
+              No anomaly blocks detected.
+            </p>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function DashboardCard({ title, description, children }: { title: string; description?: string; children: ReactNode }) {
+  return (
+    <article className="rounded-lg border border-slate-200 bg-white p-4 shadow-sm" aria-live="polite">
+      <h3 className="text-sm font-semibold text-slate-600">{title}</h3>
+      {description && <p className="text-xs text-slate-400">{description}</p>}
+      <div className="mt-3">{children}</div>
+    </article>
+  );
+}

--- a/apps/web/console/src/pages/Queues.tsx
+++ b/apps/web/console/src/pages/Queues.tsx
@@ -1,0 +1,266 @@
+import { useQuery } from "@tanstack/react-query";
+import { FormEvent, useEffect, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { api, QueueItem } from "../api";
+import { CopyToClipboard, DataGrid, Drawer, JsonViewer, Tag } from "../components";
+import { formatDateTime } from "../utils/format";
+
+const queueLabels: Record<QueueItem["type"], string> = {
+  anomaly: "Anomalies",
+  unreconciled: "Unreconciled",
+  dlq: "Dead letter",
+};
+
+const severityTone: Record<string, "info" | "warning" | "danger"> = {
+  info: "info",
+  low: "info",
+  medium: "warning",
+  high: "danger",
+  critical: "danger",
+};
+
+const statusOptions = [
+  { label: "All statuses", value: "" },
+  { label: "New", value: "new" },
+  { label: "Investigating", value: "investigating" },
+  { label: "Resolved", value: "resolved" },
+];
+
+export function QueuesPage() {
+  const [queue, setQueue] = useState<"anomalies" | "unreconciled" | "dlq">("anomalies");
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState("");
+  const [searchParams, setSearchParams] = useSearchParams();
+  const initialTrace = searchParams.get("trace") ?? "";
+  const [search, setSearch] = useState(initialTrace);
+  const [searchField, setSearchField] = useState(initialTrace);
+  const [selected, setSelected] = useState<QueueItem | null>(null);
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["queues", queue, page, status, search],
+    queryFn: () => api.getQueueItems({ queue, page, pageSize: 20, status, search }),
+    keepPreviousData: true,
+  });
+
+  const totalPages = data?.totalPages ?? 1;
+
+  const rows = useMemo(() => data?.items ?? [], [data]);
+
+  const traceParam = searchParams.get("trace");
+
+  useEffect(() => {
+    if (traceParam) {
+      setSearch(traceParam);
+      setSearchField(traceParam);
+      setPage(1);
+      setSearchParams({}, { replace: true });
+    }
+  }, [traceParam, setSearchParams]);
+
+  useEffect(() => {
+    setSearchField(search);
+  }, [search]);
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSearch(searchField);
+    setPage(1);
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">Queues</h1>
+          <p className="text-sm text-slate-600">Investigate anomalies, reconcile outstanding payments, and clear DLQ items.</p>
+        </div>
+        <nav className="flex gap-2" aria-label="Queue types">
+          <QueueTab
+            label="Anomalies"
+            active={queue === "anomalies"}
+            onClick={() => {
+              setQueue("anomalies");
+              setPage(1);
+            }}
+          />
+          <QueueTab
+            label="Unreconciled"
+            active={queue === "unreconciled"}
+            onClick={() => {
+              setQueue("unreconciled");
+              setPage(1);
+            }}
+          />
+          <QueueTab
+            label="DLQ"
+            active={queue === "dlq"}
+            onClick={() => {
+              setQueue("dlq");
+              setPage(1);
+            }}
+          />
+        </nav>
+      </header>
+
+      <form className="flex flex-wrap items-end gap-3" onSubmit={handleSubmit} role="search">
+        <label className="flex flex-1 min-w-[200px] flex-col text-xs font-semibold text-slate-600">
+          Search
+          <input
+            name="search"
+            value={searchField}
+            onChange={(event) => setSearchField(event.target.value)}
+            type="search"
+            placeholder="Customer, reference, trace id…"
+            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500/30"
+          />
+        </label>
+        <label className="flex w-48 flex-col text-xs font-semibold text-slate-600">
+          Status
+          <select
+            value={status}
+            onChange={(event) => {
+              setStatus(event.target.value);
+              setPage(1);
+            }}
+            className="mt-1 rounded-md border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500/30"
+          >
+            {statusOptions.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <button
+          type="submit"
+          className="inline-flex items-center rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-800 focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60"
+        >
+          Apply
+        </button>
+      </form>
+
+      {error && (
+        <p className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
+          Unable to load queue data.
+        </p>
+      )}
+
+      <DataGrid
+        data={rows}
+        getRowId={(item) => item.id}
+        caption={`${queue === "anomalies" ? "Anomalies" : queue === "unreconciled" ? "Unreconciled" : "Dead letter"} queue`}
+        emptyState={<span>No items in this queue.</span>}
+        onRowClick={setSelected}
+        columns={[
+          {
+            key: "title",
+            header: "Title",
+            render: (item) => (
+              <div>
+                <p className="font-medium text-slate-900">{item.title}</p>
+                <p className="text-xs text-slate-500">Updated {formatDateTime(item.updatedAt)}</p>
+              </div>
+            ),
+          },
+          {
+            key: "severity",
+            header: "Severity",
+            render: (item) => <Tag tone={severityTone[item.severity] ?? "info"}>{item.severity.toUpperCase()}</Tag>,
+          },
+          {
+            key: "status",
+            header: "Status",
+            render: (item) => (item.status ? <span className="text-sm text-slate-700">{item.status}</span> : <span className="text-slate-400">—</span>),
+          },
+          {
+            key: "traceId",
+            header: "Trace",
+            render: (item) =>
+              item.traceId ? (
+                <button
+                  type="button"
+                  className="text-xs font-semibold text-blue-600 hover:underline"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    setSelected(item);
+                  }}
+                >
+                  {item.traceId.slice(0, 12)}…
+                </button>
+              ) : (
+                <span className="text-slate-400">—</span>
+              ),
+          },
+        ]}
+        footer={
+          <div className="flex items-center justify-between text-xs text-slate-600">
+            <span>
+              Page {data?.page ?? 1} of {totalPages}
+            </span>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setPage((value) => Math.max(1, value - 1))}
+                disabled={page <= 1 || isLoading}
+                className="inline-flex items-center rounded-md border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                onClick={() => setPage((value) => (data && value < totalPages ? value + 1 : value))}
+                disabled={!data || page >= totalPages || isLoading}
+                className="inline-flex items-center rounded-md border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-700 transition hover:bg-slate-100 disabled:cursor-not-allowed disabled:text-slate-400"
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        }
+      />
+
+      <Drawer
+        open={Boolean(selected)}
+        onClose={() => setSelected(null)}
+        title={selected?.title ?? "Queue item"}
+        description={selected?.summary}
+      >
+        {selected && (
+          <div className="space-y-4 text-sm text-slate-700">
+            <div className="flex flex-wrap items-center gap-3 text-xs">
+              <Tag tone={severityTone[selected.severity] ?? "info"}>{selected.severity.toUpperCase()}</Tag>
+              {selected.status && <Tag tone="info">{selected.status}</Tag>}
+              <span className="text-slate-500">Updated {formatDateTime(selected.updatedAt)}</span>
+            </div>
+            {selected.traceId && (
+              <div className="flex items-center gap-2 text-xs">
+                <span className="font-semibold text-slate-600">Trace</span>
+                <code className="rounded bg-slate-100 px-2 py-1">{selected.traceId}</code>
+                <CopyToClipboard value={selected.traceId} label="Copy trace" />
+              </div>
+            )}
+            {selected.payload && <JsonViewer value={selected.payload} title="Payload" />}
+            <p className="text-xs text-slate-500">
+              Queue: {queueLabels[selected.type]} • Item ID: {selected.id}
+            </p>
+          </div>
+        )}
+      </Drawer>
+    </div>
+  );
+}
+
+function QueueTab({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`inline-flex items-center rounded-full px-4 py-2 text-sm font-semibold transition focus:outline-none focus-visible:ring focus-visible:ring-blue-500/60 ${
+        active ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-700 hover:bg-slate-200"
+      }`}
+      aria-pressed={active}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/web/console/src/pages/Rpts.tsx
+++ b/apps/web/console/src/pages/Rpts.tsx
@@ -1,0 +1,76 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api";
+import { DataGrid, Tag } from "../components";
+import { formatCurrency, formatDateTime } from "../utils/format";
+
+const statusTone: Record<string, "info" | "success" | "warning" | "danger"> = {
+  draft: "info",
+  pending: "warning",
+  issued: "success",
+  failed: "danger",
+};
+
+export function RptsPage() {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["rpts"],
+    queryFn: () => api.getRptSchedule(),
+    staleTime: 15_000,
+  });
+
+  if (isLoading) {
+    return <p className="text-sm text-slate-600">Loading RPT schedule…</p>;
+  }
+
+  if (error || !data) {
+    return (
+      <p className="rounded-md border border-rose-200 bg-rose-50 p-4 text-sm text-rose-900">
+        Unable to load RPT data.
+      </p>
+    );
+  }
+
+  return (
+    <section className="space-y-4">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-semibold text-slate-900">RPT timeline</h1>
+          <p className="text-sm text-slate-600">Monitor lodgement progress and reconcile rate versions.</p>
+        </div>
+      </header>
+      <DataGrid
+        data={data.items}
+        getRowId={(item) => item.id}
+        caption="RPT schedule"
+        emptyState={<span>No RPTs scheduled.</span>}
+        columns={[
+          {
+            key: "period",
+            header: "Period",
+            render: (item) => <span className="font-medium text-slate-900">{item.period}</span>,
+          },
+          {
+            key: "status",
+            header: "Status",
+            render: (item) => <Tag tone={statusTone[item.status] ?? "info"}>{item.status.toUpperCase()}</Tag>,
+          },
+          {
+            key: "issuedAt",
+            header: "Issued",
+            render: (item) => (item.issuedAt ? formatDateTime(item.issuedAt) : <span className="text-slate-400">Pending</span>),
+          },
+          {
+            key: "total",
+            header: "Total",
+            align: "right",
+            render: (item) => formatCurrency(item.total, item.currency),
+          },
+          {
+            key: "ratesVersion",
+            header: "Rates version",
+            render: (item) => <code className="rounded bg-slate-100 px-2 py-1 text-xs">v{item.ratesVersion}</code>,
+          },
+        ]}
+      />
+    </section>
+  );
+}

--- a/apps/web/console/src/pages/Settings.tsx
+++ b/apps/web/console/src/pages/Settings.tsx
@@ -1,0 +1,64 @@
+import { ReactNode } from "react";
+
+export function SettingsPage() {
+  return (
+    <div className="space-y-6">
+      <header>
+        <h1 className="text-xl font-semibold text-slate-900">Console settings</h1>
+        <p className="text-sm text-slate-600">Manage notifications, security controls, and preferences for the BAS console.</p>
+      </header>
+      <section className="grid gap-6 lg:grid-cols-2">
+        <SettingsCard
+          title="Notifications"
+          description="Choose which operational signals to receive by email."
+        >
+          <fieldset className="space-y-3">
+            <legend className="sr-only">Notification preferences</legend>
+            <label className="flex items-center gap-3 text-sm text-slate-700">
+              <input type="checkbox" defaultChecked className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
+              BAS submissions
+            </label>
+            <label className="flex items-center gap-3 text-sm text-slate-700">
+              <input type="checkbox" className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
+              Queue escalations
+            </label>
+            <label className="flex items-center gap-3 text-sm text-slate-700">
+              <input type="checkbox" defaultChecked className="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" />
+              Audit anomalies
+            </label>
+          </fieldset>
+        </SettingsCard>
+        <SettingsCard title="Security" description="Enforce MFA and privileged actions for BAS operations.">
+          <div className="space-y-4 text-sm text-slate-700">
+            <label className="flex items-center justify-between">
+              <span>Require MFA for dry-run</span>
+              <input type="checkbox" className="h-4 w-8 rounded-full border-slate-300 bg-slate-200 focus:ring-blue-500" defaultChecked />
+            </label>
+            <label className="flex items-center justify-between">
+              <span>Session timeout (minutes)</span>
+              <input
+                type="number"
+                min={5}
+                max={240}
+                defaultValue={30}
+                className="w-24 rounded-md border border-slate-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring focus:ring-blue-500/30"
+              />
+            </label>
+          </div>
+        </SettingsCard>
+      </section>
+    </div>
+  );
+}
+
+function SettingsCard({ title, description, children }: { title: string; description: string; children: ReactNode }) {
+  return (
+    <section className="rounded-lg border border-slate-200 bg-white p-6 shadow-sm" aria-label={title}>
+      <header className="mb-4">
+        <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+        <p className="text-sm text-slate-600">{description}</p>
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/apps/web/console/src/pages/index.ts
+++ b/apps/web/console/src/pages/index.ts
@@ -1,0 +1,6 @@
+export * from "./Audit";
+export * from "./Bas";
+export * from "./Dashboard";
+export * from "./Queues";
+export * from "./Rpts";
+export * from "./Settings";

--- a/apps/web/console/src/utils/format.ts
+++ b/apps/web/console/src/utils/format.ts
@@ -1,0 +1,25 @@
+export function formatCurrency(amount: number, currency: string): string {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  }).format(amount);
+}
+
+export function formatDateTime(value: string | Date): string {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return new Intl.DateTimeFormat("en-AU", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export function formatRelativeSeconds(seconds: number): string {
+  if (seconds <= 0) return "now";
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+  return `${minutes}m ${remainingSeconds}s`;
+}


### PR DESCRIPTION
## Summary
- scaffold the console application shell with navigation and new routes for dashboard, BAS, RPTs, queues, audit, and settings
- add a shared API client plus Tailwind-style UI primitives including data grid, drawer, toast provider, tags, and utilities
- implement BAS workflow, dashboard metrics, queue management UI, and audit log streaming with evidence viewers and trace navigation

## Testing
- `npm install` *(fails: registry access is forbidden in this environment)*
- `npm --prefix apps/web/console run build` *(fails: missing React type declarations because packages could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e2644531d48327b5f9a4a248f75b0e