### PR TITLE
Add reusable safety env defaults

### DIFF
--- a/apps/services/payments/src/loadEnv.ts
+++ b/apps/services/payments/src/loadEnv.ts
@@ -2,6 +2,7 @@
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import dotenv from 'dotenv';
+import { applySafetyDefaults } from '../../../../libs/envDefaults.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname  = dirname(__filename);
@@ -10,3 +11,5 @@ const __dirname  = dirname(__filename);
 dotenv.config({ path: resolve(__dirname, '../../../../.env.local') });
 // then a local .env (optional)
 dotenv.config();
+// finally ensure repo safety defaults are populated when unset
+applySafetyDefaults();

--- a/libs/envDefaults.ts
+++ b/libs/envDefaults.ts
@@ -1,0 +1,24 @@
+export const SAFETY_DEFAULTS = Object.freeze({
+  PROTO_KILL_SWITCH: "true",
+  PROVIDERS: "bank=mock;kms=mock;rates=mock;statements=mock;anomaly=mock",
+  PROTO_BLOCK_ON_ANOMALY: "false",
+  PROTO_ENFORCE_RATES_VERSION: "true",
+  ALLOW_PERIOD_REOPEN: "true",
+  TZ: "Australia/Brisbane",
+});
+
+export type SafetyDefaultKey = keyof typeof SAFETY_DEFAULTS;
+
+/**
+ * Apply safety-first environment defaults without clobbering explicit values.
+ * Returns the mutated env map for convenience/testing.
+ */
+export function applySafetyDefaults(env: NodeJS.ProcessEnv = process.env) {
+  for (const [key, value] of Object.entries(SAFETY_DEFAULTS)) {
+    const current = env[key];
+    if (current === undefined || current === "") {
+      env[key] = value;
+    }
+  }
+  return env;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 ﻿// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
+import { applySafetyDefaults } from "../libs/envDefaults";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
@@ -8,6 +9,7 @@ import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
+applySafetyDefaults();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));


### PR DESCRIPTION
## Summary
- add a shared helper that applies the requested safety-focused environment defaults when unset
- ensure the main Express server and payments service load the helper after dotenv so the defaults are active during development

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e26b62dc448327888b92409602ded2