### PR TITLE
Refactor SQL utilities to enforce parameterized queries

### DIFF
--- a/db/sql.ts
+++ b/db/sql.ts
@@ -1,0 +1,36 @@
+import pg, { PoolClient, QueryResultRow } from "pg";
+
+const { Pool } = pg;
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  (process.env.PGHOST || process.env.PGUSER || process.env.PGDATABASE
+    ? `postgres://${process.env.PGUSER || "apgms"}:${encodeURIComponent(process.env.PGPASSWORD || "")}` +
+      `@${process.env.PGHOST || "127.0.0.1"}:${process.env.PGPORT || "5432"}/${process.env.PGDATABASE || "apgms"}`
+    : undefined);
+
+export const pool = new Pool(connectionString ? { connectionString } : undefined);
+
+export function q<T extends QueryResultRow = QueryResultRow>(text: string, values: any[] = []) {
+  return pool.query<T>(text, values);
+}
+
+export async function tx<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (rollbackErr) {
+      // eslint-disable-next-line no-console
+      console.error("rollback failed", rollbackErr);
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "if grep -R '\\`[^\\n]*WHERE [^\\n]* = \\${' --exclude-dir=node_modules --exclude-dir=.git --line-number .; then echo 'Found interpolated SQL'; exit 1; else echo 'SQL interpolation lint passed'; fi",
+        "test": "tsx --test tests/**/*.test.ts",
+        "lint:sql": "if grep -R '\\`[^\\n]*WHERE [^\\n]* = \\${' --exclude-dir=node_modules --exclude-dir=.git --line-number .; then echo 'Found interpolated SQL'; exit 1; else echo 'SQL interpolation lint passed'; fi"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,1 @@
+export { pool, q, tx } from "../db/sql";

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,11 +1,17 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { q } from "../db";
+
+export const SQL_SELECT_PERIOD_FOR_BUNDLE =
+  "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3";
+export const SQL_SELECT_RPT_FOR_BUNDLE =
+  "SELECT * FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1";
+export const SQL_SELECT_LEDGER_FOR_BUNDLE =
+  "SELECT created_at AS ts, amount_cents, hash_after, bank_receipt_hash FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id";
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const p = (await q(SQL_SELECT_PERIOD_FOR_BUNDLE, [abn, taxType, periodId])).rows[0];
+  const rpt = (await q(SQL_SELECT_RPT_FOR_BUNDLE, [abn, taxType, periodId])).rows[0];
+  const deltas = (await q(SQL_SELECT_LEDGER_FOR_BUNDLE, [abn, taxType, periodId])).rows;
+  const last = deltas[deltas.length - 1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
     rpt_payload: rpt?.payload ?? null,
@@ -13,7 +19,7 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [], // TODO: populate from recon diffs
   };
   return bundle;
 }

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,24 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import type { Request, Response, NextFunction } from "express";
+import { q } from "../db";
+
+export const SQL_INSERT_IDEMPOTENCY_KEY =
+  "INSERT INTO idempotency_keys(key,last_status) VALUES ($1,$2)";
+export const SQL_SELECT_IDEMPOTENCY_KEY =
+  "SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1";
+
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: Request, res: Response, next: NextFunction) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await q(SQL_INSERT_IDEMPOTENCY_KEY, [key, "INIT"]);
       return next();
-    } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+    } catch (err: any) {
+      const r = await q(SQL_SELECT_IDEMPOTENCY_KEY, [key]);
+      return res
+        .status(200)
+        .json({ idempotent: true, status: r.rows[0]?.last_status || "DONE" });
     }
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,42 +1,90 @@
-﻿import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { q, tx } from "../db";
+
+type Rail = "EFT" | "BPAY";
+
+export const SQL_SELECT_DESTINATION =
+  "SELECT * FROM remittance_destinations WHERE abn=$1 AND rail=$2 AND reference=$3";
+export const SQL_INSERT_IDEMPOTENCY_KEY =
+  "INSERT INTO idempotency_keys(key,last_status) VALUES ($1,$2)";
+export const SQL_SELECT_LEDGER_TAIL =
+  "SELECT balance_after_cents, hash_after FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1";
+export const SQL_INSERT_LEDGER_RELEASE =
+  "INSERT INTO owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)";
+export const SQL_UPDATE_IDEMPOTENCY_DONE =
+  "UPDATE idempotency_keys SET last_status=$2, response_hash=$3 WHERE key=$1";
+
+class DuplicateIdempotencyError extends Error {
+  constructor(public readonly key: string) {
+    super("IDEMPOTENCY_CONFLICT");
+  }
+}
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
-  const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
-    [abn, rail, reference]
-  );
+export async function resolveDestination(abn: string, rail: Rail, reference: string) {
+  const { rows } = await q(SQL_SELECT_DESTINATION, [abn, rail, reference]);
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
   return rows[0];
 }
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: Rail,
+  reference: string
+) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
-  } catch {
-    return { transfer_uuid, status: "DUPLICATE" };
+    return await tx(async (client) => {
+      await client.query(SQL_INSERT_IDEMPOTENCY_KEY, [transfer_uuid, "INIT"]).catch((err: any) => {
+        if (err?.code === "23505") {
+          throw new DuplicateIdempotencyError(transfer_uuid);
+        }
+        throw err;
+      });
+
+      const { rows } = await client.query<{ balance_after_cents: number; hash_after: string | null }>(
+        SQL_SELECT_LEDGER_TAIL,
+        [abn, taxType, periodId]
+      );
+      const prevBal = Number(rows[0]?.balance_after_cents ?? 0);
+      const prevHash = rows[0]?.hash_after ?? "";
+      const newBal = prevBal - amountCents;
+      const bank_receipt_hash = "bank:" + transfer_uuid.slice(0, 12);
+      const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
+
+      await client.query(SQL_INSERT_LEDGER_RELEASE, [
+        abn,
+        taxType,
+        periodId,
+        transfer_uuid,
+        -amountCents,
+        newBal,
+        bank_receipt_hash,
+        prevHash,
+        hashAfter,
+      ]);
+
+      await appendAudit(
+        "rails",
+        "release",
+        { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash },
+        client
+      );
+
+      await client.query(SQL_UPDATE_IDEMPOTENCY_DONE, [transfer_uuid, "DONE", null]);
+
+      return { transfer_uuid, bank_receipt_hash };
+    });
+  } catch (err) {
+    if (err instanceof DuplicateIdempotencyError) {
+      return { transfer_uuid: err.key, status: "DUPLICATE" };
+    }
+    throw err;
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
-
-  const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
-  const prevHash = rows[0]?.hash_after ?? "";
-  const newBal = prevBal - amountCents;
-  const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
-
-  await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
-  );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,63 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { q } from "../db";
 
-export async function closeAndIssue(req:any, res:any) {
+export const SQL_SELECT_LATEST_RPT =
+  "SELECT * FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1";
+export const SQL_UPDATE_PERIOD_RELEASED =
+  "UPDATE periods SET state='RELEASED' WHERE abn=$1 AND tax_type=$2 AND period_id=$3";
+
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds || {
+      epsilon_cents: 50,
+      variance_ratio: 0.25,
+      dup_rate: 0.01,
+      gap_minutes: 60,
+      delta_vs_baseline: 0.2,
+    };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await q(SQL_SELECT_LATEST_RPT, [abn, taxType, periodId]);
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await q(SQL_UPDATE_PERIOD_RELEASED, [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,63 @@
-﻿import { Pool } from "pg";
 import crypto from "crypto";
+import { q, tx } from "../db";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
+
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-  if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
-  const row = p.rows[0];
+export const SQL_SELECT_PERIOD =
+  "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3";
+export const SQL_MARK_BLOCKED_ANOMALY =
+  "UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1";
+export const SQL_MARK_BLOCKED_DISCREPANCY =
+  "UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1";
+export const SQL_INSERT_RPT_TOKEN =
+  "INSERT INTO rpt_tokens(abn,tax_type,period_id,payload,signature) VALUES ($1,$2,$3,$4,$5)";
+export const SQL_MARK_READY_RPT =
+  "UPDATE periods SET state='READY_RPT' WHERE id=$1";
+
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>
+) {
+  const period = await q(SQL_SELECT_PERIOD, [abn, taxType, periodId]);
+  if (period.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+  const row = period.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await q(SQL_MARK_BLOCKED_ANOMALY, [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await q(SQL_MARK_BLOCKED_DISCREPANCY, [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+
+  await tx(async (client) => {
+    await client.query(SQL_INSERT_RPT_TOKEN, [abn, taxType, periodId, payload, signature]);
+    await client.query(SQL_MARK_READY_RPT, [row.id]);
+  });
+
   return { payload, signature };
 }

--- a/tests/sql/audit.test.ts
+++ b/tests/sql/audit.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SQL_INSERT_AUDIT_ENTRY,
+  SQL_SELECT_AUDIT_TAIL,
+} from "../../src/audit/appendOnly";
+
+test("audit logging queries are parameterized", () => {
+  assert.match(SQL_SELECT_AUDIT_TAIL, /ORDER BY seq DESC LIMIT 1$/);
+  assert.match(SQL_INSERT_AUDIT_ENTRY, /VALUES \(\$1,\$2,\$3,\$4,\$5\)/);
+});

--- a/tests/sql/evidence.test.ts
+++ b/tests/sql/evidence.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SQL_SELECT_LEDGER_FOR_BUNDLE,
+  SQL_SELECT_PERIOD_FOR_BUNDLE,
+  SQL_SELECT_RPT_FOR_BUNDLE,
+} from "../../src/evidence/bundle";
+
+test("evidence bundle queries filter by positional arguments", () => {
+  assert.match(SQL_SELECT_PERIOD_FOR_BUNDLE, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+  assert.match(SQL_SELECT_RPT_FOR_BUNDLE, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+  assert.match(SQL_SELECT_LEDGER_FOR_BUNDLE, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+});

--- a/tests/sql/idempotency.test.ts
+++ b/tests/sql/idempotency.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SQL_INSERT_IDEMPOTENCY_KEY,
+  SQL_SELECT_IDEMPOTENCY_KEY,
+} from "../../src/middleware/idempotency";
+
+test("idempotency middleware uses positional parameters", () => {
+  assert.match(SQL_INSERT_IDEMPOTENCY_KEY, /VALUES \(\$1,\$2\)/);
+  assert.match(SQL_SELECT_IDEMPOTENCY_KEY, /WHERE key=\$1/);
+});

--- a/tests/sql/payments.test.ts
+++ b/tests/sql/payments.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SQL_INSERT_IDEMPOTENCY_KEY,
+  SQL_INSERT_LEDGER_RELEASE,
+  SQL_SELECT_DESTINATION,
+  SQL_SELECT_LEDGER_TAIL,
+  SQL_UPDATE_IDEMPOTENCY_DONE,
+} from "../../src/rails/adapter";
+
+test("payments SQL uses positional placeholders", () => {
+  assert.match(SQL_SELECT_DESTINATION, /WHERE abn=\$1 AND rail=\$2 AND reference=\$3/);
+  assert.match(SQL_INSERT_IDEMPOTENCY_KEY, /VALUES \(\$1,\$2\)/);
+  assert.match(SQL_SELECT_LEDGER_TAIL, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+  assert.match(SQL_INSERT_LEDGER_RELEASE, /VALUES \(\$1,\$2,\$3,\$4,\$5,\$6,\$7,\$8,\$9\)/);
+  assert.match(SQL_UPDATE_IDEMPOTENCY_DONE, /WHERE key=\$1/);
+});

--- a/tests/sql/recon.test.ts
+++ b/tests/sql/recon.test.ts
@@ -1,0 +1,11 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SQL_SELECT_LATEST_RPT,
+  SQL_UPDATE_PERIOD_RELEASED,
+} from "../../src/routes/reconcile";
+
+test("reconciliation routes query RPT and periods with placeholders", () => {
+  assert.match(SQL_SELECT_LATEST_RPT, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+  assert.match(SQL_UPDATE_PERIOD_RELEASED, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+});

--- a/tests/sql/rpt.test.ts
+++ b/tests/sql/rpt.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  SQL_INSERT_RPT_TOKEN,
+  SQL_MARK_BLOCKED_ANOMALY,
+  SQL_MARK_BLOCKED_DISCREPANCY,
+  SQL_MARK_READY_RPT,
+  SQL_SELECT_PERIOD,
+} from "../../src/rpt/issuer";
+
+test("RPT issuer SQL strings are parameterized", () => {
+  assert.match(SQL_SELECT_PERIOD, /WHERE abn=\$1 AND tax_type=\$2 AND period_id=\$3/);
+  assert.match(SQL_MARK_BLOCKED_ANOMALY, /WHERE id=\$1/);
+  assert.match(SQL_MARK_BLOCKED_DISCREPANCY, /WHERE id=\$1/);
+  assert.match(SQL_INSERT_RPT_TOKEN, /VALUES \(\$1,\$2,\$3,\$4,\$5\)/);
+  assert.match(SQL_MARK_READY_RPT, /WHERE id=\$1/);
+});


### PR DESCRIPTION
## Summary
- add shared db/sql helpers exposing q/tx and re-export them for application code
- update audit, reconciliation, RPT, and payments logic to use parameterized SQL with SERIALIZABLE transactions where appropriate
- add SQL interpolation lint plus focused tests that assert key queries use $1-style placeholders

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e26af452208327a0646b532e4a4dc6