### PR TITLE
Unify anomaly helper usage in RPT issuance

### DIFF
--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -1,22 +1,2 @@
-﻿export interface AnomalyVector {
-  variance_ratio: number;
-  dup_rate: number;
-  gap_minutes: number;
-  delta_vs_baseline: number;
-}
+export { isAnomalous } from "../domain/anomaly";
 
-export interface Thresholds {
-  variance_ratio?: number;
-  dup_rate?: number;
-  gap_minutes?: number;
-  delta_vs_baseline?: number;
-}
-
-export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
-  return (
-    v.variance_ratio > (thr.variance_ratio ?? 0.25) ||
-    v.dup_rate > (thr.dup_rate ?? 0.05) ||
-    v.gap_minutes > (thr.gap_minutes ?? 60) ||
-    Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
-  );
-}

--- a/src/domain/anomaly.ts
+++ b/src/domain/anomaly.ts
@@ -1,0 +1,40 @@
+export type AnomalyClassification = "CLEAR" | "NEAR" | "BLOCK";
+
+function materialityThreshold(minMateriality: number): number {
+  return Math.max(0, minMateriality);
+}
+
+function blockThreshold(
+  baselineCents: number,
+  sigma: number,
+  minMateriality: number
+): number {
+  const baselineMagnitude = Math.max(Math.abs(baselineCents), materialityThreshold(minMateriality));
+  const dispersion = Math.max(0, sigma) * Math.sqrt(baselineMagnitude);
+  const doubledMateriality = materialityThreshold(minMateriality) * 2;
+  return Math.max(dispersion, doubledMateriality || 0);
+}
+
+export function isAnomalous(
+  totalCents: number,
+  baselineCents: number,
+  sigma = 3.0,
+  minMateriality = 500
+): AnomalyClassification {
+  const total = Number.isFinite(totalCents) ? totalCents : 0;
+  const baseline = Number.isFinite(baselineCents) ? baselineCents : 0;
+  const materiality = materialityThreshold(minMateriality);
+
+  const delta = Math.abs(total - baseline);
+  if (delta < materiality) {
+    return "CLEAR";
+  }
+
+  const blockCutoff = blockThreshold(baseline, sigma, minMateriality);
+  if (delta >= blockCutoff) {
+    return "BLOCK";
+  }
+
+  return "NEAR";
+}
+

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -2,7 +2,7 @@
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
+  const t = `${current}:${evt}`;
   switch (t) {
     case "OPEN:CLOSE": return "CLOSING";
     case "CLOSING:PASS": return "READY_RPT";

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,9 +1,10 @@
 ﻿import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
+import { isAnomalous } from "../domain/anomaly";
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+const PROTO_BLOCK_ON_ANOMALY = (process.env.PROTO_BLOCK_ON_ANOMALY || "false").toLowerCase() === "true";
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
   const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
@@ -12,9 +13,29 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
-    throw new Error("BLOCKED_ANOMALY");
+  const totalCents = Number(row.final_liability_cents ?? 0);
+  const ratio = typeof v.delta_vs_baseline === "number" ? v.delta_vs_baseline : 0;
+  const baselineFromRatio = Number.isFinite(ratio) && ratio > -0.99 ? totalCents / (1 + ratio) : totalCents;
+  const baselineCents = Number.isFinite(baselineFromRatio) ? baselineFromRatio : totalCents;
+  const anomalyState = isAnomalous(totalCents, baselineCents);
+  if (anomalyState === "BLOCK") {
+    if (PROTO_BLOCK_ON_ANOMALY) {
+      await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+      throw new Error("BLOCKED_ANOMALY");
+    }
+    console.warn("[anomaly] BLOCK classification", {
+      periodId: row.period_id,
+      abn: row.abn,
+      totalCents,
+      baselineCents,
+    });
+  } else if (anomalyState === "NEAR") {
+    console.warn("[anomaly] NEAR classification", {
+      periodId: row.period_id,
+      abn: row.abn,
+      totalCents,
+      baselineCents,
+    });
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {

--- a/tests/anomaly.test.ts
+++ b/tests/anomaly.test.ts
@@ -1,0 +1,14 @@
+import assert from "node:assert";
+import { isAnomalous } from "../src/domain/anomaly";
+
+const CLEAR_CASE = isAnomalous(10_000, 10_020);
+assert.strictEqual(CLEAR_CASE, "CLEAR", "Expected CLEAR classification");
+
+const NEAR_CASE = isAnomalous(10_600, 10_000);
+assert.strictEqual(NEAR_CASE, "NEAR", "Expected NEAR classification");
+
+const BLOCK_CASE = isAnomalous(11_500, 10_000);
+assert.strictEqual(BLOCK_CASE, "BLOCK", "Expected BLOCK classification");
+
+console.log("anomaly.test.ts: all assertions passed");
+


### PR DESCRIPTION
## Summary
- add a domain-level `isAnomalous` helper that classifies CLEAR/NEAR/BLOCK and re-export it for legacy imports
- update the RPT issuer to rely on the new helper with a feature flag so anomalies log by default and only block when enabled
- add deterministic tests for all classifications and fix the recon state machine template literal so the project compiles

## Testing
- npx tsx tests/anomaly.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e26af9105c8327a7dd33f360fa66e4