### PR TITLE
Enhance payments release idempotency and allowlist validations

### DIFF
--- a/apps/services/payments/src/bank/eftBpayAdapter.ts
+++ b/apps/services/payments/src/bank/eftBpayAdapter.ts
@@ -8,6 +8,7 @@ type Params = {
   amount_cents: number;
   destination: { bpay_biller?: string; crn?: string; bsb?: string; acct?: string };
   idempotencyKey: string;
+  traceId?: string;
 };
 
 const agent = new https.Agent({
@@ -31,7 +32,8 @@ export async function sendEftOrBpay(p: Params): Promise<{transfer_uuid: string; 
     destination: p.destination
   };
 
-  const headers = { "Idempotency-Key": p.idempotencyKey };
+  const headers: Record<string, string> = { "Idempotency-Key": p.idempotencyKey };
+  if (p.traceId) headers["X-Trace-Id"] = p.traceId;
   const maxAttempts = 3;
   let attempt = 0, lastErr: any;
 

--- a/apps/services/payments/src/bank/paytoAdapter.ts
+++ b/apps/services/payments/src/bank/paytoAdapter.ts
@@ -22,7 +22,9 @@ export async function verifyMandate(mandate_id: string) {
   return r.data;
 }
 export async function debitMandate(mandate_id: string, amount_cents: number, meta: any) {
-  const r = await client.post(`/payto/mandates/${mandate_id}/debit`, { amount_cents, meta });
+  const headers: Record<string, string> = {};
+  if (meta?.traceId) headers["X-Trace-Id"] = meta.traceId;
+  const r = await client.post(`/payto/mandates/${mandate_id}/debit`, { amount_cents, meta }, { headers });
   return r.data;
 }
 export async function cancelMandate(mandate_id: string) {

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -1,93 +1,138 @@
-﻿// apps/services/payments/src/routes/payAto.ts
-import { Request, Response } from 'express';
-import crypto from 'crypto';
-import pg from 'pg'; const { Pool } = pg;
-import { pool } from '../index.js';
+import { Request, Response } from "express";
+import { pool } from "../index.js";
+import { releasePayment, type ReleaseResult } from "../../../../../src/rails/adapter.js";
+import { sendEftOrBpay } from "../bank/eftBpayAdapter.js";
+import { debitMandate } from "../bank/paytoAdapter.js";
 
-function genUUID() {
-  return crypto.randomUUID();
+function normalizeRail(raw: string | undefined): "EFT" | "BPAY" | "PayTo" {
+  const upper = (raw || "EFT").toUpperCase();
+  if (upper === "BPAY") return "BPAY";
+  if (upper === "PAYTO" || upper === "PAYID") return "PayTo";
+  return "EFT";
 }
 
-/**
- * Minimal release path:
- * - Requires rptGate to have attached req.rpt
- * - Inserts a single negative ledger entry for the given period
- * - Sets rpt_verified=true and a unique release_uuid to satisfy constraints
- */
 export async function payAtoRelease(req: Request, res: Response) {
   const { abn, taxType, periodId, amountCents } = req.body || {};
   if (!abn || !taxType || !periodId) {
-    return res.status(400).json({ error: 'Missing abn/taxType/periodId' });
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
   }
 
-  // default a tiny test debit if not provided
-  const amt = Number.isFinite(Number(amountCents)) ? Number(amountCents) : -100;
-
-  // must be negative for a release
+  const amt = Number(amountCents);
+  if (!Number.isFinite(amt)) {
+    return res.status(400).json({ error: "amountCents must be numeric" });
+  }
   if (amt >= 0) {
-    return res.status(400).json({ error: 'amountCents must be negative for a release' });
+    return res.status(400).json({ error: "amountCents must be negative for a release" });
   }
 
-  // rptGate attaches req.rpt when verification succeeds
   const rpt = (req as any).rpt;
-  if (!rpt) {
-    return res.status(403).json({ error: 'RPT not verified' });
+  if (!rpt || !rpt.rpt_id) {
+    return res.status(403).json({ error: "RPT not verified" });
   }
 
-  const client = await pool.connect();
   try {
-    await client.query('BEGIN');
-
-    // compute running balance AFTER this entry:
-    // fetch last balance in this period (by id order), default 0
-    const { rows: lastRows } = await client.query<{
-      balance_after_cents: string | number;
-    }>(
-      `SELECT balance_after_cents
-       FROM owa_ledger
-       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-       ORDER BY id DESC
-       LIMIT 1`,
-      [abn, taxType, periodId]
+    const rptRow = await pool.query<{ payload_c14n: string }>(
+      "SELECT payload_c14n FROM rpt_tokens WHERE id=$1",
+      [rpt.rpt_id]
     );
-    const lastBal = lastRows.length ? Number(lastRows[0].balance_after_cents) : 0;
-    const newBal = lastBal + amt;
+    if (!rptRow.rowCount) {
+      return res.status(403).json({ error: "RPT payload unavailable" });
+    }
+    const payload = JSON.parse(rptRow.rows[0].payload_c14n || "{}") as Record<string, any>;
+    const payloadRail = normalizeRail(String(payload.rail_id ?? payload.rail ?? "EFT"));
+    const reference = String(payload.reference ?? "");
+    const rptAmount = Number(payload.amount_cents ?? 0);
+    const debitAmount = Math.abs(amt);
 
-    const release_uuid = genUUID();
+    if (!reference) {
+      return res.status(400).json({ error: "RPT reference missing" });
+    }
+    if (!Number.isFinite(rptAmount) || rptAmount <= 0) {
+      return res.status(400).json({ error: "RPT amount invalid" });
+    }
+    if (rptAmount !== debitAmount) {
+      return res.status(409).json({ error: "Requested amount does not match RPT" });
+    }
 
-    const insert = `
-      INSERT INTO owa_ledger
-        (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents,
-         rpt_verified, release_uuid, created_at)
-      VALUES ($1,$2,$3,$4,$5,$6, TRUE, $7, now())
-      RETURNING id, transfer_uuid, balance_after_cents
-    `;
-    const transfer_uuid = genUUID();
-    const { rows: ins } = await client.query(insert, [
+    const idempotencyKey = `payato:${abn}:${taxType}:${periodId}`;
+
+    const result: ReleaseResult = await releasePayment(
       abn,
       taxType,
       periodId,
-      transfer_uuid,
-      amt,
-      newBal,
-      release_uuid,
-    ]);
+      debitAmount,
+      payloadRail,
+      reference,
+      {
+        idempotencyKey,
+        callRail: async ({ rail, traceId, destination }) => {
+          if (rail === "EFT") {
+            const dest = {
+              bsb: destination.account_bsb ?? "",
+              acct: destination.account_number ?? "",
+            };
+            const bank = await sendEftOrBpay({
+              abn,
+              taxType,
+              periodId,
+              amount_cents: debitAmount,
+              destination: dest,
+              idempotencyKey,
+              traceId,
+            });
+            return bank;
+          }
+          if (rail === "BPAY") {
+            const dest = {
+              bpay_biller: destination.reference,
+              crn: reference,
+            };
+            const bank = await sendEftOrBpay({
+              abn,
+              taxType,
+              periodId,
+              amount_cents: debitAmount,
+              destination: dest,
+              idempotencyKey,
+              traceId,
+            });
+            return bank;
+          }
+          const mandateId =
+            destination.metadata?.payto?.mandate_id ||
+            destination.metadata?.mandate_id ||
+            destination.reference;
+          if (!mandateId) {
+            throw new Error("PAYTO_MANDATE_UNKNOWN");
+          }
+          const payto = await debitMandate(mandateId, debitAmount, { traceId, abn, taxType, periodId, reference });
+          if (payto.status !== "OK") {
+            throw new Error(`PAYTO_${payto.status}`);
+          }
+          return {
+            providerReceiptId: payto.bank_ref ?? `payto-${traceId.slice(0, 12)}`,
+          };
+        },
+      }
+    );
 
-    await client.query('COMMIT');
-
-    return res.json({
-      ok: true,
-      ledger_id: ins[0].id,
-      transfer_uuid,
-      release_uuid,
-      balance_after_cents: ins[0].balance_after_cents,
-      rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
-    });
-  } catch (e: any) {
-    await client.query('ROLLBACK');
-    // common failures: unique single-release-per-period, allow-list, etc.
-    return res.status(400).json({ error: 'Release failed', detail: String(e?.message || e) });
-  } finally {
-    client.release();
+    return res.json({ ok: result.status === "OK", ...result });
+  } catch (err: any) {
+    const message = String(err?.message || err);
+    if (message === "DEST_NOT_ALLOW_LISTED") {
+      return res.status(403).json({ error: "Destination not allowlisted" });
+    }
+    if (message === "INSUFFICIENT_FUNDS") {
+      return res.status(409).json({ error: message });
+    }
+    if (message === "RELEASE_IN_PROGRESS") {
+      return res.status(409).json({ error: message });
+    }
+    if (message.startsWith("PAYTO_")) {
+      const code = message.slice("PAYTO_".length);
+      const status = code === "INSUFFICIENT_FUNDS" ? 409 : code === "BANK_ERROR" ? 502 : 400;
+      return res.status(status).json({ error: message });
+    }
+    return res.status(400).json({ error: "Release failed", detail: message });
   }
 }

--- a/apps/services/payments/src/utils/allowlist.ts
+++ b/apps/services/payments/src/utils/allowlist.ts
@@ -1,7 +1,36 @@
-﻿import pg from "pg";
-export type Dest = { bsb?: string; acct?: string; bpay_biller?: string; crn?: string };
+import { Pool } from "pg";
+import type { PoolClient } from "pg";
+import {
+  matchAllowlistedDestination as matchRemittanceDestination,
+  resolveDestinationByReference,
+  type AllowlistDestination,
+  type RemittanceDestination,
+  type Rail,
+} from "../../../../../libs/patent/remittance.js";
 
-export function isAllowlisted(abn: string, dest: Dest): boolean {
-  if (dest.bpay_biller === "75556" && dest.crn && dest.crn.length >= 10) return true;
-  return false;
+export type Dest = AllowlistDestination;
+
+const connectionString = process.env.DATABASE_URL;
+const defaultPool = new Pool(connectionString ? { connectionString } : undefined);
+
+function getQueryer(db?: Pool | PoolClient | null): Pool | PoolClient {
+  if (db) return db;
+  return defaultPool;
+}
+
+export async function isAllowlisted(abn: string, dest: Dest, db?: Pool | PoolClient | null): Promise<boolean> {
+  if (!abn || !dest) return false;
+  const queryer = getQueryer(db);
+  const match = await matchRemittanceDestination(queryer, abn, dest);
+  return Boolean(match);
+}
+
+export async function findAllowlistedDestination(abn: string, dest: Dest, db?: Pool | PoolClient | null): Promise<RemittanceDestination | null> {
+  const queryer = getQueryer(db);
+  return matchRemittanceDestination(queryer, abn, dest);
+}
+
+export async function resolveAllowlistedReference(abn: string, rail: Rail, reference: string, db?: Pool | PoolClient | null): Promise<RemittanceDestination | null> {
+  const queryer = getQueryer(db);
+  return resolveDestinationByReference(queryer, abn, rail, reference);
 }

--- a/apps/services/payments/test/allowlist.test.ts
+++ b/apps/services/payments/test/allowlist.test.ts
@@ -1,7 +1,47 @@
-import { isAllowlisted } from "../src/utils/allowlist";
-test("allowlist ok for ATO BPAY", () => {
-  expect(isAllowlisted("123", { bpay_biller:"75556", crn:"12345678901" })).toBe(true);
+import { Pool } from "pg";
+import { isAllowlisted, resolveAllowlistedReference } from "../src/utils/allowlist.js";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const TEST_ABN = "99999999999";
+
+beforeAll(async () => {
+  await pool.query("DELETE FROM remittance_destinations WHERE abn=$1", [TEST_ABN]);
+  await pool.query(
+    `INSERT INTO remittance_destinations (abn,label,rail,reference,account_bsb,account_number)
+     VALUES ($1,'TEST_EFT','EFT','PRN123',$2,$3)
+     ON CONFLICT (abn,rail,reference) DO UPDATE SET account_bsb=EXCLUDED.account_bsb, account_number=EXCLUDED.account_number`,
+    [TEST_ABN, "092-009", "12345678"]
+  );
+  await pool.query(
+    `INSERT INTO remittance_destinations (abn,label,rail,reference,account_number)
+     VALUES ($1,'TEST_BPAY','BPAY','75556',$2)
+     ON CONFLICT (abn,rail,reference) DO UPDATE SET account_number=EXCLUDED.account_number`,
+    [TEST_ABN, JSON.stringify({ crn: { min: 10, max: 15 } })]
+  );
 });
-test("deny non-ATO", () => {
-  expect(isAllowlisted("123", { bsb:"012345", acct:"999999" })).toBe(false);
+
+afterAll(async () => {
+  await pool.query("DELETE FROM remittance_destinations WHERE abn=$1", [TEST_ABN]);
+  await pool.end();
+});
+
+test("allowlist ok for EFT", async () => {
+  await expect(isAllowlisted(TEST_ABN, { bsb: "092-009", acct: "12345678" })).resolves.toBe(true);
+});
+
+test("deny wrong EFT account", async () => {
+  await expect(isAllowlisted(TEST_ABN, { bsb: "092-009", acct: "00000000" })).resolves.toBe(false);
+});
+
+test("allowlist BPAY within CRN range", async () => {
+  await expect(isAllowlisted(TEST_ABN, { bpay_biller: "75556", crn: "12345678901" })).resolves.toBe(true);
+});
+
+test("reject BPAY when CRN too short", async () => {
+  await expect(isAllowlisted(TEST_ABN, { bpay_biller: "75556", crn: "12345" })).resolves.toBe(false);
+});
+
+test("resolve destination by reference", async () => {
+  const dest = await resolveAllowlistedReference(TEST_ABN, "EFT", "PRN123");
+  expect(dest?.account_bsb).toBe("092-009");
 });

--- a/apps/services/payments/test/idempotency.test.ts
+++ b/apps/services/payments/test/idempotency.test.ts
@@ -1,6 +1,45 @@
-import { createHash } from "crypto";
-test("idempotency key stable", () => {
-  const key = "payato:111:PAYGW:2025-09";
-  const h = createHash("sha256").update(key).digest("hex");
-  expect(h).toHaveLength(64);
+import { Pool } from "pg";
+import { randomUUID } from "crypto";
+import { releasePayment } from "../../../../src/rails/adapter.js";
+import { appendLedgerEntry } from "../../../../libs/patent/ledger.js";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const TEST_ABN = "99999999999";
+const TAX_TYPE = "GST";
+const PERIOD_ID = "2099-01";
+const RELEASE_KEY = `release:${TEST_ABN}:${TAX_TYPE}:${PERIOD_ID}`;
+
+beforeAll(async () => {
+  await pool.query("DELETE FROM idempotency_keys WHERE key=$1", [RELEASE_KEY]);
+  await pool.query("DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [TEST_ABN, TAX_TYPE, PERIOD_ID]);
+  await pool.query(
+    `INSERT INTO remittance_destinations (abn,label,rail,reference,account_bsb,account_number)
+     VALUES ($1,'TEST_EFT','EFT','PRN123',$2,$3)
+     ON CONFLICT (abn,rail,reference) DO NOTHING`,
+    [TEST_ABN, "092-009", "12345678"]
+  );
+  await appendLedgerEntry({
+    client: pool,
+    abn: TEST_ABN,
+    taxType: TAX_TYPE,
+    periodId: PERIOD_ID,
+    amountCents: 50000,
+    transferUuid: randomUUID(),
+    bankReceiptHash: "seed-credit",
+  });
+});
+
+afterAll(async () => {
+  await pool.query("DELETE FROM idempotency_keys WHERE key=$1", [RELEASE_KEY]);
+  await pool.query("DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [TEST_ABN, TAX_TYPE, PERIOD_ID]);
+  await pool.end();
+});
+
+test("releasePayment is idempotent per period", async () => {
+  const result1 = await releasePayment(TEST_ABN, TAX_TYPE, PERIOD_ID, 10000, "EFT", "PRN123", { idempotencyKey: RELEASE_KEY });
+  expect(result1.status).toBe("OK");
+  const result2 = await releasePayment(TEST_ABN, TAX_TYPE, PERIOD_ID, 10000, "EFT", "PRN123", { idempotencyKey: RELEASE_KEY });
+  expect(result2.status).toBe("DUPLICATE");
+  expect(result2.transfer_uuid).toBe(result1.transfer_uuid);
+  expect(result2.bank_receipt_hash).toBe(result1.bank_receipt_hash);
 });

--- a/apps/services/payments/test/paytoAdapter.test.ts
+++ b/apps/services/payments/test/paytoAdapter.test.ts
@@ -1,0 +1,24 @@
+import { createMandate, debit, cancelMandate } from "../../../../src/payto/adapter.js";
+
+test("payto mandate lifecycle", async () => {
+  const mandate = await createMandate("123", 5000, "mandate-1");
+  expect(mandate.status).toBe("CREATED");
+  const ok = await debit("123", 2000, "mandate-1");
+  expect(ok.status).toBe("OK");
+  const cancel = await cancelMandate(mandate.mandateId!);
+  expect(cancel.status).toBe("CANCELLED");
+  const afterCancel = await debit("123", 1000, "mandate-1");
+  expect(afterCancel.status).toBe("MANDATE_CANCELLED");
+});
+
+test("payto debit failure modes", async () => {
+  await createMandate("456", 1000, "mandate-fail-insufficient");
+  const insufficient = await debit("456", 2000, "mandate-fail-insufficient");
+  expect(insufficient.status).toBe("INSUFFICIENT_FUNDS");
+
+  await createMandate("789", 1000, "mandate-fail-bank-once");
+  const first = await debit("789", 500, "mandate-fail-bank-once");
+  expect(first.status).toBe("BANK_ERROR");
+  const second = await debit("789", 500, "mandate-fail-bank-once");
+  expect(second.status).toBe("OK");
+});

--- a/apps/services/payments/tsconfig.json
+++ b/apps/services/payments/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "sourceMap": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "../../../src/**/*.ts", "../../../libs/**/*.ts"]
 }

--- a/libs/patent/ledger.ts
+++ b/libs/patent/ledger.ts
@@ -1,0 +1,127 @@
+import { createHash } from "crypto";
+import type { Pool, PoolClient, QueryResult } from "pg";
+
+export interface LedgerTail {
+  balanceAfter: number;
+  hashAfter: string;
+}
+
+type Queryable = Pick<Pool, "query"> | PoolClient | { query: (text: string, params?: any[]) => Promise<QueryResult<any>> };
+
+let cachedLedgerColumns: Set<string> | null = null;
+
+async function ensureLedgerColumns(db: Queryable): Promise<Set<string>> {
+  if (cachedLedgerColumns) return cachedLedgerColumns;
+  const { rows } = await db.query(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_name = 'owa_ledger'
+        AND table_schema = ANY (current_schemas(false))`
+  );
+  cachedLedgerColumns = new Set(rows.map(r => String(r.column_name)));
+  return cachedLedgerColumns;
+}
+
+export function computeLedgerHash(prevHash: string | null | undefined, bankReceiptHash: string | null | undefined, balanceAfter: number): string {
+  const h = createHash("sha256");
+  h.update(prevHash ?? "");
+  h.update(bankReceiptHash ?? "");
+  h.update(String(balanceAfter));
+  return h.digest("hex");
+}
+
+export async function fetchLedgerTail(db: Queryable, abn: string, taxType: string, periodId: string): Promise<LedgerTail> {
+  const { rows } = await db.query(
+    `SELECT balance_after_cents, hash_after
+       FROM owa_ledger
+      WHERE abn = $1 AND tax_type = $2 AND period_id = $3
+      ORDER BY id DESC
+      LIMIT 1`,
+    [abn, taxType, periodId]
+  );
+  if (!rows.length) return { balanceAfter: 0, hashAfter: "" };
+  const row = rows[0];
+  return {
+    balanceAfter: Number(row.balance_after_cents ?? 0),
+    hashAfter: String(row.hash_after ?? ""),
+  };
+}
+
+export interface AppendLedgerParams {
+  client: Queryable;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: number;
+  transferUuid: string;
+  bankReceiptHash: string | null;
+  releaseUuid?: string | null;
+  rptVerified?: boolean;
+  bankReceiptId?: string | null;
+  createdAt?: Date;
+}
+
+export interface AppendLedgerResult {
+  id: number;
+  balanceAfter: number;
+  hashAfter: string;
+  prevBalance: number;
+  prevHash: string;
+}
+
+export async function appendLedgerEntry(params: AppendLedgerParams): Promise<AppendLedgerResult> {
+  const { client, abn, taxType, periodId } = params;
+  const tail = await fetchLedgerTail(client, abn, taxType, periodId);
+  const prevBalance = tail.balanceAfter;
+  const prevHash = tail.hashAfter;
+  const newBalance = prevBalance + params.amountCents;
+  const hashAfter = computeLedgerHash(prevHash, params.bankReceiptHash, newBalance);
+
+  const cols = [
+    "abn",
+    "tax_type",
+    "period_id",
+    "transfer_uuid",
+    "amount_cents",
+    "balance_after_cents",
+    "bank_receipt_hash",
+    "prev_hash",
+    "hash_after",
+    "created_at",
+  ];
+  const values: any[] = [
+    abn,
+    taxType,
+    periodId,
+    params.transferUuid,
+    params.amountCents,
+    newBalance,
+    params.bankReceiptHash,
+    prevHash || null,
+    hashAfter,
+    params.createdAt ?? new Date(),
+  ];
+
+  const optionalColumns = await ensureLedgerColumns(client);
+  const addOptional = (column: string, value: any) => {
+    if (!optionalColumns.has(column)) return;
+    cols.push(column);
+    values.push(value);
+  };
+
+  addOptional("rpt_verified", params.rptVerified ?? false);
+  addOptional("release_uuid", params.releaseUuid ?? null);
+  addOptional("bank_receipt_id", params.bankReceiptId ?? null);
+
+  const placeholders = cols.map((_, idx) => `$${idx + 1}`);
+  const sql = `INSERT INTO owa_ledger(${cols.join(",")}) VALUES (${placeholders.join(",")}) RETURNING id, balance_after_cents, hash_after`;
+  const { rows } = await client.query(sql, values);
+  const inserted = rows[0];
+  return {
+    id: Number(inserted.id),
+    balanceAfter: Number(inserted.balance_after_cents),
+    hashAfter: String(inserted.hash_after ?? hashAfter),
+    prevBalance,
+    prevHash,
+  };
+}

--- a/libs/patent/remittance.ts
+++ b/libs/patent/remittance.ts
@@ -1,0 +1,229 @@
+import type { Pool, PoolClient, QueryResult } from "pg";
+
+export type Rail = "EFT" | "BPAY" | "PayTo" | "PAYTO" | "PAYID";
+
+export type AllowlistDestination = {
+  bsb?: string;
+  acct?: string;
+  bpay_biller?: string;
+  crn?: string;
+  payid?: string;
+};
+
+export interface RemittanceDestination {
+  id: number;
+  abn: string;
+  rail: Rail;
+  reference: string;
+  account_bsb: string | null;
+  account_number: string | null;
+  metadata: Record<string, any>;
+}
+
+type Queryable = Pick<Pool, "query"> | PoolClient | { query: (text: string, params?: any[]) => Promise<QueryResult<any>> };
+
+const CANDIDATE_META_COLUMNS = ["settings", "metadata", "rail_settings", "config", "destination_settings"] as const;
+
+let cachedColumnSelect: string | null = null;
+
+function isQueryable(obj: any): obj is Queryable {
+  return obj && typeof obj.query === "function";
+}
+
+async function ensureColumnSelect(db: Queryable): Promise<string> {
+  if (cachedColumnSelect) return cachedColumnSelect;
+  const placeholders = CANDIDATE_META_COLUMNS.map((_, idx) => `$${idx + 1}`).join(",");
+  const { rows } = await db.query(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_name = 'remittance_destinations'
+        AND table_schema = ANY (current_schemas(false))
+        AND column_name = ANY(ARRAY[${placeholders}])`,
+    [...CANDIDATE_META_COLUMNS]
+  );
+  const found = new Set(rows.map(r => String(r.column_name)));
+  const extras = Array.from(found)
+    .sort()
+    .map(col => `, ${col}`)
+    .join("");
+  cachedColumnSelect = `SELECT id, abn, rail, reference, account_bsb, account_number${extras} FROM remittance_destinations WHERE abn = $1`;
+  return cachedColumnSelect;
+}
+
+function parseMaybeJson(value: unknown): any {
+  if (value == null) return undefined;
+  if (typeof value === "object") return value;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return undefined;
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function mergeMetadata(base: Record<string, any>, addition: any) {
+  if (!addition || typeof addition !== "object") return;
+  for (const [key, val] of Object.entries(addition)) {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      if (!base[key] || typeof base[key] !== "object") base[key] = {};
+      mergeMetadata(base[key], val);
+    } else {
+      base[key] = val;
+    }
+  }
+}
+
+function normaliseDigits(value: string | null | undefined): string {
+  if (!value) return "";
+  return value.replace(/[^0-9]/g, "");
+}
+
+export function normaliseBsb(value: string | null | undefined): string {
+  const digits = normaliseDigits(value);
+  if (digits.length === 6) return `${digits.slice(0, 3)}-${digits.slice(3)}`;
+  return digits;
+}
+
+function extractCrnRange(meta: any): { min: number; max: number; prefix?: string } | null {
+  if (!meta) return null;
+  const source = meta.crn ?? meta.crn_range ?? meta.crnRange ?? meta.range ?? meta;
+  const prefix = source?.prefix ?? meta.prefix ?? undefined;
+
+  const tryNumbers = (...keys: string[]) => {
+    for (const key of keys) {
+      const val = source?.[key] ?? meta?.[key];
+      if (typeof val === "number" && Number.isFinite(val)) return val;
+    }
+    return undefined;
+  };
+
+  let min = tryNumbers("min", "min_length", "minLength", "minDigits", "min_digits");
+  let max = tryNumbers("max", "max_length", "maxLength", "maxDigits", "max_digits");
+
+  if (typeof source?.length === "number") {
+    min = max = source.length;
+  }
+  if (Array.isArray(source?.lengths) && source.lengths.length) {
+    const nums = source.lengths.map((n: any) => Number(n)).filter((n: number) => Number.isFinite(n));
+    if (nums.length) {
+      min = Math.min(...nums);
+      max = Math.max(...nums);
+    }
+  }
+  if (Array.isArray(source?.range) && source.range.length >= 2) {
+    const [a, b] = source.range;
+    if (Number.isFinite(Number(a)) && Number.isFinite(Number(b))) {
+      min = Number(a);
+      max = Number(b);
+    }
+  }
+  if (typeof source?.min === "number" && typeof source?.max === "number") {
+    min = source.min;
+    max = source.max;
+  }
+
+  if (typeof min === "number" && typeof max === "number" && min > 0 && max >= min) {
+    return { min, max, prefix: typeof prefix === "string" && prefix ? prefix : undefined };
+  }
+  return null;
+}
+
+function inflateRow(raw: any): RemittanceDestination {
+  const metadata: Record<string, any> = {};
+  for (const key of CANDIDATE_META_COLUMNS) {
+    if (key in raw) mergeMetadata(metadata, parseMaybeJson(raw[key]));
+  }
+  mergeMetadata(metadata, parseMaybeJson(raw.account_bsb));
+  mergeMetadata(metadata, parseMaybeJson(raw.account_number));
+  return {
+    id: Number(raw.id),
+    abn: String(raw.abn),
+    rail: String(raw.rail) as Rail,
+    reference: String(raw.reference),
+    account_bsb: raw.account_bsb ?? null,
+    account_number: raw.account_number ?? null,
+    metadata,
+  };
+}
+
+async function loadDestinations(db: Queryable, abn: string): Promise<RemittanceDestination[]> {
+  if (!isQueryable(db)) throw new Error("Database connection missing query method");
+  const sql = await ensureColumnSelect(db);
+  const { rows } = await db.query(sql, [abn]);
+  return rows.map(inflateRow);
+}
+
+function matchEft(rows: RemittanceDestination[], dest: AllowlistDestination): RemittanceDestination | null {
+  const wantBsb = normaliseDigits(dest.bsb ?? "");
+  const wantAcct = normaliseDigits(dest.acct ?? "");
+  if (!wantBsb || !wantAcct) return null;
+  for (const row of rows) {
+    if (String(row.rail).toUpperCase() !== "EFT") continue;
+    if (normaliseDigits(row.account_bsb ?? "") !== wantBsb) continue;
+    if (normaliseDigits(row.account_number ?? "") !== wantAcct) continue;
+    return row;
+  }
+  return null;
+}
+
+function matchBpay(rows: RemittanceDestination[], dest: AllowlistDestination): RemittanceDestination | null {
+  const biller = (dest.bpay_biller || "").trim();
+  const crn = (dest.crn || "").trim();
+  if (!biller || !crn || !/^\d+$/.test(crn)) return null;
+  const length = crn.length;
+  for (const row of rows) {
+    if (String(row.rail).toUpperCase() !== "BPAY") continue;
+    if (String(row.reference) !== biller) continue;
+    const meta = row.metadata?.bpay ?? row.metadata;
+    const range = extractCrnRange(meta);
+    if (!range) continue;
+    if (range.prefix && !crn.startsWith(range.prefix)) continue;
+    if (length < range.min || length > range.max) continue;
+    return row;
+  }
+  return null;
+}
+
+function matchPayTo(rows: RemittanceDestination[], dest: AllowlistDestination): RemittanceDestination | null {
+  const handle = (dest.payid || "").trim();
+  if (!handle) return null;
+  for (const row of rows) {
+    const rail = String(row.rail).toUpperCase();
+    if (rail !== "PAYTO" && rail !== "PAYID") continue;
+    const knownHandle = row.metadata?.payto?.handle ?? row.metadata?.payid?.handle ?? row.metadata?.handle;
+    if (typeof knownHandle === "string" && knownHandle.trim().length) {
+      if (knownHandle.trim().toLowerCase() === handle.toLowerCase()) return row;
+      continue;
+    }
+    if (row.reference.trim().toLowerCase() === handle.toLowerCase()) return row;
+  }
+  return null;
+}
+
+export async function matchAllowlistedDestination(db: Queryable, abn: string, dest: AllowlistDestination): Promise<RemittanceDestination | null> {
+  const rows = await loadDestinations(db, abn);
+  if (dest.bpay_biller) return matchBpay(rows, dest);
+  if (dest.bsb && dest.acct) return matchEft(rows, dest);
+  if (dest.payid) return matchPayTo(rows, dest);
+  return null;
+}
+
+export async function resolveDestinationByReference(db: Queryable, abn: string, rail: Rail, reference: string): Promise<RemittanceDestination | null> {
+  const rows = await loadDestinations(db, abn);
+  const targetRail = String(rail).toUpperCase();
+  for (const row of rows) {
+    if (String(row.reference) !== reference) continue;
+    const rowRail = String(row.rail).toUpperCase();
+    if (rowRail === targetRail) return row;
+    if (targetRail === "PAYTO" && (rowRail === "PAYTO" || rowRail === "PAYID")) return row;
+  }
+  return null;
+}
+
+export async function listDestinations(db: Queryable, abn: string): Promise<RemittanceDestination[]> {
+  return loadDestinations(db, abn);
+}

--- a/src/payto/adapter.ts
+++ b/src/payto/adapter.ts
@@ -1,5 +1,97 @@
-﻿/** PayTo BAS Sweep adapter (stub) */
-export interface PayToDebitResult { status: "OK"|"INSUFFICIENT_FUNDS"|"BANK_ERROR"; bank_ref?: string; }
-export async function createMandate(abn: string, capCents: number, reference: string) { return { status: "OK", mandateId: "demo-mandate" }; }
-export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> { return { status: "OK", bank_ref: "payto:" + reference.slice(0,12) }; }
-export async function cancelMandate(mandateId: string) { return { status: "OK" }; }
+import { randomUUID } from "crypto";
+
+/** PayTo BAS Sweep adapter (simulated) */
+export interface PayToMandateResult { status: "CREATED" | "EXISTS" | "BANK_ERROR"; mandateId?: string; reason?: string; }
+export interface PayToDebitResult { status: "OK" | "INSUFFICIENT_FUNDS" | "MANDATE_NOT_FOUND" | "MANDATE_CANCELLED" | "BANK_ERROR"; bank_ref?: string; }
+export interface PayToCancelResult { status: "CANCELLED" | "NOT_FOUND" | "ALREADY_CANCELLED"; }
+
+interface MandateRecord {
+  id: string;
+  abn: string;
+  reference: string;
+  capCents: number;
+  status: "ACTIVE" | "CANCELLED";
+  failPlan: FailPlan | null;
+}
+
+interface FailPlan {
+  mode: "BANK_ERROR" | "INSUFFICIENT_FUNDS";
+  remaining: number; // Infinity = always
+}
+
+const mandatesById = new Map<string, MandateRecord>();
+const mandatesByKey = new Map<string, MandateRecord>();
+
+function mandateKey(abn: string, reference: string) {
+  return `${abn}|${reference}`;
+}
+
+function parseFailPlan(reference: string): FailPlan | null {
+  const lower = reference.toLowerCase();
+  if (lower.includes("fail-bank-once")) return { mode: "BANK_ERROR", remaining: 1 };
+  if (lower.includes("fail-bank")) return { mode: "BANK_ERROR", remaining: Number.POSITIVE_INFINITY };
+  if (lower.includes("fail-insufficient-once")) return { mode: "INSUFFICIENT_FUNDS", remaining: 1 };
+  if (lower.includes("fail-insufficient")) return { mode: "INSUFFICIENT_FUNDS", remaining: Number.POSITIVE_INFINITY };
+  return null;
+}
+
+export async function createMandate(abn: string, capCents: number, reference: string): Promise<PayToMandateResult> {
+  const key = mandateKey(abn, reference);
+  const existing = mandatesByKey.get(key);
+  if (existing && existing.status === "ACTIVE") {
+    return { status: "EXISTS", mandateId: existing.id };
+  }
+  if (reference.toLowerCase().includes("fail-create")) {
+    return { status: "BANK_ERROR", reason: "Upstream rejected mandate" };
+  }
+  const id = existing?.id ?? `mdt_${randomUUID().slice(0, 8)}`;
+  const record: MandateRecord = {
+    id,
+    abn,
+    reference,
+    capCents,
+    status: "ACTIVE",
+    failPlan: parseFailPlan(reference),
+  };
+  mandatesById.set(id, record);
+  mandatesByKey.set(key, record);
+  return { status: "CREATED", mandateId: id };
+}
+
+export async function debit(abn: string, amountCents: number, reference: string): Promise<PayToDebitResult> {
+  if (amountCents <= 0) return { status: "BANK_ERROR" };
+  let record = mandatesById.get(reference);
+  if (!record) record = mandatesByKey.get(mandateKey(abn, reference));
+  if (!record) return { status: "MANDATE_NOT_FOUND" };
+  if (record.status === "CANCELLED") return { status: "MANDATE_CANCELLED" };
+
+  if (record.capCents < amountCents) return { status: "INSUFFICIENT_FUNDS" };
+
+  if (record.failPlan) {
+    if (record.failPlan.mode === "BANK_ERROR") {
+      if (record.failPlan.remaining > 0) {
+        if (Number.isFinite(record.failPlan.remaining)) record.failPlan.remaining -= 1;
+        return { status: "BANK_ERROR" };
+      }
+    } else if (record.failPlan.mode === "INSUFFICIENT_FUNDS") {
+      if (record.failPlan.remaining > 0) {
+        if (Number.isFinite(record.failPlan.remaining)) record.failPlan.remaining -= 1;
+        return { status: "INSUFFICIENT_FUNDS" };
+      }
+    }
+    if (record.failPlan.remaining === 0) record.failPlan = null;
+  }
+
+  record.capCents = Math.max(0, record.capCents - amountCents);
+  const bankRef = `payto:${record.id}:${Date.now().toString(16)}`;
+  return { status: "OK", bank_ref: bankRef };
+}
+
+export async function cancelMandate(mandateId: string): Promise<PayToCancelResult> {
+  const record = mandatesById.get(mandateId);
+  if (!record) return { status: "NOT_FOUND" };
+  if (record.status === "CANCELLED") return { status: "ALREADY_CANCELLED" };
+  record.status = "CANCELLED";
+  mandatesByKey.set(mandateKey(record.abn, record.reference), record);
+  return { status: "CANCELLED" };
+}

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,42 +1,191 @@
-﻿import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
 import { v4 as uuidv4 } from "uuid";
+import { createHash } from "crypto";
 import { appendAudit } from "../audit/appendOnly";
-import { sha256Hex } from "../crypto/merkle";
+import { appendLedgerEntry, fetchLedgerTail } from "../../libs/patent/ledger.js";
+import {
+  resolveDestinationByReference,
+  type RemittanceDestination,
+} from "../../libs/patent/remittance.js";
+
 const pool = new Pool();
 
-/** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
-  const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
-    [abn, rail, reference]
-  );
-  if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
-  return rows[0];
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY" | "PayTo", reference: string, db?: Pool | PoolClient): Promise<RemittanceDestination> {
+  const queryer = db ?? pool;
+  const dest = await resolveDestinationByReference(queryer, abn, rail, reference);
+  if (!dest) throw new Error("DEST_NOT_ALLOW_LISTED");
+  return dest;
 }
 
-/** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
-  const transfer_uuid = uuidv4();
+export interface ReleaseRailContext {
+  traceId: string;
+  rail: "EFT" | "BPAY" | "PayTo";
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: number;
+  reference: string;
+  destination: RemittanceDestination;
+}
+
+export interface ReleaseRailResult {
+  providerReceiptId: string;
+  transferUuid?: string;
+  bankReceiptHash?: string;
+}
+
+export interface ReleaseOptions {
+  callRail?: (ctx: ReleaseRailContext) => Promise<ReleaseRailResult>;
+  idempotencyKey?: string;
+  traceId?: string;
+}
+
+export interface ReleaseResult {
+  status: "OK" | "DUPLICATE";
+  transfer_uuid: string;
+  release_uuid: string;
+  bank_receipt_hash: string;
+  provider_receipt_id?: string;
+  trace_id: string;
+  amount_cents: number;
+  balance_after_cents?: number;
+  rail: "EFT" | "BPAY" | "PayTo";
+  reference: string;
+}
+
+function hashResponse(payload: Record<string, unknown>): string {
+  const h = createHash("sha256");
+  h.update(JSON.stringify(payload));
+  return h.digest("hex");
+}
+
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY" | "PayTo",
+  reference: string,
+  options: ReleaseOptions = {}
+): Promise<ReleaseResult> {
+  if (amountCents <= 0) throw new Error("AMOUNT_MUST_BE_POSITIVE");
+  const client = await pool.connect();
+  const idempotencyKey = options.idempotencyKey ?? `release:${abn}:${taxType}:${periodId}`;
+  const traceId = options.traceId ?? uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
-  } catch {
-    return { transfer_uuid, status: "DUPLICATE" };
+    await client.query("BEGIN");
+    const inserted = await client.query(
+      "INSERT INTO idempotency_keys(key,last_status,response_hash) VALUES($1,$2,$3) ON CONFLICT DO NOTHING RETURNING key",
+      [idempotencyKey, "PENDING", null]
+    );
+
+    if (inserted.rowCount === 0) {
+      const existing = await client.query("SELECT last_status FROM idempotency_keys WHERE key=$1 FOR UPDATE", [idempotencyKey]);
+      if (existing.rowCount === 0) throw new Error("IDEMPOTENCY_STATE_MISSING");
+      const status = existing.rows[0].last_status;
+      if (status === "DONE") {
+        const dup = await client.query(
+          `SELECT transfer_uuid, release_uuid, bank_receipt_hash, bank_receipt_id, amount_cents, balance_after_cents
+             FROM owa_ledger
+            WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND amount_cents < 0
+            ORDER BY id DESC LIMIT 1`,
+          [abn, taxType, periodId]
+        );
+        await client.query("COMMIT");
+        if (!dup.rowCount) throw new Error("IDEMPOTENCY_CONFLICT");
+        const row = dup.rows[0];
+        if (Math.abs(Number(row.amount_cents)) !== amountCents) throw new Error("IDEMPOTENCY_CONFLICT");
+        return {
+          status: "DUPLICATE",
+          transfer_uuid: row.transfer_uuid,
+          release_uuid: row.release_uuid,
+          bank_receipt_hash: row.bank_receipt_hash,
+          provider_receipt_id: row.bank_receipt_id ?? undefined,
+          trace_id: traceId,
+          amount_cents: amountCents,
+          balance_after_cents: Number(row.balance_after_cents ?? 0),
+          rail,
+          reference,
+        };
+      }
+      if (status !== "FAILED") {
+        throw new Error("RELEASE_IN_PROGRESS");
+      }
+      await client.query("UPDATE idempotency_keys SET last_status=$2, response_hash=$3 WHERE key=$1", [idempotencyKey, "PENDING", null]);
+    }
+
+    const destination = await resolveDestination(abn, rail, reference, client);
+    const tail = await fetchLedgerTail(client, abn, taxType, periodId);
+    if (tail.balanceAfter < amountCents) {
+      await client.query("UPDATE idempotency_keys SET last_status=$2 WHERE key=$1", [idempotencyKey, "FAILED"]);
+      await client.query("ROLLBACK");
+      throw new Error("INSUFFICIENT_FUNDS");
+    }
+
+    let railResult: ReleaseRailResult | null = null;
+    if (options.callRail) {
+      try {
+        railResult = await options.callRail({ traceId, rail, abn, taxType, periodId, amountCents, reference, destination });
+      } catch (err) {
+        await client.query("UPDATE idempotency_keys SET last_status=$2 WHERE key=$1", [idempotencyKey, "FAILED"]);
+        await client.query("ROLLBACK");
+        throw err;
+      }
+    }
+
+    const providerReceiptId = railResult?.providerReceiptId ?? `synthetic-${traceId.slice(0, 12)}`;
+    const transferUuid = railResult?.transferUuid ?? uuidv4();
+    const bankReceiptHash = railResult?.bankReceiptHash ?? createHash("sha256").update(providerReceiptId).digest("hex");
+    const releaseUuid = uuidv4();
+
+    const ledger = await appendLedgerEntry({
+      client,
+      abn,
+      taxType,
+      periodId,
+      amountCents: -Math.abs(amountCents),
+      transferUuid,
+      bankReceiptHash,
+      releaseUuid,
+      rptVerified: true,
+      bankReceiptId: providerReceiptId,
+    });
+
+    const responseHash = hashResponse({ transferUuid, releaseUuid, bankReceiptHash });
+    await client.query("UPDATE idempotency_keys SET last_status=$2, response_hash=$3 WHERE key=$1", [idempotencyKey, "DONE", responseHash]);
+
+    await appendAudit("rails", "release", {
+      abn,
+      taxType,
+      periodId,
+      amountCents,
+      rail,
+      reference,
+      bank_receipt_hash: bankReceiptHash,
+      trace_id: traceId,
+    });
+
+    await client.query("COMMIT");
+    return {
+      status: "OK",
+      transfer_uuid: transferUuid,
+      release_uuid: releaseUuid,
+      bank_receipt_hash: bankReceiptHash,
+      provider_receipt_id: providerReceiptId,
+      trace_id: traceId,
+      amount_cents: amountCents,
+      balance_after_cents: ledger.balanceAfter,
+      rail,
+      reference,
+    };
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* ignore */
+    }
+    throw err;
+  } finally {
+    client.release();
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
-
-  const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
-  const prevHash = rows[0]?.hash_after ?? "";
-  const newBal = prevBal - amountCents;
-  const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
-
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
-  );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "libs"]
 }


### PR DESCRIPTION
## Summary
- add shared remittance and ledger helpers so EFT/BPAY/PayTo allow-list checks use the database configuration
- update the release adapter and payAto route to share hash chaining, enforce idempotency, and forward trace IDs to the mock rails
- simulate PayTo mandate lifecycle states and expand the payments test suite to cover allow-list failures, duplicate releases, and PayTo errors

## Testing
- `npm test` *(fails: jest binary not installed and registry access is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2602eb21483279486969520efe975