### PR TITLE
Add seed/smoke tooling and CI coverage for compliance flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_DB: apgms
+          POSTGRES_USER: apgms
+          POSTGRES_PASSWORD: apgms_pw
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -d apgms -U apgms" --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      PGHOST: localhost
+      PGUSER: apgms
+      PGPASSWORD: apgms_pw
+      PGDATABASE: apgms
+      PGPORT: "5432"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install dependencies
+        run: npm ci
+      - name: Run migrations
+        run: npm run migrate
+      - name: Run tests
+        run: npm test

--- a/migrations/003_seed_support.sql
+++ b/migrations/003_seed_support.sql
@@ -1,0 +1,48 @@
+-- 003_seed_support.sql
+-- Support tables used by seed/smoke flows
+
+CREATE TABLE IF NOT EXISTS bas_labels (
+  id SERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  labels JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (abn, tax_type, period_id)
+);
+
+CREATE OR REPLACE FUNCTION bas_labels_touch() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS bas_labels_touch ON bas_labels;
+CREATE TRIGGER bas_labels_touch
+BEFORE UPDATE ON bas_labels
+FOR EACH ROW EXECUTE FUNCTION bas_labels_touch();
+
+CREATE TABLE IF NOT EXISTS recon_inputs (
+  id SERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  payload JSONB NOT NULL DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (abn, tax_type, period_id)
+);
+
+CREATE OR REPLACE FUNCTION recon_inputs_touch() RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS recon_inputs_touch ON recon_inputs;
+CREATE TRIGGER recon_inputs_touch
+BEFORE UPDATE ON recon_inputs
+FOR EACH ROW EXECUTE FUNCTION recon_inputs_touch();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "migrate": "tsx scripts/migrate.ts",
+        "seed": "tsx scripts/seed.ts",
+        "smoke": "tsx scripts/smoke.ts",
+        "test": "node --import tsx --test tests/unit/schedules.spec.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,30 @@
+import "dotenv/config";
+import { Pool } from "pg";
+import { readdirSync, readFileSync } from "fs";
+import { join } from "path";
+
+async function run() {
+  const pool = new Pool();
+  const client = await pool.connect();
+  try {
+    const dir = join(process.cwd(), "migrations");
+    const files = readdirSync(dir)
+      .filter((f) => f.endsWith(".sql"))
+      .sort();
+
+    for (const file of files) {
+      const sql = readFileSync(join(dir, file), "utf8");
+      console.log(`[migrate] running ${file}`);
+      await client.query(sql);
+    }
+    console.log("[migrate] done");
+  } catch (error) {
+    console.error("[migrate] failed", error);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+run();

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,112 @@
+import "dotenv/config";
+import { Pool, PoolClient } from "pg";
+
+const DEFAULT_ABN = "11122233344";
+const DEFAULT_TAX_TYPE: "PAYGW" | "GST" = "GST";
+const DEFAULT_PERIOD_ID = "2025-09";
+const DEFAULT_FINAL_LIABILITY = 50_000;
+
+const basLabelSeed = {
+  W1: 185000,
+  W2: 92500,
+  "1A": 50000,
+  "1B": 15000,
+};
+
+const reconSeed = {
+  bank_feed: [
+    { txn_id: "dep-1", amount_cents: 20000, received_at: new Date().toISOString() },
+    { txn_id: "dep-2", amount_cents: 30000, received_at: new Date().toISOString() },
+  ],
+  erp_feed: [
+    { invoice: "INV-1001", gst_collected_cents: 4200, paygw_withheld_cents: 7100 },
+    { invoice: "INV-1002", gst_collected_cents: 5800, paygw_withheld_cents: 8900 },
+  ],
+  variance_cents: 0,
+};
+
+async function tableExists(client: PoolClient, table: string) {
+  const { rows } = await client.query<{ exists: boolean }>(
+    "SELECT to_regclass($1) IS NOT NULL AS exists",
+    [`public.${table}`]
+  );
+  return rows[0]?.exists ?? false;
+}
+
+async function truncateIfExists(client: PoolClient, table: string) {
+  if (await tableExists(client, table)) {
+    await client.query(`TRUNCATE TABLE ${table} RESTART IDENTITY CASCADE`);
+  }
+}
+
+async function seed() {
+  const pool = new Pool();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const tables = ["recon_inputs", "bas_labels", "rpt_tokens", "owa_ledger", "periods"];
+    for (const table of tables) {
+      await truncateIfExists(client, table);
+    }
+
+    await client.query(
+      `INSERT INTO periods
+         (abn, tax_type, period_id, state, basis, accrued_cents, credited_to_owa_cents, final_liability_cents,
+          merkle_root, running_balance_hash, anomaly_vector, thresholds)
+       VALUES ($1,$2,$3,'CLOSING','ACCRUAL',$4,0,$5,$6,$7,$8,$9)
+       ON CONFLICT (abn, tax_type, period_id) DO UPDATE SET
+         state=EXCLUDED.state,
+         basis=EXCLUDED.basis,
+         accrued_cents=EXCLUDED.accrued_cents,
+         credited_to_owa_cents=EXCLUDED.credited_to_owa_cents,
+         final_liability_cents=EXCLUDED.final_liability_cents,
+         merkle_root=EXCLUDED.merkle_root,
+         running_balance_hash=EXCLUDED.running_balance_hash,
+         anomaly_vector=EXCLUDED.anomaly_vector,
+         thresholds=EXCLUDED.thresholds`,
+      [
+        DEFAULT_ABN,
+        DEFAULT_TAX_TYPE,
+        DEFAULT_PERIOD_ID,
+        DEFAULT_FINAL_LIABILITY,
+        DEFAULT_FINAL_LIABILITY,
+        "seed_merkle_root",
+        "seed_balance_hash",
+        { variance_ratio: 0.1, dup_rate: 0.01, gap_minutes: 10, delta_vs_baseline: 0.05 },
+        { epsilon_cents: 100, variance_ratio: 0.25, dup_rate: 0.02, gap_minutes: 60, delta_vs_baseline: 0.2 },
+      ]
+    );
+
+    if (await tableExists(client, "bas_labels")) {
+      await client.query(
+        `INSERT INTO bas_labels (abn, tax_type, period_id, labels)
+         VALUES ($1,$2,$3,$4)
+         ON CONFLICT (abn, tax_type, period_id) DO UPDATE SET labels=EXCLUDED.labels`,
+        [DEFAULT_ABN, DEFAULT_TAX_TYPE, DEFAULT_PERIOD_ID, basLabelSeed]
+      );
+    }
+
+    if (await tableExists(client, "recon_inputs")) {
+      await client.query(
+        `INSERT INTO recon_inputs (abn, tax_type, period_id, payload)
+         VALUES ($1,$2,$3,$4)
+         ON CONFLICT (abn, tax_type, period_id) DO UPDATE SET payload=EXCLUDED.payload,
+                                                         updated_at=now()`,
+        [DEFAULT_ABN, DEFAULT_TAX_TYPE, DEFAULT_PERIOD_ID, reconSeed]
+      );
+    }
+
+    await client.query("COMMIT");
+    console.log(`Seeded period ${DEFAULT_PERIOD_ID} for ABN ${DEFAULT_ABN}`);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    console.error("Seed failed", error);
+    process.exitCode = 1;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+seed();

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,43 @@
+import "dotenv/config";
+
+const API_BASE = (process.env.SMOKE_BASE_URL || "http://localhost:3000/api/v1").replace(/\/$/, "");
+const ABN = process.env.SMOKE_ABN || "11122233344";
+const TAX_TYPE = (process.env.SMOKE_TAX_TYPE || "GST").toUpperCase();
+const PERIOD_ID = process.env.SMOKE_PERIOD_ID || "2025-09";
+const DEPOSIT_CENTS = Number.parseInt(process.env.SMOKE_DEPOSIT_CENTS || "50000", 10);
+
+async function request(path: string, init?: RequestInit) {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "content-type": "application/json", ...(init?.headers || {}) },
+    ...init,
+  });
+  const text = await res.text();
+  const payload = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    throw new Error(`${init?.method || "GET"} ${path} -> ${res.status}: ${JSON.stringify(payload)}`);
+  }
+  return payload;
+}
+
+async function main() {
+  console.log(`[smoke] targeting ${API_BASE}`);
+  const deposit = await request("/deposit", {
+    method: "POST",
+    body: JSON.stringify({ abn: ABN, taxType: TAX_TYPE, periodId: PERIOD_ID, amountCents: DEPOSIT_CENTS }),
+  });
+  console.log("[smoke] deposit", deposit);
+
+  const rpt = await request("/reconcile/close-and-issue", {
+    method: "POST",
+    body: JSON.stringify({ abn: ABN, taxType: TAX_TYPE, periodId: PERIOD_ID }),
+  });
+  console.log("[smoke] close-and-issue", rpt);
+
+  const evidence = await request(`/evidence/${ABN}/${TAX_TYPE}-${PERIOD_ID}`);
+  console.log("[smoke] evidence", JSON.stringify(evidence, null, 2));
+}
+
+main().catch((err) => {
+  console.error("[smoke] failed", err);
+  process.exitCode = 1;
+});

--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -20,3 +20,20 @@ export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
     Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
   );
 }
+
+export function exceeds(v: Partial<AnomalyVector> = {}, thr: Record<string, number> = {}): boolean {
+  return isAnomalous(
+    {
+      variance_ratio: v.variance_ratio ?? 0,
+      dup_rate: v.dup_rate ?? 0,
+      gap_minutes: v.gap_minutes ?? 0,
+      delta_vs_baseline: v.delta_vs_baseline ?? 0,
+    },
+    {
+      variance_ratio: thr.variance_ratio,
+      dup_rate: thr.dup_rate,
+      gap_minutes: thr.gap_minutes,
+      delta_vs_baseline: thr.delta_vs_baseline,
+    }
+  );
+}

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,6 +1,5 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { sha256Hex } from "../crypto/merkle";
+import { pool } from "../services/db";
 
 export async function appendAudit(actor: string, action: string, payload: any) {
   const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,38 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../services/db";
+
+const DEFAULT_LABELS = { W1: null, W2: null, "1A": null, "1B": null } as Record<string, number | null>;
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const rpt = (
+    await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [
+      abn,
+      taxType,
+      periodId,
+    ])
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, balance_after_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
+  const basLabels = (
+    await pool.query("select labels from bas_labels where abn= and tax_type= and period_id=", [abn, taxType, periodId])
+  ).rows[0]?.labels as Record<string, number | null> | undefined;
+  const reconPayload = (
+    await pool.query("select payload from recon_inputs where abn= and tax_type= and period_id=", [abn, taxType, periodId])
+  ).rows[0]?.payload;
+  const last = deltas[deltas.length - 1];
   const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
+    bas_labels: basLabels || DEFAULT_LABELS,
     rpt_payload: rpt?.payload ?? null,
     rpt_signature: rpt?.signature ?? null,
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: reconPayload?.discrepancies || [],
+    recon_inputs: reconPayload || null,
   };
   return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { v1Router } from "./routes/v1";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -17,6 +18,9 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+// API v1 shim for smoke/e2e
+app.use("/api/v1", v1Router);
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,8 +1,8 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../services/db";
+
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
@@ -10,7 +10,7 @@ export function idempotency() {
       return next();
     } catch {
       const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+      return res.status(200).json({ idempotent: true, status: r.rows[0]?.last_status || "DONE" });
     }
   };
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,11 +1,10 @@
-﻿import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { pool } from "../services/db";
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
   const { rows } = await pool.query(
     "select * from remittance_destinations where abn= and rail= and reference=",
     [abn, rail, reference]
@@ -15,18 +14,26 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 }
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY",
+  reference: string
+) {
   const transfer_uuid = uuidv4();
   try {
     await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
+  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0, 12);
 
   const { rows } = await pool.query(
     "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -3,8 +3,7 @@ import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../services/db";
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;

--- a/src/routes/v1.ts
+++ b/src/routes/v1.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import { deposit } from "./deposit";
+import { closeAndIssue } from "./reconcile";
+import { buildEvidenceBundle } from "../evidence/bundle";
+
+export const v1Router = Router();
+
+v1Router.post("/deposit", deposit);
+v1Router.post("/reconcile/close-and-issue", closeAndIssue);
+
+v1Router.get("/evidence/:abn/:pid", async (req, res) => {
+  try {
+    const { abn, pid } = req.params as { abn: string; pid: string };
+    const [taxTypePart, ...rest] = pid.split("-");
+    if (!taxTypePart || rest.length === 0) {
+      return res.status(400).json({ error: "pid must be formatted as <taxType>-<periodId>" });
+    }
+    const taxType = taxTypePart.toUpperCase();
+    const periodId = rest.join("-");
+    const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+    return res.json({
+      meta: {
+        generated_at: new Date().toISOString(),
+        abn,
+        taxType,
+        periodId,
+      },
+      evidence: bundle,
+    });
+  } catch (err: any) {
+    return res.status(500).json({ error: err?.message || "Evidence build failed" });
+  }
+});

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,0 +1,22 @@
+import { Pool } from "pg";
+
+const {
+  DATABASE_URL,
+  PGHOST,
+  PGPORT,
+  PGDATABASE,
+  PGUSER,
+  PGPASSWORD,
+} = process.env;
+
+const poolConfig = DATABASE_URL
+  ? { connectionString: DATABASE_URL }
+  : {
+      host: PGHOST || undefined,
+      port: PGPORT ? Number(PGPORT) : undefined,
+      database: PGDATABASE || undefined,
+      user: PGUSER || undefined,
+      password: PGPASSWORD || undefined,
+    };
+
+export const pool = new Pool(poolConfig);

--- a/tests/unit/schedules.spec.ts
+++ b/tests/unit/schedules.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { calculatePaygw } from "../../src/utils/paygw";
+import { calculateGst } from "../../src/utils/gst";
+import { calculatePenalties } from "../../src/utils/penalties";
+
+function atoWeeklyPaygw(grossDollars: number): number {
+  const grossCents = Math.round(grossDollars * 100);
+  if (grossCents <= 0) return 0;
+  const bracket = 80_000;
+  if (grossCents <= bracket) return Math.round(grossCents * 0.15) / 100;
+  const base = Math.round(bracket * 0.15);
+  const excess = grossCents - bracket;
+  return (base + Math.round(excess * 0.2)) / 100;
+}
+
+function atoPenalty(daysLate: number, amountDue: number): number {
+  const basePenalty = amountDue * 0.10;
+  const dailyInterest = amountDue * 0.0005;
+  return basePenalty + dailyInterest * daysLate;
+}
+
+describe("schedule comparisons", () => {
+  it("PAYGW placeholder over-withholds compared to ATO schedule", () => {
+    const grossIncome = 5_000;
+    const ato = atoWeeklyPaygw(grossIncome);
+    const placeholder = calculatePaygw({ grossIncome, taxWithheld: 0, period: "weekly" });
+    assert.ok(placeholder > ato, "placeholder should withhold more than ATO progressive scale");
+    assert.ok(Math.abs(placeholder - ato) < 100, "difference stays within a realistic band");
+  });
+
+  it("GST placeholder matches ATO 10% rate", () => {
+    const amount = 2_200;
+    const ato = amount * 0.1;
+    const placeholder = calculateGst({ saleAmount: amount, exempt: false });
+    assert.strictEqual(placeholder, ato);
+    const exempt = calculateGst({ saleAmount: amount, exempt: true });
+    assert.strictEqual(exempt, 0);
+  });
+
+  it("Penalty placeholder is softer than ATO guidance", () => {
+    const daysLate = 30;
+    const amountDue = 10_000;
+    const ato = atoPenalty(daysLate, amountDue);
+    const placeholder = calculatePenalties(daysLate, amountDue);
+    assert.ok(placeholder < ato, "placeholder penalties should be less aggressive");
+    assert.ok(placeholder > 0, "penalties should remain positive when overdue");
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "scripts", "tests"]
 }


### PR DESCRIPTION
## Summary
- add Postgres migration plus seed/migrate/smoke scripts to bootstrap ABN 11122233344 test data
- expose an /api/v1 smoke router, share a DB pool, and enrich evidence bundles with BAS and recon context
- add schedule unit coverage with the built-in node:test runner and wire CI to run migrations and tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e2fb216cac8327847ace5648898328