### PR TITLE
Implement STP submission and banking integrations

### DIFF
--- a/src/utils/bankApi.ts
+++ b/src/utils/bankApi.ts
@@ -1,24 +1,303 @@
-export async function submitSTPReport(data: any): Promise<boolean> {
-  console.log("Submitting STP report to ATO:", data);
-  return true;
+import { randomUUID } from 'node:crypto';
+import nacl from 'tweetnacl';
+
+export interface StpEmployeePayment {
+  employeeId: string;
+  taxFileNumber: string;
+  gross: number;
+  paygWithheld: number;
+  superannuation?: number;
+  allowances?: number;
+  deductions?: number;
+}
+
+export interface StpSubmissionRequest {
+  organisationName: string;
+  abn: string;
+  bmsId: string;
+  payPeriodStart: string;
+  payPeriodEnd: string;
+  payrollEvent: 'REGULAR' | 'UPDATE';
+  payments: StpEmployeePayment[];
+}
+
+export interface StpSubmissionResult {
+  success: boolean;
+  receiptNumber?: string;
+  rawResponse: string;
+}
+
+export class StpSubmissionError extends Error {
+  constructor(message: string, public readonly responseBody?: string) {
+    super(message);
+    this.name = 'StpSubmissionError';
+  }
+}
+
+export class BankApiError extends Error {
+  constructor(message: string, public readonly responseBody?: unknown) {
+    super(message);
+    this.name = 'BankApiError';
+  }
+}
+
+interface BankPaymentResponse {
+  id: string;
+  status: string;
+  confirmationReference?: string;
+}
+
+const SBR2_ENDPOINT = process.env.SBR2_ENDPOINT;
+const SBR2_CLIENT_ID = process.env.SBR2_CLIENT_ID;
+const SBR2_CLIENT_SECRET = process.env.SBR2_CLIENT_SECRET;
+const BANK_API_BASE_URL = process.env.BANK_API_BASE_URL;
+const BANK_API_CLIENT_ID = process.env.BANK_API_CLIENT_ID;
+const BANK_API_CLIENT_SECRET = process.env.BANK_API_CLIENT_SECRET;
+const BANK_SIGNING_SECRET = process.env.BANK_SIGNING_SECRET;
+const BANK_POLL_INTERVAL_MS = Number(process.env.BANK_POLL_INTERVAL_MS ?? '2000');
+const BANK_POLL_TIMEOUT_MS = Number(process.env.BANK_POLL_TIMEOUT_MS ?? '60000');
+
+function ensureEnv(value: string | undefined, name: string): string {
+  if (!value) {
+    throw new Error(`Missing required configuration: ${name}`);
+  }
+  return value;
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function buildStpSoapEnvelope(request: StpSubmissionRequest): string {
+  const eventId = randomUUID();
+  const paymentsXml = request.payments
+    .map((payment) => `
+        <ns2:PayrollEvent>
+          <ns2:EmployeeIdentifier>${escapeXml(payment.employeeId)}</ns2:EmployeeIdentifier>
+          <ns2:TaxFileNumber>${escapeXml(payment.taxFileNumber)}</ns2:TaxFileNumber>
+          <ns2:GrossAmount>${payment.gross.toFixed(2)}</ns2:GrossAmount>
+          <ns2:PAYGWithheld>${payment.paygWithheld.toFixed(2)}</ns2:PAYGWithheld>
+          ${payment.superannuation ? `<ns2:Superannuation>${payment.superannuation.toFixed(2)}</ns2:Superannuation>` : ''}
+          ${payment.allowances ? `<ns2:Allowances>${payment.allowances.toFixed(2)}</ns2:Allowances>` : ''}
+          ${payment.deductions ? `<ns2:Deductions>${payment.deductions.toFixed(2)}</ns2:Deductions>` : ''}
+        </ns2:PayrollEvent>
+      `)
+    .join('\n');
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+  <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"
+                    xmlns:ns="http://ato.gov.au/sbr/gov/ato/payload"
+                    xmlns:ns2="http://ato.gov.au/sbr/gov/ato/payevnt">
+    <soapenv:Header>
+      <ns:MessageHeader>
+        <ns:MessageID>${eventId}</ns:MessageID>
+        <ns:SenderID>${escapeXml(request.bmsId)}</ns:SenderID>
+        <ns:ABN>${escapeXml(request.abn)}</ns:ABN>
+        <ns:SoftwareInformation>
+          <ns:ProductName>APGMS Payroll</ns:ProductName>
+          <ns:ProductVersion>1.0</ns:ProductVersion>
+        </ns:SoftwareInformation>
+      </ns:MessageHeader>
+    </soapenv:Header>
+    <soapenv:Body>
+      <ns2:PAYEVNT>
+        <ns2:EmployerDetails>
+          <ns2:OrganisationName>${escapeXml(request.organisationName)}</ns2:OrganisationName>
+          <ns2:ABN>${escapeXml(request.abn)}</ns2:ABN>
+        </ns2:EmployerDetails>
+        <ns2:Payroll>
+          <ns2:PayrollEventType>${request.payrollEvent}</ns2:PayrollEventType>
+          <ns2:PayPeriod>
+            <ns2:StartDate>${escapeXml(request.payPeriodStart)}</ns2:StartDate>
+            <ns2:EndDate>${escapeXml(request.payPeriodEnd)}</ns2:EndDate>
+          </ns2:PayPeriod>
+          ${paymentsXml}
+        </ns2:Payroll>
+      </ns2:PAYEVNT>
+    </soapenv:Body>
+  </soapenv:Envelope>`;
+}
+
+function parseStpReceipt(xml: string): string | undefined {
+  const receiptMatch = xml.match(/<SubmissionReceiptNumber>([^<]+)<\/SubmissionReceiptNumber>/);
+  if (receiptMatch) {
+    return receiptMatch[1];
+  }
+  const fallbackMatch = xml.match(/<MessageID>([^<]+)<\/MessageID>/);
+  return fallbackMatch?.[1];
+}
+
+async function httpRequest(
+  url: string,
+  init: RequestInit,
+  expectedStatuses: number[] = [200, 201, 202, 204]
+): Promise<{ status: number; body: string; headers: Headers }> {
+  const response = await fetch(url, init);
+  const body = await response.text();
+  if (!expectedStatuses.includes(response.status)) {
+    throw new BankApiError(`Unexpected status ${response.status} from ${url}`, body);
+  }
+  return { status: response.status, body, headers: response.headers };
+}
+
+export async function submitSTPReport(request: StpSubmissionRequest): Promise<StpSubmissionResult> {
+  const endpoint = ensureEnv(SBR2_ENDPOINT, 'SBR2_ENDPOINT');
+  ensureEnv(SBR2_CLIENT_ID, 'SBR2_CLIENT_ID');
+  ensureEnv(SBR2_CLIENT_SECRET, 'SBR2_CLIENT_SECRET');
+
+  const soapEnvelope = buildStpSoapEnvelope(request);
+
+  const { body } = await httpRequest(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/xml',
+      Accept: 'application/xml',
+      Authorization: `Basic ${Buffer.from(`${SBR2_CLIENT_ID}:${SBR2_CLIENT_SECRET}`).toString('base64')}`,
+    },
+    body: soapEnvelope,
+  });
+
+  const receipt = parseStpReceipt(body);
+  if (!receipt) {
+    throw new StpSubmissionError('Unable to locate submission receipt in SBR2 response', body);
+  }
+
+  return {
+    success: true,
+    receiptNumber: receipt,
+    rawResponse: body,
+  };
 }
 
 export async function signTransaction(amount: number, account: string): Promise<string> {
-  return `SIGNED-${amount}-${account}-${Date.now()}`;
+  const secret = ensureEnv(BANK_SIGNING_SECRET, 'BANK_SIGNING_SECRET');
+  const secretKey = Buffer.from(secret, 'base64');
+  if (secretKey.length !== nacl.sign.secretKeyLength) {
+    throw new Error('BANK_SIGNING_SECRET must be a base64 encoded Ed25519 64-byte secret key');
+  }
+  const payload = Buffer.from(
+    JSON.stringify({
+      account,
+      amount,
+      timestamp: new Date().toISOString(),
+    })
+  );
+  const signature = nacl.sign.detached(payload, secretKey);
+  return Buffer.from(signature).toString('base64');
+}
+
+async function createPaymentInstruction(amount: number, from: string, to: string): Promise<BankPaymentResponse> {
+  const baseUrl = ensureEnv(BANK_API_BASE_URL, 'BANK_API_BASE_URL');
+  const { body } = await httpRequest(`${baseUrl}/payments`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Basic ${Buffer.from(`${ensureEnv(BANK_API_CLIENT_ID, 'BANK_API_CLIENT_ID')}:${ensureEnv(BANK_API_CLIENT_SECRET, 'BANK_API_CLIENT_SECRET')}`).toString('base64')}`,
+    },
+    body: JSON.stringify({
+      amount,
+      fromAccount: from,
+      toAccount: to,
+      requiresDualAuthorization: true,
+    }),
+  });
+  return JSON.parse(body) as BankPaymentResponse;
+}
+
+async function submitPaymentSignature(paymentId: string, signature: string): Promise<void> {
+  const baseUrl = ensureEnv(BANK_API_BASE_URL, 'BANK_API_BASE_URL');
+  await httpRequest(`${baseUrl}/payments/${paymentId}/signature`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Basic ${Buffer.from(`${ensureEnv(BANK_API_CLIENT_ID, 'BANK_API_CLIENT_ID')}:${ensureEnv(BANK_API_CLIENT_SECRET, 'BANK_API_CLIENT_SECRET')}`).toString('base64')}`,
+    },
+    body: JSON.stringify({ signature }),
+  });
+}
+
+async function requestDualAuthorization(paymentId: string): Promise<void> {
+  const baseUrl = ensureEnv(BANK_API_BASE_URL, 'BANK_API_BASE_URL');
+  await httpRequest(`${baseUrl}/payments/${paymentId}/authorisations`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      Authorization: `Basic ${Buffer.from(`${ensureEnv(BANK_API_CLIENT_ID, 'BANK_API_CLIENT_ID')}:${ensureEnv(BANK_API_CLIENT_SECRET, 'BANK_API_CLIENT_SECRET')}`).toString('base64')}`,
+    },
+  });
+}
+
+async function pollPaymentConfirmation(paymentId: string): Promise<BankPaymentResponse> {
+  const baseUrl = ensureEnv(BANK_API_BASE_URL, 'BANK_API_BASE_URL');
+  const start = Date.now();
+  while (Date.now() - start < BANK_POLL_TIMEOUT_MS) {
+    const { body } = await httpRequest(`${baseUrl}/payments/${paymentId}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Basic ${Buffer.from(`${ensureEnv(BANK_API_CLIENT_ID, 'BANK_API_CLIENT_ID')}:${ensureEnv(BANK_API_CLIENT_SECRET, 'BANK_API_CLIENT_SECRET')}`).toString('base64')}`,
+      },
+    });
+    const status = JSON.parse(body) as BankPaymentResponse;
+    if (status.status === 'CONFIRMED' || status.status === 'SETTLED') {
+      return status;
+    }
+    if (status.status === 'REJECTED') {
+      throw new BankApiError(`Payment ${paymentId} rejected`, status);
+    }
+    await new Promise((resolve) => setTimeout(resolve, BANK_POLL_INTERVAL_MS));
+  }
+  throw new BankApiError(`Timed out waiting for confirmation of payment ${paymentId}`);
 }
 
 export async function transferToOneWayAccount(amount: number, from: string, to: string): Promise<boolean> {
+  const payment = await createPaymentInstruction(amount, from, to);
   const signature = await signTransaction(amount, to);
-  console.log(`Transfer $${amount} from ${from} to ${to} [${signature}]`);
+  await submitPaymentSignature(payment.id, signature);
+  await requestDualAuthorization(payment.id);
+  await pollPaymentConfirmation(payment.id);
   return true;
 }
 
 export async function verifyFunds(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
+  const baseUrl = ensureEnv(BANK_API_BASE_URL, 'BANK_API_BASE_URL');
+  const { body } = await httpRequest(`${baseUrl}/funds/verify`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Basic ${Buffer.from(`${ensureEnv(BANK_API_CLIENT_ID, 'BANK_API_CLIENT_ID')}:${ensureEnv(BANK_API_CLIENT_SECRET, 'BANK_API_CLIENT_SECRET')}`).toString('base64')}`,
+    },
+    body: JSON.stringify({
+      paygwDue,
+      gstDue,
+    }),
+  });
+  const result = JSON.parse(body) as { sufficient: boolean };
+  return result.sufficient;
 }
 
 export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
+  const baseUrl = ensureEnv(BANK_API_BASE_URL, 'BANK_API_BASE_URL');
+  const { body } = await httpRequest(`${baseUrl}/funds/initiate`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Basic ${Buffer.from(`${ensureEnv(BANK_API_CLIENT_ID, 'BANK_API_CLIENT_ID')}:${ensureEnv(BANK_API_CLIENT_SECRET, 'BANK_API_CLIENT_SECRET')}`).toString('base64')}`,
+    },
+    body: JSON.stringify({
+      paygwDue,
+      gstDue,
+    }),
+  });
+  const result = JSON.parse(body) as { paymentId?: string; status?: string };
+  return Boolean(result.paymentId || result.status === 'QUEUED');
 }

--- a/src/utils/payrollApi.ts
+++ b/src/utils/payrollApi.ts
@@ -1,3 +1,100 @@
-// Placeholder for payroll API integration logic
+import { randomUUID } from 'node:crypto';
 
-export {};
+export interface PayrollApiConfig {
+  baseUrl: string;
+  apiKey: string;
+}
+
+export interface PayrollEmployee {
+  id: string;
+  externalId?: string;
+  fullName: string;
+  taxFileNumber: string;
+}
+
+export interface PayrollEarningsType {
+  code: string;
+  description: string;
+  category: string;
+  taxTreatment: 'TAXABLE' | 'ALLOWANCE' | 'DEDUCTED';
+}
+
+export interface PayrollAdjustment {
+  type: 'DEDUCTION' | 'ALLOWANCE' | 'SUPER';
+  code: string;
+  description: string;
+  amount: number;
+}
+
+export interface PayrollLineItem {
+  employeeId: string;
+  earningsType: string;
+  amount: number;
+  paygWithheld: number;
+  adjustments: PayrollAdjustment[];
+}
+
+export interface PayrollRun {
+  id: string;
+  periodStart: string;
+  periodEnd: string;
+  lines: PayrollLineItem[];
+}
+
+export class PayrollApiClient {
+  constructor(private readonly config: PayrollApiConfig) {}
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(`${this.config.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Payroll API ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  async fetchEmployees(): Promise<PayrollEmployee[]> {
+    return this.request<PayrollEmployee[]>('/employees');
+  }
+
+  async fetchEarningsTypes(): Promise<PayrollEarningsType[]> {
+    return this.request<PayrollEarningsType[]>('/metadata/earnings-types');
+  }
+
+  async fetchAdjustments(): Promise<PayrollAdjustment[]> {
+    return this.request<PayrollAdjustment[]>('/metadata/adjustments');
+  }
+
+  async fetchPayRun(periodStart: string, periodEnd: string): Promise<PayrollRun> {
+    const id = randomUUID();
+    const lines = await this.request<PayrollLineItem[]>(
+      `/payruns?periodStart=${encodeURIComponent(periodStart)}&periodEnd=${encodeURIComponent(periodEnd)}`
+    );
+
+    return {
+      id,
+      periodStart,
+      periodEnd,
+      lines,
+    };
+  }
+}
+
+export function createPayrollClient(): PayrollApiClient {
+  const baseUrl = process.env.PAYROLL_API_BASE_URL;
+  const apiKey = process.env.PAYROLL_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error('PAYROLL_API_BASE_URL and PAYROLL_API_KEY must be configured');
+  }
+
+  return new PayrollApiClient({ baseUrl, apiKey });
+}

--- a/src/utils/posApi.ts
+++ b/src/utils/posApi.ts
@@ -1,6 +1,80 @@
-// Placeholder for POS API integration logic
+export interface PosApiConfig {
+  baseUrl: string;
+  apiKey: string;
+}
 
-export {};
-// Placeholder for POS API integration logic
+export interface PosTaxCode {
+  code: string;
+  rate: number;
+  description: string;
+}
 
-export {};
+export interface PosSaleLine {
+  id: string;
+  sku: string;
+  description: string;
+  quantity: number;
+  unitPrice: number;
+  taxCode: string;
+  taxAmount: number;
+}
+
+export interface PosSettlement {
+  id: string;
+  locationId: string;
+  periodStart: string;
+  periodEnd: string;
+  grossSales: number;
+  netSales: number;
+  gstCollected: number;
+  adjustments: Array<{
+    type: 'DISCOUNT' | 'REFUND' | 'MANUAL_ADJUSTMENT';
+    reason: string;
+    amount: number;
+  }>;
+  lines: PosSaleLine[];
+}
+
+export class PosApiClient {
+  constructor(private readonly config: PosApiConfig) {}
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const response = await fetch(`${this.config.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${this.config.apiKey}`,
+        ...(init.headers ?? {}),
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`POS API ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as T;
+  }
+
+  async fetchTaxCodes(): Promise<PosTaxCode[]> {
+    return this.request<PosTaxCode[]>('/metadata/tax-codes');
+  }
+
+  async fetchSettlement(periodStart: string, periodEnd: string, locationId?: string): Promise<PosSettlement> {
+    const params = new URLSearchParams({ periodStart, periodEnd });
+    if (locationId) {
+      params.append('locationId', locationId);
+    }
+    return this.request<PosSettlement>(`/settlements?${params.toString()}`);
+  }
+}
+
+export function createPosClient(): PosApiClient {
+  const baseUrl = process.env.POS_API_BASE_URL;
+  const apiKey = process.env.POS_API_KEY;
+  if (!baseUrl || !apiKey) {
+    throw new Error('POS_API_BASE_URL and POS_API_KEY must be configured');
+  }
+
+  return new PosApiClient({ baseUrl, apiKey });
+}

--- a/tests/integration/stpBank.integration.test.ts
+++ b/tests/integration/stpBank.integration.test.ts
@@ -1,0 +1,133 @@
+import { createServer } from 'node:http';
+import { AddressInfo } from 'node:net';
+import { once } from 'node:events';
+import assert from 'node:assert/strict';
+import { after, before, describe, it } from 'node:test';
+import nacl from 'tweetnacl';
+
+const keyPair = nacl.sign.keyPair();
+process.env.BANK_SIGNING_SECRET = Buffer.from(keyPair.secretKey).toString('base64');
+process.env.SBR2_CLIENT_ID = 'test-client';
+process.env.SBR2_CLIENT_SECRET = 'test-secret';
+process.env.BANK_API_CLIENT_ID = 'bank-client';
+process.env.BANK_API_CLIENT_SECRET = 'bank-secret';
+
+let submissionCount = 0;
+let paymentStatus = 'PENDING_SIGNATURE';
+let statusPolls = 0;
+
+const server = createServer(async (req, res) => {
+  const url = req.url ?? '';
+  const method = req.method ?? 'GET';
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Uint8Array);
+  }
+  const body = Buffer.concat(chunks).toString();
+
+  if (url === '/sbr2' && method === 'POST') {
+    submissionCount += 1;
+    res.writeHead(200, { 'Content-Type': 'application/xml' });
+    res.end(`<?xml version="1.0"?><Response><SubmissionReceiptNumber>SRN-${submissionCount}</SubmissionReceiptNumber></Response>`);
+    return;
+  }
+
+  if (url === '/funds/verify' && method === 'POST') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ sufficient: true }));
+    return;
+  }
+
+  if (url === '/funds/initiate' && method === 'POST') {
+    res.writeHead(202, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ paymentId: 'payment-123', status: 'QUEUED' }));
+    return;
+  }
+
+  if (url === '/payments' && method === 'POST') {
+    paymentStatus = 'PENDING_SIGNATURE';
+    res.writeHead(201, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id: 'payment-123', status: paymentStatus }));
+    return;
+  }
+
+  if (url === '/payments/payment-123/signature' && method === 'POST') {
+    paymentStatus = 'AWAITING_DUAL_AUTH';
+    res.writeHead(204).end();
+    return;
+  }
+
+  if (url === '/payments/payment-123/authorisations' && method === 'POST') {
+    paymentStatus = 'AWAITING_CONFIRMATION';
+    res.writeHead(202).end();
+    return;
+  }
+
+  if (url === '/payments/payment-123' && method === 'GET') {
+    statusPolls += 1;
+    if (statusPolls > 1) {
+      paymentStatus = 'CONFIRMED';
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ id: 'payment-123', status: paymentStatus, confirmationReference: 'CONF-001' }));
+    return;
+  }
+
+  res.writeHead(404).end();
+});
+
+let bankApi: typeof import('../../src/utils/bankApi');
+
+before(async () => {
+  server.listen(0);
+  await once(server, 'listening');
+  const port = (server.address() as AddressInfo).port;
+  const baseUrl = `http://127.0.0.1:${port}`;
+  process.env.SBR2_ENDPOINT = `${baseUrl}/sbr2`;
+  process.env.BANK_API_BASE_URL = baseUrl;
+
+  bankApi = await import('../../src/utils/bankApi');
+});
+
+after(async () => {
+  server.close();
+  await once(server, 'close');
+});
+
+describe('STP and bank integrations', () => {
+  it('submits STP reports and returns a receipt', async () => {
+    const result = await bankApi.submitSTPReport({
+      organisationName: 'ACME Pty Ltd',
+      abn: '53004085616',
+      bmsId: 'APGMS-BMS-01',
+      payPeriodStart: '2024-07-01',
+      payPeriodEnd: '2024-07-07',
+      payrollEvent: 'REGULAR',
+      payments: [
+        {
+          employeeId: 'E001',
+          taxFileNumber: '123456789',
+          gross: 2500,
+          paygWithheld: 500,
+        },
+      ],
+    });
+
+    assert.equal(result.success, true);
+    assert.match(result.receiptNumber ?? '', /^SRN-/);
+  });
+
+  it('performs dual-authorised transfers to one-way accounts', async () => {
+    statusPolls = 0;
+    const completed = await bankApi.transferToOneWayAccount(1500, 'business', 'one-way');
+    assert.equal(completed, true);
+  });
+
+  it('verifies funds and initiates release', async () => {
+    const fundsOk = await bankApi.verifyFunds(1200, 400);
+    assert.equal(fundsOk, true);
+
+    const initiated = await bankApi.initiateTransfer(1200, 400);
+    assert.equal(initiated, true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement SBR2 PAYEVNT payload generation and submission with structured response handling
- replace mock banking transfer logic with dual-authorisation payment workflow and fund verification endpoints
- add payroll and POS connectors for retrieving earnings, adjustments, and GST classifications
- add integration coverage that simulates STP lodgement and fund release flows against mocked services

## Testing
- npx tsx --test tests/integration/stpBank.integration.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2902b1a90832789821f400310860d