### PR TITLE
Add simulator adapter modes and evidence enrichment

### DIFF
--- a/apps/services/payments/src/bank/paytoAdapter.ts
+++ b/apps/services/payments/src/bank/paytoAdapter.ts
@@ -1,31 +1,116 @@
-﻿import pg from "pg";
-import axios from "axios";
-import https from "https";
-const agent = new https.Agent({
-  ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
-  cert: process.env.BANK_TLS_CERT ? require("fs").readFileSync(process.env.BANK_TLS_CERT) : undefined,
-  key: process.env.BANK_TLS_KEY ? require("fs").readFileSync(process.env.BANK_TLS_KEY) : undefined,
-  rejectUnauthorized: true
-});
-const client = axios.create({
-  baseURL: process.env.BANK_API_BASE,
-  timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
-  httpsAgent: agent
-});
+import { createHash } from "crypto";
+import { AdapterCallContext, AdapterMode, getAdapterMode, recordAdapterCall } from "./simulatorState.js";
 
-export async function createMandate(abn: string, periodId: string, cap_cents: number) {
-  const r = await client.post("/payto/mandates", { abn, periodId, cap_cents });
-  return r.data;
+export interface MandateResult {
+  status: "OK" | "ERROR";
+  mandate_id: string;
+  mode: AdapterMode;
+  callId: string;
 }
-export async function verifyMandate(mandate_id: string) {
-  const r = await client.post(`/payto/mandates/${mandate_id}/verify`, {});
-  return r.data;
+
+export interface VerifyResult {
+  status: "OK" | "ERROR";
+  verified: boolean;
+  mode: AdapterMode;
+  callId: string;
 }
-export async function debitMandate(mandate_id: string, amount_cents: number, meta: any) {
-  const r = await client.post(`/payto/mandates/${mandate_id}/debit`, { amount_cents, meta });
-  return r.data;
+
+export interface DebitResultSuccess {
+  status: "OK";
+  bank_ref: string;
+  receipt_signature: string;
+  mode: AdapterMode;
+  callId: string;
 }
-export async function cancelMandate(mandate_id: string) {
-  const r = await client.post(`/payto/mandates/${mandate_id}/cancel`, {});
-  return r.data;
+
+export interface DebitResultInsufficient {
+  status: "INSUFFICIENT_FUNDS";
+  reason: string;
+  mode: AdapterMode;
+  callId: string;
+}
+
+export type DebitResult = DebitResultSuccess | DebitResultInsufficient;
+
+export async function createMandate(abn: string, periodId: string, cap_cents: number, context?: AdapterCallContext): Promise<MandateResult> {
+  const mode = getAdapterMode("payto");
+  const payload = { abn, periodId, cap_cents };
+  if (mode === "error") {
+    recordAdapterCall("payto", payload, context, { error: "Simulated PayTo outage" });
+    throw new Error("Simulated PayTo outage");
+  }
+  const response: MandateResult = {
+    status: "OK",
+    mandate_id: `SIM-M-${periodId}`,
+    mode,
+    callId: recordAdapterCall("payto", payload, context, { response: { status: "OK" } }),
+  };
+  return response;
+}
+
+export async function verifyMandate(mandate_id: string, context?: AdapterCallContext): Promise<VerifyResult> {
+  const mode = getAdapterMode("payto");
+  const payload = { mandate_id };
+  if (mode === "error") {
+    recordAdapterCall("payto", payload, context, { error: "Simulated PayTo verification outage" });
+    throw new Error("Simulated PayTo verification outage");
+  }
+  const response: VerifyResult = {
+    status: "OK",
+    verified: true,
+    mode,
+    callId: recordAdapterCall("payto", payload, context, { response: { status: "OK", verified: true } }),
+  };
+  return response;
+}
+
+export async function debitMandate(
+  mandate_id: string,
+  amount_cents: number,
+  meta: AdapterCallContext & { reference?: string; sources?: Array<{ basLabel?: string; amount_cents?: number; reference?: string; channel?: string; description?: string }> }
+): Promise<DebitResult> {
+  const mode = getAdapterMode("payto");
+  const payload = { mandate_id, amount_cents, meta };
+
+  if (mode === "error") {
+    recordAdapterCall("payto", payload, meta, { error: "Simulated PayTo debit failure" });
+    throw new Error("Simulated PayTo debit failure");
+  }
+
+  if (mode === "insufficient") {
+    const response: DebitResultInsufficient = {
+      status: "INSUFFICIENT_FUNDS",
+      reason: "Simulated PayTo mandate cap reached",
+      mode,
+      callId: recordAdapterCall("payto", payload, meta, {
+        response: { status: "INSUFFICIENT_FUNDS", reason: "Simulated PayTo mandate cap reached" },
+      }),
+    };
+    return response;
+  }
+
+  const bank_ref = `PAYTO-${mandate_id.slice(0, 8)}-${String(amount_cents).padStart(6, "0")}`;
+  const receipt_signature = createHash("sha256").update(JSON.stringify({ mandate_id, amount_cents, meta })).digest("hex");
+  const response: DebitResultSuccess = {
+    status: "OK",
+    bank_ref,
+    receipt_signature,
+    mode,
+    callId: recordAdapterCall("payto", payload, meta, { response: { status: "OK", bank_ref, receipt_signature } }),
+  };
+  return response;
+}
+
+export async function cancelMandate(mandate_id: string, context?: AdapterCallContext) {
+  const mode = getAdapterMode("payto");
+  const payload = { mandate_id };
+  if (mode === "error") {
+    recordAdapterCall("payto", payload, context, { error: "Simulated PayTo cancel outage" });
+    throw new Error("Simulated PayTo cancel outage");
+  }
+  return {
+    status: "OK",
+    mode,
+    callId: recordAdapterCall("payto", payload, context, { response: { status: "OK" } }),
+  };
 }

--- a/apps/services/payments/src/bank/simulatorState.ts
+++ b/apps/services/payments/src/bank/simulatorState.ts
@@ -1,0 +1,121 @@
+import { randomUUID } from "crypto";
+
+export type AdapterName = "bank" | "payto" | "payroll" | "pos";
+export type AdapterMode = "success" | "insufficient" | "error";
+
+export interface AdapterCallContext {
+  abn?: string;
+  taxType?: string;
+  periodId?: string;
+}
+
+export interface AdapterCallLedgerLink {
+  ledger_id?: number;
+  amount_cents?: number;
+  balance_after_cents?: number;
+  sources?: Array<{ basLabel?: string; amount_cents?: number; reference?: string; channel?: string; description?: string }>;
+}
+
+export interface AdapterCallLog {
+  id: string;
+  adapter: AdapterName;
+  mode: AdapterMode;
+  ts: string;
+  payload: unknown;
+  response?: unknown;
+  error?: string;
+  context?: AdapterCallContext;
+  ledger?: AdapterCallLedgerLink;
+}
+
+const adapterModes: Record<AdapterName, AdapterMode> = {
+  bank: "success",
+  payto: "success",
+  payroll: "success",
+  pos: "success",
+};
+
+const callLog: AdapterCallLog[] = [];
+const MAX_LOG_ENTRIES = 200;
+
+function cloneValue<T>(value: T): T {
+  if (value === undefined) return value;
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function pruneLogs() {
+  if (callLog.length > MAX_LOG_ENTRIES) {
+    callLog.splice(0, callLog.length - MAX_LOG_ENTRIES);
+  }
+}
+
+export function getAdapterMode(adapter: AdapterName): AdapterMode {
+  return adapterModes[adapter];
+}
+
+export function getAdapterModes(): Record<AdapterName, AdapterMode> {
+  return { ...adapterModes };
+}
+
+export function setAdapterMode(adapter: AdapterName, mode: AdapterMode) {
+  adapterModes[adapter] = mode;
+}
+
+export function recordAdapterCall(
+  adapter: AdapterName,
+  payload: unknown,
+  context: AdapterCallContext | undefined,
+  result: { response?: unknown; error?: string }
+): string {
+  const id = randomUUID();
+  callLog.push({
+    id,
+    adapter,
+    mode: adapterModes[adapter],
+    ts: new Date().toISOString(),
+    payload,
+    response: result.response,
+    error: result.error,
+    context,
+  });
+  pruneLogs();
+  return id;
+}
+
+export function attachLedgerToCall(id: string, ledger: AdapterCallLedgerLink) {
+  const entry = callLog.find((c) => c.id === id);
+  if (entry) {
+    entry.ledger = { ...entry.ledger, ...ledger };
+  }
+}
+
+export function getAdapterTrail(filter: AdapterCallContext): AdapterCallLog[] {
+  return callLog
+    .filter((c) => {
+      if (filter.abn && c.context?.abn !== filter.abn) return false;
+      if (filter.taxType && c.context?.taxType !== filter.taxType) return false;
+      if (filter.periodId && c.context?.periodId !== filter.periodId) return false;
+      return true;
+    })
+    .map((c) => ({
+      ...c,
+      payload: cloneValue(c.payload),
+      response: cloneValue(c.response),
+      ledger: c.ledger
+        ? {
+            ...c.ledger,
+            sources: c.ledger.sources ? cloneValue(c.ledger.sources) : undefined,
+          }
+        : undefined,
+    }));
+}
+
+export function resetSimulator() {
+  callLog.splice(0, callLog.length);
+  Object.assign(adapterModes, {
+    bank: "success",
+    payto: "success",
+    payroll: "success",
+    pos: "success",
+  });
+}

--- a/apps/services/payments/src/evidence/evidenceBundle.ts
+++ b/apps/services/payments/src/evidence/evidenceBundle.ts
@@ -1,16 +1,29 @@
 ﻿import pg from "pg";
 const { PoolClient } = pg;
 import { canonicalJson, sha256Hex } from "../utils/crypto";
+import { getAdapterTrail } from "../bank/simulatorState.js";
 
 type BuildParams = {
-  abn: string; taxType: string; periodId: string;
-  bankReceipts: Array<{provider: string; receipt_id: string}>;
-  atoReceipts: Array<{submission_id: string; receipt_id: string}>;
-  operatorOverrides: Array<{who: string; why: string; ts: string}>;
-  owaAfterHash: string;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  bankReceipts?: Array<{ provider: string; receipt_id: string; signature?: string; ledger_id?: number | null; mode?: string }>;
+  atoReceipts?: Array<{ submission_id: string; receipt_id: string; ledger_id?: number | null; mode?: string }>;
+  operatorOverrides?: Array<{ who: string; why: string; ts: string }>;
+  owaAfterHash?: string;
 };
 
 export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
+  const periodQ = await client.query(
+    `SELECT accrued_cents, credited_to_owa_cents, final_liability_cents,
+            thresholds_json, anomaly_vector
+       FROM periods
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+    [p.abn, p.taxType, p.periodId]
+  );
+  if (!periodQ.rows.length) throw new Error("Missing period for bundle");
+  const period = periodQ.rows[0];
+
   const rpt = await client.query(
     "SELECT rpt_id, payload_c14n, payload_sha256, signature FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED' ORDER BY created_at DESC LIMIT 1",
     [p.abn, p.taxType, p.periodId]
@@ -18,9 +31,11 @@ export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
   if (!rpt.rows.length) throw new Error("Missing RPT for bundle");
   const r = rpt.rows[0];
 
-  const thresholds = { variance_pct: 0.02, dup_rate: 0.01, gap_allowed: 3 };
-  const anomalies = { variance: 0.0, dups: 0, gaps: 0 };
-  const normalization = { payroll_hash: "NA", pos_hash: "NA" };
+  const thresholds = {
+    variance_pct: Number(period.thresholds_json?.variance_pct ?? 0.05),
+    dup_rate: Number(period.thresholds_json?.dup_rate ?? 0.05),
+    gap_minutes: Number(period.thresholds_json?.gap_minutes ?? 60),
+  };
 
   const beforeQ = await client.query(
     "SELECT COALESCE(SUM(amount_cents),0) bal FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND entry_id < (SELECT max(entry_id) FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3)",
@@ -35,25 +50,164 @@ export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
 
   const payload_sha256 = sha256Hex(r.payload_c14n);
 
+  const deltas = await client.query(
+    `SELECT id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at
+       FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id`,
+    [p.abn, p.taxType, p.periodId]
+  );
+
+  const adapterTrail = getAdapterTrail({ abn: p.abn, taxType: p.taxType, periodId: p.periodId });
+
+  const ledgerRows = deltas.rows.map((row) => ({
+    id: Number(row.id),
+    amount_cents: Number(row.amount_cents),
+    balance_after_cents: Number(row.balance_after_cents),
+    bank_receipt_hash: row.bank_receipt_hash,
+    prev_hash: row.prev_hash,
+    hash_after: row.hash_after,
+    created_at: row.created_at,
+  }));
+
+  const inbound = ledgerRows.filter((row) => row.amount_cents > 0);
+  const outbound = ledgerRows.filter((row) => row.amount_cents < 0);
+  const inboundSum = inbound.reduce((acc, row) => acc + row.amount_cents, 0);
+  const outboundSum = outbound.reduce((acc, row) => acc + row.amount_cents, 0);
+  const creditedToOwa = Number(period.credited_to_owa_cents ?? 0);
+  const finalLiability = Number(period.final_liability_cents ?? 0);
+
+  const variancePct = inboundSum === 0 ? 0 : Math.abs(inboundSum - creditedToOwa) / Math.max(Math.abs(inboundSum), 1);
+
+  const amountCounts = new Map<number, number>();
+  ledgerRows.forEach((row) => {
+    const count = amountCounts.get(row.amount_cents) ?? 0;
+    amountCounts.set(row.amount_cents, count + 1);
+  });
+  const duplicateEntries = Array.from(amountCounts.values()).filter((v) => v > 1).reduce((acc, v) => acc + v - 1, 0);
+  const dupRate = ledgerRows.length ? duplicateEntries / ledgerRows.length : 0;
+
+  const orderedDates = ledgerRows.map((row) => new Date(row.created_at).getTime()).sort((a, b) => a - b);
+  let gapMinutes = 0;
+  for (let i = 1; i < orderedDates.length; i++) {
+    const gapMs = orderedDates[i] - orderedDates[i - 1];
+    gapMinutes = Math.max(gapMinutes, gapMs / 60000);
+  }
+
+  const anomalies = {
+    variance_pct: Number(variancePct.toFixed(6)),
+    dup_rate: Number(dupRate.toFixed(6)),
+    gap_minutes: Number(gapMinutes.toFixed(2)),
+  };
+
+  const basTotals: Record<string, number> = {};
+  adapterTrail.forEach((log) => {
+    log.ledger?.sources?.forEach((src) => {
+      if (!src?.basLabel) return;
+      const amt = Number(src.amount_cents);
+      if (!Number.isFinite(amt)) return;
+      basTotals[src.basLabel] = (basTotals[src.basLabel] ?? 0) + amt;
+    });
+  });
+
+  const bas_labels = {
+    W1: basTotals["W1"] ?? null,
+    W2: basTotals["W2"] ?? null,
+    "1A": basTotals["1A"] ?? null,
+    "1B": basTotals["1B"] ?? null,
+  };
+
+  const discrepancy_log: Array<{ ts: string; type: string; detail: string; delta_cents: number }> = [];
+  if (Math.round(inboundSum) !== Math.round(creditedToOwa)) {
+    discrepancy_log.push({
+      ts: new Date().toISOString(),
+      type: "INBOUND_VS_CREDITED",
+      detail: `Inbound ledger ${inboundSum} vs credited ${creditedToOwa}`,
+      delta_cents: inboundSum - creditedToOwa,
+    });
+  }
+  const outboundAbs = Math.abs(outboundSum);
+  if (Math.round(outboundAbs) !== Math.round(finalLiability)) {
+    discrepancy_log.push({
+      ts: new Date().toISOString(),
+      type: "RELEASE_VS_LIABILITY",
+      detail: `Released ${outboundAbs} vs liability ${finalLiability}`,
+      delta_cents: outboundAbs - finalLiability,
+    });
+  }
+
+  adapterTrail.forEach((log) => {
+    const response = log.response as any;
+    if (log.error) {
+      discrepancy_log.push({
+        ts: log.ts,
+        type: `${log.adapter.toUpperCase()}_ERROR`,
+        detail: log.error,
+        delta_cents: Number(log.ledger?.amount_cents ?? 0),
+      });
+    } else if (response?.status && response.status !== "OK") {
+      discrepancy_log.push({
+        ts: log.ts,
+        type: `${log.adapter.toUpperCase()}_${response.status}`,
+        detail: response.reason || "Adapter returned non-OK status",
+        delta_cents: Number(log.ledger?.amount_cents ?? 0),
+      });
+    }
+  });
+
+  const normalization = { payroll_hash: "NA", pos_hash: "NA" };
+
+  const bankReceipts = adapterTrail
+    .filter((log) => log.adapter === "bank" && (log.response as any)?.status === "OK")
+    .map((log) => {
+      const response = log.response as any;
+      return {
+        provider: "EFT/BPAY",
+        receipt_id: response?.provider_receipt_id ?? null,
+        signature: response?.receipt_signature ?? null,
+        bank_receipt_hash: response?.bank_receipt_hash ?? null,
+        ledger_id: log.ledger?.ledger_id ?? null,
+        mode: log.mode,
+      };
+    });
+
+  const atoReceipts = adapterTrail
+    .filter((log) => log.adapter === "payto" && (log.response as any)?.status === "OK")
+    .map((log) => {
+      const response = log.response as any;
+      return {
+        submission_id: response?.bank_ref ?? log.id,
+        receipt_id: response?.receipt_signature ?? null,
+        ledger_id: log.ledger?.ledger_id ?? null,
+        mode: log.mode,
+      };
+    });
+
+  const operatorOverrides = p.operatorOverrides ?? [];
+
   const ins = `
     INSERT INTO evidence_bundles (
       abn, tax_type, period_id, payload_sha256, rpt_id, rpt_payload, rpt_signature,
       thresholds_json, anomaly_vector, normalization_hashes,
       owa_balance_before, owa_balance_after,
-      bank_receipts, ato_receipts, operator_overrides
-    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,$11,$12,$13::jsonb,$14::jsonb,$15::jsonb)
+      bank_receipts, ato_receipts, operator_overrides,
+      bas_labels, discrepancy_log
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,$11,$12,$13::jsonb,$14::jsonb,$15::jsonb,$16::jsonb,$17::jsonb)
     ON CONFLICT (abn, tax_type, period_id) DO UPDATE SET
       bank_receipts = EXCLUDED.bank_receipts,
       ato_receipts = EXCLUDED.ato_receipts,
       owa_balance_before = EXCLUDED.owa_balance_before,
-      owa_balance_after = EXCLUDED.owa_balance_after
+      owa_balance_after = EXCLUDED.owa_balance_after,
+      bas_labels = EXCLUDED.bas_labels,
+      discrepancy_log = EXCLUDED.discrepancy_log
     RETURNING bundle_id
   `;
   const vals = [
     p.abn, p.taxType, p.periodId, payload_sha256, r.rpt_id, r.payload_c14n, r.signature,
     canonicalJson(thresholds), canonicalJson(anomalies), canonicalJson(normalization),
     balBefore, balAfter,
-    canonicalJson(p.bankReceipts), canonicalJson(p.atoReceipts), canonicalJson(p.operatorOverrides)
+    canonicalJson(bankReceipts), canonicalJson(atoReceipts), canonicalJson(operatorOverrides),
+    canonicalJson(bas_labels), canonicalJson(discrepancy_log)
   ];
   const out = await client.query(ins, vals);
   return out.rows[0].bundle_id as number;

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -10,6 +10,7 @@ import { payAtoRelease } from './routes/payAto.js';
 import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
+import { getSimulatorModes, updateSimulatorMode } from './routes/simulator.js';
 
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -34,6 +35,8 @@ app.post('/deposit', deposit);
 app.post('/payAto', rptGate, payAtoRelease);
 app.get('/balance', balance);
 app.get('/ledger', ledger);
+app.get('/simulator/modes', getSimulatorModes);
+app.post('/simulator/modes', updateSimulatorMode);
 
 // 404 fallback
 app.use((_req, res) => res.status(404).send('Not found'));

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,10 +1,39 @@
 import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { debitMandate } from "../bank/paytoAdapter.js";
+import type { DebitResultSuccess } from "../bank/paytoAdapter.js";
+import { attachLedgerToCall } from "../bank/simulatorState.js";
+
+type SourceAnnotation = {
+  basLabel?: string;
+  amount_cents?: number;
+  reference?: string;
+  channel?: string;
+  description?: string;
+};
+
+function normaliseSources(raw: unknown): SourceAnnotation[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const e = entry as Record<string, unknown>;
+      const amount = Number(e.amount_cents);
+      return {
+        basLabel: typeof e.basLabel === "string" ? e.basLabel : undefined,
+        amount_cents: Number.isFinite(amount) ? amount : undefined,
+        reference: typeof e.reference === "string" ? e.reference : undefined,
+        channel: typeof e.channel === "string" ? e.channel : undefined,
+        description: typeof e.description === "string" ? e.description : undefined,
+      };
+    })
+    .filter((e): e is SourceAnnotation => !!e);
+}
 
 export async function deposit(req: Request, res: Response) {
   try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
+    const { abn, taxType, periodId, amountCents, sources } = req.body || {};
     if (!abn || !taxType || !periodId) return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     const amt = Number(amountCents);
     if (!Number.isFinite(amt) || amt <= 0) return res.status(400).json({ error: "amountCents must be positive for a deposit" });
@@ -12,6 +41,22 @@ export async function deposit(req: Request, res: Response) {
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
+
+      const normalisedSources = normaliseSources(sources);
+      const payto = await debitMandate(
+        `SIM-${abn}-${periodId}`,
+        amt,
+        { abn, taxType, periodId, reference: "OWA_DEPOSIT", sources: normalisedSources }
+      );
+
+      if (payto.status === "INSUFFICIENT_FUNDS") {
+        await client.query("ROLLBACK");
+        return res.status(409).json({
+          error: "PAYTO_INSUFFICIENT_FUNDS",
+          detail: payto.reason,
+          adapter_call_id: payto.callId,
+        });
+      }
 
       const { rows: last } = await client.query(
         `SELECT balance_after_cents FROM owa_ledger
@@ -30,8 +75,25 @@ export async function deposit(req: Request, res: Response) {
         [abn, taxType, periodId, randomUUID(), amt, newBal]
       );
 
+      const paytoSuccess = payto as DebitResultSuccess;
+
+      attachLedgerToCall(payto.callId, {
+        ledger_id: ins[0].id,
+        amount_cents: amt,
+        balance_after_cents: Number(ins[0].balance_after_cents),
+        sources: normalisedSources,
+      });
+
       await client.query("COMMIT");
-      return res.json({ ok: true, ledger_id: ins[0].id, balance_after_cents: ins[0].balance_after_cents });
+      return res.json({
+        ok: true,
+        ledger_id: ins[0].id,
+        transfer_uuid: ins[0].transfer_uuid,
+        balance_after_cents: ins[0].balance_after_cents,
+        adapter_call_id: payto.callId,
+        bank_reference: paytoSuccess.bank_ref,
+        receipt_signature: paytoSuccess.receipt_signature,
+      });
 
     } catch (e:any) {
       await client.query("ROLLBACK");

--- a/apps/services/payments/src/routes/simulator.ts
+++ b/apps/services/payments/src/routes/simulator.ts
@@ -1,0 +1,21 @@
+import type { Request, Response } from "express";
+import { AdapterMode, AdapterName, getAdapterModes, setAdapterMode } from "../bank/simulatorState.js";
+
+const adapters: AdapterName[] = ["bank", "payto", "payroll", "pos"];
+const modes: AdapterMode[] = ["success", "insufficient", "error"];
+
+export function getSimulatorModes(_req: Request, res: Response) {
+  res.json({ modes: getAdapterModes() });
+}
+
+export function updateSimulatorMode(req: Request, res: Response) {
+  const { adapter, mode } = req.body || {};
+  if (!adapters.includes(adapter)) {
+    return res.status(400).json({ error: "UNKNOWN_ADAPTER" });
+  }
+  if (!modes.includes(mode)) {
+    return res.status(400).json({ error: "UNKNOWN_MODE" });
+  }
+  setAdapterMode(adapter, mode);
+  res.json({ ok: true, modes: getAdapterModes() });
+}

--- a/libs/simulatorClient.ts
+++ b/libs/simulatorClient.ts
@@ -1,0 +1,37 @@
+import { AdapterMode, AdapterModes, AdapterName } from "../src/simulator/types";
+
+const BASE =
+  process.env.NEXT_PUBLIC_PAYMENTS_BASE_URL ||
+  process.env.PAYMENTS_BASE_URL ||
+  "http://localhost:3001";
+
+async function handle(res: Response) {
+  const text = await res.text();
+  let json: any;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    /* noop */
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || json?.detail || text || `HTTP ${res.status}`);
+  }
+  return json;
+}
+
+export const SimulatorClient = {
+  async fetchModes(): Promise<AdapterModes> {
+    const res = await fetch(`${BASE}/simulator/modes`);
+    const json = await handle(res);
+    return json?.modes as AdapterModes;
+  },
+  async updateMode(adapter: AdapterName, mode: AdapterMode): Promise<AdapterModes> {
+    const res = await fetch(`${BASE}/simulator/modes`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ adapter, mode }),
+    });
+    const json = await handle(res);
+    return json?.modes as AdapterModes;
+  },
+};

--- a/src/components/AdapterSimulator.tsx
+++ b/src/components/AdapterSimulator.tsx
@@ -1,0 +1,62 @@
+import React, { useContext } from "react";
+import { AppContext } from "../context/AppContext";
+import { AdapterMode, AdapterName } from "../simulator/types";
+
+const modeLabels: Record<AdapterMode, string> = {
+  success: "Happy path",
+  insufficient: "Insufficient",
+  error: "Error",
+};
+
+const adapterLabels: Record<AdapterName, string> = {
+  bank: "Bank (EFT/BPAY)",
+  payto: "PayTo Mandate",
+  payroll: "Payroll STP",
+  pos: "POS Sales",
+};
+
+export default function AdapterSimulator() {
+  const { adapterModes, setAdapterMode, adapterEvents } = useContext(AppContext);
+
+  const handleChange = (adapter: AdapterName) => (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const mode = event.target.value as AdapterMode;
+    setAdapterMode(adapter, mode);
+  };
+
+  return (
+    <div className="card" style={{ marginTop: 16 }}>
+      <h3>Simulator Adapter Modes</h3>
+      <p style={{ fontSize: "0.9rem", color: "#555" }}>
+        Flip adapters between success, insufficiency, and outage states to demonstrate anomaly gates.
+      </p>
+      <div style={{ display: "grid", gap: 12 }}>
+        {(Object.keys(adapterModes) as AdapterName[]).map(adapter => (
+          <label key={adapter} style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+            <span style={{ fontWeight: 600 }}>{adapterLabels[adapter]}</span>
+            <select value={adapterModes[adapter]} onChange={handleChange(adapter)} className="settings-input">
+              {Object.entries(modeLabels).map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          </label>
+        ))}
+      </div>
+      {adapterEvents.length > 0 && (
+        <details style={{ marginTop: 16 }}>
+          <summary style={{ cursor: "pointer" }}>Recent adapter calls</summary>
+          <ul style={{ marginTop: 8, fontSize: "0.85rem" }}>
+            {adapterEvents.slice(0, 5).map(event => (
+              <li key={event.id}>
+                <strong>{adapterLabels[event.adapter]}</strong> [{modeLabels[event.mode]}] –
+                {" "}
+                {event.error ? `Error: ${event.error}` : `Response: ${JSON.stringify(event.response)}`}
+              </li>
+            ))}
+          </ul>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/components/FundSecuring.tsx
+++ b/src/components/FundSecuring.tsx
@@ -1,11 +1,28 @@
-import React from "react";
+import React, { useContext } from "react";
 import { transferToOneWayAccount } from "../utils/bankApi";
+import { AppContext } from "../context/AppContext";
 
 export default function FundSecuring({ paygwDue, gstDue }: { paygwDue: number; gstDue: number }) {
+  const { adapterModes, logAdapterEvent } = useContext(AppContext);
+
   async function secureFunds() {
-    await transferToOneWayAccount(paygwDue, "businessRevenueAcc", "oneWayPaygwAcc");
-    await transferToOneWayAccount(gstDue, "businessRevenueAcc", "oneWayGstAcc");
-    alert("Funds secured in designated one-way accounts.");
+    try {
+      const paygw = await transferToOneWayAccount(paygwDue, "businessRevenueAcc", "oneWayPaygwAcc", {
+        mode: adapterModes.bank,
+        log: logAdapterEvent,
+      });
+      const gst = await transferToOneWayAccount(gstDue, "businessRevenueAcc", "oneWayGstAcc", {
+        mode: adapterModes.bank,
+        log: logAdapterEvent,
+      });
+      if (paygw.status === "OK" && gst.status === "OK") {
+        alert("Funds secured in designated one-way accounts.");
+      } else {
+        alert("Bank adapter reported insufficiency while securing funds.");
+      }
+    } catch (err: any) {
+      alert(`Bank adapter error: ${err?.message || err}`);
+    }
   }
   return (
     <div className="card">

--- a/src/components/PayrollIntegration.tsx
+++ b/src/components/PayrollIntegration.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
+import { AppContext } from "../context/AppContext";
+import { submitStpEvent } from "../utils/payrollApi";
 
 interface PayrollIntegrationProps {
   payroll: { employee: string; gross: number; withheld: number }[];
@@ -6,16 +8,25 @@ interface PayrollIntegrationProps {
 }
 
 export default function PayrollIntegration({ payroll, onAdd }: PayrollIntegrationProps) {
+  const { adapterModes, logAdapterEvent } = useContext(AppContext);
   const [employee, setEmployee] = useState("");
   const [gross, setGross] = useState(0);
   const [withheld, setWithheld] = useState(0);
 
-  function handleAdd() {
+  async function handleAdd() {
     if (employee && gross > 0) {
-      onAdd(employee, gross, withheld);
-      setEmployee("");
-      setGross(0);
-      setWithheld(0);
+      try {
+        await submitStpEvent({ employee, gross, withheld }, {
+          mode: adapterModes.payroll,
+          log: logAdapterEvent,
+        });
+        onAdd(employee, gross, withheld);
+        setEmployee("");
+        setGross(0);
+        setWithheld(0);
+      } catch (err: any) {
+        alert(`Payroll adapter error: ${err?.message || err}`);
+      }
     }
   }
 

--- a/src/components/PosIntegration.tsx
+++ b/src/components/PosIntegration.tsx
@@ -1,4 +1,6 @@
-import React, { useState } from "react";
+import React, { useContext, useState } from "react";
+import { AppContext } from "../context/AppContext";
+import { submitSale } from "../utils/posApi";
 
 interface Sale {
   id: string;
@@ -11,16 +13,22 @@ interface PosIntegrationProps {
 }
 
 export default function PosIntegration({ sales, onAdd }: PosIntegrationProps) {
+  const { adapterModes, logAdapterEvent } = useContext(AppContext);
   const [id, setId] = useState("");
   const [amount, setAmount] = useState(0);
   const [exempt, setExempt] = useState(false);
 
-  function handleAdd() {
+  async function handleAdd() {
     if (id && amount > 0) {
-      onAdd(id, amount, exempt);
-      setId("");
-      setAmount(0);
-      setExempt(false);
+      try {
+        await submitSale({ id, amount, exempt }, { mode: adapterModes.pos, log: logAdapterEvent });
+        onAdd(id, amount, exempt);
+        setId("");
+        setAmount(0);
+        setExempt(false);
+      } catch (err: any) {
+        alert(`POS adapter error: ${err?.message || err}`);
+      }
     }
   }
 

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,6 +1,8 @@
-import React, { createContext, useState } from "react";
+import React, { createContext, useCallback, useEffect, useMemo, useState } from "react";
 import { mockPayroll, mockSales, mockBasHistory } from "../utils/mockData";
 import { BASHistory } from "../types/tax";
+import { AdapterEvent, AdapterMode, AdapterModes, AdapterName } from "../simulator/types";
+import { SimulatorClient } from "../../libs/simulatorClient";
 
 export const AppContext = createContext<any>(null);
 
@@ -11,6 +13,67 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [sales, setSales] = useState(mockSales);
   const [basHistory, setBasHistory] = useState<BASHistory[]>(mockBasHistory);
   const [auditLog, setAuditLog] = useState<any[]>([]);
+  const [adapterModes, setAdapterModes] = useState<AdapterModes>({
+    bank: "success",
+    payto: "success",
+    payroll: "success",
+    pos: "success",
+  });
+  const [adapterEvents, setAdapterEvents] = useState<AdapterEvent[]>([]);
+
+  const logAdapterEvent = useCallback(
+    (adapter: AdapterName, mode: AdapterMode, payload: unknown, result: { response?: unknown; error?: string }) => {
+      setAdapterEvents(prev => {
+        const id = typeof crypto !== "undefined" && crypto.randomUUID ? crypto.randomUUID() : `${adapter}-${Date.now()}`;
+        const next: AdapterEvent = {
+          id,
+          ts: Date.now(),
+          adapter,
+          mode,
+          payload,
+          response: result.response,
+          error: result.error,
+        };
+        return [next, ...prev].slice(0, 50);
+      });
+    },
+    []
+  );
+
+  const syncModes = useCallback(async () => {
+    try {
+      const modes = await SimulatorClient.fetchModes();
+      if (modes) setAdapterModes(prev => ({ ...prev, ...modes }));
+    } catch (err) {
+      console.warn("Failed to sync simulator modes", err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      syncModes();
+    }
+  }, [syncModes]);
+
+  const setAdapterMode = useCallback(
+    async (adapter: AdapterName, mode: AdapterMode) => {
+      setAdapterModes(prev => ({ ...prev, [adapter]: mode }));
+      if (adapter === "bank" || adapter === "payto") {
+        try {
+          const modes = await SimulatorClient.updateMode(adapter, mode);
+          if (modes) setAdapterModes(prev => ({ ...prev, ...modes }));
+        } catch (err) {
+          console.error("Failed to update simulator adapter mode", err);
+        }
+      }
+    },
+    []
+  );
+
+  const simulatorContext = useMemo(
+    () => ({ adapterModes, setAdapterMode, logAdapterEvent, adapterEvents }),
+    [adapterModes, setAdapterMode, logAdapterEvent, adapterEvents]
+  );
 
   return (
     <AppContext.Provider value={{
@@ -20,6 +83,7 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
       sales, setSales,
       basHistory, setBasHistory,
       auditLog, setAuditLog,
+      ...simulatorContext,
     }}>
       {children}
     </AppContext.Provider>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import AdapterSimulator from "../components/AdapterSimulator";
 
 const tabs = [
   "Business Profile",
@@ -206,8 +207,11 @@ export default function Settings() {
         )}
         {activeTab === "Advanced" && (
           <div style={{ maxWidth: 600, margin: "0 auto" }}>
-            <h3>Export Data</h3>
-            <button className="button">Export as CSV</button>
+            <h3>Sandbox Toolkit</h3>
+            <p style={{ color: "#666", fontSize: 14 }}>
+              Use the simulator below to flip adapter responses between success and error conditions.
+            </p>
+            <AdapterSimulator />
           </div>
         )}
       </div>

--- a/src/routes/deposit.ts
+++ b/src/routes/deposit.ts
@@ -1,10 +1,39 @@
 ﻿import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { debitMandate } from "../bank/paytoAdapter.js";
+import type { DebitResultSuccess } from "../bank/paytoAdapter.js";
+import { attachLedgerToCall } from "../bank/simulatorState.js";
+
+type SourceAnnotation = {
+  basLabel?: string;
+  amount_cents?: number;
+  reference?: string;
+  channel?: string;
+  description?: string;
+};
+
+function normaliseSources(raw: unknown): SourceAnnotation[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const e = entry as Record<string, unknown>;
+      const amount = Number(e.amount_cents);
+      return {
+        basLabel: typeof e.basLabel === "string" ? e.basLabel : undefined,
+        amount_cents: Number.isFinite(amount) ? amount : undefined,
+        reference: typeof e.reference === "string" ? e.reference : undefined,
+        channel: typeof e.channel === "string" ? e.channel : undefined,
+        description: typeof e.description === "string" ? e.description : undefined,
+      };
+    })
+    .filter((e): e is SourceAnnotation => !!e);
+}
 
 export async function deposit(req: Request, res: Response) {
   try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
+    const { abn, taxType, periodId, amountCents, sources } = req.body || {};
     if (!abn || !taxType || !periodId) {
       return res.status(400).json({ error: "Missing abn/taxType/periodId" });
     }
@@ -16,6 +45,22 @@ export async function deposit(req: Request, res: Response) {
     const client = await pool.connect();
     try {
       await client.query("BEGIN");
+
+      const normalisedSources = normaliseSources(sources);
+      const payto = await debitMandate(
+        `SIM-${abn}-${periodId}`,
+        amt,
+        { abn, taxType, periodId, reference: "OWA_DEPOSIT", sources: normalisedSources }
+      );
+
+      if (payto.status === "INSUFFICIENT_FUNDS") {
+        await client.query("ROLLBACK");
+        return res.status(409).json({
+          error: "PAYTO_INSUFFICIENT_FUNDS",
+          detail: payto.reason,
+          adapter_call_id: payto.callId,
+        });
+      }
 
       const { rows: last } = await client.query(
         `SELECT balance_after_cents FROM owa_ledger
@@ -34,12 +79,24 @@ export async function deposit(req: Request, res: Response) {
         [abn, taxType, periodId, randomUUID(), amt, newBal]
       );
 
+      const paytoSuccess = payto as DebitResultSuccess;
+
+      attachLedgerToCall(payto.callId, {
+        ledger_id: ins[0].id,
+        amount_cents: amt,
+        balance_after_cents: Number(ins[0].balance_after_cents),
+        sources: normalisedSources,
+      });
+
       await client.query("COMMIT");
       return res.json({
         ok: true,
         ledger_id: ins[0].id,
         transfer_uuid: ins[0].transfer_uuid,
-        balance_after_cents: ins[0].balance_after_cents
+        balance_after_cents: ins[0].balance_after_cents,
+        adapter_call_id: payto.callId,
+        bank_reference: paytoSuccess.bank_ref,
+        receipt_signature: paytoSuccess.receipt_signature,
       });
 
     } catch (e:any) {

--- a/src/simulator/types.ts
+++ b/src/simulator/types.ts
@@ -1,0 +1,14 @@
+export type AdapterName = "bank" | "payto" | "payroll" | "pos";
+export type AdapterMode = "success" | "insufficient" | "error";
+
+export type AdapterModes = Record<AdapterName, AdapterMode>;
+
+export interface AdapterEvent {
+  id: string;
+  ts: number;
+  adapter: AdapterName;
+  mode: AdapterMode;
+  payload: unknown;
+  response?: unknown;
+  error?: string;
+}

--- a/src/utils/adapterTypes.ts
+++ b/src/utils/adapterTypes.ts
@@ -1,0 +1,13 @@
+import { AdapterMode, AdapterName } from "../simulator/types";
+
+export type AdapterLogger = (
+  adapter: AdapterName,
+  mode: AdapterMode,
+  payload: unknown,
+  result: { response?: unknown; error?: string }
+) => void;
+
+export interface AdapterCallOptions {
+  mode: AdapterMode;
+  log: AdapterLogger;
+}

--- a/src/utils/bankApi.ts
+++ b/src/utils/bankApi.ts
@@ -1,24 +1,60 @@
-export async function submitSTPReport(data: any): Promise<boolean> {
-  console.log("Submitting STP report to ATO:", data);
-  return true;
+import { AdapterCallOptions } from "./adapterTypes";
+
+export async function transferToOneWayAccount(
+  amount: number,
+  from: string,
+  to: string,
+  opts: AdapterCallOptions
+) {
+  const payload = { amount, from, to };
+  if (opts.mode === "error") {
+    const error = "Simulated bank adapter outage";
+    opts.log("bank", opts.mode, payload, { error });
+    throw new Error(error);
+  }
+  if (opts.mode === "insufficient") {
+    const response = { status: "INSUFFICIENT_FUNDS", reason: "Simulated source account empty" };
+    opts.log("bank", opts.mode, payload, { response });
+    return response;
+  }
+  const response = {
+    status: "OK",
+    signature: `SIGNED-${amount}-${to}-${Date.now()}`,
+  };
+  opts.log("bank", opts.mode, payload, { response });
+  return response;
 }
 
-export async function signTransaction(amount: number, account: string): Promise<string> {
-  return `SIGNED-${amount}-${account}-${Date.now()}`;
+export async function verifyFunds(paygwDue: number, gstDue: number, opts: AdapterCallOptions) {
+  const payload = { paygwDue, gstDue };
+  if (opts.mode === "error") {
+    const error = "Simulated balance verification failure";
+    opts.log("bank", opts.mode, payload, { error });
+    throw new Error(error);
+  }
+  if (opts.mode === "insufficient") {
+    const response = { status: "INSUFFICIENT_FUNDS", available: 0 };
+    opts.log("bank", opts.mode, payload, { response });
+    return response;
+  }
+  const response = { status: "OK", available: paygwDue + gstDue };
+  opts.log("bank", opts.mode, payload, { response });
+  return response;
 }
 
-export async function transferToOneWayAccount(amount: number, from: string, to: string): Promise<boolean> {
-  const signature = await signTransaction(amount, to);
-  console.log(`Transfer $${amount} from ${from} to ${to} [${signature}]`);
-  return true;
-}
-
-export async function verifyFunds(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
-}
-
-export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<boolean> {
-  // For mock: always return true
-  return true;
+export async function initiateTransfer(paygwDue: number, gstDue: number, opts: AdapterCallOptions) {
+  const payload = { paygwDue, gstDue };
+  if (opts.mode === "error") {
+    const error = "Simulated transfer gateway outage";
+    opts.log("bank", opts.mode, payload, { error });
+    throw new Error(error);
+  }
+  if (opts.mode === "insufficient") {
+    const response = { status: "INSUFFICIENT_FUNDS", reason: "Mandate limit exceeded" };
+    opts.log("bank", opts.mode, payload, { response });
+    return response;
+  }
+  const response = { status: "OK", receipt: `ATO-${Date.now()}` };
+  opts.log("bank", opts.mode, payload, { response });
+  return response;
 }

--- a/src/utils/payrollApi.ts
+++ b/src/utils/payrollApi.ts
@@ -1,3 +1,18 @@
-// Placeholder for payroll API integration logic
+import { AdapterCallOptions } from "./adapterTypes";
 
-export {};
+export async function submitStpEvent(payload: any, opts: AdapterCallOptions) {
+  const meta = { type: "STP", payload };
+  if (opts.mode === "error") {
+    const error = "Simulated STP gateway outage";
+    opts.log("payroll", opts.mode, meta, { error });
+    throw new Error(error);
+  }
+  if (opts.mode === "insufficient") {
+    const response = { status: "REJECTED", reason: "ATO validation failed" };
+    opts.log("payroll", opts.mode, meta, { response });
+    return response;
+  }
+  const response = { status: "OK", submission_reference: `STP-${Date.now()}` };
+  opts.log("payroll", opts.mode, meta, { response });
+  return response;
+}

--- a/src/utils/posApi.ts
+++ b/src/utils/posApi.ts
@@ -1,6 +1,18 @@
-// Placeholder for POS API integration logic
+import { AdapterCallOptions } from "./adapterTypes";
 
-export {};
-// Placeholder for POS API integration logic
-
-export {};
+export async function submitSale(payload: any, opts: AdapterCallOptions) {
+  const meta = { type: "POS", payload };
+  if (opts.mode === "error") {
+    const error = "Simulated POS API outage";
+    opts.log("pos", opts.mode, meta, { error });
+    throw new Error(error);
+  }
+  if (opts.mode === "insufficient") {
+    const response = { status: "REJECTED", reason: "Duplicate sale detected" };
+    opts.log("pos", opts.mode, meta, { response });
+    return response;
+  }
+  const response = { status: "OK", receipt: `POS-${Date.now()}` };
+  opts.log("pos", opts.mode, meta, { response });
+  return response;
+}


### PR DESCRIPTION
## Summary
- replace the banking and PayTo adapters with deterministic simulator fakes, record adapter calls, and expose simulator mode APIs
- enrich `buildEvidenceBundle` to derive BAS labels, discrepancy logs, anomalies, and adapter receipts from ledger activity and simulator logs
- add front-end adapter mode toggles with logged deterministic fakes for bank, payroll, and POS integrations to demo happy/error paths

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2e1ee95cc83278ab74ae9fbc74b72