### PR TITLE
Add authentication and auditing security baseline

### DIFF
--- a/migrations/003_audit_events.sql
+++ b/migrations/003_audit_events.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS audit_events (
+    id BIGSERIAL PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    actor_sub TEXT NOT NULL,
+    action TEXT NOT NULL,
+    target_url TEXT NOT NULL,
+    response_status INTEGER NOT NULL,
+    event_payload JSONB NOT NULL,
+    prev_hash TEXT,
+    event_hash TEXT NOT NULL UNIQUE
+);
+
+CREATE INDEX IF NOT EXISTS audit_events_created_at_idx ON audit_events (created_at);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const api = Router();

--- a/src/crypto/rptSigner.ts
+++ b/src/crypto/rptSigner.ts
@@ -1,0 +1,53 @@
+import { signRpt as localSign, RptPayload } from "./ed25519";
+
+interface RptSigner {
+  sign(payload: RptPayload): Promise<string>;
+}
+
+class LocalEd25519Signer implements RptSigner {
+  private readonly secretKey: Uint8Array;
+
+  constructor(secretKeyB64: string) {
+    const key = Buffer.from(secretKeyB64, "base64");
+    if (key.length !== 64) {
+      throw new Error("RPT_ED25519_SECRET_BASE64_INVALID");
+    }
+    this.secretKey = new Uint8Array(key);
+  }
+
+  async sign(payload: RptPayload): Promise<string> {
+    return localSign(payload, this.secretKey);
+  }
+}
+
+class KmsRptSigner implements RptSigner {
+  async sign(_payload: RptPayload): Promise<string> {
+    console.warn("FEATURE_KMS enabled but no KMS adapter is configured");
+    throw new Error("KMS_SIGNER_NOT_IMPLEMENTED");
+  }
+}
+
+let cachedSigner: RptSigner | null = null;
+
+function getSigner(): RptSigner {
+  if (cachedSigner) {
+    return cachedSigner;
+  }
+
+  if (process.env.FEATURE_KMS === "true") {
+    cachedSigner = new KmsRptSigner();
+    return cachedSigner;
+  }
+
+  const secret = process.env.RPT_ED25519_SECRET_BASE64;
+  if (!secret) {
+    throw new Error("RPT_ED25519_SECRET_BASE64_MISSING");
+  }
+  cachedSigner = new LocalEd25519Signer(secret);
+  return cachedSigner;
+}
+
+export async function signRpt(payload: RptPayload): Promise<string> {
+  const signer = getSigner();
+  return signer.sign(payload);
+}

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,118 @@
+import type { NextFunction, Request, Response, RequestHandler } from "express";
+import crypto from "crypto";
+
+export type Role = "auditor" | "accountant" | "admin";
+
+export interface JwtClaims {
+  sub: string;
+  role: Role;
+  exp?: number;
+  [key: string]: unknown;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      auth?: JwtClaims;
+    }
+  }
+}
+
+const BEARER = /^Bearer\s+(.+)$/i;
+
+export function requireRole(...roles: Role[]): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const secret = process.env.AUTH_JWT_SECRET;
+    if (!secret) {
+      return res.status(500).json({ error: "AUTH_MISCONFIGURED" });
+    }
+
+    const token = extractBearer(req.headers.authorization);
+    if (!token) {
+      return res.status(401).json({ error: "MISSING_BEARER" });
+    }
+
+    let claims: JwtClaims;
+    try {
+      claims = verifyJwt(token, secret);
+    } catch (err: any) {
+      return res.status(401).json({ error: "INVALID_TOKEN", detail: err?.message });
+    }
+
+    if (roles.length > 0 && !roles.includes(claims.role)) {
+      return res.status(403).json({ error: "FORBIDDEN" });
+    }
+
+    req.auth = claims;
+    return next();
+  };
+}
+
+function extractBearer(header: string | undefined): string | null {
+  if (!header) return null;
+  const match = header.match(BEARER);
+  return match ? match[1].trim() : null;
+}
+
+function verifyJwt(token: string, secret: string): JwtClaims {
+  const segments = token.split(".");
+  if (segments.length !== 3) {
+    throw new Error("TOKEN_FORMAT");
+  }
+  const [encodedHeader, encodedPayload, signature] = segments;
+  const headerJson = decodeBase64Url(encodedHeader);
+  const payloadJson = decodeBase64Url(encodedPayload);
+
+  let header: { alg?: string; typ?: string };
+  let payload: JwtClaims;
+  try {
+    header = JSON.parse(headerJson);
+    payload = JSON.parse(payloadJson);
+  } catch {
+    throw new Error("TOKEN_DECODE");
+  }
+
+  if (header.alg !== "HS256" || header.typ !== "JWT") {
+    throw new Error("UNSUPPORTED_ALG");
+  }
+
+  const expected = createSignature(`${encodedHeader}.${encodedPayload}`, secret);
+  if (!timingSafeEquals(expected, signature)) {
+    throw new Error("BAD_SIGNATURE");
+  }
+
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) {
+    throw new Error("BAD_SUB");
+  }
+
+  if (!isRole(payload.role)) {
+    throw new Error("BAD_ROLE");
+  }
+
+  if (typeof payload.exp === "number" && Date.now() >= payload.exp * 1000) {
+    throw new Error("TOKEN_EXPIRED");
+  }
+
+  return payload;
+}
+
+function decodeBase64Url(value: string): string {
+  return Buffer.from(value, "base64url").toString("utf8");
+}
+
+function createSignature(data: string, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(data).digest("base64url");
+}
+
+function timingSafeEquals(expected: string, actual: string): boolean {
+  const expectedBuf = Buffer.from(expected);
+  const actualBuf = Buffer.from(actual);
+  if (expectedBuf.length !== actualBuf.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expectedBuf, actualBuf);
+}
+
+function isRole(value: unknown): value is Role {
+  return value === "auditor" || value === "accountant" || value === "admin";
+}

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,26 @@
+import type { RequestHandler } from "express";
+
+export type ValidationIssue = {
+  path: (string | number)[];
+  message: string;
+  code: string;
+};
+
+export interface Schema<T> {
+  safeParse(data: unknown):
+    | { success: true; data: T }
+    | { success: false; error: { issues: ValidationIssue[] } };
+}
+
+export type RequestLocation = "body" | "query" | "params";
+
+export function validate<T>(schema: Schema<T>, location: RequestLocation = "body"): RequestHandler {
+  return (req, res, next) => {
+    const result = schema.safeParse((req as any)[location]);
+    if (!result.success) {
+      return res.status(400).json({ error: "INVALID_REQUEST", issues: result.error.issues });
+    }
+    (req as any)[location] = result.data;
+    return next();
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,39 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+  settlementWebhook,
+  evidence,
+  validateCloseAndIssue,
+  validatePayAto,
+  validatePaytoSweep,
+} from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { securityHeaders } from "./middleware/securityHeaders";
+import { cors } from "./middleware/cors";
+import { rateLimit } from "./middleware/rateLimit";
+import { auditTrail } from "./middleware/auditTrail";
+import { requireRole } from "./http/auth";
 
 dotenv.config();
 
 const app = express();
+app.disable("x-powered-by");
+
+const corsOrigins = (process.env.CORS_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+app.use(securityHeaders());
+app.use(cors({ origins: corsOrigins }));
+app.use(rateLimit({ windowMs: 60_000, max: 120 }));
 app.use(express.json({ limit: "2mb" }));
+app.use(auditTrail());
 
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
@@ -19,17 +44,21 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+const accountantAccess = requireRole("accountant", "admin");
+const auditorAccess = requireRole("auditor", "accountant", "admin");
+const adminAccess = requireRole("admin");
+
+app.post("/api/pay", accountantAccess, validatePayAto, idempotency(), payAto);
+app.post("/api/close-issue", accountantAccess, validateCloseAndIssue, closeAndIssue);
+app.post("/api/payto/sweep", accountantAccess, validatePaytoSweep, paytoSweep);
+app.post("/api/settlement/webhook", adminAccess, settlementWebhook);
+app.get("/api/evidence", auditorAccess, evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
+app.use("/api", auditorAccess, paymentsApi);
 
 // Existing API router(s) after
-app.use("/api", api);
+app.use("/api", auditorAccess, api);
 
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));

--- a/src/middleware/auditTrail.ts
+++ b/src/middleware/auditTrail.ts
@@ -1,0 +1,57 @@
+import crypto from "crypto";
+import type { RequestHandler } from "express";
+import { Pool } from "pg";
+
+interface AuditEvent {
+  actorSub: string;
+  method: string;
+  targetUrl: string;
+  status: number;
+  timestamp: string;
+}
+
+const pool = new Pool();
+
+export function auditTrail(): RequestHandler {
+  return (req, res, next) => {
+    res.on("finish", () => {
+      if (req.method === "OPTIONS") return;
+      const event: AuditEvent = {
+        actorSub: req.auth?.sub ?? "anonymous",
+        method: req.method,
+        targetUrl: req.originalUrl,
+        status: res.statusCode,
+        timestamp: new Date().toISOString(),
+      };
+      void persistAuditEvent(event).catch((err) => {
+        console.error("audit trail failure", err);
+      });
+    });
+    next();
+  };
+}
+
+async function persistAuditEvent(event: AuditEvent): Promise<void> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const { rows } = await client.query<{
+      event_hash: string;
+    }>("SELECT event_hash FROM audit_events ORDER BY id DESC LIMIT 1 FOR UPDATE");
+    const prevHash = rows[0]?.event_hash ?? null;
+    const payload = { ...event };
+    const payloadString = JSON.stringify(payload);
+    const eventHash = crypto.createHash("sha256").update((prevHash ?? "") + payloadString).digest("hex");
+    await client.query(
+      `INSERT INTO audit_events(actor_sub, action, target_url, response_status, event_payload, prev_hash, event_hash)
+       VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+      [event.actorSub, event.method, event.targetUrl, event.status, payload, prevHash, eventHash]
+    );
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -1,0 +1,36 @@
+import type { RequestHandler } from "express";
+
+export interface CorsOptions {
+  origins: string[];
+}
+
+export function cors(options: CorsOptions): RequestHandler {
+  const allowed = options.origins.map((origin) => origin.trim()).filter(Boolean);
+  return (req, res, next) => {
+    res.setHeader("Vary", "Origin");
+    const origin = req.headers.origin;
+    const isAllowed = !origin || allowed.includes(origin);
+
+    if (origin) {
+      if (!isAllowed) {
+        return res.status(403).json({ error: "CORS_ORIGIN_FORBIDDEN" });
+      }
+      res.setHeader("Access-Control-Allow-Origin", origin);
+    }
+
+    res.setHeader("Access-Control-Allow-Credentials", "true");
+    const requestHeaders = req.headers["access-control-request-headers"];
+    if (requestHeaders) {
+      res.setHeader("Access-Control-Allow-Headers", String(requestHeaders));
+    } else {
+      res.setHeader("Access-Control-Allow-Headers", "Authorization,Content-Type");
+    }
+    res.setHeader("Access-Control-Allow-Methods", "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS");
+
+    if (req.method === "OPTIONS") {
+      return res.status(204).end();
+    }
+
+    return next();
+  };
+}

--- a/src/middleware/rateLimit.ts
+++ b/src/middleware/rateLimit.ts
@@ -1,0 +1,44 @@
+import type { RequestHandler } from "express";
+
+export interface RateLimitOptions {
+  windowMs: number;
+  max: number;
+}
+
+interface Bucket {
+  expiresAt: number;
+  count: number;
+}
+
+export function rateLimit(options: RateLimitOptions): RequestHandler {
+  const buckets = new Map<string, Bucket>();
+
+  function cleanup(now: number) {
+    for (const [key, bucket] of buckets) {
+      if (bucket.expiresAt <= now) {
+        buckets.delete(key);
+      }
+    }
+  }
+
+  return (req, res, next) => {
+    const now = Date.now();
+    cleanup(now);
+    const key = req.ip || req.socket.remoteAddress || "anonymous";
+    const bucket = buckets.get(key);
+
+    if (!bucket || bucket.expiresAt <= now) {
+      buckets.set(key, { count: 1, expiresAt: now + options.windowMs });
+      return next();
+    }
+
+    bucket.count += 1;
+    if (bucket.count > options.max) {
+      const retryAfter = Math.max(0, Math.ceil((bucket.expiresAt - now) / 1000));
+      res.setHeader("Retry-After", String(retryAfter));
+      return res.status(429).json({ error: "RATE_LIMIT_EXCEEDED" });
+    }
+
+    return next();
+  };
+}

--- a/src/middleware/securityHeaders.ts
+++ b/src/middleware/securityHeaders.ts
@@ -1,0 +1,14 @@
+import type { RequestHandler } from "express";
+
+export function securityHeaders(): RequestHandler {
+  const csp = ["default-src 'self'"].join("; ");
+  return (_req, res, next) => {
+    res.setHeader("Content-Security-Policy", csp);
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("X-Frame-Options", "DENY");
+    res.setHeader("Strict-Transport-Security", "max-age=31536000; includeSubDomains; preload");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("X-DNS-Prefetch-Control", "off");
+    next();
+  };
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,210 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import type { Request, Response } from "express";
+import { Pool } from "pg";
+
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import { validate, type Schema, type ValidationIssue } from "../http/validate";
+
+type TaxType = "PAYGW" | "GST";
+type Rail = "EFT" | "BPAY";
+
+interface CloseAndIssueBody {
+  abn: string;
+  taxType: TaxType;
+  periodId: string;
+  thresholds?: Partial<Record<string, number>>;
+}
+
+interface PayAtoBody {
+  abn: string;
+  taxType: TaxType;
+  periodId: string;
+  rail: Rail;
+}
+
+interface PaytoSweepBody {
+  abn: string;
+  amount_cents: number;
+  reference: string;
+}
+
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+const closeAndIssueSchema: Schema<CloseAndIssueBody> = {
+  safeParse(data) {
+    const issues: ValidationIssue[] = [];
+    if (!isRecord(data)) {
+      issues.push({ path: [], message: "Expected object", code: "invalid_type" });
+      return { success: false, error: { issues } };
+    }
+
+    const abn = readString(data, "abn", issues);
+    const taxType = readTaxType(data, issues);
+    const periodId = readString(data, "periodId", issues);
+    const thresholds = readThresholds(data.thresholds, issues);
+
+    if (issues.length > 0) {
+      return { success: false, error: { issues } };
+    }
+
+    return { success: true, data: { abn, taxType, periodId, thresholds } };
+  },
+};
+
+const payAtoSchema: Schema<PayAtoBody> = {
+  safeParse(data) {
+    const issues: ValidationIssue[] = [];
+    if (!isRecord(data)) {
+      issues.push({ path: [], message: "Expected object", code: "invalid_type" });
+      return { success: false, error: { issues } };
+    }
+    const abn = readString(data, "abn", issues);
+    const taxType = readTaxType(data, issues);
+    const periodId = readString(data, "periodId", issues);
+    const rail = readRail(data, issues);
+    if (issues.length > 0) {
+      return { success: false, error: { issues } };
+    }
+    return { success: true, data: { abn, taxType, periodId, rail } };
+  },
+};
+
+const paytoSweepSchema: Schema<PaytoSweepBody> = {
+  safeParse(data) {
+    const issues: ValidationIssue[] = [];
+    if (!isRecord(data)) {
+      issues.push({ path: [], message: "Expected object", code: "invalid_type" });
+      return { success: false, error: { issues } };
+    }
+    const abn = readString(data, "abn", issues);
+    const amount = readNumber(data, "amount_cents", issues);
+    if (amount !== undefined && amount <= 0) {
+      issues.push({ path: ["amount_cents"], message: "amount_cents must be > 0", code: "too_small" });
+    }
+    const reference = readString(data, "reference", issues);
+    if (issues.length > 0) {
+      return { success: false, error: { issues } };
+    }
+    return { success: true, data: { abn, amount_cents: amount!, reference } };
+  },
+};
+
+export const validateCloseAndIssue = validate(closeAndIssueSchema);
+export const validatePayAto = validate(payAtoSchema);
+export const validatePaytoSweep = validate(paytoSweepSchema);
+
+export async function closeAndIssue(req: Request<unknown, unknown, CloseAndIssueBody>, res: Response) {
   const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr = { ...DEFAULT_THRESHOLDS, ...(thresholds ?? {}) };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: Request<unknown, unknown, PayAtoBody>, res: Response) {
+  const { abn, taxType, periodId, rail } = req.body;
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query("update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: Request<unknown, unknown, PaytoSweepBody>, res: Response) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
+export async function settlementWebhook(req: Request, res: Response) {
+  const csvText = (req.body as any)?.csv || "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+export async function evidence(req: Request, res: Response) {
+  const { abn, taxType, periodId } = req.query as Record<string, string>;
+  res.json(await buildEvidenceBundle(abn, taxType as TaxType, periodId));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(data: Record<string, unknown>, key: string, issues: ValidationIssue[]): string {
+  const value = data[key];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    issues.push({ path: [key], message: `${key} must be a non-empty string`, code: "invalid_type" });
+    return "";
+  }
+  return value.trim();
+}
+
+function readNumber(data: Record<string, unknown>, key: string, issues: ValidationIssue[]): number | undefined {
+  const value = data[key];
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    issues.push({ path: [key], message: `${key} must be a number`, code: "invalid_type" });
+    return undefined;
+  }
+  return value;
+}
+
+function readTaxType(data: Record<string, unknown>, issues: ValidationIssue[]): TaxType {
+  const value = data["taxType"];
+  if (value === "PAYGW" || value === "GST") {
+    return value;
+  }
+  issues.push({ path: ["taxType"], message: "taxType must be PAYGW or GST", code: "invalid_enum" });
+  return "PAYGW";
+}
+
+function readRail(data: Record<string, unknown>, issues: ValidationIssue[]): Rail {
+  const value = data["rail"];
+  if (value === "EFT" || value === "BPAY") {
+    return value;
+  }
+  issues.push({ path: ["rail"], message: "rail must be EFT or BPAY", code: "invalid_enum" });
+  return "EFT";
+}
+
+function readThresholds(value: unknown, issues: ValidationIssue[]): Partial<Record<string, number>> | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  if (!isRecord(value)) {
+    issues.push({ path: ["thresholds"], message: "thresholds must be an object", code: "invalid_type" });
+    return undefined;
+  }
+  const result: Record<string, number> = {};
+  for (const [key, raw] of Object.entries(value)) {
+    if (typeof raw !== "number" || Number.isNaN(raw)) {
+      issues.push({ path: ["thresholds", key], message: "threshold values must be numeric", code: "invalid_type" });
+      continue;
+    }
+    result[key] = raw;
+  }
+  return result;
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,24 +1,23 @@
 ﻿import { Pool } from "pg";
 import crypto from "crypto";
-import { signRpt, RptPayload } from "../crypto/ed25519";
+import { signRpt } from "../crypto/rptSigner";
+import type { RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
 const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
-
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
@@ -29,9 +28,9 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
+  const signature = await signRpt(payload);
+  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
     [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }


### PR DESCRIPTION
## Summary
- add JWT bearer middleware and use it to protect API routes by role
- enforce security headers, origin restrictions, rate limiting, and chained audit logging
- validate money-movement payloads and sign RPTs through the new Ed25519/KMS abstraction with a supporting migration

## Testing
- npx tsc --noEmit *(fails: existing syntax error in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fb12007483279f5a77a6387b137b