### PR TITLE
feat: convert RPT flows to RS256 JWS tokens

### DIFF
--- a/apps/services/bank-egress/main.py
+++ b/apps/services/bank-egress/main.py
@@ -1,14 +1,20 @@
 ﻿# apps/services/bank-egress/main.py
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import os, psycopg2, json
-from libs.rpt.rpt import verify
+import os, psycopg2, json, time
+from datetime import datetime, timezone
+from psycopg2 import errors
+from libs.rpt import ReplayError, SignatureError, TokenExpiredError, decode, verify
 
 app = FastAPI(title="bank-egress")
 
 class EgressReq(BaseModel):
     period_id: str
-    rpt: dict
+    rpt: str
+
+
+class VerifyReq(BaseModel):
+    token: str
 
 def db():
     return psycopg2.connect(
@@ -19,18 +25,58 @@ def db():
         port=int(os.getenv("PGPORT","5432"))
     )
 
+def _record_jti(cur, conn, jti: str, exp_dt: datetime) -> bool:
+    try:
+        cur.execute("INSERT INTO rpt_jti(jti, exp) VALUES (%s,%s)", (jti, exp_dt))
+        return True
+    except errors.UniqueViolation:
+        conn.rollback()
+        return False
+
+
 @app.post("/egress/remit")
 def remit(req: EgressReq):
-    if "signature" not in req.rpt or not verify({k:v for k,v in req.rpt.items() if k!="signature"}, req.rpt["signature"]):
-        raise HTTPException(400, "invalid RPT signature")
     conn = db(); cur = conn.cursor()
-    cur.execute("SELECT state FROM bas_gate_states WHERE period_id=%s", (req.period_id,))
-    row = cur.fetchone()
-    if not row or row[0] != "RPT-Issued":
-        raise HTTPException(409, "gate not in RPT-Issued")
-    # Here you would call the real bank API via mTLS. For now, we just log.
-    payload = json.dumps({"period_id": req.period_id, "action": "remit"})
-    cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('egress',%s,NULL,NULL)", (payload,))
-    cur.execute("UPDATE bas_gate_states SET state='Remitted', updated_at=NOW() WHERE period_id=%s", (req.period_id,))
-    conn.commit(); cur.close(); conn.close()
-    return {"ok": True}
+    try:
+        def remember(jti: str, exp_dt: datetime) -> bool:
+            return _record_jti(cur, conn, jti, exp_dt)
+
+        try:
+            claims = verify(req.rpt, jti_store=remember)
+        except ReplayError:
+            raise HTTPException(409, "rpt replayed")
+        except TokenExpiredError:
+            raise HTTPException(400, "rpt expired")
+        except SignatureError:
+            raise HTTPException(400, "invalid RPT signature")
+
+        if claims.get("period_id") != req.period_id:
+            raise HTTPException(400, "period mismatch")
+
+        cur.execute("SELECT state FROM bas_gate_states WHERE period_id=%s", (req.period_id,))
+        row = cur.fetchone()
+        if not row or row[0] != "RPT-Issued":
+            raise HTTPException(409, "gate not in RPT-Issued")
+        payload = json.dumps({"period_id": req.period_id, "action": "remit"})
+        cur.execute("INSERT INTO audit_log(category,message,hash_prev,hash_this) VALUES ('egress',%s,NULL,NULL)", (payload,))
+        cur.execute("UPDATE bas_gate_states SET state='Remitted', updated_at=NOW() WHERE period_id=%s", (req.period_id,))
+        conn.commit()
+        return {
+            "ok": True,
+            "jti": claims.get("jti"),
+            "exp": datetime.fromtimestamp(claims["exp"], tz=timezone.utc).isoformat(),
+        }
+    finally:
+        cur.close(); conn.close()
+
+
+@app.post("/rpt/verify")
+def rpt_verify(req: VerifyReq):
+    try:
+        payload = verify(req.token, now=int(time.time()))
+        decoded = decode(req.token)
+        return {"valid": True, "payload": payload, "header": decoded["header"]}
+    except TokenExpiredError:
+        raise HTTPException(400, "rpt expired")
+    except SignatureError:
+        raise HTTPException(400, "invalid RPT signature")

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,77 @@
-﻿import React from "react";
+import React, { useMemo, useState } from "react";
 import { createRoot } from "react-dom/client";
+
+type DecodedJws = {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+};
+
+function decodeJws(compact: string): DecodedJws | null {
+  if (!compact) return null;
+  const parts = compact.split(".");
+  if (parts.length !== 3) return null;
+  try {
+    const decode = (segment: string) => {
+      const padded = segment + "=".repeat((4 - (segment.length % 4)) % 4);
+      const normalized = padded.replace(/-/g, "+").replace(/_/g, "/");
+      const json = atob(normalized);
+      return JSON.parse(json);
+    };
+    return { header: decode(parts[0]), payload: decode(parts[1]) };
+  } catch (e) {
+    console.error("decodeJws", e);
+    return null;
+  }
+}
+
+function EvidenceDrawer() {
+  const [token, setToken] = useState<string>("");
+  const decoded = useMemo(() => decodeJws(token.trim()), [token]);
+
+  return (
+    <section style={{ marginTop: 24 }}>
+      <h2>Evidence Drawer</h2>
+      <p style={{ maxWidth: 560 }}>
+        Paste a compact RPT JWS here to inspect the protected header and payload
+        bundled in the reconciliation evidence.
+      </p>
+      <textarea
+        value={token}
+        onChange={(e) => setToken(e.target.value)}
+        placeholder="eyJhbGciOi..."
+        rows={4}
+        style={{ width: "100%", fontFamily: "monospace" }}
+      />
+      {decoded ? (
+        <div style={{ display: "grid", gap: 12, marginTop: 16 }}>
+          <div>
+            <h3 style={{ marginBottom: 4 }}>Protected Header</h3>
+            <pre style={{ background: "#111", color: "#f5f5f5", padding: 12, borderRadius: 4 }}>
+              {JSON.stringify(decoded.header, null, 2)}
+            </pre>
+          </div>
+          <div>
+            <h3 style={{ marginBottom: 4 }}>Payload Claims</h3>
+            <pre style={{ background: "#111", color: "#f5f5f5", padding: 12, borderRadius: 4 }}>
+              {JSON.stringify(decoded.payload, null, 2)}
+            </pre>
+          </div>
+        </div>
+      ) : token ? (
+        <p style={{ color: "#b91c1c" }}>Invalid or non-decodable JWS token.</p>
+      ) : null}
+    </section>
+  );
+}
 
 function App() {
   return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
+    <div style={{ padding: 16, fontFamily: "system-ui", maxWidth: 720, margin: "0 auto" }}>
       <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
+      <p>Quick tools for reconciliation evidence review.</p>
+      <EvidenceDrawer />
     </div>
   );
 }
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/libs/rpt/__init__.py
+++ b/libs/rpt/__init__.py
@@ -1,1 +1,21 @@
-﻿
+from .rpt import (
+    ReplayError,
+    SignatureError,
+    TokenExpiredError,
+    build,
+    canonical_json,
+    decode,
+    sign,
+    verify,
+)
+
+__all__ = [
+    "build",
+    "canonical_json",
+    "decode",
+    "sign",
+    "verify",
+    "ReplayError",
+    "SignatureError",
+    "TokenExpiredError",
+]

--- a/libs/rpt/rpt.py
+++ b/libs/rpt/rpt.py
@@ -1,36 +1,211 @@
-﻿# libs/rpt/rpt.py
-import json, hmac, hashlib, os, time
-from typing import Dict, Any
+"""RPT signing helpers.
 
-def _key() -> bytes:
-    k = os.getenv("APGMS_RPT_SECRET", "dev-secret-change-me")
-    return k.encode("utf-8")
+This module now produces compact JWS tokens (RS256) that wrap the
+reconciliation payload.  The helpers expose a deterministic canonical JSON
+encoding so other services (Node, TypeScript) can share the same
+representation when computing payload hashes.
+"""
 
-def sign(payload: Dict[str, Any]) -> str:
-    msg = json.dumps(payload, sort_keys=True, separators=(",",":")).encode("utf-8")
-    return hmac.new(_key(), msg, hashlib.sha256).hexdigest()
+import json
+import os
+import time
+import uuid
+from base64 import urlsafe_b64decode, urlsafe_b64encode
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Optional, Tuple
 
-def verify(payload: Dict[str, Any], signature: str) -> bool:
-    try:
-        exp = sign(payload)
-        return hmac.compare_digest(exp, signature)
-    except Exception:
-        return False
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 
-def build(period_id: str,
-          paygw_total: float,
-          gst_total: float,
-          source_digests: Dict[str,str],
-          anomaly_score: float,
-          ttl_seconds: int = 3600) -> Dict[str, Any]:
-    rpt = {
+__all__ = [
+    "build",
+    "sign",
+    "verify",
+    "decode",
+    "canonical_json",
+    "ReplayError",
+    "SignatureError",
+    "TokenExpiredError",
+]
+
+
+class RptError(RuntimeError):
+    """Base class for RPT errors."""
+
+
+class SignatureError(RptError):
+    """Raised when the JWS signature is invalid."""
+
+
+class TokenExpiredError(RptError):
+    """Raised when a token has expired."""
+
+
+class ReplayError(RptError):
+    """Raised when a token JTI has already been observed."""
+
+
+_private_key: Optional[RSAPrivateKey] = None
+_public_key: Optional[RSAPublicKey] = None
+
+
+def _load_private_key() -> RSAPrivateKey:
+    global _private_key
+    if _private_key is not None:
+        return _private_key
+    pem = os.getenv("APGMS_RPT_PRIVATE_KEY_PEM")
+    if not pem:
+        raise RuntimeError("APGMS_RPT_PRIVATE_KEY_PEM is not set")
+    _private_key = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+    return _private_key
+
+
+def _load_public_key() -> RSAPublicKey:
+    global _public_key
+    if _public_key is not None:
+        return _public_key
+    pem = os.getenv("APGMS_RPT_PUBLIC_KEY_PEM")
+    if not pem:
+        raise RuntimeError("APGMS_RPT_PUBLIC_KEY_PEM is not set")
+    _public_key = serialization.load_pem_public_key(pem.encode("utf-8"))
+    return _public_key
+
+
+def canonical_json(value: Dict[str, Any]) -> str:
+    """Return canonical JSON (sorted keys, compact separators)."""
+
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _b64url(data: bytes) -> str:
+    return urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding_len = (4 - len(data) % 4) % 4
+    return urlsafe_b64decode(data + "=" * padding_len)
+
+
+def _protected_header(kid: Optional[str]) -> Dict[str, Any]:
+    header: Dict[str, Any] = {"alg": "RS256", "typ": "JWT"}
+    if kid:
+        header["kid"] = kid
+    return header
+
+
+def sign(claims: Dict[str, Any], *, kid: Optional[str] = None) -> Tuple[str, str]:
+    """Sign claims into a compact JWS and return the token + canonical payload."""
+
+    header = _protected_header(kid)
+    encoded_header = _b64url(canonical_json(header).encode("utf-8"))
+    payload_c14n = canonical_json(claims)
+    encoded_payload = _b64url(payload_c14n.encode("utf-8"))
+    signing_input = f"{encoded_header}.{encoded_payload}".encode("ascii")
+
+    key = _load_private_key()
+    signature = key.sign(signing_input, padding.PKCS1v15(), hashes.SHA256())
+    token = f"{encoded_header}.{encoded_payload}.{_b64url(signature)}"
+    return token, payload_c14n
+
+
+def build(
+    *,
+    period_id: str,
+    paygw_total: float,
+    gst_total: float,
+    source_digests: Dict[str, str],
+    anomaly_score: float,
+    rates_version: str,
+    evidence_root: str,
+    ttl_seconds: int = 3600,
+    kid: Optional[str] = None,
+    nonce: Optional[str] = None,
+    iat: Optional[int] = None,
+    exp: Optional[int] = None,
+    jti: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build and sign an RPT JWS.
+
+    Returns a dictionary containing the JWS token, decoded claims, and
+    canonical payload string so callers can persist both artifacts.
+    """
+
+    issued_at = int(iat if iat is not None else time.time())
+    expires_at = int(exp if exp is not None else issued_at + ttl_seconds)
+    claims: Dict[str, Any] = {
+        "type": "APGMS_RPT",
         "period_id": period_id,
-        "paygw_total": round(paygw_total,2),
-        "gst_total": round(gst_total,2),
+        "paygw_total": round(paygw_total, 2),
+        "gst_total": round(gst_total, 2),
         "source_digests": source_digests,
         "anomaly_score": anomaly_score,
-        "expires_at": int(time.time()) + ttl_seconds,
-        "nonce": os.urandom(8).hex()
+        "rates_version": rates_version,
+        "evidence_root": evidence_root,
+        "nonce": nonce or uuid.uuid4().hex,
+        "iat": issued_at,
+        "exp": expires_at,
+        "jti": jti or str(uuid.uuid4()),
     }
-    rpt["signature"] = sign(rpt)
-    return rpt
+    token, payload_c14n = sign(claims, kid=kid)
+    return {"token": token, "claims": claims, "payload_c14n": payload_c14n}
+
+
+def decode(token: str) -> Dict[str, Any]:
+    """Decode a compact JWS without verifying the signature."""
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise SignatureError("Token must have three parts")
+    header_b64, payload_b64, signature_b64 = parts
+    header = json.loads(_b64url_decode(header_b64).decode("utf-8"))
+    payload = json.loads(_b64url_decode(payload_b64).decode("utf-8"))
+    return {"header": header, "payload": payload, "signature_b64": signature_b64}
+
+
+def verify(
+    token: str,
+    *,
+    jti_store: Optional[Callable[[str, datetime], bool]] = None,
+    now: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Verify the token signature and return the payload claims.
+
+    If ``jti_store`` is provided it will be invoked with ``(jti, exp_dt)``.
+    The callable should return ``True`` if the JTI was recorded (first
+    sighting) or ``False`` if the JTI has already been seen.  A replay raises
+    :class:`ReplayError`.
+    """
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        raise SignatureError("Token must have three parts")
+
+    header_b64, payload_b64, signature_b64 = parts
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    signature = _b64url_decode(signature_b64)
+
+    key = _load_public_key()
+    try:
+        key.verify(signature, signing_input, padding.PKCS1v15(), hashes.SHA256())
+    except Exception as exc:  # pragma: no cover - cryptography gives rich errors
+        raise SignatureError("Invalid signature") from exc
+
+    payload = json.loads(_b64url_decode(payload_b64).decode("utf-8"))
+
+    exp = payload.get("exp")
+    if exp is None:
+        raise SignatureError("Token missing exp claim")
+    now_ts = int(now if now is not None else time.time())
+    if now_ts >= int(exp):
+        raise TokenExpiredError("Token expired")
+
+    jti = payload.get("jti")
+    if jti_store is not None:
+        if not jti:
+            raise SignatureError("Token missing jti claim")
+        exp_dt = datetime.fromtimestamp(int(exp), tz=timezone.utc)
+        if not jti_store(jti, exp_dt):
+            raise ReplayError(f"JTI {jti} has already been used")
+
+    return payload

--- a/migrations/002_patent_extensions.sql
+++ b/migrations/002_patent_extensions.sql
@@ -19,7 +19,12 @@ CREATE INDEX IF NOT EXISTS owa_ledger_period_order_idx
 -- (B) RPT: canonical storage (you already added; keep for completeness)
 ALTER TABLE rpt_tokens
   ADD COLUMN IF NOT EXISTS payload_c14n   text,
-  ADD COLUMN IF NOT EXISTS payload_sha256 text;
+  ADD COLUMN IF NOT EXISTS payload_sha256 text,
+  ADD COLUMN IF NOT EXISTS compact_jws    text,
+  ADD COLUMN IF NOT EXISTS expires_at     timestamptz,
+  ADD COLUMN IF NOT EXISTS nonce          text,
+  ADD COLUMN IF NOT EXISTS kid            text,
+  ADD COLUMN IF NOT EXISTS jti            text;
 
 -- (C) State machine check (guardrails)
 DO $$

--- a/migrations/003_rpt_jti.sql
+++ b/migrations/003_rpt_jti.sql
@@ -1,0 +1,7 @@
+-- 003_rpt_jti.sql
+CREATE TABLE IF NOT EXISTS rpt_jti (
+  jti text PRIMARY KEY,
+  exp timestamptz NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS rpt_jti_exp_idx ON rpt_jti(exp);

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = apps/services/tax-engine
+pythonpath = . apps/services/tax-engine

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ orjson==3.10.7
 nats-py==2.7.2
 prometheus-client==0.20.0
 httpx==0.27.2
+cryptography==43.0.3
+

--- a/tests/test_rpt_jws.py
+++ b/tests/test_rpt_jws.py
@@ -1,0 +1,95 @@
+import pytest
+
+from libs.rpt import ReplayError, build, verify
+
+_PRIVATE_KEY = """-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDKSe9QJ0XXczeroGVFRN9xy7IWaED1VYKD8xLNWoxvawaru6FMHKkqzdnq/Jmc3qFYnw7zvViQO7/6
+jH6u0HN/O7KCZI2mQmzNPMNEcibjloM01ZISDkpoVDMyeoPxuqtl/zyNYz82KyqZM2sGDXo0JgyWt+yMc+jbvhJyGODy6gO+u82Tqg8KET24VpUu6KONbUg/9e37MzKy
+84LGEoaMb0ws+kY6JQs6f895NIuOA8i87i1S8N1Spv+e1uvjbf2Tbgexeo2MX9QwcECAOmXpkJzl+pxst6DKe67JYN9RVj22Bm9oAerW8cS7iBdXUMbEezzkk6buH4Af
+uums/A6HAgMBAAECggEASLBPl6g9DwG+X+QXb9AjUJNG74lPyjiLWRm3yGXAr+qv73bRK3XjDdgBddCF7FoNdThWmZwQ3mcyAXiJrwyFbBNJ/lPemH8m9IrgidBRDBfS
+FuKlhepvr1SOPxXKIssWeuS/3/hpRvA08u8IhpjCMEn53RDDJecipg+DNk+dSXvMDaE69Cyf05Dwf7q5SYaV8JvLtOfgSzYD98BPeJ01YwxC/sY0Q5exWC0j49DEwQ2O
+MKGWZ29IiKHvt6h3pHlY8VnVTHDhA0b1YlnhCcFLiqkRiNVluUb8xh/oWZu2ph+f7MzFcflA8o8vk3zvUpzKDLhekqIJMUKkZ4DbmLyJnQKBgQD929mw6GOcLBPOMgA+
+VglX5hRwp4K9LT34ide73j9vv8QmUfaNVZuia8ZVxjqkLg94WFWioguJ4Tgl6wKExs1T3Txz3ldrt5ziVgmoYI4aCi3H1VCewUnoI7FfYOFHKvcPU6K/l+XQ/unTqILb
+YC1NSsUEi3dDMkM9wfDweCaCJQKBgQDL/rsfjQKgU5CWH/W4WW+qG3XGzxXWD2xoCDi3xNc0IDrrCJ7Xb6vrT9o+lEaKp6upkaFXWpHDWOG+oiK2UQeuIkidxh+AeEpANhpwzCTs7wRXhS1Yu1SFvL9FcIf71g5TAjQBUEBrvvNpLtgL9bPR0PSkXAoUave9FvrMV4bQOwKBgFKPZ7MTQSIPa7mJpW6giJVfrJIeyHRB/H+SROlClJsBYQedbHP2vZELQAuxVm0C1eEryV4FGX+UEbCzR7Rq+2gk8X41d3T+2DT8ClQKYuyxFsaA56FZ93FZ+luspFeC76q6ZpmtCv73iJBfo385PkJ+6Khbu0PNWvUA2B081jlJAoGAGkrv1WY4Y2/B4AeohSVJ5jP53zEL0HZWc6YzoUQGtNo+ndKTnpLvJro5F/3GhdKMpqN1lyu+Q95t4kNFlBgnlEMo9uT1ZHqcn2AZ0lYNoFhCSAGLUbd7cm1cfde+PzBc0kgjadPtKbYH65O1Fv2JOs7i6VhPmEgdPEr88l+JqccCgYAPEpkTVx0uHkx6HEgu8D7qM3RwKivcSOb+dXilrEp1x+96tzWK0MKTqlSyNeyx3ZiI3UI/grw1WMS5E9VZevGS7xjyN2oUdQ7H2p7HJZ6rW3STZgTlrdZywQ3B7X3fEHg1LK5/aIyW/zUCcYJp1e41Tr8MdUNh1PhtJFZ5/L5xUQ==
+-----END PRIVATE KEY-----"""
+
+_PUBLIC_KEY = """-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyknvUCdF13M3q6BlRUTfccuyFmhA9VWCg/MSzVqMb2sGq7uhTBypKs3Z6vyZnN6hWJ8O871YkDu/+ox+rtBz
+fzuygmSNpkJszTzDRHIm45aDNNWSEg5KaFQzMnqD8bqrZf88jWM/NisqmTNrBg16NCYMlrfsjHPo274Schjg8uoDvrvNk6oPChE9uFaVLuijjW1IP/Xt+zMysvOCxhKG
+jG9MLPpGOiULOn/PeTSLjgPIvO4tUvDdUqb/ntbr4239k24HsXqNjF/UMHBAgDpl6ZCc5fqcbLegynuuyWDfUVY9tgZvaAHq1vHEu4gXV1DGxHs85JOm7h+AH7rprPwO
+hwIDAQAB
+-----END PUBLIC KEY-----"""
+
+
+def _install_keys(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("APGMS_RPT_PRIVATE_KEY_PEM", _PRIVATE_KEY)
+    monkeypatch.setenv("APGMS_RPT_PUBLIC_KEY_PEM", _PUBLIC_KEY)
+    # reset cached keys between tests
+    from libs.rpt import rpt as module  # local import to avoid circulars
+
+    module._private_key = None
+    module._public_key = None
+
+
+def test_golden_compact_jws(monkeypatch: pytest.MonkeyPatch):
+    _install_keys(monkeypatch)
+    result = build(
+        period_id="2025-Q4",
+        paygw_total=1234.56,
+        gst_total=789.01,
+        source_digests={"payroll": "b3ab7e", "pos": "6be231"},
+        anomaly_score=0.17,
+        rates_version="2025-10",
+        evidence_root="abc123def",
+        ttl_seconds=600,
+        kid="rpt-key-1",
+        nonce="deadbeefcafebabe",
+        iat=1_700_000_000,
+        exp=1_700_000_600,
+        jti="rpt-jti-0001",
+    )
+    token = result["token"]
+    assert token  # sanity
+    assert result["claims"]["evidence_root"] == "abc123def"
+    # Expected token filled after first run
+    assert token == GOLDEN_JWS
+
+
+def test_replayed_jti_rejected(monkeypatch: pytest.MonkeyPatch):
+    _install_keys(monkeypatch)
+    token = build(
+        period_id="2025-Q4",
+        paygw_total=10.0,
+        gst_total=5.0,
+        source_digests={"payroll": "aaa"},
+        anomaly_score=0.0,
+        rates_version="2025-10",
+        evidence_root="root",
+        ttl_seconds=600,
+        nonce="cafefeed",
+        iat=1_700_000_000,
+        exp=1_700_000_600,
+        jti="rpt-jti-0002",
+    )["token"]
+
+    seen: set[str] = set()
+
+    def remember(jti: str, _exp_dt) -> bool:
+        if jti in seen:
+            return False
+        seen.add(jti)
+        return True
+
+    payload = verify(token, jti_store=remember, now=1_700_000_100)
+    assert payload["jti"] == "rpt-jti-0002"
+
+    with pytest.raises(ReplayError):
+        verify(token, jti_store=remember, now=1_700_000_100)
+
+
+# Golden token asserted by the test for deterministic signing output.
+GOLDEN_JWS = "".join([
+    "eyJhbGciOiJSUzI1NiIsImtpZCI6InJwdC1rZXktMSIsInR5cCI6IkpXVCJ9.",
+    "eyJhbm9tYWx5X3Njb3JlIjowLjE3LCJldmlkZW5jZV9yb290IjoiYWJjMTIzZGVmIiwiZXhwIjoxNzAwMDAwNjAwLCJnc3RfdG90YWwiOjc4OS4wMSwiaWF0IjoxNzAwMDAwMDAwLCJqdGkiOiJycHQtanRpLTAwMDEiLCJub25jZSI6ImRlYWRiZWVmY2FmZWJhYmUiLCJwYXlnd190b3RhbCI6MTIzNC41NiwicGVyaW9kX2lkIjoiMjAyNS1RNCIsInJhdGVzX3ZlcnNpb24iOiIyMDI1LTEwIiwic291cmNlX2RpZ2VzdHMiOnsicGF5cm9sbCI6ImIzYWI3ZSIsInBvcyI6IjZiZTIzMSJ9LCJ0eXBlIjoiQVBHTVNfUlBUIn0.",
+    "f-r5aipaUqLVxHnuU0srWQyA0PUfZX2CKD2pzJrkMbPvoAfzCv9IL0dtaQ6JFiqWpxPXZvPAcvj9Ivqd9RAb_rHCAbqjSRCps3a6HGyQ9VDzQ52HYMUTjuS9zSZMLR3viGmES_pgByjGRLliPdoM6vmmUIKQq6uAi52OXTLQS1-SSkwJgMzNDGxQ2wIj5_2Hu7D-pFfd3RbOUMGwNSa0bdoTrKnYacqH-3LzKugylR9X2Q3RZ0lVJQDvMgZ0UmjZtjz2X_wKnz3pGFhNXzo6lyFLNseuQ3hfqf8VSsGJmOXz0y_IO0zahUOyOZFxvXbCxuZ4GsNOO1AsYcJSz10saw",
+])


### PR DESCRIPTION
## Summary
- replace the legacy HMAC-based RPT helper with an RS256 JWS implementation that exposes canonical payloads and decode helpers
- add a replay-protection table/migration and upgrade the bank-egress service to record JTIs, verify compact tokens, and expose a `/rpt/verify` debug endpoint
- refresh the console evidence drawer so operators can paste a compact JWS and inspect its header and payload
- cover the new signer with pytest to lock in the golden token and replay rejection behaviour

## Testing
- pytest tests/test_rpt_jws.py

------
https://chatgpt.com/codex/tasks/task_e_68e26b417a988327974565ca9cdeb03c