### PR TITLE
Add evidence bundle persistence and retrieval

### DIFF
--- a/migrations/013_evidence_bundles.sql
+++ b/migrations/013_evidence_bundles.sql
@@ -1,0 +1,11 @@
+create table if not exists evidence_bundles (
+  id bigserial primary key,
+  abn text not null,
+  period_id bigint not null,
+  rpt_token text,
+  delta_cents bigint not null default 0,
+  tolerance_bps integer not null default 0,
+  details jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now()
+);
+create index if not exists ix_ev_abn_pid on evidence_bundles (abn, period_id);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,84 @@
-﻿import { issueRPT } from "../rpt/issuer";
-import { buildEvidenceBundle } from "../evidence/bundle";
+import { issueRPT } from "../rpt/issuer";
+import { getLatestEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds ||
+    {
+      epsilon_cents: 50,
+      variance_ratio: 0.25,
+      dup_rate: 0.01,
+      gap_minutes: 60,
+      delta_vs_baseline: 0.2,
+    };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn = $1 and tax_type = $2 and period_id = $3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    const r = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      payload.reference
+    );
+    await pool.query(
+      "update periods set state = 'RELEASED' where abn = $1 and tax_type = $2 and period_id = $3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+export async function evidence(req: any, res: any) {
+  const { abn, periodId } = req.query as any;
+  if (!abn || typeof periodId === "undefined") {
+    return res.status(400).json({ error: "MISSING_PARAMS" });
+  }
+  const parsedPeriodId = Number(periodId);
+  if (!Number.isFinite(parsedPeriodId)) {
+    return res.status(400).json({ error: "INVALID_PERIOD" });
+  }
+  const bundle = await getLatestEvidenceBundle(abn, parsedPeriodId);
+  if (!bundle) {
+    return res.status(404).json({ error: "NOT_FOUND" });
+  }
+  res.json(bundle);
 }


### PR DESCRIPTION
## Summary
- add an evidence_bundles table and supporting index for storing bundle metadata
- expose helpers to persist and load evidence bundles with parameterized queries
- update the evidence route to return the latest bundle for an ABN/period and harden SQL usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2faf4ac808327bd55b9231c9b28a6