### PR TITLE
Implement durable idempotency across services

### DIFF
--- a/apps/services/payments/src/bank/eftBpayAdapter.ts
+++ b/apps/services/payments/src/bank/eftBpayAdapter.ts
@@ -1,6 +1,7 @@
 ﻿import pg from "pg";
 import https from "https";
 import axios from "axios";
+import { attachAxiosIdempotencyInterceptor } from "../../../../../libs/idempotency/express.js";
 import { createHash, randomUUID } from "crypto";
 
 type Params = {
@@ -22,6 +23,8 @@ const client = axios.create({
   timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
   httpsAgent: agent
 });
+
+attachAxiosIdempotencyInterceptor(client);
 
 export async function sendEftOrBpay(p: Params): Promise<{transfer_uuid: string; bank_receipt_hash: string; provider_receipt_id: string}> {
   const transfer_uuid = randomUUID();

--- a/apps/services/payments/src/bank/paytoAdapter.ts
+++ b/apps/services/payments/src/bank/paytoAdapter.ts
@@ -1,5 +1,6 @@
 ﻿import pg from "pg";
 import axios from "axios";
+import { attachAxiosIdempotencyInterceptor } from "../../../../../libs/idempotency/express.js";
 import https from "https";
 const agent = new https.Agent({
   ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
@@ -12,6 +13,8 @@ const client = axios.create({
   timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
   httpsAgent: agent
 });
+
+attachAxiosIdempotencyInterceptor(client);
 
 export async function createMandate(abn: string, periodId: string, cap_cents: number) {
   const r = await client.post("/payto/mandates", { abn, periodId, cap_cents });

--- a/apps/services/payments/test/idempotency.test.ts
+++ b/apps/services/payments/test/idempotency.test.ts
@@ -1,6 +1,118 @@
-import { createHash } from "crypto";
-test("idempotency key stable", () => {
-  const key = "payato:111:PAYGW:2025-09";
-  const h = createHash("sha256").update(key).digest("hex");
-  expect(h).toHaveLength(64);
+import express from "express";
+import { AddressInfo } from "net";
+import { once } from "events";
+import { createHash, randomUUID } from "crypto";
+import { Pool } from "pg";
+
+import {
+  createExpressIdempotencyMiddleware,
+  derivePayoutKey,
+  installFetchIdempotencyPropagation,
+} from "../../../../libs/idempotency/express.js";
+
+describe("idempotency", () => {
+  const connectionString =
+    process.env.DATABASE_URL || "postgres://apgms:apgms_pw@127.0.0.1:5432/apgms";
+  const pool = new Pool({ connectionString });
+  installFetchIdempotencyPropagation();
+
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  test("concurrent payout requests share one mutation and response", async () => {
+    const app = express();
+    app.use(express.json());
+
+    const idem = createExpressIdempotencyMiddleware({
+      pool,
+      deriveKey: (req) => {
+        const path = (req.path || req.originalUrl || "").toLowerCase();
+        if (path === "/payout") {
+          return derivePayoutKey(req.body) ?? undefined;
+        }
+        return undefined;
+      },
+    });
+    app.use(idem);
+
+    const abn = "12345678901";
+    const taxType = "GST";
+    const periodId = "2025-10";
+    const amountCents = -5000;
+    const semanticKey = derivePayoutKey({ abn, periodId, amountCents });
+
+    await pool.query("DELETE FROM idempotency_keys WHERE id=$1", [semanticKey]);
+    await pool.query(
+      "DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
+
+    app.post("/payout", async (req, res) => {
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
+        const { rows: last } = await client.query(
+          `SELECT balance_after_cents FROM owa_ledger
+             WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+             ORDER BY id DESC LIMIT 1`,
+          [abn, taxType, periodId]
+        );
+        const prev = Number(last[0]?.balance_after_cents ?? 0);
+        const amt = Number(req.body?.amountCents ?? 0);
+        const newBal = prev + amt;
+        const transfer = randomUUID();
+        const { rows: inserted } = await client.query(
+          `INSERT INTO owa_ledger
+             (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
+           VALUES ($1,$2,$3,$4,$5,$6,now())
+           RETURNING id,balance_after_cents`,
+          [abn, taxType, periodId, transfer, amt, newBal]
+        );
+        await client.query("COMMIT");
+        res.json({ ok: true, ledger_id: inserted[0].id, balance_after_cents: inserted[0].balance_after_cents });
+      } catch (err: any) {
+        await client.query("ROLLBACK");
+        res.status(500).json({ error: "ledger insert failed", detail: String(err?.message || err) });
+      } finally {
+        client.release();
+      }
+    });
+
+    const server = app.listen(0);
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const body = { abn, taxType, periodId, amountCents };
+    const requests = Array.from({ length: 10 }, () =>
+      fetch(`http://127.0.0.1:${port}/payout`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(body),
+      })
+    );
+
+    const responses = await Promise.all(requests);
+    const payloads = await Promise.all(responses.map((r) => r.json()));
+    responses.forEach((r) => expect(r.status).toBe(200));
+
+    const serialized = payloads.map((p) => JSON.stringify(p));
+    expect(new Set(serialized).size).toBe(1);
+
+    const hash = createHash("sha256").update(serialized[0]).digest("hex");
+    const { rows: ledgerCount } = await pool.query(
+      "SELECT COUNT(*)::int AS count FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
+    expect(ledgerCount[0].count).toBe(1);
+
+    const { rows: idemRows } = await pool.query(
+      "SELECT status, response_hash FROM idempotency_keys WHERE id=$1",
+      [semanticKey]
+    );
+    expect(idemRows[0].status).toBe("applied");
+    expect(idemRows[0].response_hash).toBe(hash);
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
 });

--- a/libs/idempotency/express.d.ts
+++ b/libs/idempotency/express.d.ts
@@ -1,0 +1,26 @@
+import type { Pool } from 'pg';
+import type { Request, Response, NextFunction } from 'express';
+import type { AxiosInstance } from 'axios';
+
+declare interface ExpressIdempotencyOptions {
+  pool: Pool;
+  deriveKey?: (req: Request) => string | undefined;
+  defaultTtlSeconds?: number;
+  methods?: string[];
+}
+
+export declare function getIdempotencyKey(): string | undefined;
+export declare function installFetchIdempotencyPropagation(): void;
+export declare function attachAxiosIdempotencyInterceptor<T extends AxiosInstance>(instance: T): T;
+export declare function derivePayoutKey(body: any): string | undefined;
+export declare function createExpressIdempotencyMiddleware(options: ExpressIdempotencyOptions): (req: Request, res: Response, next: NextFunction) => void;
+
+declare const _default: {
+  getIdempotencyKey: typeof getIdempotencyKey;
+  installFetchIdempotencyPropagation: typeof installFetchIdempotencyPropagation;
+  attachAxiosIdempotencyInterceptor: typeof attachAxiosIdempotencyInterceptor;
+  createExpressIdempotencyMiddleware: typeof createExpressIdempotencyMiddleware;
+  derivePayoutKey: typeof derivePayoutKey;
+};
+
+export default _default;

--- a/libs/idempotency/express.js
+++ b/libs/idempotency/express.js
@@ -1,0 +1,264 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { randomUUID, createHash } from 'node:crypto';
+
+const storage = new AsyncLocalStorage();
+let fetchPatched = false;
+const axiosInterceptors = new WeakSet();
+
+function getStore() {
+  return storage.getStore() || null;
+}
+
+export function getIdempotencyKey() {
+  return getStore()?.key;
+}
+
+export function installFetchIdempotencyPropagation() {
+  if (fetchPatched || typeof globalThis.fetch !== 'function') {
+    return;
+  }
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = async (input, init = {}) => {
+    const key = getIdempotencyKey();
+    if (key) {
+      const headers = new Headers(init.headers || {});
+      if (!headers.has('Idempotency-Key')) {
+        headers.set('Idempotency-Key', key);
+      }
+      init = { ...init, headers };
+    }
+    return originalFetch(input, init);
+  };
+  fetchPatched = true;
+}
+
+export function attachAxiosIdempotencyInterceptor(instance) {
+  if (!instance || axiosInterceptors.has(instance)) {
+    return instance;
+  }
+  instance.interceptors.request.use((config) => {
+    const key = getIdempotencyKey();
+    if (key) {
+      config.headers = config.headers || {};
+      if (!('Idempotency-Key' in config.headers)) {
+        config.headers['Idempotency-Key'] = key;
+      }
+    }
+    return config;
+  });
+  axiosInterceptors.add(instance);
+  return instance;
+}
+
+export function derivePayoutKey(body) {
+  if (!body) return undefined;
+  const abn = body.abn || body.ABN;
+  const period = body.periodId || body.period_id || body.period;
+  const amtRaw = body.amountCents ?? body.amount_cents ?? body.amount;
+  const amount = Number(amtRaw);
+  if (!abn || !period || !Number.isFinite(amount)) {
+    return undefined;
+  }
+  return `ABN:${abn}:BAS:${period}:PAYMENT:${Math.trunc(amount)}`;
+}
+
+function parseTtl(headerValue, fallback) {
+  if (!headerValue) return fallback;
+  const parsed = Number(headerValue);
+  if (Number.isFinite(parsed) && parsed > 0) {
+    return Math.trunc(parsed);
+  }
+  return fallback;
+}
+
+export function createExpressIdempotencyMiddleware(options) {
+  const {
+    pool,
+    deriveKey,
+    defaultTtlSeconds = 24 * 60 * 60,
+    methods = ['POST', 'PUT', 'PATCH', 'DELETE'],
+  } = options || {};
+  if (!pool) {
+    throw new Error('createExpressIdempotencyMiddleware requires a pg Pool');
+  }
+
+  return async function idempotencyMiddleware(req, res, next) {
+    const method = (req.method || '').toUpperCase();
+    const shouldTrack = methods.includes(method);
+    let key = req.header('Idempotency-Key');
+    if (!key && typeof deriveKey === 'function') {
+      try {
+        key = deriveKey(req) || undefined;
+      } catch (err) {
+        console.warn('[idem] deriveKey failed:', err);
+      }
+    }
+    if (!key) {
+      key = randomUUID();
+    }
+    res.setHeader('Idempotency-Key', key);
+
+    if (!shouldTrack) {
+      storage.run({ key }, () => next());
+      return;
+    }
+
+    const client = await pool.connect();
+    let activeClient = client;
+    let finalized = false;
+    const ttl = parseTtl(req.header('Idempotency-Ttl'), defaultTtlSeconds);
+
+    const finishWith = async (fn) => {
+      if (!activeClient || finalized) return;
+      finalized = true;
+      try {
+        await fn();
+      } catch (err) {
+        try {
+          await activeClient.query('ROLLBACK');
+        } catch (rollbackErr) {
+          console.error('[idem] rollback failed', rollbackErr);
+        }
+        throw err;
+      } finally {
+        activeClient.release();
+        activeClient = null;
+      }
+    };
+
+    try {
+      await client.query('BEGIN');
+      await client.query(
+        `INSERT INTO idempotency_keys (id, status, ttl_secs)
+         VALUES ($1, 'pending', $2)
+         ON CONFLICT (id) DO NOTHING`,
+        [key, ttl]
+      );
+      const { rows } = await client.query(
+        `SELECT status, response_hash, response_body, http_status, response_content_type, last_error
+           FROM idempotency_keys
+          WHERE id=$1
+          FOR UPDATE`,
+        [key]
+      );
+      if (!rows.length) {
+        throw new Error('Idempotency record missing');
+      }
+      const record = rows[0];
+      if (record.status === 'applied') {
+        await client.query('COMMIT');
+        const bodyBuf = record.response_body ? Buffer.from(record.response_body) : Buffer.alloc(0);
+        if (bodyBuf.length) {
+          if (record.response_content_type) {
+            res.setHeader('Content-Type', record.response_content_type);
+          }
+          res.setHeader('Idempotency-Replayed', 'true');
+          res.status(record.http_status || 200);
+          res.send(bodyBuf);
+        } else {
+          res.setHeader('Idempotency-Replayed', 'true');
+          res.sendStatus(record.http_status || 200);
+        }
+        client.release();
+        return;
+      }
+      if (record.status === 'failed') {
+        await client.query('COMMIT');
+        client.release();
+        res.setHeader('Idempotency-Replayed', 'true');
+        res.status(409).json({ error: 'Idempotency replay rejected', detail: record.last_error || null });
+        return;
+      }
+
+      let capturedBody = null;
+      const originalSend = res.send.bind(res);
+      res.send = function patchedSend(body) {
+        if (body === undefined || body === null) {
+          capturedBody = Buffer.alloc(0);
+        } else if (Buffer.isBuffer(body)) {
+          capturedBody = Buffer.from(body);
+        } else if (typeof body === 'string') {
+          capturedBody = Buffer.from(body);
+        } else if (typeof body === 'object') {
+          try {
+            capturedBody = Buffer.from(JSON.stringify(body));
+          } catch {
+            capturedBody = Buffer.from(String(body));
+          }
+        } else {
+          capturedBody = Buffer.from(String(body));
+        }
+        return originalSend(body);
+      };
+
+      const finalize = async (status, bodyBuffer, errorDetail) => {
+        const contentType = res.getHeader('Content-Type');
+        if (status >= 200 && status < 400) {
+          const payload = bodyBuffer ?? Buffer.alloc(0);
+          const hash = createHash('sha256').update(payload).digest('hex');
+          await client.query(
+            `UPDATE idempotency_keys
+                SET status='applied', response_hash=$2, response_body=$3, http_status=$4,
+                    response_content_type=$5, updated_at=now(), applied_at=now()
+              WHERE id=$1`,
+            [key, hash, payload, status, contentType ? String(contentType) : null]
+          );
+        } else {
+          await client.query(
+            `UPDATE idempotency_keys
+                SET status='failed', http_status=$2, last_error=$3, updated_at=now()
+              WHERE id=$1`,
+            [key, status, errorDetail?.slice(0, 500) ?? null]
+          );
+        }
+        await client.query('COMMIT');
+      };
+
+      res.once('finish', () => {
+        const status = res.statusCode || 200;
+        const bodyBuffer = capturedBody;
+        const detail = bodyBuffer ? bodyBuffer.toString('utf8') : null;
+        finishWith(() => finalize(status, bodyBuffer, detail)).catch((err) => {
+          console.error('[idem] finalize error', err);
+        });
+      });
+      res.once('close', () => {
+        if (res.writableEnded) {
+          return;
+        }
+        finishWith(async () => {
+          await client.query(
+            `UPDATE idempotency_keys
+                SET status='failed', http_status=499, last_error='client_closed', updated_at=now()
+              WHERE id=$1`,
+            [key]
+          );
+          await client.query('COMMIT');
+        }).catch((err) => {
+          console.error('[idem] close finalize error', err);
+        });
+      });
+
+      storage.run({ key }, () => next());
+    } catch (err) {
+      if (activeClient) {
+        try {
+          await activeClient.query('ROLLBACK');
+        } catch (rollbackErr) {
+          console.error('[idem] rollback error', rollbackErr);
+        }
+        activeClient.release();
+        activeClient = null;
+      }
+      next(err);
+    }
+  };
+}
+
+export default {
+  getIdempotencyKey,
+  installFetchIdempotencyPropagation,
+  attachAxiosIdempotencyInterceptor,
+  createExpressIdempotencyMiddleware,
+  derivePayoutKey,
+};

--- a/migrations/003_idempotency.sql
+++ b/migrations/003_idempotency.sql
@@ -1,0 +1,35 @@
+DO $$
+BEGIN
+  CREATE TYPE idempotency_status AS ENUM ('pending', 'applied', 'failed');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END$$;
+
+ALTER TABLE idempotency_keys RENAME COLUMN key TO id;
+ALTER TABLE idempotency_keys RENAME COLUMN created_at TO first_seen;
+
+ALTER TABLE idempotency_keys
+  ADD COLUMN IF NOT EXISTS status idempotency_status NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS response_body BYTEA,
+  ADD COLUMN IF NOT EXISTS http_status INT,
+  ADD COLUMN IF NOT EXISTS response_content_type TEXT,
+  ADD COLUMN IF NOT EXISTS ttl_secs INT NOT NULL DEFAULT 86400,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS last_error TEXT,
+  ADD COLUMN IF NOT EXISTS applied_at TIMESTAMPTZ;
+
+UPDATE idempotency_keys
+   SET status = CASE COALESCE(last_status, 'INIT')
+                  WHEN 'DONE' THEN 'applied'
+                  WHEN 'FAILED' THEN 'failed'
+                  ELSE 'pending'
+                END;
+
+ALTER TABLE idempotency_keys DROP COLUMN IF EXISTS last_status;
+
+UPDATE idempotency_keys
+   SET updated_at = COALESCE(updated_at, first_seen),
+       applied_at = CASE WHEN status = 'applied' AND applied_at IS NULL THEN first_seen ELSE applied_at END;
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_first_seen ON idempotency_keys (first_seen);
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_expiry ON idempotency_keys ((first_seen + make_interval(secs => COALESCE(ttl_secs, 0))));

--- a/portal-api/app.py
+++ b/portal-api/app.py
@@ -3,7 +3,12 @@ from pydantic import BaseModel
 from typing import List, Dict, Any
 import time
 
+from pyshared.idempotency import IdempotencyMiddleware, install_httpx_idempotency
+
 app = FastAPI(title="APGMS Portal API", version="0.1.0")
+
+install_httpx_idempotency()
+app.add_middleware(IdempotencyMiddleware)
 
 @app.get("/readyz")
 def readyz(): return {"ok": True, "ts": time.time()}

--- a/portal-api/requirements.txt
+++ b/portal-api/requirements.txt
@@ -1,2 +1,3 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
+asyncpg==0.29.0

--- a/pyshared/__init__.py
+++ b/pyshared/__init__.py
@@ -1,0 +1,9 @@
+"""Shared Python utilities for APGMS."""
+
+from .idempotency import IdempotencyMiddleware, install_httpx_idempotency, get_current_idempotency_key
+
+__all__ = [
+    "IdempotencyMiddleware",
+    "install_httpx_idempotency",
+    "get_current_idempotency_key",
+]

--- a/pyshared/idempotency.py
+++ b/pyshared/idempotency.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import uuid
+import hashlib
+from contextvars import ContextVar
+from typing import Callable, Iterable, Optional, Tuple
+
+import asyncpg
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse
+
+_idempotency_var: ContextVar[Optional[str]] = ContextVar("idempotency_key", default=None)
+_httpx_patched = False
+
+
+def get_current_idempotency_key() -> Optional[str]:
+    return _idempotency_var.get()
+
+
+def install_httpx_idempotency() -> None:
+    global _httpx_patched
+    if _httpx_patched:
+        return
+    try:
+        import httpx
+    except ModuleNotFoundError:  # pragma: no cover
+        return
+
+    original_async_request = httpx.AsyncClient.request
+    original_sync_request = httpx.Client.request
+
+    async def async_request(self, method, url, *args, **kwargs):  # type: ignore[override]
+        key = get_current_idempotency_key()
+        if key:
+            headers = dict(kwargs.get("headers") or {})
+            headers.setdefault("Idempotency-Key", key)
+            kwargs["headers"] = headers
+        return await original_async_request(self, method, url, *args, **kwargs)
+
+    def sync_request(self, method, url, *args, **kwargs):  # type: ignore[override]
+        key = get_current_idempotency_key()
+        if key:
+            headers = dict(kwargs.get("headers") or {})
+            headers.setdefault("Idempotency-Key", key)
+            kwargs["headers"] = headers
+        return original_sync_request(self, method, url, *args, **kwargs)
+
+    httpx.AsyncClient.request = async_request  # type: ignore[assignment]
+    httpx.Client.request = sync_request  # type: ignore[assignment]
+    _httpx_patched = True
+
+
+class IdempotencyMiddleware(BaseHTTPMiddleware):
+    def __init__(
+        self,
+        app,
+        *,
+        ttl_seconds: int = 86400,
+        dsn: Optional[str] = None,
+        derive_key: Optional[Callable[[Request], Optional[str]]] = None,
+        methods: Iterable[str] = ("POST", "PUT", "PATCH", "DELETE"),
+    ) -> None:
+        super().__init__(app)
+        self.ttl_seconds = ttl_seconds
+        self.dsn = dsn or os.getenv("DATABASE_URL") or "postgres://apgms:apgms_pw@127.0.0.1:5432/apgms"
+        self.derive_key = derive_key
+        self.methods = tuple(m.upper() for m in methods)
+        self._pool: Optional[asyncpg.Pool] = None
+        self._pool_lock = asyncio.Lock()
+        app.add_event_handler("shutdown", self._close_pool)
+
+    async def _close_pool(self) -> None:
+        if self._pool:
+            await self._pool.close()
+            self._pool = None
+
+    async def _get_pool(self) -> asyncpg.Pool:
+        if self._pool is None:
+            async with self._pool_lock:
+                if self._pool is None:
+                    self._pool = await asyncpg.create_pool(dsn=self.dsn, min_size=1, max_size=10)
+        return self._pool
+
+    def _parse_ttl(self, header_value: Optional[str]) -> int:
+        if not header_value:
+            return self.ttl_seconds
+        try:
+            value = int(header_value)
+            if value > 0:
+                return value
+        except (TypeError, ValueError):
+            pass
+        return self.ttl_seconds
+
+    async def dispatch(self, request: Request, call_next):  # type: ignore[override]
+        method = (request.method or "").upper()
+        key = request.headers.get("Idempotency-Key")
+        if not key and self.derive_key:
+            try:
+                key = self.derive_key(request) or None
+            except Exception:  # pragma: no cover - defensive
+                key = None
+        if not key:
+            key = str(uuid.uuid4())
+
+        if method not in self.methods:
+            token = _idempotency_var.set(key)
+            try:
+                response = await call_next(request)
+            finally:
+                _idempotency_var.reset(token)
+            response.headers["Idempotency-Key"] = key
+            return response
+
+        pool = await self._get_pool()
+        conn = await pool.acquire()
+        tx = conn.transaction()
+        await tx.start()
+        ttl = self._parse_ttl(request.headers.get("Idempotency-Ttl"))
+
+        try:
+            await conn.execute(
+                """
+                INSERT INTO idempotency_keys (id, status, ttl_secs)
+                VALUES ($1, 'pending', $2)
+                ON CONFLICT (id) DO NOTHING
+                """,
+                key,
+                ttl,
+            )
+            record = await conn.fetchrow(
+                """
+                SELECT status, response_body, http_status, response_content_type, last_error
+                  FROM idempotency_keys
+                 WHERE id=$1
+                 FOR UPDATE
+                """,
+                key,
+            )
+            if not record:
+                raise RuntimeError("Idempotency record missing")
+
+            if record["status"] == "applied":
+                await tx.commit()
+                body = bytes(record["response_body"]) if record["response_body"] else b""
+                response = Response(
+                    content=body,
+                    status_code=record["http_status"] or 200,
+                    media_type=record["response_content_type"],
+                )
+                response.headers["Idempotency-Key"] = key
+                response.headers["Idempotency-Replayed"] = "true"
+                return response
+
+            if record["status"] == "failed":
+                await tx.commit()
+                response = JSONResponse(
+                    status_code=409,
+                    content={"error": "Idempotency replay rejected", "detail": record["last_error"]},
+                )
+                response.headers["Idempotency-Key"] = key
+                response.headers["Idempotency-Replayed"] = "true"
+                return response
+
+            token = _idempotency_var.set(key)
+            request.state.idempotency_key = key  # type: ignore[attr-defined]
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                await conn.execute(
+                    """
+                    UPDATE idempotency_keys
+                       SET status='failed', http_status=500, last_error=$2, updated_at=now()
+                     WHERE id=$1
+                    """,
+                    key,
+                    str(exc)[:500],
+                )
+                await tx.commit()
+                raise
+            finally:
+                _idempotency_var.reset(token)
+
+            response, body = await self._capture_response(response)
+            content_type = response.headers.get("content-type")
+            if 200 <= response.status_code < 400:
+                hash_hex = hashlib.sha256(body).hexdigest()
+                await conn.execute(
+                    """
+                    UPDATE idempotency_keys
+                       SET status='applied', response_hash=$2, response_body=$3, http_status=$4,
+                           response_content_type=$5, updated_at=now(), applied_at=now()
+                     WHERE id=$1
+                    """,
+                    key,
+                    hash_hex,
+                    body,
+                    response.status_code,
+                    content_type,
+                )
+            else:
+                preview = body.decode("utf-8", errors="ignore")[:500]
+                await conn.execute(
+                    """
+                    UPDATE idempotency_keys
+                       SET status='failed', http_status=$2, last_error=$3, updated_at=now()
+                     WHERE id=$1
+                    """,
+                    key,
+                    response.status_code,
+                    preview,
+                )
+
+            await tx.commit()
+            response.headers["Idempotency-Key"] = key
+            return response
+        except Exception:
+            await tx.rollback()
+            raise
+        finally:
+            await pool.release(conn)
+
+    async def _capture_response(self, response: Response) -> Tuple[Response, bytes]:
+        if getattr(response, "body", None) is not None:
+            body = response.body or b""
+            if not isinstance(body, (bytes, bytearray)):
+                body = bytes(body)
+            new_response = Response(
+                content=body,
+                status_code=response.status_code,
+                headers=dict(response.headers),
+                media_type=response.media_type,
+                background=response.background,
+            )
+            return new_response, bytes(body)
+
+        body_chunks = []
+        body_iterator = getattr(response, "body_iterator", None)
+        if body_iterator is not None:
+            async for chunk in body_iterator:  # type: ignore
+                body_chunks.append(chunk)
+        body = b"".join(body_chunks)
+        new_response = Response(
+            content=body,
+            status_code=response.status_code,
+            headers=dict(response.headers),
+            media_type=response.media_type,
+            background=response.background,
+        )
+        return new_response, body
+
+
+__all__ = [
+    "IdempotencyMiddleware",
+    "install_httpx_idempotency",
+    "get_current_idempotency_key",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ orjson==3.10.7
 nats-py==2.7.2
 prometheus-client==0.20.0
 httpx==0.27.2
+asyncpg==0.29.0

--- a/scripts/clear_idem.ps1
+++ b/scripts/clear_idem.ps1
@@ -1,0 +1,20 @@
+param(
+  [string]$DbHost = "127.0.0.1",
+  [string]$DbName = "apgms",
+  [string]$DbUser = "apgms",
+  [string]$DbPwd  = "apgms_pw",
+  [switch]$ExpiredOnly
+)
+
+$ErrorActionPreference = "Stop"
+$env:PGPASSWORD = $DbPwd
+
+if ($ExpiredOnly) {
+  $sql = "DELETE FROM idempotency_keys WHERE first_seen + make_interval(secs => COALESCE(ttl_secs,0)) < now();"
+  Write-Host "Deleting expired idempotency keys..." -ForegroundColor Cyan
+} else {
+  $sql = "TRUNCATE idempotency_keys;"
+  Write-Host "Truncating idempotency keys table..." -ForegroundColor Yellow
+}
+
+& psql -h $DbHost -U $DbUser -d $DbName -v ON_ERROR_STOP=1 -c $sql

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,11 +15,14 @@ app.use(express.json({ limit: "2mb" }));
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
 
+// global idempotency middleware
+app.use(idempotency());
+
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
+app.post("/api/pay", payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,11 +1,15 @@
-﻿import { Pool } from "pg";
+import { createHash } from "node:crypto";
+import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
+import { derivePayoutKey, getIdempotencyKey } from "../libs/idempotency/express.js";
+
 const pool = new Pool();
+const DEFAULT_TTL_SECONDS = 24 * 60 * 60;
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
   const { rows } = await pool.query(
     "select * from remittance_destinations where abn= and rail= and reference=",
     [abn, rail, reference]
@@ -14,29 +18,139 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
   return rows[0];
 }
 
-/** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
-  const transfer_uuid = uuidv4();
+/** Durable release with shared idempotency semantics */
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY",
+  reference: string,
+) {
+  const contextKey = getIdempotencyKey();
+  const semanticKey = derivePayoutKey({ abn, taxType, periodId, amountCents });
+  const idKey = contextKey ?? semanticKey ?? `rails:${abn}:${periodId}:${uuidv4()}`;
+  const manualIdempotency = !contextKey;
+  const client = await pool.connect();
+  let committed = false;
+
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
-  } catch {
-    return { transfer_uuid, status: "DUPLICATE" };
+    if (manualIdempotency) {
+      await client.query("BEGIN");
+      await client.query(
+        `INSERT INTO idempotency_keys (id, status, ttl_secs)
+         VALUES ($1,'pending',$2)
+         ON CONFLICT (id) DO NOTHING`,
+        [idKey, DEFAULT_TTL_SECONDS]
+      );
+      const { rows } = await client.query(
+        `SELECT status, response_body, last_error
+           FROM idempotency_keys
+          WHERE id=$1
+          FOR UPDATE`,
+        [idKey]
+      );
+      if (!rows.length) throw new Error("Idempotency record missing");
+      const record = rows[0];
+      if (record.status === "applied") {
+        await client.query("COMMIT");
+        committed = true;
+        const cached = record.response_body
+          ? JSON.parse(Buffer.from(record.response_body).toString("utf8"))
+          : { idempotent: true };
+        return cached;
+      }
+      if (record.status === "failed") {
+        await client.query("COMMIT");
+        committed = true;
+        throw new Error(record.last_error || "IDEMPOTENT_REPLAY_CONFLICT");
+      }
+      await client.query("SAVEPOINT release_attempt");
+    } else {
+      await client.query("BEGIN");
+    }
+
+    const { rows: lastRows } = await client.query(
+      `SELECT balance_after_cents, hash_after
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const prevBal = Number(lastRows[0]?.balance_after_cents ?? 0);
+    const prevHash = lastRows[0]?.hash_after ?? "";
+    const debit = Number(amountCents);
+    if (!Number.isFinite(debit) || debit <= 0) {
+      throw new Error("INVALID_AMOUNT");
+    }
+    const newBal = prevBal - debit;
+    const transfer_uuid = uuidv4();
+    const bank_receipt_hash = `bank:${transfer_uuid.slice(0, 12)}`;
+    const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
+
+    await client.query(
+      `INSERT INTO owa_ledger(
+         abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,
+         bank_receipt_hash,prev_hash,hash_after,created_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())`,
+      [abn, taxType, periodId, transfer_uuid, -debit, newBal, bank_receipt_hash, prevHash, hashAfter]
+    );
+
+    const response = { transfer_uuid, bank_receipt_hash };
+    if (manualIdempotency) {
+      const payload = Buffer.from(JSON.stringify(response));
+      const hash = createHash("sha256").update(payload).digest("hex");
+      await client.query(
+        `UPDATE idempotency_keys
+            SET status='applied', response_hash=$2, response_body=$3, http_status=200,
+                response_content_type='application/json', updated_at=now(), applied_at=now()
+          WHERE id=$1`,
+        [idKey, hash, payload]
+      );
+    }
+
+    await client.query("COMMIT");
+    committed = true;
+
+    await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
+    return response;
+  } catch (err: any) {
+    const detail = String(err?.message || err);
+    if (manualIdempotency) {
+      try {
+        await client.query("ROLLBACK TO SAVEPOINT release_attempt");
+      } catch {
+        // ignore
+      }
+      try {
+        await client.query(
+          `UPDATE idempotency_keys
+              SET status='failed', http_status=500, last_error=$2, updated_at=now()
+            WHERE id=$1`,
+          [idKey, detail.slice(0, 500)]
+        );
+        await client.query("COMMIT");
+        committed = true;
+      } catch {
+        // swallow secondary failures
+      }
+    } else {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        // ignore
+      }
+    }
+    throw err;
+  } finally {
+    if (!committed) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        /* ignore */
+      }
+    }
+    client.release();
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
-
-  const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
-  const prevHash = rows[0]?.hash_after ?? "";
-  const newBal = prevBal - amountCents;
-  const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
-
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
-  );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
 }


### PR DESCRIPTION
## Summary
- add shared Express idempotency middleware that persists responses, patches fetch/axios, and apply it to payment services and the main API
- introduce a migration plus cleanup script for the new idempotency schema and adapt releasePayment to reuse the durable entries
- provide FastAPI middleware with httpx propagation and wire it into the portal API alongside new concurrency coverage for payouts

## Testing
- `npm --prefix apps/services/payments test -- idempotency.test.ts` *(fails: jest executable not present in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e26b21a438832784c13aa1aa86653b