### PR TITLE
Fix SQL parameterization and add query regression test

### DIFF
--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,6 +1,6 @@
 ﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+const pool = getPool();
 
 export async function appendAudit(actor: string, action: string, payload: any) {
   const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
@@ -8,7 +8,7 @@ export async function appendAudit(actor: string, action: string, payload: any) {
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values ($1,$2,$3,$4,$5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,20 @@
+import { Pool, PoolConfig } from "pg";
+
+let sharedPool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!sharedPool) {
+    sharedPool = new Pool();
+  }
+  return sharedPool;
+}
+
+export function initPool(config?: PoolConfig): Pool {
+  const pool = new Pool(config);
+  setPool(pool);
+  return pool;
+}
+
+export function setPool(pool: Pool) {
+  sharedPool = pool;
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,10 +1,10 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+﻿import { getPool } from "../db/pool";
+const pool = getPool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId])).rows[0];
+  const rpt = (await pool.query("select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1", [abn, taxType, periodId])).rows[0];
+  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id", [abn, taxType, periodId])).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,15 +1,15 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+﻿import { getPool } from "../db/pool";
+const pool = getPool();
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
   return async (req:any, res:any, next:any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [key, "INIT"]);
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
+      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=$1", [key]);
       return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
   };

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,13 +1,13 @@
-﻿import { Pool } from "pg";
+﻿import { getPool } from "../db/pool";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+const pool = getPool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,14 +18,14 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
     [abn, taxType, periodId]);
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
@@ -33,10 +33,10 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("update idempotency_keys set last_status=$1 where key=$2", ["DONE", transfer_uuid]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -3,8 +3,8 @@ import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+const pool = getPool();
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,24 +1,24 @@
-﻿import { Pool } from "pg";
-import crypto from "crypto";
+﻿import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
+import { isAnomalous } from "../anomaly/deterministic";
+import { getPool } from "../db/pool";
+const pool = getPool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+  if (isAnomalous(v, thresholds)) {
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +30,8 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, JSON.stringify(payload), signature]);
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }

--- a/tests/regression/queryRegression.test.ts
+++ b/tests/regression/queryRegression.test.ts
@@ -1,0 +1,327 @@
+import assert from "node:assert/strict";
+import nacl from "tweetnacl";
+import { setPool } from "../../src/db/pool";
+
+type PeriodRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  anomaly_vector: Record<string, number>;
+  thresholds: Record<string, number>;
+  final_liability_cents: number;
+  credited_to_owa_cents: number;
+  merkle_root: string;
+  running_balance_hash: string;
+};
+
+type RptTokenRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  payload: any;
+  signature: string;
+  created_at: string;
+};
+
+type RemittanceDestination = {
+  id: number;
+  abn: string;
+  rail: "EFT" | "BPAY";
+  reference: string;
+};
+
+type OwaLedgerRow = {
+  id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  transfer_uuid: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string;
+  prev_hash: string;
+  hash_after: string;
+  created_at: string;
+};
+
+type AuditLogRow = {
+  seq: number;
+  terminal_hash: string;
+};
+
+type IdempotencyRecord = {
+  key: string;
+  last_status: string | null;
+  response_hash: string | null;
+};
+
+interface QueryResult<T = any> {
+  rows: T[];
+  rowCount: number;
+}
+
+class InMemoryPool {
+  private periods: PeriodRow[] = [];
+  private rptTokens: RptTokenRow[] = [];
+  private remittanceDestinations: RemittanceDestination[] = [];
+  private owaLedger: OwaLedgerRow[] = [];
+  private auditLog: AuditLogRow[] = [];
+  private idempotencyKeys = new Map<string, IdempotencyRecord>();
+  private rptSeq = 0;
+  private ledgerSeq = 0;
+  private auditSeq = 0;
+
+  seedPeriod(row: PeriodRow) {
+    this.periods.push(row);
+  }
+
+  seedRemittance(row: RemittanceDestination) {
+    this.remittanceDestinations.push(row);
+  }
+
+  async query(text: string, params: any[] = []): Promise<QueryResult> {
+    const sql = text.trim();
+    if (sql.startsWith("select * from periods")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.periods.filter(
+        (p) => p.abn === abn && p.tax_type === taxType && p.period_id === periodId
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("select * from rpt_tokens")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.rptTokens
+        .filter((r) => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, sql.includes("limit 1") ? 1 : undefined);
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("select created_at as ts")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter((r) => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => a.id - b.id)
+        .map((r) => ({
+          ts: r.created_at,
+          amount_cents: r.amount_cents,
+          hash_after: r.hash_after,
+          bank_receipt_hash: r.bank_receipt_hash,
+        }));
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("select balance_after_cents")) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.owaLedger
+        .filter((r) => r.abn === abn && r.tax_type === taxType && r.period_id === periodId)
+        .sort((a, b) => b.id - a.id)
+        .slice(0, 1)
+        .map((r) => ({ balance_after_cents: r.balance_after_cents, hash_after: r.hash_after }));
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("select * from remittance_destinations")) {
+      const [abn, rail, reference] = params;
+      const rows = this.remittanceDestinations.filter(
+        (r) => r.abn === abn && r.rail === rail && r.reference === reference
+      );
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("select terminal_hash from audit_log")) {
+      const rows = this.auditLog
+        .slice()
+        .sort((a, b) => b.seq - a.seq)
+        .slice(0, 1)
+        .map((r) => ({ terminal_hash: r.terminal_hash }));
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("select last_status, response_hash from idempotency_keys")) {
+      const [key] = params;
+      const record = this.idempotencyKeys.get(key);
+      const rows = record ? [{ last_status: record.last_status, response_hash: record.response_hash }] : [];
+      return { rows, rowCount: rows.length };
+    }
+    if (sql.startsWith("insert into rpt_tokens")) {
+      const [abn, taxType, periodId, payloadJson, signature] = params;
+      const payload = typeof payloadJson === "string" ? JSON.parse(payloadJson) : payloadJson;
+      this.rptTokens.push({
+        id: ++this.rptSeq,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        payload,
+        signature,
+        created_at: new Date().toISOString(),
+      });
+      return { rows: [], rowCount: 1 };
+    }
+    if (sql.startsWith("insert into idempotency_keys")) {
+      const [key, status] = params;
+      if (this.idempotencyKeys.has(key)) {
+        const err: any = new Error("duplicate key value violates unique constraint");
+        err.code = "23505";
+        throw err;
+      }
+      this.idempotencyKeys.set(key, { key, last_status: status, response_hash: null });
+      return { rows: [], rowCount: 1 };
+    }
+    if (sql.startsWith("insert into owa_ledger")) {
+      const [abn, taxType, periodId, transfer_uuid, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after] =
+        params;
+      this.owaLedger.push({
+        id: ++this.ledgerSeq,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        transfer_uuid,
+        amount_cents,
+        balance_after_cents,
+        bank_receipt_hash,
+        prev_hash,
+        hash_after,
+        created_at: new Date().toISOString(),
+      });
+      return { rows: [], rowCount: 1 };
+    }
+    if (sql.startsWith("insert into audit_log")) {
+      const [actor, action, payload_hash, prev_hash, terminal_hash] = params;
+      this.auditLog.push({ seq: ++this.auditSeq, terminal_hash });
+      return { rows: [], rowCount: 1 };
+    }
+    if (sql.startsWith("update periods set state='BLOCKED_ANOMALY'")) {
+      const [id] = params;
+      const row = this.periods.find((p) => p.id === id);
+      if (row) row.state = "BLOCKED_ANOMALY";
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    if (sql.startsWith("update periods set state='BLOCKED_DISCREPANCY'")) {
+      const [id] = params;
+      const row = this.periods.find((p) => p.id === id);
+      if (row) row.state = "BLOCKED_DISCREPANCY";
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    if (sql.startsWith("update periods set state='READY_RPT'")) {
+      const [id] = params;
+      const row = this.periods.find((p) => p.id === id);
+      if (row) row.state = "READY_RPT";
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    if (sql.startsWith("update periods set state='RELEASED'")) {
+      const [abn, taxType, periodId] = params;
+      const row = this.periods.find((p) => p.abn === abn && p.tax_type === taxType && p.period_id === periodId);
+      if (row) row.state = "RELEASED";
+      return { rows: [], rowCount: row ? 1 : 0 };
+    }
+    if (sql.startsWith("update idempotency_keys set last_status")) {
+      const [status, key] = params;
+      const record = this.idempotencyKeys.get(key);
+      if (record) {
+        record.last_status = status;
+        this.idempotencyKeys.set(key, record);
+        return { rows: [], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    }
+    throw new Error(`Unsupported query: ${sql}`);
+  }
+
+  dumpState() {
+    return {
+      periods: this.periods,
+      rptTokens: this.rptTokens,
+      owaLedger: this.owaLedger,
+      auditLog: this.auditLog,
+      idempotency: Array.from(this.idempotencyKeys.values()),
+    };
+  }
+}
+
+(async () => {
+  const pool = new InMemoryPool();
+  setPool(pool as any);
+
+  process.env.ATO_PRN = "PRN123";
+  const keyPair = nacl.sign.keyPair();
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(keyPair.secretKey).toString("base64");
+
+  pool.seedPeriod({
+    id: 1,
+    abn: "12345678901",
+    tax_type: "GST",
+    period_id: "2025-09",
+    state: "CLOSING",
+    anomaly_vector: {},
+    thresholds: { epsilon_cents: 100 },
+    final_liability_cents: 50000,
+    credited_to_owa_cents: 50000,
+    merkle_root: "root",
+    running_balance_hash: "hash",
+  });
+  pool.seedRemittance({ id: 1, abn: "12345678901", rail: "EFT", reference: "PRN123" });
+
+  const { issueRPT } = await import("../../src/rpt/issuer");
+  const { payAto } = await import("../../src/routes/reconcile");
+  const { buildEvidenceBundle } = await import("../../src/evidence/bundle");
+  const { idempotency } = await import("../../src/middleware/idempotency");
+
+  const thresholds = { epsilon_cents: 200 };
+  const rpt = await issueRPT("12345678901", "GST", "2025-09", thresholds);
+  assert.equal(rpt.payload.amount_cents, 50000);
+
+  const stateAfterRpt = pool.dumpState().periods[0].state;
+  assert.equal(stateAfterRpt, "READY_RPT");
+
+  const req: any = { body: { abn: "12345678901", taxType: "GST", periodId: "2025-09", rail: "EFT" } };
+  const res: any = {
+    statusCode: 200,
+    body: undefined as any,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.body = payload;
+      return this;
+    },
+  };
+  await payAto(req, res);
+  assert.equal(res.statusCode, 200);
+  assert.ok(res.body.transfer_uuid);
+
+  const dump = pool.dumpState();
+  assert.equal(dump.periods[0].state, "RELEASED");
+  assert.equal(dump.owaLedger.length, 1);
+  assert.equal(dump.auditLog.length, 1);
+
+  const bundle = await buildEvidenceBundle("12345678901", "GST", "2025-09");
+  assert.deepEqual(bundle.rpt_payload, rpt.payload);
+
+  const mw = idempotency();
+  const req2: any = { header: (name: string) => (name === "Idempotency-Key" ? "abc123" : undefined) };
+  let nextCalled = false;
+  const res2: any = {
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(payload: any) {
+      this.payload = payload;
+      return this;
+    },
+  };
+  await mw(req2, res2, () => {
+    nextCalled = true;
+  });
+  assert.equal(nextCalled, true);
+
+  nextCalled = false;
+  await mw(req2, res2, () => {
+    nextCalled = true;
+  });
+  assert.equal(res2.statusCode, 200);
+  assert.equal(res2.payload.status, "INIT");
+  assert.equal(nextCalled, false);
+
+  console.log("SQL query regression checks passed");
+})();


### PR DESCRIPTION
## Summary
- replace ad-hoc pg placeholders in the reconciliation, RPT, evidence, rails, audit, and idempotency modules with positional parameters
- centralize Pool construction to allow dependency injection and serialize RPT payloads before storage
- add an in-memory regression harness that exercises the affected queries against seeded sample data

## Testing
- npx tsx tests/regression/queryRegression.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e26a52f3b08327bf09e571f7324315