### PR TITLE
Harden reconciliation state machine transitions

### DIFF
--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -1,15 +1,20 @@
 ﻿export type PeriodState = "OPEN"|"CLOSING"|"READY_RPT"|"BLOCKED_DISCREPANCY"|"BLOCKED_ANOMALY"|"RELEASED"|"FINALIZED";
 export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
 
+const transitions = new Map<string, PeriodState>([
+  ["OPEN:CLOSE", "CLOSING"],
+  ["CLOSING:PASS", "READY_RPT"],
+  ["CLOSING:FAIL_DISCREPANCY", "BLOCKED_DISCREPANCY"],
+  ["CLOSING:FAIL_ANOMALY", "BLOCKED_ANOMALY"],
+  ["READY_RPT:RELEASE", "RELEASED"],
+  ["RELEASED:FINALIZE", "FINALIZED"],
+]);
+
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
+  const t = `${current}:${evt}`;
+  const next = transitions.get(t);
+  if (!next) {
+    throw new Error(`Unsupported transition: ${t}`);
   }
+  return next;
 }

--- a/tests/stateMachine.test.ts
+++ b/tests/stateMachine.test.ts
@@ -1,0 +1,35 @@
+import { strict as assert } from "node:assert";
+
+import { nextState, PeriodState } from "../src/recon/stateMachine";
+
+const cases: Array<[PeriodState, string, PeriodState]> = [
+  ["OPEN", "CLOSE", "CLOSING"],
+  ["CLOSING", "PASS", "READY_RPT"],
+  ["CLOSING", "FAIL_DISCREPANCY", "BLOCKED_DISCREPANCY"],
+  ["CLOSING", "FAIL_ANOMALY", "BLOCKED_ANOMALY"],
+  ["READY_RPT", "RELEASE", "RELEASED"],
+  ["RELEASED", "FINALIZE", "FINALIZED"],
+];
+
+for (const [current, evt, expected] of cases) {
+  const result = nextState(current, evt);
+  assert.equal(
+    result,
+    expected,
+    `Transition ${current} --${evt}--> should resolve to ${expected}, received ${result}`,
+  );
+}
+
+assert.throws(
+  () => nextState("OPEN", "UNKNOWN"),
+  /Unsupported transition: OPEN:UNKNOWN/,
+  "Unsupported events should surface as errors",
+);
+
+assert.throws(
+  () => nextState("READY_RPT", "FINALIZE"),
+  /Unsupported transition: READY_RPT:FINALIZE/,
+  "Transitions that skip required steps should be rejected",
+);
+
+console.log("stateMachine transitions: all assertions passed");


### PR DESCRIPTION
## Summary
- fix the state machine transition lookup and align the ready-to-release event label
- raise an error when an unsupported transition is requested instead of silently keeping the old state
- add a regression test that covers both valid transitions and defensive handling of invalid events

## Testing
- npx tsx tests/stateMachine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e277993a008327b6704b399ae68fa0