### PR TITLE
Restore API router and add health endpoint tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test:api": "tsx --test tests/api/api-router.test.ts",
+        "api-router-check": "npm run test:api"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,57 @@
+import { Router } from "express";
+
+import { idempotency } from "../middleware/idempotency";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+  settlementWebhook,
+  evidence,
+} from "../routes/reconcile";
+import { paymentsApi } from "./payments";
+
+const apiRouter = Router();
+
+const reconRouter = Router();
+reconRouter.post("/close-issue", closeAndIssue);
+reconRouter.post("/pay", idempotency(), payAto);
+
+const paytoRouter = Router();
+paytoRouter.post("/sweep", paytoSweep);
+
+const settlementRouter = Router();
+settlementRouter.post("/webhook", settlementWebhook);
+
+const evidenceRouter = Router();
+evidenceRouter.get("/", evidence);
+
+const healthRouter = Router();
+healthRouter.get("/", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+const debugRouter = Router();
+debugRouter.get("/ping", (_req, res) => {
+  res.json({ status: "debug" });
+});
+
+apiRouter.use("/payments", paymentsApi);
+apiRouter.use("/recon", reconRouter);
+apiRouter.use("/payto", paytoRouter);
+apiRouter.use("/settlement", settlementRouter);
+apiRouter.use("/evidence", evidenceRouter);
+apiRouter.use("/health", healthRouter);
+apiRouter.use("/debug", debugRouter);
+
+apiRouter.post("/pay", idempotency(), payAto);
+apiRouter.post("/close-issue", closeAndIssue);
+apiRouter.post("/payto/sweep", paytoSweep);
+apiRouter.post("/settlement/webhook", settlementWebhook);
+apiRouter.get("/evidence", evidence);
+
+apiRouter.use((_req, res) => {
+  res.status(404).json({ error: "Not Found" });
+});
+
+export default apiRouter;
+export { apiRouter };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,4 @@
-﻿// src/index.ts
-import express from "express";
-import dotenv from "dotenv";
-
-import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
-import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
-
-dotenv.config();
-
-const app = express();
-app.use(express.json({ limit: "2mb" }));
-
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
-
-// Simple health check
-app.get("/health", (_req, res) => res.json({ ok: true }));
-
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
-
-// ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
-
-// Existing API router(s) after
-app.use("/api", api);
-
-// 404 fallback (must be last)
-app.use((_req, res) => res.status(404).send("Not found"));
+import app from "./server";
 
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => console.log("APGMS server listening on", port));

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,24 @@
+import express from "express";
+import dotenv from "dotenv";
+
+import apiRouter from "./api";
+
+dotenv.config();
+
+const app = express();
+
+app.use(express.json({ limit: "2mb" }));
+
+app.use((req, _res, next) => {
+  console.log(`[app] ${req.method} ${req.url}`);
+  next();
+});
+
+app.use("/api", apiRouter);
+
+app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.use((_req, res) => res.status(404).json({ error: "Not Found" }));
+
+export default app;
+export { app };

--- a/tests/api/api-router.test.ts
+++ b/tests/api/api-router.test.ts
@@ -1,0 +1,21 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import request from "supertest";
+
+import app from "../../src/server";
+
+test("GET /api/health responds with ok status", async () => {
+  const response = await request(app).get("/api/health");
+
+  assert.equal(response.status, 200);
+  assert.ok(response.type.startsWith("application/json"));
+  assert.deepEqual(response.body, { status: "ok" });
+});
+
+test("unknown API route responds with JSON 404", async () => {
+  const response = await request(app).get("/api/does-not-exist");
+
+  assert.equal(response.status, 404);
+  assert.ok(response.type.startsWith("application/json"));
+  assert.deepEqual(response.body, { error: "Not Found" });
+});

--- a/tests/support/supertest.ts
+++ b/tests/support/supertest.ts
@@ -1,0 +1,99 @@
+import type { Express } from "express";
+import type { AddressInfo } from "net";
+
+interface JsonLike {
+  [key: string]: unknown;
+}
+
+type Method = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+type Body = JsonLike | undefined;
+
+type Response = {
+  status: number;
+  type: string;
+  body: unknown;
+};
+
+type RequestExecutor = (path: string, body?: Body) => Promise<Response>;
+
+type RequestBuilder = {
+  get: RequestExecutor;
+  post: RequestExecutor;
+  put: RequestExecutor;
+  patch: RequestExecutor;
+  delete: RequestExecutor;
+};
+
+export default function request(app: Express): RequestBuilder {
+  return {
+    get: (path) => performRequest(app, "GET", path),
+    post: (path, body) => performRequest(app, "POST", path, body),
+    put: (path, body) => performRequest(app, "PUT", path, body),
+    patch: (path, body) => performRequest(app, "PATCH", path, body),
+    delete: (path, body) => performRequest(app, "DELETE", path, body),
+  };
+}
+
+async function performRequest(
+  app: Express,
+  method: Method,
+  path: string,
+  body?: Body,
+): Promise<Response> {
+  const server = app.listen(0);
+  try {
+    const address = server.address() as AddressInfo;
+    const target = new URL(path, `http://127.0.0.1:${address.port}`);
+
+    const headers: Record<string, string> = {};
+    let payload: string | undefined;
+
+    if (body && method !== "GET") {
+      payload = JSON.stringify(body);
+      headers["content-type"] = "application/json";
+    }
+
+    const response = await fetch(target, {
+      method,
+      headers,
+      body: payload,
+    });
+
+    const contentType = response.headers.get("content-type") ?? "";
+    const text = await response.text();
+    const parsedBody = parseBody(text, contentType);
+
+    return {
+      status: response.status,
+      type: contentType,
+      body: parsedBody,
+    };
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+function parseBody(text: string, contentType: string): unknown {
+  if (!text) {
+    return undefined;
+  }
+
+  if (contentType.startsWith("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  return text;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "supertest": ["tests/support/supertest"]
+    }
   },
-  "include": ["src"]
+  "include": ["src", "tests"]
 }


### PR DESCRIPTION
## Summary
- add a default-exported Express API router that mounts the payments, recon, payto, settlement, evidence, health, and debug sub-routes with a JSON 404 fallback
- expose the Express application from a new server.ts entry point and keep index.ts focused on starting the listener
- add node:test coverage for the API health endpoint, update TypeScript paths for the supertest helper, and wire npm scripts for CI

## Testing
- npm run test:api
- npm run api-router-check

------
https://chatgpt.com/codex/tasks/task_e_68e26add6e9483279e5c6fe391976c59