### PR TITLE
Surface verified RPT metadata in release responses

### DIFF
--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -16,7 +16,7 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
 
     // Accept pending/active. Order by created_at so newest wins.
     const q = `
-      SELECT id as rpt_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce
+      SELECT id as rpt_id, key_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce
       FROM rpt_tokens
       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
         AND status IN ('pending','active')
@@ -43,7 +43,12 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
     const ok = await kms.verify(payload, sig);
     if (!ok) return res.status(403).json({ error: "RPT signature invalid" });
 
-    (req as any).rpt = { rpt_id: r.rpt_id, nonce: r.nonce, payload_sha256: r.payload_sha256 };
+    (req as any).rpt = {
+      rpt_id: r.rpt_id,
+      key_id: r.key_id,
+      nonce: r.nonce,
+      payload_sha256: r.payload_sha256,
+    };
     return next();
   } catch (e: any) {
     return res.status(500).json({ error: "RPT verification error", detail: String(e?.message || e) });

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -33,6 +33,7 @@ export async function payAtoRelease(req: Request, res: Response) {
   if (!rpt) {
     return res.status(403).json({ error: 'RPT not verified' });
   }
+  const { rpt_id, key_id, nonce, payload_sha256 } = rpt;
 
   const client = await pool.connect();
   try {
@@ -81,7 +82,7 @@ export async function payAtoRelease(req: Request, res: Response) {
       transfer_uuid,
       release_uuid,
       balance_after_cents: ins[0].balance_after_cents,
-      rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
+      rpt_ref: { rpt_id, key_id, nonce, payload_sha256 },
     });
   } catch (e: any) {
     await client.query('ROLLBACK');

--- a/apps/services/payments/test/payato_release_metadata.test.ts
+++ b/apps/services/payments/test/payato_release_metadata.test.ts
@@ -1,0 +1,56 @@
+import type { Request, Response } from "express";
+
+const mockQuery = jest.fn();
+const mockRelease = jest.fn();
+const mockClient = { query: mockQuery, release: mockRelease };
+const mockConnect = jest.fn().mockResolvedValue(mockClient);
+
+jest.mock("../src/index.js", () => ({
+  pool: { connect: mockConnect },
+}));
+
+import { payAtoRelease } from "../src/routes/payAto.js";
+
+describe("payAtoRelease", () => {
+  beforeEach(() => {
+    mockConnect.mockClear();
+    mockQuery.mockReset();
+    mockRelease.mockClear();
+  });
+
+  test("includes verified RPT metadata in release response", async () => {
+    mockQuery
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 42, transfer_uuid: "uuid-x", balance_after_cents: "-100" }] })
+      .mockResolvedValueOnce({});
+
+    const req = {
+      body: { abn: "12345678901", taxType: "GST", periodId: "2025-09", amountCents: -100 },
+      rpt: {
+        rpt_id: 7,
+        key_id: "ato-key-1",
+        nonce: "nonce-123",
+        payload_sha256: "a".repeat(64),
+      },
+    } as unknown as Request & { rpt: any };
+
+    const json = jest.fn();
+    const res = {
+      status: jest.fn().mockReturnThis(),
+      json,
+    } as unknown as Response;
+
+    await payAtoRelease(req, res);
+
+    expect(json).toHaveBeenCalledTimes(1);
+    const payload = json.mock.calls[0][0];
+    expect(payload.ok).toBe(true);
+    expect(payload.rpt_ref).toEqual({
+      rpt_id: 7,
+      key_id: "ato-key-1",
+      nonce: "nonce-123",
+      payload_sha256: "a".repeat(64),
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- extend rptGate to select and attach the canonical RPT metadata needed downstream
- update payAtoRelease to surface the verified RPT metadata in the release payload
- cover the release handler with a unit test that asserts the response includes the verified metadata

## Testing
- pnpm --filter payments test *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*
- npx jest --runInBand *(fails: npm returned 403 when attempting to download jest from the registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e2779d6fec83279d81840f67e8ab0e