### PR TITLE
Add Express API router for reconcile endpoints

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,28 @@
+import { Router } from "express";
+
+import { idempotency } from "../middleware/idempotency";
+import {
+  closeAndIssue,
+  evidence,
+  payAto,
+  paytoSweep,
+  settlementWebhook
+} from "../routes/reconcile";
+
+export const api = Router();
+
+api.post("/pay", idempotency(), payAto);
+api.post("/close-issue", closeAndIssue);
+api.post("/payto/sweep", paytoSweep);
+api.post("/settlement/webhook", settlementWebhook);
+api.get("/evidence", evidence);
+
+export {
+  closeAndIssue,
+  evidence,
+  payAto,
+  paytoSweep,
+  settlementWebhook
+};
+
+export default api;

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@
 import express from "express";
 import dotenv from "dotenv";
 
-import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -17,13 +15,6 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
-
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);


### PR DESCRIPTION
## Summary
- add a concrete Express router under `src/api/index.ts` that wires the existing reconcile handlers
- update the server bootstrap to mount the shared API router instead of duplicating route bindings

## Testing
- pnpm tsc --noEmit *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*
- npx tsc --noEmit *(fails: src/recon/stateMachine.ts:5:14 - error TS1005: ',' expected.)*

------
https://chatgpt.com/codex/tasks/task_e_68e277963da88327a4b916aec575a8d8