### PR TITLE
Ensure pytest can import in-repo Python SDK modules

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+"""Test configuration for ensuring internal Python packages are importable."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Ensure the repository root contains reusable Python packages under ``libs`` and ``libs/py-sdk``.
+ROOT = Path(__file__).resolve().parent
+PY_SDK = ROOT / "libs" / "py-sdk"
+LIBS = ROOT / "libs"
+
+for path in (PY_SDK, LIBS):
+    if path.exists():
+        sys_path = str(path)
+        if sys_path not in sys.path:
+            sys.path.insert(0, sys_path)

--- a/libs/__init__.py
+++ b/libs/__init__.py
@@ -1,0 +1,5 @@
+"""Python package marker for reusable APGMS libraries.
+
+This file allows ``import libs.*`` statements from test helpers without
+requiring installation of the entire repository as a distribution.
+"""


### PR DESCRIPTION
## Summary
- add a repository-level pytest bootstrap so in-repo SDK packages resolve without installation
- mark the shared `libs` directory as a Python package for acceptance helpers

## Testing
- pytest tests/test_math.py libs/py-sdk/tests/test_rpt.py tests/acceptance/test_patent_paths.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e2e2b49bf08327853eaaa2b77c2c9a