### PR TITLE
Fix nextState transition mapping and add unit tests

### DIFF
--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -2,7 +2,7 @@
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
+  const t = `${current}:${evt}`;
   switch (t) {
     case "OPEN:CLOSE": return "CLOSING";
     case "CLOSING:PASS": return "READY_RPT";

--- a/tests/stateMachine.test.ts
+++ b/tests/stateMachine.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+
+import { nextState, PeriodState } from '../src/recon/stateMachine';
+
+describe('nextState', () => {
+  const scenarios: Array<{ current: PeriodState; evt: string; expected: PeriodState }> = [
+    { current: 'OPEN', evt: 'CLOSE', expected: 'CLOSING' },
+    { current: 'CLOSING', evt: 'PASS', expected: 'READY_RPT' },
+    { current: 'CLOSING', evt: 'FAIL_DISCREPANCY', expected: 'BLOCKED_DISCREPANCY' },
+    { current: 'CLOSING', evt: 'FAIL_ANOMALY', expected: 'BLOCKED_ANOMALY' },
+    { current: 'READY_RPT', evt: 'RELEASED', expected: 'RELEASED' },
+    { current: 'RELEASED', evt: 'FINALIZE', expected: 'FINALIZED' },
+  ];
+
+  for (const { current, evt, expected } of scenarios) {
+    it(`transitions ${current} + ${evt} -> ${expected}`, () => {
+      assert.strictEqual(nextState(current, evt), expected);
+    });
+  }
+
+  it('returns current state when transition is not defined', () => {
+    assert.strictEqual(nextState('OPEN', 'UNKNOWN'), 'OPEN');
+    assert.strictEqual(nextState('READY_RPT', 'PASS'), 'READY_RPT');
+  });
+});


### PR DESCRIPTION
## Summary
- correct the transition key composition in the recon state machine
- add node:test coverage verifying each valid nextState transition and default behavior

## Testing
- npx tsx tests/stateMachine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e26a514e548327825bf57da6e7e2a5