### PR TITLE
Implement ATO-aligned tax calculators and tests

### DIFF
--- a/src/components/BasLodgment.tsx
+++ b/src/components/BasLodgment.tsx
@@ -6,6 +6,7 @@ import { calculatePenalties } from '../utils/penalties';
 export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gstDue: number }) {
   const { basHistory, setBasHistory, auditLog, setAuditLog } = useContext(AppContext);
   const [isProcessing, setIsProcessing] = useState(false);
+  const penaltyPreview = calculatePenalties(7, paygwDue + gstDue);
 
   async function handleLodgment() {
     setIsProcessing(true);
@@ -19,7 +20,7 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
             gstPaid: 0,
             status: "Late",
             daysLate: 7,
-            penalties: calculatePenalties(7, paygwDue + gstDue)
+            penalties: penaltyPreview.total
           },
           ...basHistory
         ]);
@@ -52,6 +53,9 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
       <div>PAYGW: ${paygwDue.toFixed(2)}</div>
       <div>GST: ${gstDue.toFixed(2)}</div>
       <div className="total">Total: ${(paygwDue + gstDue).toFixed(2)}</div>
+      <div style={{ fontSize: "0.9em", marginTop: "0.4em", color: "#92400e" }}>
+        Potential 7-day late penalty: ${penaltyPreview.total.toFixed(2)} (GIC ${penaltyPreview.generalInterestCharge.toFixed(2)} + FTL ${penaltyPreview.failureToLodgePenalty.toFixed(2)})
+      </div>
       <button onClick={handleLodgment} disabled={isProcessing}>
         {isProcessing ? "Processing..." : "Lodge BAS & Transfer Funds"}
       </button>

--- a/src/components/GstCalculator.tsx
+++ b/src/components/GstCalculator.tsx
@@ -1,9 +1,16 @@
 import React, { useState } from "react";
 import { GstInput } from "../types/tax";
-import { calculateGst } from "../utils/gst";
+import { calculateGst, GstBreakdown } from "../utils/gst";
 
-export default function GstCalculator({ onResult }: { onResult: (liability: number) => void }) {
+export default function GstCalculator({ onResult }: { onResult?: (result: GstBreakdown) => void }) {
   const [form, setForm] = useState<GstInput>({ saleAmount: 0, exempt: false });
+  const [result, setResult] = useState<GstBreakdown | null>(null);
+
+  function handleCalculate() {
+    const breakdown = calculateGst(form);
+    setResult(breakdown);
+    onResult?.(breakdown);
+  }
 
   return (
     <div className="card">
@@ -32,9 +39,21 @@ export default function GstCalculator({ onResult }: { onResult: (liability: numb
         />
         GST Exempt
       </label>
-      <button style={{ marginTop: "0.7em" }} onClick={() => onResult(calculateGst(form))}>
+      <button style={{ marginTop: "0.7em" }} onClick={handleCalculate}>
         Calculate GST
       </button>
+      {result && (
+        <div className="result" style={{ marginTop: "1em", fontSize: "0.95em", color: "#1f2a44" }}>
+          {result.isExempt ? (
+            <div><strong>No GST payable</strong> — the supply is marked as exempt.</div>
+          ) : (
+            <>
+              <div><strong>GST payable (1A):</strong> ${result.gstPayable.toFixed(2)}</div>
+              <div><strong>Net of GST (G1 less 1A):</strong> ${result.taxableAmount.toFixed(2)}</div>
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/PaygwCalculator.tsx
+++ b/src/components/PaygwCalculator.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from "react";
 import { PaygwInput } from "../types/tax";
-import { calculatePaygw } from "../utils/paygw";
+import { calculatePaygw, PaygwBreakdown } from "../utils/paygw";
 
-export default function PaygwCalculator({ onResult }: { onResult: (liability: number) => void }) {
+export default function PaygwCalculator({ onResult }: { onResult?: (result: PaygwBreakdown) => void }) {
   const [form, setForm] = useState<PaygwInput>({
     employeeName: "",
     grossIncome: 0,
@@ -10,6 +10,13 @@ export default function PaygwCalculator({ onResult }: { onResult: (liability: nu
     period: "monthly",
     deductions: 0,
   });
+  const [result, setResult] = useState<PaygwBreakdown | null>(null);
+
+  function handleCalculate() {
+    const breakdown = calculatePaygw(form);
+    setResult(breakdown);
+    onResult?.(breakdown);
+  }
 
   return (
     <div className="card">
@@ -71,9 +78,20 @@ export default function PaygwCalculator({ onResult }: { onResult: (liability: nu
           <option value="quarterly">Quarterly</option>
         </select>
       </label>
-      <button style={{ marginTop: "0.7em" }} onClick={() => onResult(calculatePaygw(form))}>
+      <button style={{ marginTop: "0.7em" }} onClick={handleCalculate}>
         Calculate PAYGW
       </button>
+      {result && (
+        <div className="result" style={{ marginTop: "1em", fontSize: "0.95em", color: "#133a2c" }}>
+          <div><strong>Required withholding:</strong> ${result.requiredWithholding.toFixed(2)}</div>
+          <div><strong>Already withheld:</strong> ${result.amountAlreadyWithheld.toFixed(2)}</div>
+          <div><strong>Deductions applied:</strong> ${result.deductionsApplied.toFixed(2)}</div>
+          <div><strong>PAYGW shortfall:</strong> ${result.shortfall.toFixed(2)}</div>
+          <div style={{ color: "#4b5563", marginTop: "0.4em" }}>
+            Annualised income reference: ${result.annualisedIncome.toFixed(2)}
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/utils/gst.ts
+++ b/src/utils/gst.ts
@@ -1,6 +1,28 @@
 import { GstInput } from "../types/tax";
 
-export function calculateGst({ saleAmount, exempt = false }: GstInput): number {
-  if (exempt) return 0;
-  return saleAmount * 0.1;
+export type GstBreakdown = {
+  taxableAmount: number;
+  gstPayable: number;
+  isExempt: boolean;
+};
+
+function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+/**
+ * Implements the GST inclusive price split per "Calculating GST" (ATO QC 22088)
+ * where the tax component of an amount that already includes GST is equal to
+ * one eleventh of the consideration. Results are rounded to the nearest cent in
+ * line with ATO guidance.
+ */
+export function calculateGst({ saleAmount, exempt = false }: GstInput): GstBreakdown {
+  if (exempt) {
+    return { taxableAmount: roundCurrency(saleAmount), gstPayable: 0, isExempt: true };
+  }
+
+  const gstPayable = roundCurrency(saleAmount / 11);
+  const taxableAmount = roundCurrency(saleAmount - gstPayable);
+
+  return { taxableAmount, gstPayable, isExempt: false };
 }

--- a/src/utils/paygw.ts
+++ b/src/utils/paygw.ts
@@ -1,7 +1,69 @@
 import { PaygwInput } from "../types/tax";
 
-export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): number {
-  const baseRate = 0.20;
-  const liability = grossIncome * baseRate - deductions - taxWithheld;
-  return Math.max(liability, 0);
+export type PaygwBreakdown = {
+  /** Annualised earnings used to align with the ATO withholding schedule. */
+  annualisedIncome: number;
+  /** Amount that should be withheld for the selected period. */
+  requiredWithholding: number;
+  /** Amount that has already been withheld from payroll. */
+  amountAlreadyWithheld: number;
+  /** Additional deductions or offsets applied this period. */
+  deductionsApplied: number;
+  /** Residual liability payable to the ATO (never negative). */
+  shortfall: number;
+};
+
+const PERIODS_PER_YEAR: Record<PaygwInput["period"], number> = {
+  weekly: 52,
+  fortnightly: 26,
+  monthly: 12,
+  quarterly: 4,
+};
+
+function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+function calculateAnnualTax(taxableIncome: number): number {
+  if (taxableIncome <= 18_200) {
+    return 0;
+  }
+  if (taxableIncome <= 45_000) {
+    return (taxableIncome - 18_200) * 0.16;
+  }
+  if (taxableIncome <= 135_000) {
+    return 4_288 + (taxableIncome - 45_000) * 0.3;
+  }
+  if (taxableIncome <= 190_000) {
+    return 31_288 + (taxableIncome - 135_000) * 0.37;
+  }
+  return 51_638 + (taxableIncome - 190_000) * 0.45;
+}
+
+/**
+ * Mirrors the 2024–25 ATO withholding schedule by annualising earnings before
+ * applying the progressive tax rates published in "Individual income tax rates
+ * 2024–25" (ATO QC 102601) and the accompanying "Statement of formulas for
+ * calculating amounts to be withheld" NAT 1004 (effective 1 July 2024). These
+ * sources prescribe annual thresholds which we convert back to the nominated
+ * pay period after rounding to the nearest cent.
+ */
+export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): PaygwBreakdown {
+  const periodsPerYear = PERIODS_PER_YEAR[period];
+  const annualisedIncome = grossIncome * periodsPerYear;
+  const annualTax = calculateAnnualTax(annualisedIncome);
+  const requiredWithholding = roundCurrency(annualTax / periodsPerYear);
+  const alreadyWithheld = roundCurrency(taxWithheld);
+  const deductionsApplied = roundCurrency(deductions);
+
+  const rawShortfall = requiredWithholding - alreadyWithheld - deductionsApplied;
+  const shortfall = rawShortfall > 0 ? roundCurrency(rawShortfall) : 0;
+
+  return {
+    annualisedIncome: roundCurrency(annualisedIncome),
+    requiredWithholding,
+    amountAlreadyWithheld: alreadyWithheld,
+    deductionsApplied,
+    shortfall,
+  };
 }

--- a/src/utils/penalties.ts
+++ b/src/utils/penalties.ts
@@ -1,5 +1,47 @@
-export function calculatePenalties(daysLate: number, amountDue: number): number {
-  const basePenalty = amountDue * 0.05;
-  const dailyInterest = amountDue * 0.0002;
-  return basePenalty + (dailyInterest * daysLate);
+export type PenaltyBreakdown = {
+  generalInterestCharge: number;
+  failureToLodgePenalty: number;
+  penaltyUnitsApplied: number;
+  total: number;
+};
+
+function roundCurrency(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+const DAYS_PER_PENALTY_PERIOD = 28;
+const PENALTY_UNIT_AMOUNT = 330; // ATO penalty unit from 1 July 2024 (ATO QC 18146)
+const ENTITY_MULTIPLIERS: Record<"small" | "medium" | "large", number> = {
+  small: 1,
+  medium: 2,
+  large: 5,
+};
+const GIC_ANNUAL_RATE = 0.1134; // General interest charge rate for Q1 2025 (ATO QC 52225)
+
+/**
+ * Calculates the combined general interest charge (daily compounding) and the
+ * failure to lodge on time (FTL) penalty. Both rules are sourced from the ATO's
+ * "Failure to lodge on time penalties" guidance (QC 18146) and "General
+ * interest charge (GIC) rates" (QC 52225). The entity size determines the
+ * multiplier applied to the base penalty unit.
+ */
+export function calculatePenalties(
+  daysLate: number,
+  amountDue: number,
+  entitySize: "small" | "medium" | "large" = "small"
+): PenaltyBreakdown {
+  if (daysLate <= 0 || amountDue <= 0) {
+    return { generalInterestCharge: 0, failureToLodgePenalty: 0, penaltyUnitsApplied: 0, total: 0 };
+  }
+
+  const periodsLate = Math.ceil(daysLate / DAYS_PER_PENALTY_PERIOD);
+  const penaltyUnits = periodsLate * ENTITY_MULTIPLIERS[entitySize];
+  const failureToLodgePenalty = roundCurrency(penaltyUnits * PENALTY_UNIT_AMOUNT);
+
+  const dailyRate = GIC_ANNUAL_RATE / 365;
+  const generalInterestCharge = roundCurrency(amountDue * (Math.pow(1 + dailyRate, daysLate) - 1));
+
+  const total = roundCurrency(generalInterestCharge + failureToLodgePenalty);
+
+  return { generalInterestCharge, failureToLodgePenalty, penaltyUnitsApplied: penaltyUnits, total };
 }

--- a/tests/taxCalculations.test.ts
+++ b/tests/taxCalculations.test.ts
@@ -1,0 +1,70 @@
+import { strict as assert } from "assert";
+import { calculatePaygw } from "../src/utils/paygw";
+import { calculateGst } from "../src/utils/gst";
+import { calculatePenalties } from "../src/utils/penalties";
+
+type Approx = {
+  expected: number;
+  actual: number;
+  tolerance?: number;
+};
+
+function assertApprox({ expected, actual, tolerance = 0.02 }: Approx) {
+  const withinTolerance = Math.abs(expected - actual) <= tolerance;
+  if (!withinTolerance) {
+    assert.fail(`Expected ${expected.toFixed(2)} but received ${actual.toFixed(2)}`);
+  }
+}
+
+(function testWeeklyMiddleBand() {
+  const breakdown = calculatePaygw({
+    employeeName: "Test", grossIncome: 800, taxWithheld: 70, period: "weekly", deductions: 0,
+  });
+  assertApprox({ expected: 41_600, actual: breakdown.annualisedIncome, tolerance: 0.5 });
+  assertApprox({ expected: 72, actual: breakdown.requiredWithholding });
+  assertApprox({ expected: 70, actual: breakdown.amountAlreadyWithheld });
+  assertApprox({ expected: 2, actual: breakdown.shortfall });
+})();
+
+(function testMonthlyHigherBand() {
+  const breakdown = calculatePaygw({
+    employeeName: "Senior", grossIncome: 10_000, taxWithheld: 2_000, period: "monthly", deductions: 0,
+  });
+  assertApprox({ expected: 120_000, actual: breakdown.annualisedIncome, tolerance: 0.5 });
+  assertApprox({ expected: 2_232.33, actual: breakdown.requiredWithholding, tolerance: 0.03 });
+  assertApprox({ expected: 232.33, actual: breakdown.shortfall, tolerance: 0.03 });
+})();
+
+(function testQuarterlyTopBandWithDeductions() {
+  const breakdown = calculatePaygw({
+    employeeName: "Director", grossIncome: 60_000, taxWithheld: 18_000, period: "quarterly", deductions: 100,
+  });
+  assertApprox({ expected: 240_000, actual: breakdown.annualisedIncome, tolerance: 0.5 });
+  assertApprox({ expected: 18_534.5, actual: breakdown.requiredWithholding, tolerance: 0.05 });
+  assertApprox({ expected: 434.5, actual: breakdown.shortfall, tolerance: 0.05 });
+})();
+
+(function testGstInclusiveCalculation() {
+  const gst = calculateGst({ saleAmount: 1_210 });
+  assert.equal(gst.isExempt, false);
+  assertApprox({ expected: 110, actual: gst.gstPayable });
+  assertApprox({ expected: 1_100, actual: gst.taxableAmount });
+})();
+
+(function testGstExempt() {
+  const gst = calculateGst({ saleAmount: 500, exempt: true });
+  assert.equal(gst.isExempt, true);
+  assertApprox({ expected: 500, actual: gst.taxableAmount });
+  assertApprox({ expected: 0, actual: gst.gstPayable });
+})();
+
+(function testPenaltiesSmallEntity() {
+  const penalties = calculatePenalties(45, 10_000, "small");
+  const dailyRate = 0.1134 / 365;
+  const expectedGic = 10_000 * (Math.pow(1 + dailyRate, 45) - 1);
+  assertApprox({ expected: expectedGic, actual: penalties.generalInterestCharge, tolerance: 0.1 });
+  assertApprox({ expected: 660, actual: penalties.failureToLodgePenalty });
+  assertApprox({ expected: penalties.generalInterestCharge + penalties.failureToLodgePenalty, actual: penalties.total, tolerance: 0.05 });
+})();
+
+console.log("All tax calculation tests passed.");


### PR DESCRIPTION
## Summary
- replace the PAYGW calculator with an annualised progressive schedule aligned to ATO 2024–25 guidance and expose a detailed breakdown for the UI
- compute GST using the one-eleventh method with exemption handling and round-to-cent rules, surfacing the breakdown in the calculator view
- apply ATO general interest charge and failure-to-lodge penalty rules, surfacing the potential penalty preview in the BAS screen
- add TypeScript unit tests covering multiple PAYGW bands, GST outcomes, and penalty scenarios

## Testing
- ./node_modules/.bin/tsx tests/taxCalculations.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e26a4ee25083278513f55c1c0bb216