### PR TITLE
Align evidence bundle builder with current schema

### DIFF
--- a/apps/services/payments/src/evidence/evidenceBundle.ts
+++ b/apps/services/payments/src/evidence/evidenceBundle.ts
@@ -12,28 +12,34 @@ type BuildParams = {
 
 export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
   const rpt = await client.query(
-    "SELECT rpt_id, payload_c14n, payload_sha256, signature FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED' ORDER BY created_at DESC LIMIT 1",
+    `SELECT id as rpt_id, payload_c14n, payload_sha256, payload, signature
+       FROM rpt_tokens
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND status='ISSUED'
+      ORDER BY created_at DESC LIMIT 1`,
     [p.abn, p.taxType, p.periodId]
   );
   if (!rpt.rows.length) throw new Error("Missing RPT for bundle");
   const r = rpt.rows[0];
 
+  const payloadC14n = r.payload_c14n ?? canonicalJson(r.payload ?? {});
+  const payloadSha = r.payload_sha256 ?? sha256Hex(payloadC14n);
+
   const thresholds = { variance_pct: 0.02, dup_rate: 0.01, gap_allowed: 3 };
   const anomalies = { variance: 0.0, dups: 0, gaps: 0 };
   const normalization = { payroll_hash: "NA", pos_hash: "NA" };
 
-  const beforeQ = await client.query(
-    "SELECT COALESCE(SUM(amount_cents),0) bal FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND entry_id < (SELECT max(entry_id) FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3)",
+  const lastEntry = await client.query(
+    `SELECT amount_cents, balance_after_cents
+       FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC
+      LIMIT 1`,
     [p.abn, p.taxType, p.periodId]
   );
-  const afterQ = await client.query(
-    "SELECT COALESCE(SUM(amount_cents),0) bal FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
-    [p.abn, p.taxType, p.periodId]
-  );
-  const balBefore = Number(beforeQ.rows[0]?.bal || 0);
-  const balAfter = Number(afterQ.rows[0]?.bal || 0);
-
-  const payload_sha256 = sha256Hex(r.payload_c14n);
+  const last = lastEntry.rows[0];
+  const balAfter = last ? Number(last.balance_after_cents ?? 0) : 0;
+  const lastAmount = last ? Number(last.amount_cents ?? 0) : 0;
+  const balBefore = balAfter - lastAmount;
 
   const ins = `
     INSERT INTO evidence_bundles (
@@ -50,7 +56,7 @@ export async function buildEvidenceBundle(client: PoolClient, p: BuildParams) {
     RETURNING bundle_id
   `;
   const vals = [
-    p.abn, p.taxType, p.periodId, payload_sha256, r.rpt_id, r.payload_c14n, r.signature,
+    p.abn, p.taxType, p.periodId, payloadSha, r.rpt_id, payloadC14n, r.signature,
     canonicalJson(thresholds), canonicalJson(anomalies), canonicalJson(normalization),
     balBefore, balAfter,
     canonicalJson(p.bankReceipts), canonicalJson(p.atoReceipts), canonicalJson(p.operatorOverrides)

--- a/apps/services/payments/test/evidence_bundle.test.ts
+++ b/apps/services/payments/test/evidence_bundle.test.ts
@@ -1,3 +1,143 @@
-test("evidence bundle schema basics", () => {
-  expect(true).toBe(true);
+import { Pool } from "pg";
+import type { PoolClient } from "pg";
+import { randomUUID } from "crypto";
+import { buildEvidenceBundle } from "../src/evidence/evidenceBundle";
+import { canonicalJson, sha256Hex } from "../src/utils/crypto";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+
+async function seedRpt(client: PoolClient, abn: string, taxType: string, periodId: string) {
+  const payload = { abn, taxType, periodId, totals: { credited: 9000 } };
+  const payloadC14n = canonicalJson(payload);
+  const payloadSha = sha256Hex(payloadC14n);
+  const signature = Buffer.from("bundle-test-signature").toString("base64");
+
+  const { rows } = await client.query(
+    `INSERT INTO rpt_tokens
+       (abn, tax_type, period_id, payload, payload_c14n, payload_sha256, signature, status)
+     VALUES ($1,$2,$3,$4::jsonb,$5,$6,$7,'ISSUED')
+     RETURNING id`,
+    [abn, taxType, periodId, payload, payloadC14n, payloadSha, signature]
+  );
+  return rows[0].id as number;
+}
+
+describe("evidence bundle builder", () => {
+  afterAll(async () => {
+    await pool.end();
+  });
+
+  test("builds bundle for deposit-only ledger", async () => {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const abn = "90000000001";
+      const taxType = "PAYGW";
+      const periodId = "2025-Q1";
+
+      await client.query("DELETE FROM evidence_bundles WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [abn, taxType, periodId]);
+      await client.query("DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [abn, taxType, periodId]);
+      await client.query("DELETE FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [abn, taxType, periodId]);
+
+      await seedRpt(client, abn, taxType, periodId);
+
+      const firstAmount = 5000;
+      const secondAmount = 3000;
+
+      await client.query(
+        `INSERT INTO owa_ledger
+           (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,now())`,
+        [abn, taxType, periodId, randomUUID(), firstAmount, firstAmount]
+      );
+
+      await client.query(
+        `INSERT INTO owa_ledger
+           (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,now())`,
+        [abn, taxType, periodId, randomUUID(), secondAmount, firstAmount + secondAmount]
+      );
+
+      const bundleId = await buildEvidenceBundle(client, {
+        abn,
+        taxType,
+        periodId,
+        bankReceipts: [{ provider: "bank-a", receipt_id: "rcpt-123" }],
+        atoReceipts: [{ submission_id: "sub-1", receipt_id: "ato-1" }],
+        operatorOverrides: [],
+        owaAfterHash: "hash-after-placeholder",
+      });
+
+      expect(typeof bundleId).toBe("number");
+
+      const { rows } = await client.query(
+        "SELECT owa_balance_before, owa_balance_after, payload_sha256 FROM evidence_bundles WHERE bundle_id=$1",
+        [bundleId]
+      );
+
+      expect(rows[0].owa_balance_before).toBe(firstAmount);
+      expect(rows[0].owa_balance_after).toBe(firstAmount + secondAmount);
+      expect(rows[0].payload_sha256).toHaveLength(64);
+    } finally {
+      await client.query("ROLLBACK");
+      client.release();
+    }
+  });
+
+  test("builds bundle when a release entry exists", async () => {
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const abn = "90000000002";
+      const taxType = "GST";
+      const periodId = "2025-Q2";
+
+      await client.query("DELETE FROM evidence_bundles WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [abn, taxType, periodId]);
+      await client.query("DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [abn, taxType, periodId]);
+      await client.query("DELETE FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3", [abn, taxType, periodId]);
+
+      await seedRpt(client, abn, taxType, periodId);
+
+      const depositAmount = 10000;
+      const releaseAmount = -4000;
+      const finalBalance = depositAmount + releaseAmount;
+
+      await client.query(
+        `INSERT INTO owa_ledger
+           (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,now())`,
+        [abn, taxType, periodId, randomUUID(), depositAmount, depositAmount]
+      );
+
+      await client.query(
+        `INSERT INTO owa_ledger
+           (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents, created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,now())`,
+        [abn, taxType, periodId, randomUUID(), releaseAmount, finalBalance]
+      );
+
+      const bundleId = await buildEvidenceBundle(client, {
+        abn,
+        taxType,
+        periodId,
+        bankReceipts: [],
+        atoReceipts: [{ submission_id: "release-sub", receipt_id: "release-receipt" }],
+        operatorOverrides: [{ who: "auditor", why: "period close", ts: new Date().toISOString() }],
+        owaAfterHash: "hash-after-release",
+      });
+
+      expect(typeof bundleId).toBe("number");
+
+      const { rows } = await client.query(
+        "SELECT owa_balance_before, owa_balance_after FROM evidence_bundles WHERE bundle_id=$1",
+        [bundleId]
+      );
+
+      expect(rows[0].owa_balance_before).toBe(depositAmount);
+      expect(rows[0].owa_balance_after).toBe(finalBalance);
+    } finally {
+      await client.query("ROLLBACK");
+      client.release();
+    }
+  });
 });

--- a/docs/evidence-bundle-contract.md
+++ b/docs/evidence-bundle-contract.md
@@ -1,0 +1,73 @@
+# Evidence Bundle Contract
+
+The payments service assembles an **evidence bundle** for each `{abn, tax_type, period_id}` combination so
+reconciliation and downstream risk engines can validate how a release was authorised. An evidence bundle is a
+single row in `evidence_bundles` keyed by `bundle_id` with a unique constraint on the period tuple. The bundle
+captures:
+
+- The canonicalised Reconciliation Pass Token (RPT) payload, its signature and a SHA-256 hash (`payload_sha256`).
+- The running balances of the OWA ledger immediately before the most recent ledger entry and after it completes.
+- Thresholds, anomaly vectors and normalisation hashes as structured JSON blobs.
+- Chains-of-custody artefacts such as bank receipts, ATO receipts and operator overrides supplied by upstream
+  services.
+
+## Required fields
+
+When calling `buildEvidenceBundle` the caller must supply the following fields inside the `BuildParams` object:
+
+| Field | Shape | Purpose |
+| --- | --- | --- |
+| `abn` | string | Australian Business Number that owns the period. |
+| `taxType` | string (`"PAYGW"` or `"GST"`) | Matches ledger and RPT rows. |
+| `periodId` | string | Billing or lodgement period identifier. |
+| `bankReceipts` | `Array<{ provider: string; receipt_id: string }>` | Evidence of deposits credited to the OWA ledger. |
+| `atoReceipts` | `Array<{ submission_id: string; receipt_id: string }>` | Receipts generated when filing with the ATO. |
+| `operatorOverrides` | `Array<{ who: string; why: string; ts: string }>` | Manual adjustments that altered bundle inputs. |
+| `owaAfterHash` | string | Content hash of the OWA ledger tail after the caller has applied their transaction. |
+
+The builder derives the remaining fields by querying the database:
+
+- The latest `rpt_tokens` row for the period is fetched and canonicalised. If `payload_c14n`/`payload_sha256` are
+  already populated they are reused; otherwise the canonical JSON string is computed from `payload` and re-hashed.
+- Ledger balances are measured using the final entry in `owa_ledger`. The `owa_balance_after` column stores the
+  last `balance_after_cents` value, while `owa_balance_before` subtracts the last `amount_cents` to give the pre-
+  transaction balance.
+
+## Thresholds and anomaly hashes
+
+Evidence bundles currently store baseline thresholds and anomaly metrics in deterministic JSON objects that are
+encoded using canonical JSON before insertion:
+
+```json
+{
+  "thresholds_json": { "variance_pct": 0.02, "dup_rate": 0.01, "gap_allowed": 3 },
+  "anomaly_vector": { "variance": 0.0, "dups": 0, "gaps": 0 },
+  "normalization_hashes": { "payroll_hash": "NA", "pos_hash": "NA" }
+}
+```
+
+Downstream services should respect these semantics:
+
+- **`variance_pct`** – percentage tolerance allowed between expected and actual withholding totals before flagging an
+  anomaly.
+- **`dup_rate`** – fraction of duplicate receipts tolerated in the reconciliation sample.
+- **`gap_allowed`** – number of missing ledger days allowed during review.
+- **`anomaly_vector`** – stores the actual computed anomaly metrics for the period. All zeros indicate no detected
+  anomalies.
+- **`normalization_hashes`** – content-addressed hashes of upstream normalisation artefacts (e.g. payroll or POS
+  exports). Use the literal string `"NA"` when a particular artefact is not available.
+
+These JSON blobs are stored verbatim (as canonical JSON) so downstream systems must provide the same structure and
+key casing when publishing overrides or when verifying an existing bundle. Receipts and overrides arrays are likewise
+stored as JSONB and should follow the example shapes above.
+
+## Ledger expectations
+
+`buildEvidenceBundle` assumes that the caller has already inserted the final ledger entry for the period. It uses that
+record to determine:
+
+- `owa_balance_after` – the current `balance_after_cents`.
+- `owa_balance_before` – the balance prior to the most recent ledger entry.
+
+To avoid uniqueness violations, callers should ensure any previous bundle for the same period is either removed or
+expect the UPSERT semantics to replace the existing row.

--- a/migrations/003_evidence_bundles.sql
+++ b/migrations/003_evidence_bundles.sql
@@ -1,0 +1,26 @@
+-- 003_evidence_bundles.sql
+-- Align evidence bundle storage with payments service expectations
+
+CREATE TABLE IF NOT EXISTS evidence_bundles (
+  bundle_id           BIGSERIAL PRIMARY KEY,
+  abn                 TEXT NOT NULL,
+  tax_type            TEXT NOT NULL,
+  period_id           TEXT NOT NULL,
+  payload_sha256      CHAR(64) NOT NULL,
+  rpt_id              BIGINT REFERENCES rpt_tokens(id) ON DELETE SET NULL,
+  rpt_payload         TEXT NOT NULL,
+  rpt_signature       TEXT NOT NULL,
+  thresholds_json     JSONB NOT NULL,
+  anomaly_vector      JSONB NOT NULL,
+  normalization_hashes JSONB NOT NULL,
+  owa_balance_before  BIGINT NOT NULL,
+  owa_balance_after   BIGINT NOT NULL,
+  bank_receipts       JSONB NOT NULL,
+  ato_receipts        JSONB NOT NULL,
+  operator_overrides  JSONB NOT NULL,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (abn, tax_type, period_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_evidence_bundles_rpt_id
+  ON evidence_bundles (rpt_id);


### PR DESCRIPTION
## Summary
- update the evidence bundle builder to rely on the schema created by the 001/002 migrations and reuse existing canonical payload data when present
- add a migration for the evidence_bundles table plus documentation that explains the contract and required payload fields
- add integration tests that insert deposits/releases and assert the evidence bundle builder runs without SQL errors

## Testing
- npm test *(fails: jest not found in PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68e2faac945c8327a9242b477597cee6