### PR TITLE
Add GST module with BAS aggregation and tests

### DIFF
--- a/src/components/GstCalculator.tsx
+++ b/src/components/GstCalculator.tsx
@@ -3,7 +3,7 @@ import { GstInput } from "../types/tax";
 import { calculateGst } from "../utils/gst";
 
 export default function GstCalculator({ onResult }: { onResult: (liability: number) => void }) {
-  const [form, setForm] = useState<GstInput>({ saleAmount: 0, exempt: false });
+  const [form, setForm] = useState<GstInput>({ saleAmount: 0, exempt: false, classification: "taxable" });
 
   return (
     <div className="card">
@@ -28,7 +28,13 @@ export default function GstCalculator({ onResult }: { onResult: (liability: numb
         <input
           type="checkbox"
           checked={form.exempt}
-          onChange={e => setForm({ ...form, exempt: e.target.checked })}
+          onChange={e =>
+            setForm({
+              ...form,
+              exempt: e.target.checked,
+              classification: e.target.checked ? "gst_free" : "taxable",
+            })
+          }
         />
         GST Exempt
       </label>

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -9,6 +9,103 @@ export type PaygwInput = {
 export type GstInput = {
   saleAmount: number;
   exempt?: boolean;
+  classification?: GstSupplyCategory;
+};
+
+export type GstSupplyCategory = "taxable" | "gst_free" | "input_taxed" | "export";
+
+export type GstEventClassification =
+  | "taxable"
+  | "gst_free"
+  | "input_taxed"
+  | "adjustment"
+  | "mixed";
+
+export type AccountingBasis = "cash" | "accrual";
+
+export type BasLabel =
+  | "G1"
+  | "G2"
+  | "G3"
+  | "G4"
+  | "G5"
+  | "G6"
+  | "G7"
+  | "G8"
+  | "G9"
+  | "G10"
+  | "G11"
+  | "G12"
+  | "G13"
+  | "G14";
+
+export type BasLabelTotals = Record<BasLabel, number>;
+
+export type ReportingPeriod = {
+  start: Date | string;
+  end: Date | string;
+  basis: AccountingBasis;
+};
+
+export type PurchaseCredit = {
+  reference: string;
+  creditDate: Date | string;
+  amount: number;
+  gstAmount: number;
+  reason?: string;
+};
+
+export type AdjustmentNote = {
+  reference: string;
+  date: Date | string;
+  amount: number;
+  gstAmount: number;
+  direction: "increasing" | "decreasing";
+  target: "sales" | "purchases";
+  reason?: string;
+};
+
+export type GstComponent = {
+  category: GstSupplyCategory;
+  amount: number;
+  gstAmount?: number;
+  description?: string;
+  capital?: boolean;
+  forInputTaxedSales?: boolean;
+  importation?: boolean;
+};
+
+export type GstTransactionBase = {
+  id: string;
+  issueDate: Date | string;
+  paymentDate?: Date | string;
+  components: GstComponent[];
+  purchaseCredits?: PurchaseCredit[];
+};
+
+export type GstSale = GstTransactionBase & {
+  kind: "sale";
+};
+
+export type GstPurchase = GstTransactionBase & {
+  kind: "purchase";
+  claimable: boolean;
+};
+
+export type GstAdjustment = {
+  kind: "adjustment";
+  note: AdjustmentNote;
+};
+
+export type GstEvent = GstSale | GstPurchase | GstAdjustment;
+
+export type BasSummary = {
+  period: ReportingPeriod;
+  basis: AccountingBasis;
+  labels: BasLabelTotals;
+  gstCollected: number;
+  gstCredits: number;
+  netAmount: number;
 };
 
 export type TaxReport = {

--- a/src/utils/gst.ts
+++ b/src/utils/gst.ts
@@ -1,6 +1,22 @@
-import { GstInput } from "../types/tax";
+import {
+  BasSummary,
+  GstEvent,
+  GstEventClassification,
+  GstInput,
+  ReportingPeriod,
+} from "../types/tax";
+import { gstModule } from "./gstModule";
 
-export function calculateGst({ saleAmount, exempt = false }: GstInput): number {
-  if (exempt) return 0;
-  return saleAmount * 0.1;
+export function calculateGst(input: GstInput): number {
+  return gstModule.calculateSimpleGst(input);
 }
+
+export function aggregateBas(events: GstEvent[], period: ReportingPeriod): BasSummary {
+  return gstModule.aggregate(events, period);
+}
+
+export function classifyGstEvent(event: GstEvent): GstEventClassification {
+  return gstModule.classify(event);
+}
+
+export { gstModule };

--- a/src/utils/gstModule.ts
+++ b/src/utils/gstModule.ts
@@ -1,0 +1,272 @@
+import {
+  AccountingBasis,
+  AdjustmentNote,
+  BasLabel,
+  BasLabelTotals,
+  BasSummary,
+  GstComponent,
+  GstEvent,
+  GstEventClassification,
+  GstInput,
+  GstPurchase,
+  GstSale,
+  ReportingPeriod,
+} from "../types/tax";
+
+const GST_RATE = 0.1;
+const BAS_LABELS: BasLabel[] = [
+  "G1",
+  "G2",
+  "G3",
+  "G4",
+  "G5",
+  "G6",
+  "G7",
+  "G8",
+  "G9",
+  "G10",
+  "G11",
+  "G12",
+  "G13",
+  "G14",
+];
+
+type MutableBasLabelTotals = Record<BasLabel, number>;
+
+export class GstModule {
+  calculateSimpleGst(input: GstInput): number {
+    if (input.exempt) return 0;
+    const classification = input.classification ?? "taxable";
+    if (classification !== "taxable") return 0;
+    return this.gstFromGross(input.saleAmount);
+  }
+
+  classify(event: GstEvent): GstEventClassification {
+    if (event.kind === "adjustment") return "adjustment";
+    const categories = new Set(
+      event.components.map(component =>
+        component.category === "export" ? "gst_free" : component.category,
+      ),
+    );
+
+    if (categories.size === 0) {
+      return "mixed";
+    }
+
+    if (categories.size === 1) {
+      const [category] = categories as unknown as ["taxable" | "gst_free" | "input_taxed"];
+      return category;
+    }
+
+    return "mixed";
+  }
+
+  aggregate(events: GstEvent[], period: ReportingPeriod): BasSummary {
+    const start = this.asDate(period.start);
+    const end = this.asDate(period.end);
+    const totals = this.createMutableTotals();
+
+    let gstCollected = 0;
+    let gstCredits = 0;
+
+    for (const event of events) {
+      if (event.kind === "adjustment") {
+        if (!this.withinPeriod(event.note.date, start, end)) continue;
+        this.applyAdjustment(event.note, totals, amount => {
+          gstCollected += amount.sales;
+          gstCredits += amount.purchases;
+        });
+        continue;
+      }
+
+      if (!this.shouldInclude(event, start, end, period.basis)) continue;
+
+      if (event.kind === "sale") {
+        gstCollected += this.applySale(event, totals);
+      } else {
+        gstCredits += this.applyPurchase(event, totals, start, end, period.basis);
+      }
+    }
+
+    totals.G5 = totals.G1 - totals.G2 - totals.G3 - totals.G4;
+    if (totals.G5 < 0) totals.G5 = 0;
+    totals.G6 = totals.G5;
+    totals.G12 = totals.G10 + totals.G11;
+    totals.G9 = totals.G7 - totals.G8;
+
+    const labels: BasLabelTotals = BAS_LABELS.reduce((acc, label) => {
+      acc[label] = this.atoRound(totals[label]);
+      return acc;
+    }, {} as BasLabelTotals);
+
+    const roundedCollected = this.atoRound(gstCollected);
+    const roundedCredits = this.atoRound(gstCredits);
+
+    return {
+      period,
+      basis: period.basis,
+      labels,
+      gstCollected: roundedCollected,
+      gstCredits: roundedCredits,
+      netAmount: this.atoRound(gstCollected - gstCredits),
+    };
+  }
+
+  private applySale(event: GstSale, totals: MutableBasLabelTotals): number {
+    let collected = 0;
+
+    for (const component of event.components) {
+      totals.G1 += component.amount;
+      switch (component.category) {
+        case "export":
+          totals.G2 += component.amount;
+          break;
+        case "gst_free":
+          totals.G3 += component.amount;
+          break;
+        case "input_taxed":
+          totals.G4 += component.amount;
+          break;
+        case "taxable":
+          collected += this.gstPortion(component);
+          break;
+        default:
+          break;
+      }
+    }
+
+    return collected;
+  }
+
+  private applyPurchase(
+    event: GstPurchase,
+    totals: MutableBasLabelTotals,
+    start: Date,
+    end: Date,
+    basis: AccountingBasis,
+  ): number {
+    let credits = 0;
+
+    for (const component of event.components) {
+      const bucket = component.capital ? "G10" : "G11";
+      totals[bucket] += component.amount;
+
+      if (component.forInputTaxedSales) {
+        totals.G13 += component.amount;
+      }
+
+      if (component.category === "gst_free" || component.category === "export") {
+        totals.G14 += component.amount;
+      }
+
+      if (event.claimable && component.category === "taxable") {
+        credits += this.gstPortion(component);
+      }
+    }
+
+    if (event.purchaseCredits) {
+      for (const credit of event.purchaseCredits) {
+        if (this.withinPeriod(credit.creditDate, start, end, basis)) {
+          credits += this.roundToCents(credit.gstAmount);
+          totals.G7 += credit.amount;
+        }
+      }
+    }
+
+    return credits;
+  }
+
+  private applyAdjustment(
+    note: AdjustmentNote,
+    totals: MutableBasLabelTotals,
+    collect: (amount: { sales: number; purchases: number }) => void,
+  ) {
+    const gstAmount = this.roundToCents(note.gstAmount);
+    const decreasesNet = this.isDecreasing(note);
+
+    if (decreasesNet) {
+      totals.G7 += note.amount;
+    } else {
+      totals.G8 += note.amount;
+    }
+
+    if (note.target === "sales") {
+      collect({
+        sales: note.direction === "decreasing" ? -gstAmount : gstAmount,
+        purchases: 0,
+      });
+    } else {
+      collect({
+        sales: 0,
+        purchases: note.direction === "increasing" ? gstAmount : -gstAmount,
+      });
+    }
+  }
+
+  private shouldInclude(
+    transaction: GstSale | GstPurchase,
+    start: Date,
+    end: Date,
+    basis: AccountingBasis,
+  ): boolean {
+    const inclusion = basis === "cash" ? transaction.paymentDate ?? transaction.issueDate : transaction.issueDate;
+    return this.withinPeriod(inclusion, start, end);
+  }
+
+  private gstPortion(component: GstComponent): number {
+    if (component.gstAmount !== undefined) {
+      return this.roundToCents(component.gstAmount);
+    }
+
+    if (component.amount === 0) return 0;
+
+    return this.gstFromGross(component.amount);
+  }
+
+  private withinPeriod(
+    value: Date | string | undefined,
+    start: Date,
+    end: Date,
+    basis?: AccountingBasis,
+  ): boolean {
+    if (!value) return false;
+    const date = this.asDate(value);
+    return date >= start && date <= end;
+  }
+
+  private isDecreasing(note: AdjustmentNote): boolean {
+    if (note.target === "sales") {
+      return note.direction === "decreasing";
+    }
+    return note.direction === "increasing";
+  }
+
+  private createMutableTotals(): MutableBasLabelTotals {
+    return BAS_LABELS.reduce((acc, label) => {
+      acc[label] = 0;
+      return acc;
+    }, {} as MutableBasLabelTotals);
+  }
+
+  private asDate(value: Date | string): Date {
+    return value instanceof Date ? value : new Date(value);
+  }
+
+  private roundToCents(value: number): number {
+    return Math.round(value * 100) / 100;
+  }
+
+  private atoRound(value: number): number {
+    const absolute = Math.abs(value);
+    const rounded = Math.round(absolute);
+    return value < 0 ? -rounded : rounded;
+  }
+
+  private gstFromGross(amount: number): number {
+    if (amount === 0) return 0;
+    const gstExclusive = amount / (1 + GST_RATE);
+    return this.roundToCents(amount - gstExclusive);
+  }
+}
+
+export const gstModule = new GstModule();

--- a/tests/gst.spec.ts
+++ b/tests/gst.spec.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { aggregateBas, calculateGst, classifyGstEvent } from "../src/utils/gst";
+import { GstEvent, ReportingPeriod } from "../src/types/tax";
+
+type TestCase = {
+  name: string;
+  run: () => void | Promise<void>;
+};
+
+const tests: TestCase[] = [
+  {
+    name: "calculates GST for taxable and exempt supplies",
+    run: () => {
+      assert.equal(calculateGst({ saleAmount: 110, classification: "taxable" }), 10);
+      assert.equal(calculateGst({ saleAmount: 110, classification: "gst_free" }), 0);
+      assert.equal(calculateGst({ saleAmount: 110, exempt: true }), 0);
+    },
+  },
+  {
+    name: "aggregates mixed supplies on accrual basis",
+    run: () => {
+      const period: ReportingPeriod = {
+        start: "2024-01-01",
+        end: "2024-03-31",
+        basis: "accrual",
+      };
+
+      const events: GstEvent[] = [
+        {
+          kind: "sale",
+          id: "S-001",
+          issueDate: "2024-02-15",
+          components: [
+            { category: "taxable", amount: 1100 },
+            { category: "gst_free", amount: 550 },
+          ],
+        },
+        {
+          kind: "sale",
+          id: "S-002",
+          issueDate: "2024-03-10",
+          components: [{ category: "export", amount: 2200 }],
+        },
+        {
+          kind: "purchase",
+          id: "P-001",
+          issueDate: "2024-02-20",
+          claimable: true,
+          components: [
+            { category: "taxable", amount: 770, capital: true },
+            { category: "taxable", amount: 330, capital: false },
+            { category: "gst_free", amount: 110, capital: false },
+          ],
+        },
+      ];
+
+      const summary = aggregateBas(events, period);
+
+      assert.equal(summary.labels.G1, 3850);
+      assert.equal(summary.labels.G2, 2200);
+      assert.equal(summary.labels.G3, 550);
+      assert.equal(summary.labels.G4, 0);
+      assert.equal(summary.labels.G5, 1100);
+      assert.equal(summary.labels.G6, 1100);
+      assert.equal(summary.labels.G10, 770);
+      assert.equal(summary.labels.G11, 440);
+      assert.equal(summary.labels.G12, 1210);
+      assert.equal(summary.labels.G14, 110);
+      assert.equal(summary.gstCollected, 100);
+      assert.equal(summary.gstCredits, 100);
+      assert.equal(summary.netAmount, 0);
+
+      assert.equal(classifyGstEvent(events[0]), "mixed");
+      assert.equal(classifyGstEvent(events[1]), "gst_free");
+    },
+  },
+  {
+    name: "respects cash basis for timing of supplies",
+    run: () => {
+      const period: ReportingPeriod = {
+        start: "2024-01-01",
+        end: "2024-03-31",
+        basis: "cash",
+      };
+
+      const events: GstEvent[] = [
+        {
+          kind: "sale",
+          id: "S-100",
+          issueDate: "2024-02-01",
+          paymentDate: "2024-04-05",
+          components: [{ category: "taxable", amount: 550 }],
+        },
+        {
+          kind: "sale",
+          id: "S-101",
+          issueDate: "2024-01-15",
+          paymentDate: "2024-03-20",
+          components: [{ category: "taxable", amount: 330 }],
+        },
+        {
+          kind: "purchase",
+          id: "P-200",
+          issueDate: "2024-01-10",
+          paymentDate: "2024-03-25",
+          claimable: true,
+          components: [{ category: "taxable", amount: 220, capital: false }],
+        },
+        {
+          kind: "purchase",
+          id: "P-201",
+          issueDate: "2024-02-10",
+          paymentDate: "2024-04-02",
+          claimable: true,
+          components: [{ category: "taxable", amount: 440, capital: true }],
+        },
+      ];
+
+      const summary = aggregateBas(events, period);
+
+      assert.equal(summary.labels.G1, 330);
+      assert.equal(summary.labels.G5, 330);
+      assert.equal(summary.labels.G11, 220);
+      assert.equal(summary.labels.G12, 220);
+      assert.equal(summary.gstCollected, 30);
+      assert.equal(summary.gstCredits, 20);
+      assert.equal(summary.netAmount, 10);
+    },
+  },
+  {
+    name: "applies adjustments, purchase credits and imports",
+    run: () => {
+      const period: ReportingPeriod = {
+        start: "2024-04-01",
+        end: "2024-06-30",
+        basis: "accrual",
+      };
+
+      const events: GstEvent[] = [
+        {
+          kind: "sale",
+          id: "S-300",
+          issueDate: "2024-04-15",
+          components: [{ category: "taxable", amount: 1210 }],
+        },
+        {
+          kind: "purchase",
+          id: "P-300",
+          issueDate: "2024-05-01",
+          claimable: true,
+          components: [
+            { category: "taxable", amount: 550, capital: false, importation: true, gstAmount: 50 },
+          ],
+          purchaseCredits: [
+            { reference: "CR-1", creditDate: "2024-05-15", amount: 55, gstAmount: 5 },
+          ],
+        },
+        {
+          kind: "adjustment",
+          note: {
+            reference: "ADJ-1",
+            date: "2024-05-30",
+            amount: 132,
+            gstAmount: 12,
+            direction: "decreasing",
+            target: "sales",
+          },
+        },
+        {
+          kind: "adjustment",
+          note: {
+            reference: "ADJ-2",
+            date: "2024-06-15",
+            amount: 66,
+            gstAmount: 6,
+            direction: "increasing",
+            target: "purchases",
+          },
+        },
+        {
+          kind: "adjustment",
+          note: {
+            reference: "ADJ-3",
+            date: "2024-06-20",
+            amount: 33,
+            gstAmount: 3,
+            direction: "decreasing",
+            target: "purchases",
+          },
+        },
+      ];
+
+      const summary = aggregateBas(events, period);
+
+      assert.equal(summary.labels.G1, 1210);
+      assert.equal(summary.labels.G5, 1210);
+      assert.equal(summary.labels.G7, 253);
+      assert.equal(summary.labels.G8, 33);
+      assert.equal(summary.labels.G9, 220);
+      assert.equal(summary.labels.G11, 550);
+      assert.equal(summary.labels.G12, 550);
+      assert.equal(summary.gstCollected, 98);
+      assert.equal(summary.gstCredits, 58);
+      assert.equal(summary.netAmount, 40);
+    },
+  },
+];
+
+for (const test of tests) {
+  try {
+    test.run();
+    console.log(`✔ ${test.name}`);
+  } catch (error) {
+    console.error(`✘ ${test.name}`);
+    throw error;
+  }
+}
+
+console.log("All GST module tests passed.");


### PR DESCRIPTION
## Summary
- introduce structured GST models for BAS periods, credits, adjustments, and labels and expose a reusable GST module
- refactor the GST utilities and calculator to delegate to the module for classification, cash/accrual handling, and rounding
- add TypeScript tests covering mixed supplies, adjustments, imports, and cash-basis timing to verify BAS totals

## Testing
- npx tsx tests/gst.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2902bff5083278c4d760a09dddc03