### PR TITLE
Add real service adapters behind feature flags

### DIFF
--- a/src/adapters/mock/banking.mock.ts
+++ b/src/adapters/mock/banking.mock.ts
@@ -1,0 +1,23 @@
+import { BankingPort } from "../../ports/banking";
+
+let counter = 0;
+
+export class MockBanking implements BankingPort {
+  async eft(abn: string, amountCents: number, reference?: string) {
+    return this.buildResponse("eft", { abn, amountCents, reference });
+  }
+
+  async bpay(abn: string, crn: string, amountCents: number) {
+    return this.buildResponse("bpay", { abn, crn, amountCents });
+  }
+
+  async payToSweep(mandateId: string, amountCents: number, ref: string) {
+    return this.buildResponse("payToSweep", { mandateId, amountCents, ref });
+  }
+
+  private async buildResponse(channel: string, payload: Record<string, unknown>) {
+    const id = `mock-${channel}-${++counter}`;
+    void payload;
+    return { id, status: "MOCKED" };
+  }
+}

--- a/src/adapters/mock/payroll.mock.ts
+++ b/src/adapters/mock/payroll.mock.ts
@@ -1,0 +1,7 @@
+import { PayrollPort } from "../../ports/payroll";
+
+export class MockPayroll implements PayrollPort {
+  async ingestStp(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/adapters/mock/pos.mock.ts
+++ b/src/adapters/mock/pos.mock.ts
@@ -1,0 +1,7 @@
+import { PosPort } from "../../ports/pos";
+
+export class MockPos implements PosPort {
+  async ingestSale(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/adapters/real/banking.real.ts
+++ b/src/adapters/real/banking.real.ts
@@ -1,0 +1,117 @@
+import https from "node:https";
+import { Pool } from "pg";
+import { v4 as uuidv4 } from "uuid";
+import { BankingPort } from "../../ports/banking";
+import { assertAbnAllowed } from "../../rails/validators";
+import { postJson } from "./http";
+
+type BankingChannel = "EFT" | "BPAY" | "PAYTOSWEEP";
+
+type IntentRecord = {
+  id: string;
+  status: string;
+};
+
+const pool = new Pool();
+
+const ensureBankingTable = pool
+  .query(`
+    create table if not exists banking_intents (
+      id uuid primary key,
+      channel text not null,
+      payload jsonb not null,
+      status text not null,
+      response jsonb,
+      created_at timestamptz not null default now(),
+      updated_at timestamptz not null default now()
+    )
+  `)
+  .then(() => undefined);
+
+export class RealBanking implements BankingPort {
+  private readonly agent?: https.Agent;
+  private readonly dryRun: boolean;
+  private readonly endpoints: Record<BankingChannel, string | undefined>;
+  private readonly timeoutMs: number;
+
+  constructor() {
+    this.dryRun = process.env.DRY_RUN === "true";
+    const cert = process.env.MTLS_CERT;
+    const key = process.env.MTLS_KEY;
+    const ca = process.env.MTLS_CA;
+
+    this.agent = cert && key
+      ? new https.Agent({
+          cert,
+          key,
+          ca,
+          rejectUnauthorized: Boolean(ca),
+        })
+      : undefined;
+
+    this.timeoutMs = Number(process.env.BANKING_TIMEOUT_MS ?? "10000");
+
+    this.endpoints = {
+      EFT: process.env.BANKING_EFT_ENDPOINT,
+      BPAY: process.env.BANKING_BPAY_ENDPOINT,
+      PAYTOSWEEP: process.env.BANKING_PAYTOSWEEP_ENDPOINT,
+    };
+  }
+
+  async eft(abn: string, amountCents: number, reference?: string): Promise<IntentRecord> {
+    await assertAbnAllowed(abn);
+    return this.dispatch("EFT", { abn, amountCents, reference });
+  }
+
+  async bpay(abn: string, crn: string, amountCents: number): Promise<IntentRecord> {
+    await assertAbnAllowed(abn);
+    return this.dispatch("BPAY", { abn, crn, amountCents });
+  }
+
+  async payToSweep(mandateId: string, amountCents: number, ref: string): Promise<IntentRecord> {
+    return this.dispatch("PAYTOSWEEP", { mandateId, amountCents, ref });
+  }
+
+  private async dispatch(channel: BankingChannel, payload: Record<string, unknown>): Promise<IntentRecord> {
+    await ensureBankingTable;
+    const id = uuidv4();
+    await pool.query(
+      "insert into banking_intents(id, channel, payload, status) values ($1, $2, $3::jsonb, $4)",
+      [id, channel, JSON.stringify(payload), this.dryRun ? "DRY_RUN" : "PENDING"]
+    );
+
+    if (this.dryRun) {
+      return { id, status: "DRY_RUN" };
+    }
+
+    const endpoint = this.getEndpoint(channel);
+
+    try {
+      const response = await postJson(endpoint, payload, this.agent, this.timeoutMs);
+      if (response.statusCode >= 400) {
+        throw new Error(`BANKING_HTTP_${response.statusCode}`);
+      }
+      const providerStatus = response.body?.status ?? "SUBMITTED";
+      const providerId = response.body?.id ?? id;
+      await pool.query(
+        "update banking_intents set status=$1, response=$2::jsonb, updated_at=now() where id=$3",
+        [providerStatus, JSON.stringify(response.body ?? null), id]
+      );
+      return { id: providerId, status: providerStatus };
+    } catch (error) {
+      await pool.query(
+        "update banking_intents set status=$1, response=$2::jsonb, updated_at=now() where id=$3",
+        ["FAILED", JSON.stringify({ error: (error as Error).message }), id]
+      );
+      throw error;
+    }
+  }
+
+  private getEndpoint(channel: BankingChannel): string {
+    const endpoint = this.endpoints[channel];
+    if (!endpoint) {
+      throw new Error(`Missing endpoint for ${channel}`);
+    }
+    return endpoint;
+  }
+}

--- a/src/adapters/real/http.ts
+++ b/src/adapters/real/http.ts
@@ -1,0 +1,60 @@
+import http from "node:http";
+import https from "node:https";
+import { URL } from "node:url";
+
+type Agent = http.Agent | https.Agent;
+
+type PostJsonResult = {
+  statusCode: number;
+  headers: http.IncomingHttpHeaders;
+  body?: any;
+};
+
+export function postJson(
+  targetUrl: string,
+  payload: unknown,
+  agent?: Agent,
+  timeoutMs = 10000
+): Promise<PostJsonResult> {
+  const url = new URL(targetUrl);
+  const isHttps = url.protocol === "https:";
+  const transport = isHttps ? https : http;
+  const data = JSON.stringify(payload ?? {});
+
+  const options: https.RequestOptions = {
+    method: "POST",
+    agent,
+    headers: {
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(data).toString(),
+    },
+  };
+
+  return new Promise((resolve, reject) => {
+    const req = transport.request(url, options, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
+      res.on("end", () => {
+        const raw = Buffer.concat(chunks).toString("utf8");
+        if (!raw) {
+          resolve({ statusCode: res.statusCode ?? 0, headers: res.headers });
+          return;
+        }
+        try {
+          const parsed = JSON.parse(raw);
+          resolve({ statusCode: res.statusCode ?? 0, headers: res.headers, body: parsed });
+        } catch (error) {
+          reject(error);
+        }
+      });
+    });
+
+    req.on("error", reject);
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error("REQUEST_TIMEOUT"));
+    });
+
+    req.write(data);
+    req.end();
+  });
+}

--- a/src/adapters/real/payroll.real.ts
+++ b/src/adapters/real/payroll.real.ts
@@ -1,0 +1,53 @@
+import { Pool } from "pg";
+import { v4 as uuidv4 } from "uuid";
+import { PayrollPort } from "../../ports/payroll";
+import { assertAbnAllowed } from "../../rails/validators";
+import { postJson } from "./http";
+
+const pool = new Pool();
+
+const ensurePayrollTable = pool
+  .query(`
+    create table if not exists payroll_events (
+      id uuid primary key,
+      abn text not null,
+      gross_cents integer not null,
+      payg_cents integer not null,
+      occurred_at timestamptz not null,
+      payload jsonb not null,
+      received_at timestamptz not null default now()
+    )
+  `)
+  .then(() => undefined);
+
+export class RealPayroll implements PayrollPort {
+  private readonly webhookEndpoint?: string;
+
+  constructor() {
+    this.webhookEndpoint = process.env.PAYROLL_WEBHOOK_ENDPOINT;
+  }
+
+  async ingestStp(event: {
+    abn: string;
+    grossCents: number;
+    paygCents: number;
+    occurredAt: string;
+  }): Promise<void> {
+    await ensurePayrollTable;
+    await assertAbnAllowed(event.abn);
+    const id = uuidv4();
+    await pool.query(
+      "insert into payroll_events(id, abn, gross_cents, payg_cents, occurred_at, payload) values ($1,$2,$3,$4,$5,$6::jsonb)",
+      [id, event.abn, event.grossCents, event.paygCents, event.occurredAt, JSON.stringify(event)]
+    );
+
+    if (!this.webhookEndpoint) {
+      return;
+    }
+
+    const response = await postJson(this.webhookEndpoint, { id, ...event });
+    if (response.statusCode >= 400) {
+      throw new Error(`PAYROLL_HTTP_${response.statusCode}`);
+    }
+  }
+}

--- a/src/adapters/real/pos.real.ts
+++ b/src/adapters/real/pos.real.ts
@@ -1,0 +1,53 @@
+import { Pool } from "pg";
+import { v4 as uuidv4 } from "uuid";
+import { PosPort } from "../../ports/pos";
+import { assertAbnAllowed } from "../../rails/validators";
+import { postJson } from "./http";
+
+const pool = new Pool();
+
+const ensurePosTable = pool
+  .query(`
+    create table if not exists pos_events (
+      id uuid primary key,
+      abn text not null,
+      gross_cents integer not null,
+      gst_cents integer not null,
+      occurred_at timestamptz not null,
+      payload jsonb not null,
+      received_at timestamptz not null default now()
+    )
+  `)
+  .then(() => undefined);
+
+export class RealPos implements PosPort {
+  private readonly webhookEndpoint?: string;
+
+  constructor() {
+    this.webhookEndpoint = process.env.POS_WEBHOOK_ENDPOINT;
+  }
+
+  async ingestSale(event: {
+    abn: string;
+    grossCents: number;
+    gstCents: number;
+    occurredAt: string;
+  }): Promise<void> {
+    await ensurePosTable;
+    await assertAbnAllowed(event.abn);
+    const id = uuidv4();
+    await pool.query(
+      "insert into pos_events(id, abn, gross_cents, gst_cents, occurred_at, payload) values ($1,$2,$3,$4,$5,$6::jsonb)",
+      [id, event.abn, event.grossCents, event.gstCents, event.occurredAt, JSON.stringify(event)]
+    );
+
+    if (!this.webhookEndpoint) {
+      return;
+    }
+
+    const response = await postJson(this.webhookEndpoint, { id, ...event });
+    if (response.statusCode >= 400) {
+      throw new Error(`POS_HTTP_${response.statusCode}`);
+    }
+  }
+}

--- a/src/composition.ts
+++ b/src/composition.ts
@@ -1,0 +1,17 @@
+import { BankingPort } from "./ports/banking";
+import { PayrollPort } from "./ports/payroll";
+import { PosPort } from "./ports/pos";
+import { MockBanking } from "./adapters/mock/banking.mock";
+import { RealBanking } from "./adapters/real/banking.real";
+import { MockPayroll } from "./adapters/mock/payroll.mock";
+import { RealPayroll } from "./adapters/real/payroll.real";
+import { MockPos } from "./adapters/mock/pos.mock";
+import { RealPos } from "./adapters/real/pos.real";
+
+const bankingEnabled = process.env.FEATURE_BANKING === "true";
+const payrollEnabled = process.env.FEATURE_PAYROLL === "true";
+const posEnabled = process.env.FEATURE_POS === "true";
+
+export const banking: BankingPort = bankingEnabled ? new RealBanking() : new MockBanking();
+export const payroll: PayrollPort = payrollEnabled ? new RealPayroll() : new MockPayroll();
+export const pos: PosPort = posEnabled ? new RealPos() : new MockPos();

--- a/src/ports/banking.ts
+++ b/src/ports/banking.ts
@@ -1,0 +1,5 @@
+export interface BankingPort {
+  eft(abn: string, amountCents: number, reference?: string): Promise<{ id: string; status: string }>;
+  bpay(abn: string, crn: string, amountCents: number): Promise<{ id: string; status: string }>;
+  payToSweep(mandateId: string, amountCents: number, ref: string): Promise<{ id: string; status: string }>;
+}

--- a/src/ports/payroll.ts
+++ b/src/ports/payroll.ts
@@ -1,0 +1,8 @@
+export interface PayrollPort {
+  ingestStp(event: {
+    abn: string;
+    grossCents: number;
+    paygCents: number;
+    occurredAt: string;
+  }): Promise<void>;
+}

--- a/src/ports/pos.ts
+++ b/src/ports/pos.ts
@@ -1,0 +1,8 @@
+export interface PosPort {
+  ingestSale(event: {
+    abn: string;
+    grossCents: number;
+    gstCents: number;
+    occurredAt: string;
+  }): Promise<void>;
+}

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -2,30 +2,40 @@
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
+import { assertAbnAllowed, assertValidBsb, assertValidCrn } from "./validators";
 const pool = new Pool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
+  await assertAbnAllowed(abn);
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
-  return rows[0];
+  const destination = rows[0];
+  if ("bsb" in destination && typeof destination.bsb === "string") {
+    destination.bsb = assertValidBsb(destination.bsb);
+  }
+  if ("crn" in destination && typeof destination.crn === "string") {
+    destination.crn = assertValidCrn(destination.crn);
+  }
+  return destination;
 }
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT" | "BPAY", reference: string) {
+  await assertAbnAllowed(abn);
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
     [abn, taxType, periodId]);
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
@@ -33,10 +43,10 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("update idempotency_keys set last_status=$1 where key=$2", ["DONE", transfer_uuid]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/rails/validators.ts
+++ b/src/rails/validators.ts
@@ -1,0 +1,40 @@
+const allowList = new Set(
+  (process.env.ALLOWLIST_ABNS ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+);
+
+export function assertAbnAllowed(abn: string) {
+  if (allowList.size === 0) {
+    return;
+  }
+
+  if (!allowList.has(abn)) {
+    const error = new Error("ABN_NOT_ALLOWLISTED");
+    (error as Error & { statusCode?: number }).statusCode = 403;
+    throw error;
+  }
+}
+
+export function assertValidBsb(bsb: string): string {
+  const normalized = bsb.replace(/[^0-9]/g, "");
+  if (normalized.length !== 6) {
+    throw buildValidationError("INVALID_BSB");
+  }
+  return normalized;
+}
+
+export function assertValidCrn(crn: string): string {
+  const normalized = crn.replace(/\s+/g, "");
+  if (!/^[-A-Za-z0-9]{2,20}$/.test(normalized)) {
+    throw buildValidationError("INVALID_CRN");
+  }
+  return normalized.toUpperCase();
+}
+
+function buildValidationError(code: string) {
+  const error = new Error(code);
+  (error as Error & { statusCode?: number }).statusCode = 400;
+  return error;
+}


### PR DESCRIPTION
## Summary
- add ports and composition bindings to toggle between mock and real adapters
- implement real banking, payroll, and POS adapters that persist intents/events and honour DRY_RUN
- introduce validator helpers and enforce ABN allow-list plus BSB/CRN format checks in the rails adapter

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e2fafe42948327ad5ce6999bf6bd15