### PR TITLE
feat(console): scaffold tailwind theme

### DIFF
--- a/apps/web/console/README.md
+++ b/apps/web/console/README.md
@@ -1,0 +1,16 @@
+# APGMS Console UI Notes
+
+The console shell is styled with Tailwind CSS tokens backed by CSS variables defined in [`src/globals.css`](./src/globals.css).
+
+## Toggling light / dark
+
+Dark mode is the default palette. To switch to the light palette, add the `.light` class to the `<html>` element (and remove it to return to dark):
+
+```ts
+const { classList } = document.documentElement;
+classList.add("light"); // light mode
+// classList.remove("light"); // dark mode
+// classList.toggle("light"); // flip between modes
+```
+
+All semantic colors (`bg`, `fg`, `accent`, `muted`, etc.), border radii, and shadows draw from those CSS variables so components remain in sync across themes.

--- a/apps/web/console/package-lock.json
+++ b/apps/web/console/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "@apgms/console",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@apgms/console",
+      "version": "0.1.0",
+      "dependencies": {
+        "@tanstack/react-query": "^5.51.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1"
+      },
+      "devDependencies": {
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "autoprefixer": "^10.4.20",
+        "postcss": "^8.4.47",
+        "tailwindcss": "^3.4.14",
+        "typescript": "^5.6.2",
+        "vite": "^5.4.8"
+      }
+    }
+  }
+}

--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -18,6 +18,9 @@
     "typescript": "^5.6.2",
     "vite": "^5.4.8",
     "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0"
+    "@types/react-dom": "^18.3.0",
+    "tailwindcss": "^3.4.14",
+    "postcss": "^8.4.47",
+    "autoprefixer": "^10.4.20"
   }
 }

--- a/apps/web/console/postcss.config.cjs
+++ b/apps/web/console/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/apps/web/console/src/globals.css
+++ b/apps/web/console/src/globals.css
@@ -1,0 +1,91 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+  --font-sans: "Inter", "Segoe UI", system-ui, -apple-system, "BlinkMacSystemFont", "Helvetica Neue", sans-serif;
+  --font-mono: "JetBrains Mono", "Fira Code", "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
+  --color-bg: #05070f;
+  --color-fg: #f8fafc;
+  --color-muted: rgba(248, 250, 252, 0.08);
+  --color-muted-fg: rgba(248, 250, 252, 0.64);
+  --color-muted-border: rgba(248, 250, 252, 0.08);
+  --color-border: rgba(248, 250, 252, 0.12);
+  --color-border-strong: rgba(248, 250, 252, 0.24);
+  --color-accent: #597bff;
+  --color-accent-fg: #0b1020;
+  --color-accent-soft: rgba(89, 123, 255, 0.18);
+  --color-success: #34d399;
+  --color-warning: #facc15;
+  --color-danger: #f87171;
+  --color-info: #38bdf8;
+  --color-overlay: rgba(5, 7, 15, 0.6);
+
+  --radius: 0.75rem;
+  --shadow-sm: 0 1px 2px rgba(5, 7, 15, 0.38);
+  --shadow-md: 0 12px 32px rgba(5, 7, 15, 0.38);
+  --shadow-lg: 0 24px 48px rgba(5, 7, 15, 0.42);
+  --shadow-xl: 0 36px 72px rgba(5, 7, 15, 0.46);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+/* Apply the `light` class to `<html>` to opt into the light palette. */
+:root.light {
+  color-scheme: light;
+  --color-bg: #f1f5f9;
+  --color-fg: #0f172a;
+  --color-muted: rgba(15, 23, 42, 0.06);
+  --color-muted-fg: rgba(15, 23, 42, 0.66);
+  --color-muted-border: rgba(15, 23, 42, 0.08);
+  --color-border: rgba(15, 23, 42, 0.16);
+  --color-border-strong: rgba(15, 23, 42, 0.28);
+  --color-accent: #2563eb;
+  --color-accent-fg: #eff6ff;
+  --color-accent-soft: rgba(37, 99, 235, 0.16);
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-danger: #dc2626;
+  --color-info: #0284c7;
+  --color-overlay: rgba(15, 23, 42, 0.5);
+
+  --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.12);
+  --shadow-md: 0 10px 28px rgba(15, 23, 42, 0.15);
+  --shadow-lg: 0 24px 52px rgba(15, 23, 42, 0.2);
+  --shadow-xl: 0 40px 70px rgba(15, 23, 42, 0.22);
+  --shadow-inset: inset 0 1px 0 rgba(255, 255, 255, 0.86);
+}
+
+@layer base {
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
+  }
+
+  html,
+  body {
+    min-height: 100%;
+  }
+
+  body {
+    margin: 0;
+    font-family: var(--font-sans);
+    background-color: var(--color-bg);
+    color: var(--color-fg);
+    text-rendering: optimizeLegibility;
+  }
+
+  button,
+  input,
+  textarea,
+  select {
+    font: inherit;
+  }
+
+  ::selection {
+    background-color: var(--color-accent);
+    color: var(--color-accent-fg);
+  }
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,39 @@
-﻿import React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
+
+import "./globals.css";
 
 function App() {
   return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
+    <div className="min-h-screen bg-bg text-fg antialiased">
+      <main className="mx-auto flex min-h-screen max-w-5xl flex-col gap-10 px-6 py-12">
+        <header className="space-y-3">
+          <p className="text-sm font-semibold uppercase tracking-[0.25em] text-muted-fg">APGMS</p>
+          <h1 className="text-4xl font-semibold tracking-tight">Console</h1>
+          <p className="max-w-2xl text-lg text-muted-fg">
+            Status tiles and RPT widgets will appear here. (P40, P41, P42)
+          </p>
+        </header>
+
+        <section className="rounded-lg border border-border bg-muted p-6 shadow-sm">
+          <h2 className="text-2xl font-semibold">Coming soon</h2>
+          <p className="mt-2 max-w-3xl text-muted-fg">
+            This surface will light up with live status tiles and reporting widgets as the modules
+            land. Hook your feature shells into the shared design tokens defined in <code>src/globals.css</code>
+            to keep styling consistent.
+          </p>
+        </section>
+      </main>
     </div>
   );
 }
-createRoot(document.getElementById("root")!).render(<App />);
+
+const rootElement = document.getElementById("root");
+
+if (rootElement) {
+  createRoot(rootElement).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: [],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-}
-

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,57 @@
+import type { Config } from "tailwindcss";
+import defaultTheme from "tailwindcss/defaultTheme";
+
+const config: Config = {
+  content: [
+    "./apps/web/console/index.html",
+    "./apps/web/console/src/**/*.{ts,tsx}",
+  ],
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", ...defaultTheme.fontFamily.sans],
+        mono: ["var(--font-mono)", ...defaultTheme.fontFamily.mono],
+      },
+      colors: {
+        bg: "var(--color-bg)",
+        fg: "var(--color-fg)",
+        muted: {
+          DEFAULT: "var(--color-muted)",
+          fg: "var(--color-muted-fg)",
+          border: "var(--color-muted-border)",
+        },
+        border: {
+          DEFAULT: "var(--color-border)",
+          strong: "var(--color-border-strong)",
+        },
+        accent: {
+          DEFAULT: "var(--color-accent)",
+          fg: "var(--color-accent-fg)",
+          soft: "var(--color-accent-soft)",
+        },
+        success: "var(--color-success)",
+        warning: "var(--color-warning)",
+        danger: "var(--color-danger)",
+        info: "var(--color-info)",
+        overlay: "var(--color-overlay)",
+      },
+      borderRadius: {
+        sm: "calc(var(--radius) - 4px)",
+        DEFAULT: "var(--radius)",
+        md: "calc(var(--radius) + 2px)",
+        lg: "calc(var(--radius) + 6px)",
+        xl: "calc(var(--radius) + 10px)",
+      },
+      boxShadow: {
+        sm: "var(--shadow-sm)",
+        DEFAULT: "var(--shadow-md)",
+        lg: "var(--shadow-lg)",
+        xl: "var(--shadow-xl)",
+        inner: "var(--shadow-inset)",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- add tailwindcss, postcss and autoprefixer to the console package along with a placeholder lockfile
- replace the Tailwind configuration with a typed setup, PostCSS config and global design tokens
- update the console root component to consume the new tokens and document the light/dark toggle flow

## Testing
- npm install --package-lock-only --no-audit *(fails: registry returns 403 Forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e264447a5883279267c145a4025ca1