### PR TITLE
Implement reconciliation flow and integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx --test tests/integration/reconcile.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,14 +1,14 @@
-﻿import { sha256Hex } from "../crypto/merkle";
+import { sha256Hex } from "../crypto/merkle";
 import { Pool } from "pg";
 const pool = new Pool();
 
 export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
+  const { rows } = await pool.query("SELECT terminal_hash FROM audit_log ORDER BY seq DESC LIMIT 1");
   const prevHash = rows[0]?.terminal_hash || "";
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    "INSERT INTO audit_log(actor,action,payload_hash,prev_hash,terminal_hash) VALUES ($1,$2,$3,$4,$5)",
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,99 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 const pool = new Pool();
 
+interface DiscrepancyEntry {
+  code: string;
+  details: Record<string, unknown>;
+}
+
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
+  const period = (
+    await pool.query(
+      "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+
+  if (!period) {
+    return {
+      bas_labels: { W1: null, W2: null, "1A": null, "1B": null },
+      rpt_payload: null,
+      rpt_signature: null,
+      owa_ledger_deltas: [],
+      bank_receipt_hash: null,
+      anomaly_thresholds: {},
+      discrepancy_log: [
+        { code: "PERIOD_NOT_FOUND", details: { abn, taxType, periodId } }
+      ]
+    };
+  }
+
+  const rpt = (
+    await pool.query(
+      "SELECT * FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0] ?? null;
+
+  const deltas = (
+    await pool.query(
+      `SELECT created_at AS ts, amount_cents, balance_after_cents, hash_after, bank_receipt_hash
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    )
+  ).rows;
+  const last = deltas[deltas.length - 1];
+
+  const discrepancyLog: DiscrepancyEntry[] = [];
+  const credited = Number(period.credited_to_owa_cents ?? 0);
+  const finalLiability = Number(period.final_liability_cents ?? 0);
+
+  const taxBalance = deltas.reduce((acc: number, row: any) => {
+    const receipt: string = row.bank_receipt_hash ?? "";
+    if (receipt.startsWith("settle:net:")) {
+      return acc;
+    }
+    return acc + Number(row.amount_cents ?? 0);
+  }, 0);
+
+  if (credited !== finalLiability) {
+    discrepancyLog.push({
+      code: "FINAL_VS_CREDITED",
+      details: {
+        credited_to_owa_cents: credited,
+        final_liability_cents: finalLiability,
+        delta_cents: finalLiability - credited
+      }
+    });
+  }
+
+  if (taxBalance !== finalLiability) {
+    discrepancyLog.push({
+      code: "TAX_LEDGER_MISMATCH",
+      details: {
+        tax_ledger_total_cents: taxBalance,
+        final_liability_cents: finalLiability,
+        delta_cents: taxBalance - finalLiability
+      }
+    });
+  }
+
+  if (!rpt) {
+    discrepancyLog.push({
+      code: "RPT_MISSING",
+      details: { state: period.state }
+    });
+  }
+
+  return {
+    bas_labels: { W1: null, W2: null, "1A": null, "1B": null },
     rpt_payload: rpt?.payload ?? null,
     rpt_signature: rpt?.signature ?? null,
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    anomaly_thresholds: period.thresholds ?? {},
+    discrepancy_log: discrepancyLog
   };
-  return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,38 +1,39 @@
-﻿// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
-import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { paymentsApi } from "./api/payments";
+import { api } from "./api";
 
 dotenv.config();
 
-const app = express();
-app.use(express.json({ limit: "2mb" }));
+export function createApp() {
+  const app = express();
+  app.use(express.json({ limit: "2mb" }));
 
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+  app.use((req, _res, next) => {
+    console.log(`[app] ${req.method} ${req.url}`);
+    next();
+  });
 
-// Simple health check
-app.get("/health", (_req, res) => res.json({ ok: true }));
+  app.get("/health", (_req, res) => res.json({ ok: true }));
 
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+  app.post("/api/pay", idempotency(), payAto);
+  app.post("/api/close-issue", closeAndIssue);
+  app.post("/api/payto/sweep", paytoSweep);
+  app.post("/api/settlement/webhook", settlementWebhook);
+  app.get("/api/evidence", evidence);
 
-// ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
+  app.use("/api", paymentsApi);
+  app.use("/api", api);
 
-// Existing API router(s) after
-app.use("/api", api);
+  app.use((_req, res) => res.status(404).send("Not found"));
+  return app;
+}
 
-// 404 fallback (must be last)
-app.use((_req, res) => res.status(404).send("Not found"));
-
-const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+if (process.env.NODE_ENV !== "test") {
+  const app = createApp();
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => console.log("APGMS server listening on", port));
+}

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,16 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 const pool = new Pool();
-/** Express middleware for idempotency via Idempotency-Key header */
+/** Express middleware for idempotency via `Idempotency-Key` header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      await pool.query("INSERT INTO idempotency_keys(key,last_status) VALUES($1,$2)", [key, "INIT"]);
       return next();
     } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+      const r = await pool.query("SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1", [key]);
+      return res.status(200).json({ idempotent: true, status: r.rows[0]?.last_status || "DONE" });
     }
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,4 +1,4 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "SELECT * FROM remittance_destinations WHERE abn=$1 AND rail=$2 AND reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,26 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("INSERT INTO idempotency_keys(key,last_status) VALUES($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
+  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0, 12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    "SELECT balance_after_cents, hash_after FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "INSERT INTO owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("UPDATE idempotency_keys SET last_status=$2 WHERE key=$1", [transfer_uuid, "DONE"]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,6 +1,8 @@
-﻿import { Request, Response } from "express";
-import { pool } from "../index.js";
+import { Request, Response } from "express";
+import { Pool } from "pg";
 import { randomUUID } from "node:crypto";
+
+const pool = new Pool();
 
 export async function deposit(req: Request, res: Response) {
   try {
@@ -42,13 +44,13 @@ export async function deposit(req: Request, res: Response) {
         balance_after_cents: ins[0].balance_after_cents
       });
 
-    } catch (e:any) {
+    } catch (e: any) {
       await client.query("ROLLBACK");
       return res.status(500).json({ error: "Deposit failed", detail: String(e.message || e) });
     } finally {
       client.release();
     }
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(500).json({ error: "Deposit error", detail: String(e.message || e) });
   }
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -4,12 +4,79 @@ import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+import { merkleRootHex } from "../crypto/merkle";
 const pool = new Pool();
 
 export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
+  const { abn, taxType, periodId, thresholds } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+  }
+
   const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const period = await client.query(
+      "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3 FOR UPDATE",
+      [abn, taxType, periodId]
+    );
+    if (period.rowCount === 0) {
+      await client.query("ROLLBACK");
+      return res.status(404).json({ error: "PERIOD_NOT_FOUND" });
+    }
+
+    const { rows: ledgerRows } = await client.query(
+      `SELECT id, amount_cents, balance_after_cents, bank_receipt_hash, hash_after
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    );
+
+    const agg = await client.query(
+      `SELECT
+         COALESCE(SUM(CASE WHEN amount_cents > 0 THEN amount_cents ELSE 0 END),0)::bigint AS credited,
+         COALESCE(SUM(amount_cents),0)::bigint AS net
+       FROM owa_ledger
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    const credited = Number(agg.rows[0]?.credited ?? 0);
+
+    const merkleRoot = merkleRootHex(
+      ledgerRows.map((row) =>
+        JSON.stringify({
+          id: row.id,
+          receipt: row.bank_receipt_hash ?? "",
+          amount_cents: String(row.amount_cents),
+          balance_after_cents: String(row.balance_after_cents ?? 0)
+        })
+      )
+    );
+    const runningHash = ledgerRows.length > 0 ? (ledgerRows[ledgerRows.length - 1].hash_after ?? "") : "";
+
+    await client.query(
+      `UPDATE periods
+          SET state='CLOSING',
+              credited_to_owa_cents=$4,
+              accrued_cents=$4,
+              final_liability_cents=$4,
+              merkle_root=$5,
+              running_balance_hash=$6,
+              thresholds=$7
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId, credited, merkleRoot, runningHash, JSON.stringify(thr)]
+    );
+
+    await client.query("COMMIT");
+  } catch (e) {
+    await client.query("ROLLBACK");
+    throw e;
+  } finally {
+    client.release();
+  }
+
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
@@ -19,14 +86,29 @@ export async function closeAndIssue(req:any, res:any) {
 }
 
 export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const { abn, taxType, periodId, rail } = req.body || {};
+  if (!abn || !taxType || !periodId || !rail) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId/rail" });
+  }
+  const pr = await pool.query(
+    "SELECT * FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    const latestHash = await pool.query(
+      `SELECT hash_after FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    await pool.query(
+      "UPDATE periods SET state='RELEASED', running_balance_hash=$4 WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId, latestHash.rows[0]?.hash_after ?? ""]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });
@@ -40,10 +122,101 @@ export async function paytoSweep(req:any, res:any) {
 }
 
 export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
+  const { abn, taxType, periodId, csv } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+  }
+  const csvText = csv || "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
-  return res.json({ ingested: rows.length });
+  if (rows.length === 0) {
+    return res.json({ ingested: 0 });
+  }
+
+  const client = await pool.connect();
+  let ingested = 0;
+  try {
+    await client.query("BEGIN");
+    await client.query(`CREATE TABLE IF NOT EXISTS settlement_txn_map (
+      abn text NOT NULL,
+      tax_type text NOT NULL,
+      period_id text NOT NULL,
+      txn_id text NOT NULL,
+      gst_cents bigint NOT NULL,
+      net_cents bigint NOT NULL,
+      settlement_ts timestamptz NOT NULL,
+      PRIMARY KEY (abn,tax_type,period_id,txn_id)
+    )`);
+
+    for (const row of rows) {
+      const existing = await client.query(
+        `SELECT gst_cents, net_cents FROM settlement_txn_map
+          WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND txn_id=$4 FOR UPDATE`,
+        [abn, taxType, periodId, row.txn_id]
+      );
+      const prevGst = Number(existing.rows[0]?.gst_cents ?? 0);
+      const prevNet = Number(existing.rows[0]?.net_cents ?? 0);
+      const deltaGst = Number(row.gst_cents ?? 0) - prevGst;
+      const deltaNet = Number(row.net_cents ?? 0) - prevNet;
+
+      if (existing.rowCount === 0) {
+        await client.query(
+          `INSERT INTO settlement_txn_map(abn,tax_type,period_id,txn_id,gst_cents,net_cents,settlement_ts)
+           VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+          [abn, taxType, periodId, row.txn_id, Number(row.gst_cents ?? 0), Number(row.net_cents ?? 0), row.settlement_ts]
+        );
+      } else if (deltaGst !== 0 || deltaNet !== 0) {
+        await client.query(
+          `UPDATE settlement_txn_map
+              SET gst_cents=$5, net_cents=$6, settlement_ts=$7
+            WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND txn_id=$4`,
+          [abn, taxType, periodId, row.txn_id, Number(row.gst_cents ?? 0), Number(row.net_cents ?? 0), row.settlement_ts]
+        );
+      }
+
+      const receiptBase = `${row.txn_id}:${row.settlement_ts}`;
+      if (deltaGst !== 0) {
+        await client.query(
+          "SELECT * FROM owa_append($1,$2,$3,$4,$5)",
+          [abn, taxType, periodId, deltaGst, `settle:gst:${receiptBase}`]
+        );
+      }
+      if (deltaNet !== 0) {
+        await client.query(
+          "SELECT * FROM owa_append($1,$2,$3,$4,$5)",
+          [abn, taxType, periodId, -deltaNet, `settle:net:${receiptBase}`]
+        );
+      }
+
+      if (deltaGst !== 0 || deltaNet !== 0) {
+        ingested += 1;
+      }
+    }
+
+    const totals = await client.query(
+      `SELECT
+         COALESCE(SUM(CASE WHEN amount_cents > 0 THEN amount_cents ELSE 0 END),0)::bigint AS credited
+       FROM owa_ledger
+       WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+
+    await client.query(
+      `UPDATE periods
+          SET credited_to_owa_cents=$4,
+              accrued_cents=$4
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId, Number(totals.rows[0]?.credited ?? 0)]
+    );
+
+    await client.query("COMMIT");
+  } catch (e) {
+    await client.query("ROLLBACK");
+    return res.status(500).json({ error: "SETTLEMENT_INGEST_FAILED", detail: String(e instanceof Error ? e.message : e) });
+  } finally {
+    client.release();
+  }
+
+  return res.json({ ingested });
 }
 
 export async function evidence(req:any, res:any) {

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,4 +1,4 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
@@ -6,32 +6,44 @@ const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "INSERT INTO rpt_tokens(abn,tax_type,period_id,payload,signature) VALUES ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await pool.query("UPDATE periods SET state='READY_RPT' WHERE id=$1", [row.id]);
   return { payload, signature };
 }

--- a/tests/integration/reconcile.test.ts
+++ b/tests/integration/reconcile.test.ts
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { promisify } from "node:util";
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Pool } from "pg";
+import nacl from "tweetnacl";
+
+process.env.NODE_ENV = "test";
+
+const execFileAsync = promisify(execFile);
+
+test("close → RPT → release → evidence on seeded Postgres", async (t) => {
+  try {
+    await execFileAsync("docker", ["--version"]);
+  } catch {
+    t.skip("Docker CLI not available");
+    return;
+  }
+
+  const containerName = `apgms_test_${process.pid}_${Date.now()}`;
+  const pgPort = 56000 + Math.floor(Math.random() * 1000);
+  const pgPassword = "apgms_pw";
+  const pgUser = "apgms";
+  const pgDb = "apgms";
+
+  const kp = nacl.sign.keyPair();
+  process.env.RPT_ED25519_SECRET_BASE64 = Buffer.from(kp.secretKey).toString("base64");
+  process.env.ATO_PRN = "1234567890";
+  process.env.PGHOST = "127.0.0.1";
+  process.env.PGPORT = String(pgPort);
+  process.env.PGDATABASE = pgDb;
+  process.env.PGUSER = pgUser;
+  process.env.PGPASSWORD = pgPassword;
+
+  await execFileAsync("docker", [
+    "run",
+    "-d",
+    "--rm",
+    "-p",
+    `${pgPort}:5432`,
+    "--name",
+    containerName,
+    "-e",
+    `POSTGRES_PASSWORD=${pgPassword}`,
+    "-e",
+    `POSTGRES_USER=${pgUser}`,
+    "-e",
+    `POSTGRES_DB=${pgDb}`,
+    "postgres:16-alpine"
+  ]);
+
+  t.after(async () => {
+    await execFileAsync("docker", ["rm", "-f", containerName]).catch(() => {});
+  });
+
+  const pool = new Pool({
+    host: "127.0.0.1",
+    port: pgPort,
+    user: pgUser,
+    password: pgPassword,
+    database: pgDb
+  });
+
+  t.after(async () => {
+    await pool.end();
+  });
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    try {
+      await pool.query("SELECT 1");
+      break;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
+  }
+
+  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  const migration1 = await readFile(path.resolve(__dirname, "../../migrations/001_apgms_core.sql"), "utf8");
+  await pool.query(migration1);
+  const migration2 = await readFile(path.resolve(__dirname, "../../migrations/002_apgms_patent_core.sql"), "utf8");
+  await pool.query(migration2);
+
+  await pool.query(
+    `INSERT INTO remittance_destinations(abn,label,rail,reference,account_bsb,account_number)
+     VALUES ($1,$2,$3,$4,$5,$6)
+     ON CONFLICT (abn,rail,reference) DO NOTHING`,
+    ["12345678901", "ATO_EFT", "EFT", "1234567890", "092-009", "12345678"]
+  );
+
+  await pool.query(
+    `INSERT INTO periods(
+       abn,tax_type,period_id,state,basis,
+       accrued_cents,credited_to_owa_cents,final_liability_cents,
+       merkle_root,running_balance_hash,anomaly_vector,thresholds)
+     VALUES ($1,$2,$3,'OPEN','ACCRUAL',0,0,0,'','','{}'::jsonb,'{}'::jsonb)
+     ON CONFLICT (abn,tax_type,period_id) DO NOTHING`,
+    ["12345678901", "GST", "2025-09"]
+  );
+
+  const { createApp } = await import("../../src/index");
+  const app = createApp();
+  const server = app.listen(0);
+  t.after(() => new Promise<void>((resolve) => server.close(() => resolve())));
+  const address = server.address();
+  const baseUrl = typeof address === "object" && address ? `http://127.0.0.1:${address.port}` : "";
+
+  const csv = [
+    "txn_id,gst_cents,net_cents,settlement_ts",
+    "tx1,5000,20000,2025-09-30T10:00:00Z"
+  ].join("\n");
+
+  const ingestResp = await fetch(`${baseUrl}/api/settlement/webhook`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ abn: "12345678901", taxType: "GST", periodId: "2025-09", csv })
+  });
+  assert.equal(ingestResp.status, 200);
+  const ingestBody = await ingestResp.json();
+  assert.equal(ingestBody.ingested, 1);
+
+  const thresholds = { epsilon_cents: 1000, variance_ratio: 0.5, dup_rate: 0.2, gap_minutes: 120, delta_vs_baseline: 0.5 };
+  const closeResp = await fetch(`${baseUrl}/api/close-issue`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ abn: "12345678901", taxType: "GST", periodId: "2025-09", thresholds })
+  });
+  assert.equal(closeResp.status, 200);
+  const closeBody = await closeResp.json();
+  assert.equal(closeBody.payload.amount_cents, 5000);
+  assert.ok(closeBody.signature);
+
+  const payResp = await fetch(`${baseUrl}/api/pay`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ abn: "12345678901", taxType: "GST", periodId: "2025-09", rail: "EFT" })
+  });
+  assert.equal(payResp.status, 200);
+  const payBody = await payResp.json();
+  assert.ok(payBody.transfer_uuid);
+  assert.ok(payBody.bank_receipt_hash);
+
+  const evidenceResp = await fetch(`${baseUrl}/api/evidence?abn=12345678901&taxType=GST&periodId=2025-09`);
+  assert.equal(evidenceResp.status, 200);
+  const evidenceBody = await evidenceResp.json();
+  assert.equal(evidenceBody.rpt_payload.amount_cents, 5000);
+  assert.ok(Array.isArray(evidenceBody.owa_ledger_deltas));
+  assert.ok(evidenceBody.owa_ledger_deltas.length >= 3);
+  const discrepancyCodes = new Set((evidenceBody.discrepancy_log || []).map((d: any) => d.code));
+  assert.ok(discrepancyCodes.has("TAX_LEDGER_MISMATCH"));
+});


### PR DESCRIPTION
## Summary
- compute closing totals, ledger hashes, and settlement ingestion before issuing RPTs while parameterising the remaining SQL
- enrich evidence bundles with discrepancy reporting and ensure ancillary adapters and middleware use safe queries
- add a Docker-backed integration test that drives close → RPT → release → evidence against a seeded Postgres database

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2779a40c88327a787362d09884ec2