### PR TITLE
feat: load compliance dashboards from backend

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from "jest";
+
+const config: Config = {
+  preset: "ts-jest",
+  testEnvironment: "jsdom",
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
+  moduleNameMapper: {
+    "\\.(css|less|scss|sass)$": "identity-obj-proxy",
+  },
+  testMatch: ["<rootDir>/src/**/*.test.(ts|tsx)", "<rootDir>/src/**/__tests__/**/*.(ts|tsx)"]
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,2 @@
+import "@testing-library/jest-dom";
+import "whatwg-fetch";

--- a/package.json
+++ b/package.json
@@ -4,24 +4,38 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "jest"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
     "packageManager": "pnpm@9",
     "devDependencies": {
+        "@testing-library/jest-dom": "^6.5.0",
+        "@testing-library/react": "^16.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "@types/express": "^5.0.3",
+        "@types/jest": "^29.5.12",
         "@types/node": "^24.6.2",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "identity-obj-proxy": "^3.0.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.2.3",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "whatwg-fetch": "^3.6.20"
     },
     "dependencies": {
+        "@tanstack/react-query": "^5.51.0",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "pg": "^8.16.3",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,9 @@
 // src/App.tsx
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AppLayout from "./components/AppLayout";
+import { ComplianceProvider } from "./context/ComplianceContext";
 
 import Dashboard from "./pages/Dashboard";
 import BAS from "./pages/BAS";
@@ -12,21 +14,34 @@ import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+    },
+  },
+});
+
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <QueryClientProvider client={queryClient}>
+      <ComplianceProvider>
+        <Router>
+          <Routes>
+            <Route element={<AppLayout />}>
+              <Route path="/" element={<Dashboard />} />
+              <Route path="/bas" element={<BAS />} />
+              <Route path="/settings" element={<Settings />} />
+              <Route path="/wizard" element={<Wizard />} />
+              <Route path="/audit" element={<Audit />} />
+              <Route path="/fraud" element={<Fraud />} />
+              <Route path="/integrations" element={<Integrations />} />
+              <Route path="/help" element={<Help />} />
+            </Route>
+          </Routes>
+        </Router>
+      </ComplianceProvider>
+    </QueryClientProvider>
   );
 }

--- a/src/api/compliance.ts
+++ b/src/api/compliance.ts
@@ -1,0 +1,53 @@
+import express from "express";
+
+const complianceApi = express.Router();
+
+const GATE_BASE = (process.env.GATE_BASE_URL || "http://localhost:8101").replace(/\/$/, "");
+const AUDIT_BASE = (process.env.AUDIT_BASE_URL || "http://localhost:8104").replace(/\/$/, "");
+
+async function forward(url: URL | string, init?: RequestInit) {
+  const res = await fetch(url, init);
+  const text = await res.text();
+  let json: any = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch (err) {
+      throw new Error(`Invalid JSON from upstream: ${(err as Error).message}`);
+    }
+  }
+  if (!res.ok) {
+    const message = (json && (json.error || json.detail)) || res.statusText || "Upstream request failed";
+    throw new Error(String(message));
+  }
+  return json;
+}
+
+complianceApi.get("/gate/transition", async (req, res) => {
+  try {
+    const { period_id, periodId } = req.query as Record<string, string | undefined>;
+    const pid = period_id || periodId;
+    if (!pid) {
+      return res.status(400).json({ error: "Missing period_id" });
+    }
+    const target = new URL(`${GATE_BASE}/gate/transition`);
+    target.searchParams.set("period_id", pid);
+    const data = await forward(target);
+    res.json(data);
+  } catch (err: any) {
+    res.status(502).json({ error: err?.message || "Gate transition fetch failed" });
+  }
+});
+
+complianceApi.get("/audit/bundle/:periodId", async (req, res) => {
+  try {
+    const { periodId } = req.params;
+    const target = `${AUDIT_BASE}/audit/bundle/${encodeURIComponent(periodId)}`;
+    const data = await forward(target);
+    res.json(data);
+  } catch (err: any) {
+    res.status(502).json({ error: err?.message || "Audit bundle fetch failed" });
+  }
+});
+
+export { complianceApi };

--- a/src/context/ComplianceContext.tsx
+++ b/src/context/ComplianceContext.tsx
@@ -1,0 +1,258 @@
+import React, { createContext, useContext, useMemo } from "react";
+import { useQuery, UseQueryResult } from "@tanstack/react-query";
+
+type ComplianceParams = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+};
+
+type BalanceResponse = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  balance_cents: number;
+  has_release: boolean;
+};
+
+type LedgerRow = {
+  id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  rpt_verified: boolean | null;
+  release_uuid: string | null;
+  bank_receipt_id: string | null;
+  created_at: string;
+};
+
+type LedgerResponse = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  rows: LedgerRow[];
+};
+
+type GateResponse = {
+  period_id: string;
+  state: string;
+  reason_code: string | null;
+  updated_at: string | null;
+};
+
+type AuditLogEntry = {
+  event_time: string;
+  category: string;
+  message: string;
+};
+
+type AuditResponse = {
+  period_id: string;
+  rpt: string | null;
+  audit: AuditLogEntry[];
+};
+
+export type ComplianceSummary = {
+  params: ComplianceParams;
+  balance?: BalanceResponse;
+  ledger?: LedgerResponse;
+  gate?: GateResponse | null;
+  audit?: AuditResponse | null;
+  lodgmentsUpToDate: boolean;
+  paymentsUpToDate: boolean;
+  overallCompliance: number;
+  lastBAS: string;
+  nextDue: string;
+  outstandingLodgments: string[];
+  outstandingAmounts: string[];
+};
+
+type ComplianceQuery = UseQueryResult<ComplianceSummary, Error> & {
+  params: ComplianceParams;
+};
+
+const ComplianceContext = createContext<ComplianceQuery | undefined>(undefined);
+
+export const DEFAULT_COMPLIANCE_PARAMS: ComplianceParams = {
+  abn: "12345678901",
+  taxType: "GST",
+  periodId: "2025-Q4",
+};
+
+const paymentsBase = (() => {
+  const env = typeof import.meta !== "undefined" ? (import.meta as any).env ?? {} : {};
+  return env.VITE_PAYMENTS_BASE_URL || process.env.VITE_PAYMENTS_BASE_URL || "/api";
+})();
+
+const gateBase = (() => {
+  const env = typeof import.meta !== "undefined" ? (import.meta as any).env ?? {} : {};
+  return env.VITE_GATE_BASE_URL || process.env.VITE_GATE_BASE_URL || "/api/gate";
+})();
+
+const auditBase = (() => {
+  const env = typeof import.meta !== "undefined" ? (import.meta as any).env ?? {} : {};
+  return env.VITE_AUDIT_BASE_URL || process.env.VITE_AUDIT_BASE_URL || "/api/audit";
+})();
+
+async function fetchJson<T>(input: RequestInfo, init?: RequestInit): Promise<T> {
+  const res = await fetch(input, init);
+  const text = await res.text();
+  let json: any = null;
+  if (text) {
+    try {
+      json = JSON.parse(text);
+    } catch (_err) {
+      throw new Error(`Invalid JSON response from ${typeof input === "string" ? input : input.toString()}`);
+    }
+  }
+
+  if (!res.ok) {
+    const message = (json && (json.error || json.detail)) || res.statusText || "Request failed";
+    const error = new Error(String(message)) as Error & { status?: number };
+    error.status = res.status;
+    throw error;
+  }
+
+  return json as T;
+}
+
+function toCurrency(amountCents: number, currency: string) {
+  const formatter = new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+  });
+  return formatter.format(amountCents / 100);
+}
+
+function computeNextDue(periodId: string) {
+  const m = /^([0-9]{4})-?Q([1-4])$/.exec(periodId);
+  if (!m) return "TBD";
+  const year = Number(m[1]);
+  const quarter = Number(m[2]);
+  const quarterEndMonth = quarter * 3; // 3, 6, 9, 12
+  const dueDate = new Date(Date.UTC(year, quarterEndMonth, 28));
+  return dueDate.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
+}
+
+function parseLastBasDate(audit: AuditResponse | null | undefined) {
+  if (!audit || !audit.audit.length) return "Not available";
+  for (let i = audit.audit.length - 1; i >= 0; i -= 1) {
+    const entry = audit.audit[i];
+    if (!entry?.message) continue;
+    try {
+      const payload = JSON.parse(entry.message);
+      if (payload?.ts) {
+        const d = new Date(Number(payload.ts) * 1000);
+        if (!Number.isNaN(d.getTime())) {
+          return d.toLocaleDateString("en-AU", { day: "numeric", month: "long", year: "numeric" });
+        }
+      }
+    } catch (_err) {
+      // ignore malformed messages and continue searching
+    }
+  }
+  return "Not available";
+}
+
+async function fetchCompliance(params: ComplianceParams): Promise<ComplianceSummary> {
+  const { abn, taxType, periodId } = params;
+  const baseUrl = typeof window !== "undefined" ? window.location.origin : "http://localhost";
+
+  const balanceUrl = new URL(`${paymentsBase.replace(/\/$/, "")}/balance`, baseUrl);
+  balanceUrl.searchParams.set("abn", abn);
+  balanceUrl.searchParams.set("taxType", taxType);
+  balanceUrl.searchParams.set("periodId", periodId);
+
+  const ledgerUrl = new URL(`${paymentsBase.replace(/\/$/, "")}/ledger`, baseUrl);
+  ledgerUrl.searchParams.set("abn", abn);
+  ledgerUrl.searchParams.set("taxType", taxType);
+  ledgerUrl.searchParams.set("periodId", periodId);
+
+  const gateUrl = new URL(`${gateBase.replace(/\/$/, "")}/transition`, baseUrl);
+  gateUrl.searchParams.set("period_id", periodId);
+
+  const auditUrl = new URL(`${auditBase.replace(/\/$/, "")}/bundle/${encodeURIComponent(periodId)}`, baseUrl);
+
+  const [balance, ledger, gate, audit] = await Promise.all([
+    fetchJson<BalanceResponse>(balanceUrl),
+    fetchJson<LedgerResponse>(ledgerUrl),
+    fetchJson<GateResponse>(gateUrl).catch((err: Error & { status?: number }) => {
+      if (err?.status === 404) {
+        return null;
+      }
+      throw err;
+    }),
+    fetchJson<AuditResponse>(auditUrl).catch((err: Error & { status?: number }) => {
+      if (err?.status === 404) {
+        return { period_id: periodId, rpt: null, audit: [] } as AuditResponse;
+      }
+      throw err;
+    }),
+  ]);
+
+  const outstandingLodgments = gate
+    ? (!["RPT-Issued", "Remitted"].includes(gate.state) ? [periodId] : [])
+    : [periodId];
+
+  const outstandingAmounts = balance.balance_cents > 0
+    ? [`${toCurrency(balance.balance_cents, "AUD")} ${taxType}`]
+    : [];
+
+  const lodgmentsUpToDate = outstandingLodgments.length === 0;
+  const paymentsUpToDate = outstandingAmounts.length === 0 && balance.has_release;
+
+  let overallCompliance = 100;
+  if (!lodgmentsUpToDate) overallCompliance -= 35;
+  if (!paymentsUpToDate) overallCompliance -= 35;
+  if (!ledger.rows.length) overallCompliance -= 10;
+  if (!audit.audit.length) overallCompliance -= 10;
+  if (!balance.has_release) overallCompliance -= 10;
+  overallCompliance = Math.max(0, Math.min(100, overallCompliance));
+
+  return {
+    params,
+    balance,
+    ledger,
+    gate,
+    audit,
+    lodgmentsUpToDate,
+    paymentsUpToDate,
+    overallCompliance,
+    lastBAS: parseLastBasDate(audit),
+    nextDue: computeNextDue(periodId),
+    outstandingLodgments,
+    outstandingAmounts,
+  };
+}
+
+function useComplianceQuery(params: ComplianceParams) {
+  return useQuery<ComplianceSummary, Error>({
+    queryKey: ["compliance", params],
+    queryFn: () => fetchCompliance(params),
+    staleTime: 30_000,
+    refetchInterval: 60_000,
+  });
+}
+
+export function ComplianceProvider({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params?: Partial<ComplianceParams>;
+}) {
+  const merged = useMemo(() => ({ ...DEFAULT_COMPLIANCE_PARAMS, ...params }), [params]);
+  const query = useComplianceQuery(merged);
+  const value = useMemo<ComplianceQuery>(() => ({ ...query, params: merged }), [query, merged]);
+  return <ComplianceContext.Provider value={value}>{children}</ComplianceContext.Provider>;
+}
+
+export function useCompliance(): ComplianceQuery {
+  const ctx = useContext(ComplianceContext);
+  if (!ctx) {
+    throw new Error("useCompliance must be used within a ComplianceProvider");
+  }
+  return ctx;
+}
+
+export { fetchCompliance };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
+import { complianceApi } from "./api/compliance";
 import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
@@ -27,6 +28,7 @@ app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+app.use("/api", complianceApi);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/pages/BAS.tsx
+++ b/src/pages/BAS.tsx
@@ -1,15 +1,37 @@
 import React from 'react';
+import { useCompliance } from '../context/ComplianceContext';
 
 export default function BAS() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65, // percentage from 0 to 100
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const { data: complianceStatus, isLoading, isError, error } = useCompliance();
+
+  if (isLoading || !complianceStatus) {
+    return (
+      <div className="main-card">
+        <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
+        <p className="text-sm text-muted-foreground mb-4">
+          Lodge your BAS on time and accurately. Below is a summary of your current obligations.
+        </p>
+        <div className="bg-white border border-gray-200 p-4 rounded-xl shadow-sm text-center">
+          <p className="text-gray-600">Loading compliance data…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="main-card space-y-4">
+        <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
+        <p className="text-sm text-muted-foreground">
+          Lodge your BAS on time and accurately. Below is a summary of your current obligations.
+        </p>
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-xl shadow">
+          <p className="font-semibold">Unable to load BAS compliance.</p>
+          <p className="text-sm">{error?.message || 'Unknown error'}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="main-card">

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,17 +1,43 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { useCompliance } from '../context/ComplianceContext';
 
 export default function Dashboard() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65,
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const { data: complianceStatus, isLoading, isError, error } = useCompliance();
+
+  if (isLoading || !complianceStatus) {
+    return (
+      <div className="main-card">
+        <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
+          <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
+          <p className="text-sm opacity-90">
+            Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
+          </p>
+        </div>
+        <div className="bg-white p-6 rounded-xl shadow text-center">
+          <p className="text-gray-600">Loading compliance data…</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="main-card space-y-4">
+        <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow">
+          <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
+          <p className="text-sm opacity-90">
+            Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
+          </p>
+        </div>
+        <div className="bg-red-50 border border-red-200 text-red-700 p-4 rounded-xl shadow">
+          <p className="font-semibold">Unable to load compliance insights.</p>
+          <p className="text-sm">{error?.message || 'Unknown error'}</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="main-card">

--- a/src/pages/__tests__/CompliancePages.test.tsx
+++ b/src/pages/__tests__/CompliancePages.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Dashboard from '../Dashboard';
+import BAS from '../BAS';
+import { ComplianceProvider } from '../../context/ComplianceContext';
+
+function createTestClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+function renderWithCompliance(ui: React.ReactElement) {
+  const queryClient = createTestClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ComplianceProvider>{ui}</ComplianceProvider>
+    </QueryClientProvider>
+  );
+}
+
+function mockFetchSequence(responses: Array<any | Error>) {
+  const fetchMock = jest.spyOn(global, 'fetch' as any).mockImplementation((input: RequestInfo) => {
+    if (!responses.length) {
+      return Promise.reject(new Error(`Unexpected fetch call for ${typeof input === 'string' ? input : input.toString()}`));
+    }
+    const next = responses.shift();
+    if (next instanceof Error) {
+      return Promise.reject(next);
+    }
+    return Promise.resolve(
+      new Response(JSON.stringify(next), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+  });
+  return fetchMock;
+}
+
+describe('Compliance driven pages', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows a loading state while compliance data is being fetched', () => {
+    jest.spyOn(global, 'fetch' as any).mockImplementation(() => new Promise(() => undefined));
+
+    renderWithCompliance(<Dashboard />);
+
+    expect(screen.getByText(/Loading compliance data/i)).toBeInTheDocument();
+  });
+
+  it('renders an error message when the compliance APIs fail', async () => {
+    jest.spyOn(global, 'fetch' as any).mockImplementation(() => Promise.reject(new Error('network down')));
+
+    renderWithCompliance(<BAS />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unable to load BAS compliance/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/network down/i)).toBeInTheDocument();
+  });
+
+  it('renders compliance data pulled from the backend services', async () => {
+    const responses = [
+      {
+        abn: '12345678901',
+        taxType: 'GST',
+        periodId: '2025-Q4',
+        balance_cents: 0,
+        has_release: true,
+      },
+      {
+        abn: '12345678901',
+        taxType: 'GST',
+        periodId: '2025-Q4',
+        rows: [
+          {
+            id: 1,
+            amount_cents: 120000,
+            balance_after_cents: 120000,
+            rpt_verified: true,
+            release_uuid: null,
+            bank_receipt_id: null,
+            created_at: new Date().toISOString(),
+          },
+        ],
+      },
+      {
+        period_id: '2025-Q4',
+        state: 'Remitted',
+        reason_code: null,
+        updated_at: new Date().toISOString(),
+      },
+      {
+        period_id: '2025-Q4',
+        rpt: null,
+        audit: [
+          {
+            event_time: new Date().toISOString(),
+            category: 'bas_gate',
+            message: JSON.stringify({ ts: Math.floor(Date.now() / 1000) }),
+          },
+        ],
+      },
+    ];
+
+    const fetchMock = mockFetchSequence(responses);
+
+    renderWithCompliance(<Dashboard />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(screen.getByText(/Compliance Score/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Up to date/i)).toBeInTheDocument();
+    expect(screen.getByText(/All paid/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a read-only GET /gate/transition endpoint to expose current gate state
- create compliance API proxy and React Query powered context for shared compliance data
- update Dashboard and BAS pages to use live compliance data with loading/error handling and unit tests

## Testing
- npm test -- --runTestsByPath src/pages/__tests__/CompliancePages.test.tsx *(fails: jest executable not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2faa9f6d083278cbe806cd352165c