### PR TITLE
Add React Query-backed dashboard using live payments data

### DIFF
--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -10,6 +10,7 @@ import { payAtoRelease } from './routes/payAto.js';
 import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
+import { evidence } from './routes/evidence';
 
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -34,6 +35,7 @@ app.post('/deposit', deposit);
 app.post('/payAto', rptGate, payAtoRelease);
 app.get('/balance', balance);
 app.get('/ledger', ledger);
+app.get('/evidence', evidence);
 
 // 404 fallback
 app.use((_req, res) => res.status(404).send('Not found'));

--- a/apps/services/payments/src/routes/evidence.ts
+++ b/apps/services/payments/src/routes/evidence.ts
@@ -1,0 +1,88 @@
+import type { Request, Response } from "express";
+import { pool } from "../index.js";
+
+type EvidenceRow = {
+  created_at: string;
+  payload: any;
+  payload_c14n: string;
+  payload_sha256: string;
+  signature: string;
+};
+
+export async function evidence(req: Request, res: Response) {
+  try {
+    const { abn, taxType, periodId } = req.query as Record<string, string>;
+    if (!abn || !taxType || !periodId) {
+      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+    }
+
+    const client = await pool.connect();
+    try {
+      const periodQ = await client.query(
+        `SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents,
+                merkle_root, running_balance_hash, anomaly_vector, thresholds
+         FROM periods
+         WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+        [abn, taxType, periodId]
+      );
+      if (!periodQ.rows.length) {
+        return res.status(404).json({ error: "Period not found" });
+      }
+      const period = periodQ.rows[0];
+
+      const rptQ = await client.query<EvidenceRow>(
+        `SELECT payload, payload_c14n, payload_sha256, signature, created_at
+         FROM rpt_tokens
+         WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+         ORDER BY created_at DESC
+         LIMIT 1`,
+        [abn, taxType, periodId]
+      );
+      const rptRow = rptQ.rows[0] || null;
+
+      const ledgerQ = await client.query(
+        `SELECT id, amount_cents, balance_after_cents, bank_receipt_hash,
+                prev_hash, hash_after, created_at
+           FROM owa_ledger
+          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+          ORDER BY id ASC`,
+        [abn, taxType, periodId]
+      );
+
+      const basLabels = { W1: null, W2: null, "1A": null, "1B": null } as Record<string, string | null>;
+
+      res.json({
+        meta: {
+          generated_at: new Date().toISOString(),
+          abn,
+          taxType,
+          periodId,
+        },
+        period: {
+          state: period.state,
+          accrued_cents: Number(period.accrued_cents ?? 0),
+          credited_to_owa_cents: Number(period.credited_to_owa_cents ?? 0),
+          final_liability_cents: Number(period.final_liability_cents ?? 0),
+          merkle_root: period.merkle_root,
+          running_balance_hash: period.running_balance_hash,
+          anomaly_vector: period.anomaly_vector,
+          thresholds: period.thresholds,
+        },
+        rpt: rptRow && {
+          payload: rptRow.payload,
+          payload_c14n: rptRow.payload_c14n,
+          payload_sha256: rptRow.payload_sha256,
+          signature: rptRow.signature,
+          created_at: rptRow.created_at,
+        },
+        owa_ledger: ledgerQ.rows,
+        bas_labels: basLabels,
+        discrepancy_log: [],
+      });
+    } finally {
+      client.release();
+    }
+  } catch (e: any) {
+    res.status(500).json({ error: "Evidence retrieval failed", detail: String(e?.message || e) });
+  }
+}

--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -3,11 +3,30 @@ type Common = { abn: string; taxType: string; periodId: string };
 export type DepositArgs = Common & { amountCents: number };   // > 0
 export type ReleaseArgs = Common & { amountCents: number };   // < 0
 
+type ClientConfig = {
+  baseUrl?: string;
+  routes?: Partial<Record<"deposit" | "payAto" | "balance" | "ledger" | "evidence", string>>;
+};
+
 // Prefer NEXT_PUBLIC_ (browser-safe), then server-only, then default
-const BASE =
+const DEFAULT_BASE =
   process.env.NEXT_PUBLIC_PAYMENTS_BASE_URL ||
   process.env.PAYMENTS_BASE_URL ||
   "http://localhost:3001";
+
+function joinUrl(base: string, path: string) {
+  const trimmedBase = base.replace(/\/$/, "");
+  const trimmedPath = path.replace(/^\//, "");
+  if (!trimmedBase) return `/${trimmedPath}`;
+  return `${trimmedBase}/${trimmedPath}`;
+}
+
+function withQuery(url: string, q: Common) {
+  const params = new URLSearchParams();
+  Object.entries(q).forEach(([k, v]) => params.set(k, String(v)));
+  const suffix = params.toString();
+  return suffix ? `${url}?${suffix}` : url;
+}
 
 async function handle(res: Response) {
   const text = await res.text();
@@ -20,33 +39,45 @@ async function handle(res: Response) {
   return json;
 }
 
-export const Payments = {
-  async deposit(args: DepositArgs) {
-    const res = await fetch(`${BASE}/deposit`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(args),
-    });
-    return handle(res);
-  },
-  async payAto(args: ReleaseArgs) {
-    const res = await fetch(`${BASE}/payAto`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(args),
-    });
-    return handle(res);
-  },
-  async balance(q: Common) {
-    const u = new URL(`${BASE}/balance`);
-    Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
-    const res = await fetch(u);
-    return handle(res);
-  },
-  async ledger(q: Common) {
-    const u = new URL(`${BASE}/ledger`);
-    Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
-    const res = await fetch(u);
-    return handle(res);
-  },
-};
+export function createPaymentsClient(config: ClientConfig = {}) {
+  const base = config.baseUrl ?? DEFAULT_BASE;
+  const routes = {
+    deposit: config.routes?.deposit ?? "/deposit",
+    payAto: config.routes?.payAto ?? "/payAto",
+    balance: config.routes?.balance ?? "/balance",
+    ledger: config.routes?.ledger ?? "/ledger",
+    evidence: config.routes?.evidence ?? "/evidence",
+  } as const;
+  return {
+    async deposit(args: DepositArgs) {
+      const res = await fetch(joinUrl(base, routes.deposit), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      });
+      return handle(res);
+    },
+    async payAto(args: ReleaseArgs) {
+      const res = await fetch(joinUrl(base, routes.payAto), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      });
+      return handle(res);
+    },
+    async balance(q: Common) {
+      const res = await fetch(withQuery(joinUrl(base, routes.balance), q));
+      return handle(res);
+    },
+    async ledger(q: Common) {
+      const res = await fetch(withQuery(joinUrl(base, routes.ledger), q));
+      return handle(res);
+    },
+    async evidence(q: Common) {
+      const res = await fetch(withQuery(joinUrl(base, routes.evidence), q));
+      return handle(res);
+    },
+  };
+}
+
+export const Payments = createPaymentsClient();

--- a/pages/api/evidence/index.ts
+++ b/pages/api/evidence/index.ts
@@ -1,0 +1,19 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { Payments } from "../../../libs/paymentsClient";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    return res.status(405).json({ error: "Method Not Allowed" });
+  }
+  try {
+    const { abn, taxType, periodId } = req.query as Record<string, string>;
+    if (!abn || !taxType || !periodId) {
+      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+    }
+    const data = await Payments.evidence({ abn, taxType, periodId });
+    return res.status(200).json(data);
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message || "Evidence failed" });
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // src/App.tsx
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AppLayout from "./components/AppLayout";
 
 import Dashboard from "./pages/Dashboard";
@@ -12,21 +13,25 @@ import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
 
+const queryClient = new QueryClient();
+
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <QueryClientProvider client={queryClient}>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </QueryClientProvider>
   );
 }

--- a/src/hooks/usePeriodData.ts
+++ b/src/hooks/usePeriodData.ts
@@ -1,0 +1,147 @@
+import { useMemo } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { createPaymentsClient } from "../../libs/paymentsClient";
+import type {
+  BalanceResponse,
+  ComplianceSnapshot,
+  EvidenceResponse,
+  LedgerResponse,
+  PeriodQuery,
+} from "../types/payments";
+
+const DEFAULT_PERIOD: PeriodQuery = {
+  abn: "12345678901",
+  taxType: "GST",
+  periodId: "2025-10",
+};
+
+const paymentsApi = createPaymentsClient({
+  baseUrl: "/api",
+  routes: { payAto: "/release" },
+});
+
+function centsToDollars(cents: number) {
+  return cents / 100;
+}
+
+function formatCurrency(cents: number) {
+  return new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    minimumFractionDigits: 2,
+  }).format(centsToDollars(cents));
+}
+
+function deriveNextDue(periodId: string) {
+  const [yearStr, monthStr] = periodId.split("-");
+  const year = Number(yearStr);
+  const month = Number(monthStr) - 1; // Date months are 0-indexed
+  if (!Number.isFinite(year) || !Number.isFinite(month)) return "TBA";
+  const next = new Date(Date.UTC(year, month + 1, 1));
+  next.setUTCDate(0); // last day of previous month (end of next period)
+  return next.toLocaleDateString("en-AU", { timeZone: "UTC" });
+}
+
+function deriveCompliance(
+  params: PeriodQuery,
+  balance?: BalanceResponse,
+  evidence?: EvidenceResponse
+): ComplianceSnapshot {
+  const outstandingCents = Math.max(balance?.balance_cents ?? 0, 0);
+  const lodgmentsUpToDate = Boolean(evidence?.rpt);
+  const paymentsUpToDate = outstandingCents === 0 || Boolean(balance?.has_release);
+  const numerator = Number(lodgmentsUpToDate) + Number(paymentsUpToDate);
+  const overallCompliance = Math.round((numerator / 2) * 100);
+
+  const lastBasTs = evidence?.rpt?.created_at || evidence?.meta.generated_at;
+  const lastBAS = lastBasTs
+    ? new Date(lastBasTs).toLocaleString("en-AU", { timeZone: "UTC" })
+    : "Pending";
+
+  const nextDue = deriveNextDue(params.periodId);
+  const outstandingLodgments = lodgmentsUpToDate ? [] : [params.periodId];
+  const outstandingAmounts = paymentsUpToDate || outstandingCents === 0
+    ? []
+    : [`${formatCurrency(outstandingCents)} ${params.taxType}`];
+
+  return {
+    lodgmentsUpToDate,
+    paymentsUpToDate,
+    overallCompliance,
+    lastBAS,
+    nextDue,
+    outstandingLodgments,
+    outstandingAmounts,
+  };
+}
+
+export function usePeriodData(params: PeriodQuery = DEFAULT_PERIOD) {
+  const queryClient = useQueryClient();
+
+  const balanceQuery = useQuery<BalanceResponse, Error>({
+    queryKey: ["period", params, "balance"],
+    queryFn: () => paymentsApi.balance(params),
+    refetchInterval: 5000,
+  });
+
+  const ledgerQuery = useQuery<LedgerResponse, Error>({
+    queryKey: ["period", params, "ledger"],
+    queryFn: () => paymentsApi.ledger(params),
+    refetchInterval: 5000,
+  });
+
+  const evidenceQuery = useQuery<EvidenceResponse, Error>({
+    queryKey: ["period", params, "evidence"],
+    queryFn: () => paymentsApi.evidence(params),
+    refetchInterval: 10000,
+  });
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ["period", params] });
+  };
+
+  const runPayrollDay = useMutation({
+    mutationFn: (amountCents?: number) =>
+      paymentsApi.deposit({ ...params, amountCents: amountCents ?? 250_00 }),
+    onSuccess: invalidate,
+  });
+
+  const releaseToAto = useMutation({
+    mutationFn: (amountCents?: number) =>
+      paymentsApi.payAto({ ...params, amountCents: amountCents ?? -250_00 }),
+    onSuccess: invalidate,
+  });
+
+  const compliance = useMemo(
+    () =>
+      deriveCompliance(params, balanceQuery.data, evidenceQuery.data),
+    [params, balanceQuery.data, evidenceQuery.data]
+  );
+
+  const isLoading =
+    balanceQuery.isLoading || ledgerQuery.isLoading || evidenceQuery.isLoading;
+  const isFetching =
+    balanceQuery.isFetching || ledgerQuery.isFetching || evidenceQuery.isFetching;
+  const error = balanceQuery.error || ledgerQuery.error || evidenceQuery.error || null;
+
+  return {
+    params,
+    balanceQuery,
+    ledgerQuery,
+    evidenceQuery,
+    compliance,
+    runPayrollDay,
+    releaseToAto,
+    isLoading,
+    isFetching,
+    isError: Boolean(error),
+    error,
+    formatCurrency,
+  };
+}
+
+export { DEFAULT_PERIOD };

--- a/src/pages/BAS.tsx
+++ b/src/pages/BAS.tsx
@@ -1,42 +1,86 @@
-import React from 'react';
+import React from "react";
+import { usePeriodData } from "../hooks/usePeriodData";
 
 export default function BAS() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65, // percentage from 0 to 100
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const {
+    compliance,
+    evidenceQuery,
+    isLoading,
+    isError,
+    error,
+    isFetching,
+    formatCurrency,
+  } = usePeriodData();
+
+  if (isLoading) {
+    return (
+      <div className="main-card">
+        <p className="text-sm text-gray-600">Loading BAS bundle…</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="main-card">
+        <p className="text-sm text-red-600">{error?.message || "Unable to load BAS evidence."}</p>
+      </div>
+    );
+  }
+
+  const evidence = evidenceQuery.data;
+  const basLabels = evidence?.bas_labels ?? {};
+  const ledgerRows = evidence?.owa_ledger ?? [];
+  const finalLiability = evidence?.period.final_liability_cents ?? 0;
+  const credited = evidence?.period.credited_to_owa_cents ?? 0;
+  const netOutstanding = Math.max(finalLiability - credited, 0);
 
   return (
     <div className="main-card">
       <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
       <p className="text-sm text-muted-foreground mb-4">
-        Lodge your BAS on time and accurately. Below is a summary of your current obligations.
+        Lodge your BAS on time and accurately. Below is a live summary from the payments simulator.
       </p>
 
-      {!complianceStatus.lodgmentsUpToDate || !complianceStatus.paymentsUpToDate ? (
+      {(!compliance.lodgmentsUpToDate || !compliance.paymentsUpToDate) && (
         <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-800 p-4 rounded">
           <p className="font-medium">Reminder:</p>
-          <p>Your BAS is overdue or payments are outstanding. Resolve to avoid penalties.</p>
+          <p>Your BAS is pending lodgment or payments are still in transit. Resolve to avoid penalties.</p>
         </div>
-      ) : null}
+      )}
 
-      <div className="bg-card p-4 rounded-xl shadow space-y-4">
-        <h2 className="text-lg font-semibold">Current Quarter</h2>
-        <ul className="list-disc pl-5 mt-2 space-y-1 text-sm">
-          <li><strong>W1:</strong> $7,500 (Gross wages)</li>
-          <li><strong>W2:</strong> $1,850 (PAYGW withheld)</li>
-          <li><strong>G1:</strong> $25,000 (Total sales)</li>
-          <li><strong>1A:</strong> $2,500 (GST on sales)</li>
-          <li><strong>1B:</strong> $450 (GST on purchases)</li>
+      {isFetching && (
+        <div className="mt-4 bg-blue-50 border border-blue-200 text-blue-700 px-4 py-3 rounded">
+          Streaming evidence updates… waiting for ledger settlement.
+        </div>
+      )}
+
+      <div className="bg-card p-4 rounded-xl shadow space-y-4 mt-4">
+        <h2 className="text-lg font-semibold">Current Period ({evidence?.meta.periodId})</h2>
+        <ul className="grid sm:grid-cols-2 gap-3 text-sm">
+          {(["W1", "W2", "1A", "1B"] as const).map((label) => (
+            <li key={label} className="bg-white rounded-lg shadow px-3 py-2">
+              <p className="text-xs uppercase text-gray-500">{label}</p>
+              <p className="text-base font-semibold text-gray-800">
+                {basLabels[label] ?? "Pending"}
+              </p>
+            </li>
+          ))}
         </ul>
-        <button className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
-          Review & Lodge
-        </button>
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+          <p className="text-sm text-gray-700">
+            Final liability: <strong>{formatCurrency(finalLiability)}</strong>. Credited to OWA:{" "}
+            <strong>{formatCurrency(credited)}</strong>.
+          </p>
+          <button className="bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
+            Review &amp; Lodge
+          </button>
+        </div>
+        {netOutstanding > 0 && (
+          <p className="text-xs text-red-600">
+            Outstanding liability {formatCurrency(netOutstanding)} awaiting release.
+          </p>
+        )}
       </div>
 
       <div className="bg-green-50 border border-green-200 p-4 rounded-xl shadow-md mt-6">
@@ -44,14 +88,14 @@ export default function BAS() {
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 mt-3 text-sm">
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Lodgments</p>
-            <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-              {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
+            <p className={compliance.lodgmentsUpToDate ? "text-green-600" : "text-red-600"}>
+              {compliance.lodgmentsUpToDate ? "Up to date ✅" : "Overdue ❌"}
             </p>
           </div>
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Payments</p>
-            <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-              {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
+            <p className={compliance.paymentsUpToDate ? "text-green-600" : "text-red-600"}>
+              {compliance.paymentsUpToDate ? "All paid ✅" : "Outstanding ❌"}
             </p>
           </div>
           <div className="bg-white p-3 rounded shadow">
@@ -72,7 +116,7 @@ export default function BAS() {
                   fill="none"
                   stroke="url(#grad)"
                   strokeWidth="2"
-                  strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
+                  strokeDasharray={`${compliance.overallCompliance}, 100`}
                 />
                 <defs>
                   <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
@@ -81,35 +125,56 @@ export default function BAS() {
                     <stop offset="100%" stopColor="green" />
                   </linearGradient>
                 </defs>
-                <text x="18" y="20.35" textAnchor="middle" fontSize="6">{complianceStatus.overallCompliance}%</text>
+                <text x="18" y="20.35" textAnchor="middle" fontSize="6">{compliance.overallCompliance}%</text>
               </svg>
             </div>
           </div>
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Status</p>
             <p className="text-sm text-gray-600">
-              {complianceStatus.overallCompliance >= 90
-                ? 'Excellent compliance'
-                : complianceStatus.overallCompliance >= 70
-                ? 'Good standing'
-                : 'Needs attention'}
+              {compliance.overallCompliance >= 90
+                ? "Excellent compliance"
+                : compliance.overallCompliance >= 70
+                ? "Good standing"
+                : "Needs attention"}
             </p>
           </div>
         </div>
         <p className="mt-4 text-sm text-gray-700">
-          Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>. Next BAS due by <strong>{complianceStatus.nextDue}</strong>.
+          Last BAS lodged on <strong>{compliance.lastBAS}</strong>. Next BAS due by <strong>{compliance.nextDue}</strong>.
         </p>
         <div className="mt-2 text-sm text-red-600">
-          {complianceStatus.outstandingLodgments.length > 0 && (
-            <p>Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
+          {compliance.outstandingLodgments.length > 0 && (
+            <p>Outstanding Lodgments: {compliance.outstandingLodgments.join(", ")}</p>
           )}
-          {complianceStatus.outstandingAmounts.length > 0 && (
-            <p>Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
+          {compliance.outstandingAmounts.length > 0 && (
+            <p>Outstanding Payments: {compliance.outstandingAmounts.join(", ")}</p>
           )}
         </div>
         <p className="mt-2 text-xs text-gray-500 italic">
           Staying highly compliant may help avoid audits, reduce penalties, and support eligibility for ATO support programs.
         </p>
+      </div>
+
+      <div className="mt-6 text-sm text-gray-600">
+        <h2 className="text-base font-semibold mb-2">Ledger Evidence</h2>
+        {ledgerRows.length === 0 ? (
+          <p>No ledger entries recorded for this period yet.</p>
+        ) : (
+          <ul className="space-y-2">
+            {ledgerRows.map((row) => (
+              <li key={row.id} className="bg-white rounded-lg shadow px-3 py-2">
+                <div className="flex flex-wrap justify-between text-xs text-gray-500">
+                  <span>{new Date(row.created_at).toLocaleString()}</span>
+                  <span>Balance {formatCurrency(row.balance_after_cents)}</span>
+                </div>
+                <p className="text-sm text-gray-700">
+                  {row.amount_cents >= 0 ? "Credit" : "Debit"}: {formatCurrency(row.amount_cents)}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,47 +1,114 @@
 // src/pages/Dashboard.tsx
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React from "react";
+import { Link } from "react-router-dom";
+import { usePeriodData } from "../hooks/usePeriodData";
 
 export default function Dashboard() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65,
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const {
+    compliance,
+    balanceQuery,
+    ledgerQuery,
+    evidenceQuery,
+    isLoading,
+    isError,
+    error,
+    isFetching,
+    runPayrollDay,
+    releaseToAto,
+    formatCurrency,
+  } = usePeriodData();
+
+  if (isLoading) {
+    return (
+      <div className="main-card">
+        <p className="text-sm text-gray-600">Loading dashboard data…</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="main-card">
+        <p className="text-sm text-red-600">{error?.message || "Unable to load payments data."}</p>
+      </div>
+    );
+  }
+
+  const balanceCents = balanceQuery.data?.balance_cents ?? 0;
+  const ledgerRows = ledgerQuery.data?.rows ?? [];
+  const latestEntry = ledgerRows.length ? ledgerRows[ledgerRows.length - 1] : null;
+  const periodState = evidenceQuery.data?.period.state ?? "PENDING";
+  const streaming = isFetching || runPayrollDay.isPending || releaseToAto.isPending;
 
   return (
     <div className="main-card">
       <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
         <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
         <p className="text-sm opacity-90">
-          Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
+          Automating PAYGW &amp; GST compliance with live settlement data. Keep an eye on the one-way account as the simulator streams activity.
         </p>
-        <div className="mt-4">
-          <Link to="/wizard" className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100">
+        <div className="mt-4 flex flex-wrap gap-3">
+          <Link
+            to="/wizard"
+            className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100"
+          >
             Get Started
           </Link>
+          <button
+            type="button"
+            onClick={() => runPayrollDay.mutate()}
+            disabled={runPayrollDay.isPending}
+            className="bg-white/20 border border-white/60 px-4 py-2 rounded hover:bg-white/10 disabled:opacity-60"
+          >
+            {runPayrollDay.isPending ? "Running payroll…" : "Run Payroll Day"}
+          </button>
+          <button
+            type="button"
+            onClick={() => releaseToAto.mutate()}
+            disabled={releaseToAto.isPending}
+            className="bg-white/20 border border-white/60 px-4 py-2 rounded hover:bg-white/10 disabled:opacity-60"
+          >
+            {releaseToAto.isPending ? "Releasing…" : "Release to ATO"}
+          </button>
         </div>
+        {(runPayrollDay.isError || releaseToAto.isError) && (
+          <p className="mt-3 text-sm text-red-100">
+            {(runPayrollDay.error as Error | undefined)?.message || (releaseToAto.error as Error | undefined)?.message}
+          </p>
+        )}
       </div>
+
+      {streaming && (
+        <div className="mb-4 bg-blue-50 border border-blue-200 text-blue-700 px-4 py-3 rounded">
+          Streaming simulator updates… new ledger entries will appear momentarily.
+        </div>
+      )}
 
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div className="bg-white p-4 rounded-xl shadow space-y-2">
           <h2 className="text-lg font-semibold">Lodgments</h2>
-          <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
+          <p className={compliance.lodgmentsUpToDate ? "text-green-600" : "text-red-600"}>
+            {compliance.lodgmentsUpToDate ? "Up to date ✅" : "Overdue ❌"}
           </p>
-          <Link to="/bas" className="text-blue-600 text-sm underline">View BAS</Link>
+          <Link to="/bas" className="text-blue-600 text-sm underline">
+            View BAS
+          </Link>
+          <p className="text-xs text-gray-500">Last bundle generated {compliance.lastBAS}.</p>
         </div>
 
         <div className="bg-white p-4 rounded-xl shadow space-y-2">
           <h2 className="text-lg font-semibold">Payments</h2>
-          <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
+          <p className={compliance.paymentsUpToDate ? "text-green-600" : "text-red-600"}>
+            {compliance.paymentsUpToDate ? "All paid ✅" : "Outstanding ❌"}
           </p>
-          <Link to="/audit" className="text-blue-600 text-sm underline">View Audit</Link>
+          <p className="text-sm text-gray-700">
+            OWA balance: <strong>{formatCurrency(balanceCents)}</strong>
+          </p>
+          {latestEntry && (
+            <p className="text-xs text-gray-500">
+              Last entry {new Date(latestEntry.created_at).toLocaleString()} ({formatCurrency(latestEntry.amount_cents)}).
+            </p>
+          )}
         </div>
 
         <div className="bg-white p-4 rounded-xl shadow text-center">
@@ -59,7 +126,7 @@ export default function Dashboard() {
                 fill="none"
                 stroke="url(#grad)"
                 strokeWidth="2"
-                strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
+                strokeDasharray={`${compliance.overallCompliance}, 100`}
               />
               <defs>
                 <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
@@ -68,27 +135,41 @@ export default function Dashboard() {
                   <stop offset="100%" stopColor="green" />
                 </linearGradient>
               </defs>
-              <text x="18" y="20.35" textAnchor="middle" fontSize="5">{complianceStatus.overallCompliance}%</text>
+              <text x="18" y="20.35" textAnchor="middle" fontSize="5">
+                {compliance.overallCompliance}%
+              </text>
             </svg>
           </div>
           <p className="text-sm mt-2 text-gray-600">
-            {complianceStatus.overallCompliance >= 90
-              ? 'Excellent'
-              : complianceStatus.overallCompliance >= 70
-              ? 'Good'
-              : 'Needs attention'}
+            {compliance.overallCompliance >= 90
+              ? "Excellent"
+              : compliance.overallCompliance >= 70
+              ? "Good"
+              : "Needs attention"}
           </p>
+          <p className="text-xs text-gray-500 mt-1">Period state: {periodState}</p>
         </div>
       </div>
 
-      <div className="mt-6 text-sm text-gray-700">
-        <p>Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>. <Link to="/bas" className="text-blue-600 underline">Go to BAS</Link></p>
-        <p>Next BAS due by <strong>{complianceStatus.nextDue}</strong>.</p>
-        {complianceStatus.outstandingLodgments.length > 0 && (
-          <p className="text-red-600">Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
+      <div className="mt-6 text-sm text-gray-700 space-y-1">
+        <p>
+          Last BAS lodged on <strong>{compliance.lastBAS}</strong>.{' '}
+          <Link to="/bas" className="text-blue-600 underline">
+            Go to BAS
+          </Link>
+        </p>
+        <p>
+          Next BAS due by <strong>{compliance.nextDue}</strong>.
+        </p>
+        {compliance.outstandingLodgments.length > 0 && (
+          <p className="text-red-600">
+            Outstanding Lodgments: {compliance.outstandingLodgments.join(", ")}
+          </p>
         )}
-        {complianceStatus.outstandingAmounts.length > 0 && (
-          <p className="text-red-600">Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
+        {compliance.outstandingAmounts.length > 0 && (
+          <p className="text-red-600">
+            Outstanding Payments: {compliance.outstandingAmounts.join(", ")}
+          </p>
         )}
       </div>
 

--- a/src/types/payments.ts
+++ b/src/types/payments.ts
@@ -1,0 +1,63 @@
+export type PeriodQuery = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+};
+
+export type BalanceResponse = PeriodQuery & {
+  balance_cents: number;
+  has_release: boolean;
+};
+
+export type LedgerRow = {
+  id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash?: string | null;
+  prev_hash?: string | null;
+  hash_after?: string | null;
+  created_at: string;
+};
+
+export type LedgerResponse = PeriodQuery & {
+  rows: LedgerRow[];
+};
+
+export type EvidenceResponse = {
+  meta: {
+    generated_at: string;
+    abn: string;
+    taxType: string;
+    periodId: string;
+  };
+  period: {
+    state: string;
+    accrued_cents: number;
+    credited_to_owa_cents: number;
+    final_liability_cents: number;
+    merkle_root: string | null;
+    running_balance_hash: string | null;
+    anomaly_vector: Record<string, unknown> | null;
+    thresholds: Record<string, unknown> | null;
+  };
+  rpt: null | {
+    payload: unknown;
+    payload_c14n: string;
+    payload_sha256: string;
+    signature: string;
+    created_at?: string;
+  };
+  owa_ledger: LedgerRow[];
+  bas_labels: Record<string, string | null>;
+  discrepancy_log: unknown[];
+};
+
+export type ComplianceSnapshot = {
+  lodgmentsUpToDate: boolean;
+  paymentsUpToDate: boolean;
+  overallCompliance: number;
+  lastBAS: string;
+  nextDue: string;
+  outstandingLodgments: string[];
+  outstandingAmounts: string[];
+};


### PR DESCRIPTION
## Summary
- add an evidence route to the payments service and expose it through the Next.js API for the console
- extend the shared payments client and introduce a React Query hook that streams balance, ledger, and evidence data with simulator controls
- refresh the dashboard and BAS pages to surface live compliance metrics with clear loading and error states

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2e1ef0d848327ac514ac089dd9244