### PR TITLE
Add deterministic anomaly helper and issuer tests

### DIFF
--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -1,4 +1,4 @@
-﻿export interface AnomalyVector {
+export interface AnomalyVector {
   variance_ratio: number;
   dup_rate: number;
   gap_minutes: number;
@@ -19,4 +19,33 @@ export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
     v.gap_minutes > (thr.gap_minutes ?? 60) ||
     Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
   );
+}
+
+function coerceNumber(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : fallback;
+}
+
+function coerceOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+export function exceeds(
+  vector: Partial<AnomalyVector> = {},
+  thresholds: Partial<Thresholds> | Record<string, number> = {}
+): boolean {
+  const normalizedVector: AnomalyVector = {
+    variance_ratio: coerceNumber(vector.variance_ratio),
+    dup_rate: coerceNumber(vector.dup_rate),
+    gap_minutes: coerceNumber(vector.gap_minutes),
+    delta_vs_baseline: coerceNumber(vector.delta_vs_baseline),
+  };
+
+  const normalizedThresholds: Thresholds = {
+    variance_ratio: coerceOptionalNumber((thresholds as Record<string, unknown>).variance_ratio),
+    dup_rate: coerceOptionalNumber((thresholds as Record<string, unknown>).dup_rate),
+    gap_minutes: coerceOptionalNumber((thresholds as Record<string, unknown>).gap_minutes),
+    delta_vs_baseline: coerceOptionalNumber((thresholds as Record<string, unknown>).delta_vs_baseline),
+  };
+
+  return isAnomalous(normalizedVector, normalizedThresholds);
 }

--- a/tests/node/issuer.test.ts
+++ b/tests/node/issuer.test.ts
@@ -1,0 +1,153 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AnomalyVector } from "../../src/anomaly/deterministic";
+
+type QueryResult = { rowCount: number; rows: unknown[] };
+
+interface FakePool {
+  queries: QueryRecord[];
+  handlers: QueryHandler[];
+  query: (sql: string, params: unknown[]) => Promise<unknown>;
+}
+
+interface QueryRecord {
+  sql: string;
+  params: unknown[];
+}
+
+type QueryHandler = (sql: string, params: unknown[]) => Promise<unknown> | unknown;
+
+async function loadIssuer() {
+  return import("../../src/rpt/issuer");
+}
+
+function createFakePool(): FakePool {
+  const pool: FakePool = {
+    queries: [],
+    handlers: [],
+    async query(sql: string, params: unknown[]) {
+      pool.queries.push({ sql, params });
+      const handler = pool.handlers.shift();
+      if (!handler) {
+        throw new Error(`Unexpected query: ${sql}`);
+      }
+      return handler(sql, params);
+    },
+  };
+  return pool;
+}
+
+function baseRow(overrides: Partial<Record<string, unknown>> = {}) {
+  const anomaly_vector: Partial<AnomalyVector> = overrides.anomaly_vector as Partial<AnomalyVector> | undefined ?? {
+    variance_ratio: 0,
+    dup_rate: 0,
+    gap_minutes: 0,
+    delta_vs_baseline: 0,
+  };
+
+  return {
+    id: 1,
+    abn: "12345678901",
+    period_id: "2024Q4",
+    tax_type: "GST",
+    state: "CLOSING",
+    final_liability_cents: 100,
+    credited_to_owa_cents: 100,
+    merkle_root: "abc",
+    running_balance_hash: "def",
+    anomaly_vector,
+    ...overrides,
+  };
+}
+
+test("anomalous periods transition to BLOCKED_ANOMALY", async () => {
+  const issuer = await loadIssuer();
+  const pool = createFakePool();
+  issuer.__setPool(pool);
+
+  try {
+    const row = baseRow({
+      anomaly_vector: {
+        variance_ratio: 0.6,
+        dup_rate: 0.01,
+        gap_minutes: 10,
+        delta_vs_baseline: 0.02,
+      },
+    });
+
+    pool.handlers.push(async () => ({ rowCount: 1, rows: [row] } satisfies QueryResult));
+    pool.handlers.push(async () => ({ rowCount: 1 }));
+
+    await assert.rejects(
+      () =>
+        issuer.issueRPT(
+          row.abn,
+          row.tax_type as "PAYGW" | "GST",
+          row.period_id,
+          {
+            variance_ratio: 0.5,
+            dup_rate: 0.05,
+            gap_minutes: 60,
+            delta_vs_baseline: 0.1,
+            epsilon_cents: 10,
+          }
+        ),
+      (err: unknown) => {
+        assert.equal((err as Error).message, "BLOCKED_ANOMALY");
+        return true;
+      }
+    );
+
+    assert.equal(pool.queries.length, 2);
+    assert.match(pool.queries[1].sql, /BLOCKED_ANOMALY/);
+  } finally {
+    issuer.__resetPool();
+  }
+});
+
+test("discrepancy transitions to BLOCKED_DISCREPANCY when epsilon exceeds", async () => {
+  const issuer = await loadIssuer();
+  const pool = createFakePool();
+  issuer.__setPool(pool);
+
+  try {
+    const row = baseRow({
+      final_liability_cents: 10_000,
+      credited_to_owa_cents: 9_000,
+      anomaly_vector: {
+        variance_ratio: 0.1,
+        dup_rate: 0.01,
+        gap_minutes: 5,
+        delta_vs_baseline: 0.02,
+      },
+    });
+
+    pool.handlers.push(async () => ({ rowCount: 1, rows: [row] } satisfies QueryResult));
+    pool.handlers.push(async () => ({ rowCount: 1 }));
+
+    await assert.rejects(
+      () =>
+        issuer.issueRPT(
+          row.abn,
+          row.tax_type as "PAYGW" | "GST",
+          row.period_id,
+          {
+            variance_ratio: 0.5,
+            dup_rate: 0.05,
+            gap_minutes: 60,
+            delta_vs_baseline: 0.1,
+            epsilon_cents: 500,
+          }
+        ),
+      (err: unknown) => {
+        assert.equal((err as Error).message, "BLOCKED_DISCREPANCY");
+        return true;
+      }
+    );
+
+    assert.equal(pool.queries.length, 2);
+    assert.match(pool.queries[1].sql, /BLOCKED_DISCREPANCY/);
+  } finally {
+    issuer.__resetPool();
+  }
+});


### PR DESCRIPTION
## Summary
- add an `exceeds` helper for deterministic anomaly checks that honours variance, duplicate, gap, and baseline thresholds
- normalise anomaly vectors in the RPT issuer and allow injecting a test pool
- cover anomaly and discrepancy blocking paths with node-based tests

## Testing
- `npx tsx --test tests/node/issuer.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e27797f0bc8327bf3a704f05719b01