### PR TITLE
Implement table-driven PAYGW schedule calculations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test:paygw": "tsx tests/paygw.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/utils/paygw.ts
+++ b/src/utils/paygw.ts
@@ -1,7 +1,131 @@
 import { PaygwInput } from "../types/tax";
 
-export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): number {
-  const baseRate = 0.20;
-  const liability = grossIncome * baseRate - deductions - taxWithheld;
-  return Math.max(liability, 0);
+type PayPeriod = PaygwInput["period"];
+
+type PeriodConfig = {
+  periodsPerYear: number;
+};
+
+const PERIOD_CONFIG: Record<PayPeriod, PeriodConfig> = {
+  weekly: { periodsPerYear: 52 },
+  fortnightly: { periodsPerYear: 26 },
+  monthly: { periodsPerYear: 12 },
+  quarterly: { periodsPerYear: 4 },
+};
+
+export type PaygwScheduleMetadata = {
+  version: string;
+  effectiveFrom: string;
+  source: string;
+};
+
+const SCHEDULE_METADATA: PaygwScheduleMetadata = {
+  version: "Schedule 1 (NAT 1004)",
+  effectiveFrom: "2024-07-01",
+  source: "ATO PAYG withholding tax tables",
+};
+
+const STAGE_3_THRESHOLDS = [0, 18_200, 45_000, 135_000, 190_000];
+const STAGE_3_RATES = [0, 0.19, 0.30, 0.37, 0.45];
+const STAGE_3_BASE_TAX = [0, 0, 5_092, 32_192, 52_927];
+
+function computeAnnualTax(income: number): number {
+  if (income <= STAGE_3_THRESHOLDS[1]) {
+    return 0;
+  }
+
+  if (income <= STAGE_3_THRESHOLDS[2]) {
+    return (income - STAGE_3_THRESHOLDS[1]) * STAGE_3_RATES[1];
+  }
+
+  if (income <= STAGE_3_THRESHOLDS[3]) {
+    return (
+      STAGE_3_BASE_TAX[2] +
+      (income - STAGE_3_THRESHOLDS[2]) * STAGE_3_RATES[2]
+    );
+  }
+
+  if (income <= STAGE_3_THRESHOLDS[4]) {
+    return (
+      STAGE_3_BASE_TAX[3] +
+      (income - STAGE_3_THRESHOLDS[3]) * STAGE_3_RATES[3]
+    );
+  }
+
+  return (
+    STAGE_3_BASE_TAX[4] + (income - STAGE_3_THRESHOLDS[4]) * STAGE_3_RATES[4]
+  );
+}
+
+function computeLowIncomeTaxOffset(income: number): number {
+  if (income <= 37_000) {
+    return 700;
+  }
+
+  if (income <= 45_000) {
+    return 700 - 0.05 * (income - 37_000);
+  }
+
+  if (income <= 66_667) {
+    return Math.max(0, 325 - 0.015 * (income - 45_000));
+  }
+
+  return 0;
+}
+
+function computeMedicareLevy(income: number): number {
+  if (income <= 26_000) {
+    return 0;
+  }
+
+  if (income <= 32_500) {
+    return (income - 26_000) * 0.1;
+  }
+
+  return income * 0.02;
+}
+
+function roundToCents(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function computeExpectedWithholding(
+  taxableEarnings: number,
+  period: PayPeriod,
+): number {
+  const multiplier = PERIOD_CONFIG[period].periodsPerYear;
+  const annualTaxable = Math.max(taxableEarnings, 0) * multiplier;
+  const grossTax = computeAnnualTax(annualTaxable);
+  const medicareLevy = computeMedicareLevy(annualTaxable);
+  const lito = computeLowIncomeTaxOffset(annualTaxable);
+  const annualLiability = Math.max(0, grossTax + medicareLevy - lito);
+  return roundToCents(annualLiability / multiplier);
+}
+
+export function calculateScheduledWithholding(
+  grossIncome: number,
+  period: PayPeriod,
+  deductions = 0,
+): number {
+  const taxableEarnings = grossIncome - deductions;
+  return computeExpectedWithholding(taxableEarnings, period);
+}
+
+export function calculatePaygw({
+  grossIncome,
+  taxWithheld,
+  period,
+  deductions = 0,
+}: PaygwInput): number {
+  const expectedWithholding = calculateScheduledWithholding(
+    grossIncome,
+    period,
+    deductions,
+  );
+  const outstanding = expectedWithholding - taxWithheld;
+  return Math.max(roundToCents(outstanding), 0);
+}
+
+export function getPaygwScheduleMetadata(): PaygwScheduleMetadata {
+  return SCHEDULE_METADATA;
 }

--- a/tests/paygw.test.ts
+++ b/tests/paygw.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+
+import {
+  calculatePaygw,
+  calculateScheduledWithholding,
+  getPaygwScheduleMetadata,
+} from "../src/utils/paygw";
+
+function assertAlmostEqual(actual: number, expected: number, precision = 2) {
+  const factor = 10 ** precision;
+  assert.equal(Math.round(actual * factor) / factor, expected);
+}
+
+(function run() {
+  const weekly = calculateScheduledWithholding(500, "weekly");
+  assertAlmostEqual(weekly, 15.04);
+
+  const fortnightlyOutstanding = calculatePaygw({
+    employeeName: "Case A",
+    grossIncome: 2000,
+    taxWithheld: 250,
+    period: "fortnightly",
+    deductions: 50,
+  });
+  assertAlmostEqual(fortnightlyOutstanding, 41.4);
+
+  const monthlyOutstanding = calculatePaygw({
+    employeeName: "Case B",
+    grossIncome: 8000,
+    taxWithheld: 1500,
+    period: "monthly",
+  });
+  assertAlmostEqual(monthlyOutstanding, 359.33);
+
+  const quarterly = calculateScheduledWithholding(12_000, "quarterly");
+  assertAlmostEqual(quarterly, 1668, 0);
+
+  const overWithheld = calculatePaygw({
+    employeeName: "Case C",
+    grossIncome: 1500,
+    taxWithheld: 400,
+    period: "weekly",
+  });
+  assertAlmostEqual(overWithheld, 0);
+
+  const metadata = getPaygwScheduleMetadata();
+  assert.deepEqual(metadata, {
+    version: "Schedule 1 (NAT 1004)",
+    effectiveFrom: "2024-07-01",
+    source: "ATO PAYG withholding tax tables",
+  });
+
+  console.log("PAYGW withholding tests passed");
+})();


### PR DESCRIPTION
## Summary
- replace the PAYGW utility with a schedule-based implementation aligned to the 2024-25 ATO withholding tables
- expose metadata and helper functions so reporting can cite the applied schedule
- add TypeScript tests covering multiple pay periods, deductions, and over-withholding scenarios

## Testing
- npx tsx tests/paygw.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2779c487083279dcb994a2e1042c6