### PR TITLE
Refine API wiring and parameterise Postgres access

### DIFF
--- a/migrations/003_idempotency_response_cache.sql
+++ b/migrations/003_idempotency_response_cache.sql
@@ -1,0 +1,4 @@
+-- 003_idempotency_response_cache.sql
+alter table if exists idempotency_keys
+  add column if not exists status_code integer,
+  add column if not exists response_body jsonb;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,25 @@
+import { Router } from "express";
+
+import { idempotency } from "../middleware/idempotency";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+  settlementWebhook,
+  evidence,
+} from "../routes/reconcile";
+import { paymentsApi } from "./payments";
+
+export const api = Router();
+
+// Re-export sub-routers first so catch-all handlers don't shadow them
+api.use("/", paymentsApi);
+
+// Legacy handlers that historically lived on the app instance
+api.post("/pay", idempotency(), payAto);
+api.post("/close-issue", closeAndIssue);
+api.post("/payto/sweep", paytoSweep);
+api.post("/settlement/webhook", settlementWebhook);
+api.get("/evidence", evidence);
+
+export { paymentsApi };

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -2,10 +2,22 @@
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const p = (
+    await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId])
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
+  const last = deltas[deltas.length - 1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
     rpt_payload: rpt?.payload ?? null,
@@ -13,7 +25,7 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [], // TODO: populate from recon diffs
   };
   return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@
 import express from "express";
 import dotenv from "dotenv";
 
-import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
-import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { api } from "./api";
 
 dotenv.config();
 
@@ -18,17 +15,7 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
-
-// ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
-
-// Existing API router(s) after
+// API router (mounts payments + legacy handlers internally)
 app.use("/api", api);
 
 // 404 fallback (must be last)

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,105 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
+import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
+
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
+
+    let claimed = false;
     try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
+      const existing = await pool.query(
+        "select last_status, response_hash, status_code, response_body from idempotency_keys where key=$1",
+        [key]
+      );
+      const row = existing.rows[0];
+      if (row) {
+        if (row.status_code != null) {
+          res.setHeader("X-Idempotent-Replay", "true");
+          return res.status(row.status_code).send(row.response_body ?? null);
+        }
+        // Another request is still computing the response
+        return res.status(409).json({ idempotent: true, status: row.last_status ?? "IN_PROGRESS" });
+      }
+
+      const inserted = await pool.query(
+        "insert into idempotency_keys(key,last_status,status_code,response_hash,response_body) values($1,$2,$3,$4,$5) on conflict do nothing",
+        [key, "INIT", null, null, null]
+      );
+      if (inserted.rowCount === 0) {
+        const retry = await pool.query(
+          "select last_status, response_hash, status_code, response_body from idempotency_keys where key=$1",
+          [key]
+        );
+        const retryRow = retry.rows[0];
+        if (retryRow && retryRow.status_code != null) {
+          res.setHeader("X-Idempotent-Replay", "true");
+          return res.status(retryRow.status_code).send(retryRow.response_body ?? null);
+        }
+        return res.status(409).json({ idempotent: true, status: retryRow?.last_status ?? "IN_PROGRESS" });
+      }
+      claimed = true;
+    } catch (err) {
+      console.error("idempotency middleware failed", err);
       return next();
-    } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
     }
+
+    let capturedBody: any = undefined;
+    const capture = (body: any) => {
+      capturedBody = body;
+    };
+
+    const originalJson = res.json.bind(res);
+    res.json = (body: any) => {
+      capture(body);
+      return originalJson(body);
+    };
+
+    const originalSend = res.send.bind(res);
+    res.send = (body: any) => {
+      capture(body);
+      return originalSend(body);
+    };
+
+    res.on("finish", () => {
+      if (!claimed) return;
+      let bodyToStore = capturedBody;
+      if (bodyToStore === undefined) {
+        bodyToStore = null;
+      }
+
+      let hashInput: string;
+      if (Buffer.isBuffer(bodyToStore)) {
+        hashInput = bodyToStore.toString("utf8");
+        bodyToStore = hashInput;
+      } else if (typeof bodyToStore === "string") {
+        hashInput = bodyToStore;
+      } else {
+        try {
+          hashInput = JSON.stringify(bodyToStore);
+        } catch {
+          hashInput = String(bodyToStore);
+        }
+      }
+
+      const statusCode = res.statusCode || 200;
+      const lastStatus = statusCode >= 400 ? "ERROR" : "DONE";
+      const responseHash = sha256Hex(hashInput ?? "");
+
+      pool
+        .query(
+          "update idempotency_keys set last_status=$2, status_code=$3, response_hash=$4, response_body=$5 where key=$1",
+          [key, lastStatus, statusCode, responseHash, bodyToStore]
+        )
+        .catch((err: unknown) => {
+          console.error("failed to persist idempotent response", err);
+        });
+    });
+
+    return next();
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,14 +18,14 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
     [abn, taxType, periodId]);
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
@@ -33,10 +33,10 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("update idempotency_keys set last_status=$2 where key=$1", [transfer_uuid, "DONE"]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -6,19 +6,22 @@ const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -30,8 +33,10 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }


### PR DESCRIPTION
## Summary
- add an aggregated Express API router that mounts payments endpoints alongside legacy reconcile handlers
- parameterise remaining Postgres queries in reconcile, evidence, and RPT issuers while wiring release rails to placeholders
- persist idempotent response status/body hashes and add a migration for the new cache columns

## Testing
- npx tsc --noEmit *(fails: repository already contains syntax errors in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e1f312d883279e6b840f835ed69a