### PR TITLE
Implement ATO-based penalty calculations with regression coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx --test tests/**/*.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/components/BasLodgment.tsx
+++ b/src/components/BasLodgment.tsx
@@ -12,6 +12,7 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
     try {
       const fundsOk = await verifyFunds(paygwDue, gstDue);
       if (!fundsOk) {
+        const penaltyBreakdown = calculatePenalties(7, paygwDue + gstDue);
         setBasHistory([
           {
             period: new Date(),
@@ -19,7 +20,7 @@ export default function BasLodgment({ paygwDue, gstDue }: { paygwDue: number, gs
             gstPaid: 0,
             status: "Late",
             daysLate: 7,
-            penalties: calculatePenalties(7, paygwDue + gstDue)
+            penalties: penaltyBreakdown.totalPenalty
           },
           ...basHistory
         ]);

--- a/src/components/ComplianceReports.tsx
+++ b/src/components/ComplianceReports.tsx
@@ -8,8 +8,9 @@ export default function ComplianceReports({ history }: { history: TaxReport[] })
       <ul>
         {history.map((rep, i) => (
           <li key={i}>
-            PAYGW: ${rep.paygwLiability.toFixed(2)} | GST: ${rep.gstPayable.toFixed(2)} | Total: ${rep.totalPayable.toFixed(2)}
-            | Status: {rep.complianceStatus}
+            PAYGW: ${rep.paygwLiability.toFixed(2)} | GST: ${rep.gstPayable.toFixed(2)} |
+            FTL Penalty: ${rep.ftlPenalty.toFixed(2)} | GIC: ${rep.gicInterest.toFixed(2)} |
+            Total: ${rep.totalPayable.toFixed(2)} | Status: {rep.complianceStatus}
           </li>
         ))}
       </ul>

--- a/src/config/ato.ts
+++ b/src/config/ato.ts
@@ -1,0 +1,19 @@
+export type AtoRatesConfig = {
+  /**
+   * Current penalty unit amount in Australian dollars.
+   * Source: ATO "Penalty unit values" (effective 1 July 2024).
+   */
+  penaltyUnitValue: number;
+  /**
+   * Annual General Interest Charge rate expressed as a decimal (e.g. 0.1134 = 11.34%).
+   * Source: ATO "General interest charge (GIC) rates" for the current quarter.
+   */
+  gicAnnualRate: number;
+};
+
+export const ATO_RATES: AtoRatesConfig = {
+  penaltyUnitValue: 330,
+  gicAnnualRate: 0.1134,
+};
+
+export const PENALTY_PERIOD_DAYS = 28;

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -14,6 +14,8 @@ export type GstInput = {
 export type TaxReport = {
   paygwLiability: number;
   gstPayable: number;
+  ftlPenalty: number;
+  gicInterest: number;
   totalPayable: number;
   discrepancies?: string[];
   complianceStatus: "OK" | "WARNING" | "ALERT";

--- a/src/utils/penalties.ts
+++ b/src/utils/penalties.ts
@@ -1,5 +1,52 @@
-export function calculatePenalties(daysLate: number, amountDue: number): number {
-  const basePenalty = amountDue * 0.05;
-  const dailyInterest = amountDue * 0.0002;
-  return basePenalty + (dailyInterest * daysLate);
+import { ATO_RATES, PENALTY_PERIOD_DAYS, type AtoRatesConfig } from "../config/ato";
+
+export type EntitySize = "small" | "medium" | "large" | "significantGlobalEntity";
+
+export type PenaltyBreakdown = {
+  /** Failure to lodge on time penalty component. */
+  ftlPenalty: number;
+  /** General interest charge accrued over the late period. */
+  gicInterest: number;
+  /** Total penalty amount (FTL + GIC). */
+  totalPenalty: number;
+  /** Number of 28-day penalty periods applied. */
+  penaltyPeriods: number;
+};
+
+const ENTITY_PENALTY_MULTIPLIER: Record<EntitySize, number> = {
+  small: 1,
+  medium: 2,
+  large: 5,
+  significantGlobalEntity: 15,
+};
+
+function roundToCents(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export function calculatePenalties(
+  daysLate: number,
+  amountDue: number,
+  entitySize: EntitySize = "small",
+  rates: AtoRatesConfig = ATO_RATES,
+): PenaltyBreakdown {
+  const safeDaysLate = Math.max(0, Math.ceil(daysLate));
+  const safeAmountDue = Math.max(0, amountDue);
+  const penaltyPeriods = safeDaysLate === 0 ? 0 : Math.ceil(safeDaysLate / PENALTY_PERIOD_DAYS);
+
+  const ftlPenalty = penaltyPeriods * rates.penaltyUnitValue * ENTITY_PENALTY_MULTIPLIER[entitySize];
+
+  const dailyRate = rates.gicAnnualRate / 365;
+  const gicInterest = safeDaysLate === 0
+    ? 0
+    : safeAmountDue * (Math.pow(1 + dailyRate, safeDaysLate) - 1);
+
+  const totalPenalty = ftlPenalty + gicInterest;
+
+  return {
+    ftlPenalty: roundToCents(ftlPenalty),
+    gicInterest: roundToCents(gicInterest),
+    totalPenalty: roundToCents(totalPenalty),
+    penaltyPeriods,
+  };
 }

--- a/src/utils/taxReport.ts
+++ b/src/utils/taxReport.ts
@@ -1,0 +1,51 @@
+import { TaxReport } from "../types/tax";
+import { calculatePenalties, type EntitySize } from "./penalties";
+
+export type TaxReportInput = {
+  paygwLiability: number;
+  gstPayable: number;
+  daysLate: number;
+  entitySize?: EntitySize;
+  discrepancies?: string[];
+};
+
+export function generateTaxReport({
+  paygwLiability,
+  gstPayable,
+  daysLate,
+  entitySize = "small",
+  discrepancies = [],
+}: TaxReportInput): TaxReport {
+  const penaltyBreakdown = calculatePenalties(daysLate, paygwLiability + gstPayable, entitySize);
+  const totalPayable = roundToCents(paygwLiability + gstPayable + penaltyBreakdown.totalPenalty);
+
+  const complianceStatus = determineComplianceStatus(daysLate, discrepancies, penaltyBreakdown.totalPenalty);
+
+  return {
+    paygwLiability: roundToCents(paygwLiability),
+    gstPayable: roundToCents(gstPayable),
+    ftlPenalty: penaltyBreakdown.ftlPenalty,
+    gicInterest: penaltyBreakdown.gicInterest,
+    totalPayable,
+    discrepancies,
+    complianceStatus,
+  };
+}
+
+function determineComplianceStatus(
+  daysLate: number,
+  discrepancies: string[],
+  penaltyTotal: number,
+): TaxReport["complianceStatus"] {
+  if (discrepancies.length > 0 || daysLate > 56) {
+    return "ALERT";
+  }
+  if (daysLate > 0 || penaltyTotal > 0) {
+    return "WARNING";
+  }
+  return "OK";
+}
+
+function roundToCents(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}

--- a/tests/penalties.test.ts
+++ b/tests/penalties.test.ts
@@ -1,0 +1,67 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ATO_RATES } from "../src/config/ato";
+import { calculatePenalties } from "../src/utils/penalties";
+import { generateTaxReport } from "../src/utils/taxReport";
+
+const EXPECTED_PENALTY_UNIT = 330;
+const EXPECTED_GIC_RATE = 0.1134;
+
+describe("ATO configuration", () => {
+  it("matches the published penalty unit and GIC rate used in regression examples", () => {
+    assert.equal(
+      ATO_RATES.penaltyUnitValue,
+      EXPECTED_PENALTY_UNIT,
+      "ATO penalty unit has changed — update penalty regression tests",
+    );
+    assert.equal(
+      ATO_RATES.gicAnnualRate,
+      EXPECTED_GIC_RATE,
+      "ATO GIC rate has changed — update penalty regression tests",
+    );
+  });
+});
+
+describe("calculatePenalties", () => {
+  it("applies 2 penalty units for a small entity 45 days late (ATO FTL example)", () => {
+    const breakdown = calculatePenalties(45, 0, "small");
+    assert.equal(breakdown.penaltyPeriods, 2);
+    assert.equal(breakdown.ftlPenalty, EXPECTED_PENALTY_UNIT * 2);
+    assert.equal(breakdown.totalPenalty, breakdown.ftlPenalty);
+  });
+
+  it("doubles the penalty units for a medium entity as per ATO guidance", () => {
+    const breakdown = calculatePenalties(45, 0, "medium");
+    assert.equal(breakdown.penaltyPeriods, 2);
+    assert.equal(breakdown.ftlPenalty, EXPECTED_PENALTY_UNIT * 4);
+  });
+
+  it("compounds GIC daily using the published rate", () => {
+    const breakdown = calculatePenalties(30, 10_000, "small");
+    assert.equal(breakdown.ftlPenalty, EXPECTED_PENALTY_UNIT * 2); // 30 days => 2 penalty periods
+    assert.equal(breakdown.gicInterest, 93.63);
+    assert.equal(breakdown.totalPenalty, breakdown.ftlPenalty + breakdown.gicInterest);
+  });
+});
+
+describe("generateTaxReport", () => {
+  it("surfaces separate FTL and GIC components in the report", () => {
+    const report = generateTaxReport({
+      paygwLiability: 7500,
+      gstPayable: 2500,
+      daysLate: 30,
+      entitySize: "small",
+      discrepancies: [],
+    });
+
+    const expectedPenalty = calculatePenalties(30, 10_000, "small");
+
+    assert.equal(report.paygwLiability, 7500);
+    assert.equal(report.gstPayable, 2500);
+    assert.equal(report.ftlPenalty, expectedPenalty.ftlPenalty);
+    assert.equal(report.gicInterest, expectedPenalty.gicInterest);
+    assert.equal(report.totalPayable, 10_000 + expectedPenalty.totalPenalty);
+    assert.ok(["WARNING", "ALERT"].includes(report.complianceStatus));
+  });
+});


### PR DESCRIPTION
## Summary
- replace the penalty utility with ATO penalty unit logic and configurable GIC compounding
- surface discrete failure-to-lodge and GIC amounts when generating tax reports and compliance output
- add regression tests aligned with published ATO penalty scenarios and wire up a TypeScript test script

## Testing
- npx tsx --test tests/penalties.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e2902ae2b8832795d9e2f8777a585f