### PR TITLE
feat: add configurable tax schedules

### DIFF
--- a/src/tax/atoSchedules.ts
+++ b/src/tax/atoSchedules.ts
@@ -1,0 +1,25 @@
+import { Schedules } from "./ports";
+
+export class ATOSchedules implements Schedules {
+  paygw(taxableCents: number, frequency: "weekly" | "fortnightly" | "monthly"): number {
+    const annual = taxableCents * (frequency === "weekly" ? 52 : frequency === "fortnightly" ? 26 : 12);
+    let tax = 0;
+    if (annual <= 1_820_000) tax = 0;
+    else if (annual <= 4_500_000) tax = (annual - 1_820_000) * 0.19;
+    else if (annual <= 12_000_000) tax = 509_200 + (annual - 4_500_000) * 0.325;
+    else if (annual <= 18_000_000) tax = 2_946_700 + (annual - 12_000_000) * 0.37;
+    else tax = 5_166_700 + (annual - 18_000_000) * 0.45;
+    const divisor = frequency === "weekly" ? 52 : frequency === "fortnightly" ? 26 : 12;
+    return Math.max(0, Math.round(tax / divisor));
+  }
+
+  gst(taxableCents: number): number {
+    return Math.round(taxableCents / 11);
+  }
+
+  penalty(underpaidCents: number, daysLate: number): number {
+    const interest = Math.round(underpaidCents * 0.00022 * daysLate);
+    const latePenalty = underpaidCents > 0 ? Math.round(Math.min(underpaidCents * 0.2, 100_00)) : 0;
+    return interest + latePenalty;
+  }
+}

--- a/src/tax/index.ts
+++ b/src/tax/index.ts
@@ -1,0 +1,5 @@
+import { ATOSchedules } from "./atoSchedules";
+import { PlaceholderSchedules } from "./placeholderSchedules";
+
+export const schedules =
+  process.env.FEATURE_ATO_TABLES === "true" ? new ATOSchedules() : new PlaceholderSchedules();

--- a/src/tax/placeholderSchedules.ts
+++ b/src/tax/placeholderSchedules.ts
@@ -1,0 +1,15 @@
+import { Schedules } from "./ports";
+
+export class PlaceholderSchedules implements Schedules {
+  paygw(taxableCents: number, _frequency: "weekly" | "fortnightly" | "monthly"): number {
+    return Math.round(taxableCents * 0.2);
+  }
+
+  gst(taxableCents: number): number {
+    return Math.round(taxableCents / 11);
+  }
+
+  penalty(_underpaidCents: number, _daysLate: number): number {
+    return 0;
+  }
+}

--- a/src/tax/ports.ts
+++ b/src/tax/ports.ts
@@ -1,0 +1,5 @@
+export interface Schedules {
+  paygw(taxableCents: number, frequency: "weekly" | "fortnightly" | "monthly"): number;
+  gst(taxableCents: number): number;
+  penalty(underpaidCents: number, daysLate: number): number;
+}

--- a/src/utils/gst.ts
+++ b/src/utils/gst.ts
@@ -1,6 +1,9 @@
 import { GstInput } from "../types/tax";
+import { schedules } from "../tax";
 
 export function calculateGst({ saleAmount, exempt = false }: GstInput): number {
   if (exempt) return 0;
-  return saleAmount * 0.1;
+  const taxableCents = Math.round(saleAmount * 100);
+  const gstCents = schedules.gst(taxableCents);
+  return gstCents / 100;
 }

--- a/src/utils/paygw.ts
+++ b/src/utils/paygw.ts
@@ -1,7 +1,20 @@
 import { PaygwInput } from "../types/tax";
+import { schedules } from "../tax";
 
 export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): number {
-  const baseRate = 0.20;
-  const liability = grossIncome * baseRate - deductions - taxWithheld;
-  return Math.max(liability, 0);
+  const taxableAmount = Math.max(0, grossIncome - deductions);
+  const taxWithheldCents = Math.round(taxWithheld * 100);
+
+  if (period === "quarterly") {
+    const monthlyTaxableCents = Math.round((taxableAmount / 3) * 100);
+    const monthlyLiabilityCents = schedules.paygw(monthlyTaxableCents, "monthly");
+    const quarterlyLiabilityCents = monthlyLiabilityCents * 3;
+    const quarterlyNetCents = quarterlyLiabilityCents - taxWithheldCents;
+    return Math.max(0, quarterlyNetCents) / 100;
+  }
+
+  const taxableCents = Math.round(taxableAmount * 100);
+  const liabilityCents = schedules.paygw(taxableCents, period);
+  const netCents = liabilityCents - taxWithheldCents;
+  return Math.max(0, netCents) / 100;
 }

--- a/src/utils/penalties.ts
+++ b/src/utils/penalties.ts
@@ -1,5 +1,7 @@
+import { schedules } from "../tax";
+
 export function calculatePenalties(daysLate: number, amountDue: number): number {
-  const basePenalty = amountDue * 0.05;
-  const dailyInterest = amountDue * 0.0002;
-  return basePenalty + (dailyInterest * daysLate);
+  const liabilityCents = Math.round(amountDue * 100);
+  const penaltyCents = schedules.penalty(liabilityCents, daysLate);
+  return penaltyCents / 100;
 }


### PR DESCRIPTION
## Summary
- add tax schedule interfaces plus placeholder and ATO-backed implementations
- route paygw, GST, and penalty calculations through the selected schedule depending on FEATURE_ATO_TABLES

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e2fadfb4188327b296cecd78c47df3