### PR TITLE
Implement recon ingestion across tax-engine and recon services

### DIFF
--- a/apps/services/recon/main.py
+++ b/apps/services/recon/main.py
@@ -1,25 +1,342 @@
-﻿# apps/services/recon/main.py
-from fastapi import FastAPI
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+
+import orjson
+import psycopg
+from fastapi import FastAPI, HTTPException, Response
+from nats.aio.client import Client as NATS
+from nats.aio.errors import ErrNoServers
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
 from pydantic import BaseModel
-import os, psycopg2, json, math
 
 app = FastAPI(title="recon")
 
-class ReconReq(BaseModel):
-    period_id: str
-    paygw_total: float
-    gst_total: float
-    owa_paygw: float
-    owa_gst: float
-    anomaly_score: float
-    tolerance: float = 0.01
+SUBJECT_RECON = os.getenv("SUBJECT_RECON", "recon.v1.result")
+NATS_URL = os.getenv("NATS_URL", "nats://nats:4222")
 
-@app.post("/recon/run")
-def run(req: ReconReq):
-    pay_ok = math.isclose(req.paygw_total, req.owa_paygw, abs_tol=req.tolerance)
-    gst_ok = math.isclose(req.gst_total, req.owa_gst, abs_tol=req.tolerance)
-    anomaly_ok = req.anomaly_score < 0.8
-    if pay_ok and gst_ok and anomaly_ok:
-        return {"pass": True, "reason_code": None, "controls": ["BAS-GATE","RPT"], "next_state": "RPT-Issued"}
-    reason = "shortfall" if (not pay_ok or not gst_ok) else "anomaly_breach"
-    return {"pass": False, "reason_code": reason, "controls": ["BLOCK"], "next_state": "Blocked"}
+_nc: Optional[NATS] = None
+_db_conn: Optional[psycopg.AsyncConnection] = None
+_db_lock = asyncio.Lock()
+_started = asyncio.Event()
+_ready = asyncio.Event()
+
+if not logging.getLogger().handlers:
+    logging.basicConfig(level=getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO))
+
+logger = logging.getLogger("recon")
+
+
+def _pg_dsn() -> str:
+    if url := os.getenv("DATABASE_URL"):
+        return url
+    host = os.getenv("PGHOST", "postgres")
+    user = os.getenv("PGUSER", "apgms")
+    password = os.getenv("PGPASSWORD", "apgms_pw")
+    database = os.getenv("PGDATABASE", "apgms")
+    port = os.getenv("PGPORT", "5432")
+    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+
+
+PG_DSN = _pg_dsn()
+
+RECON_MESSAGES = Counter("recon_messages_total", "Recon summaries processed", ["status"])
+RECON_ERRORS = Counter("recon_messages_errors_total", "Recon summaries that failed")
+NATS_CONNECTED = Gauge("recon_nats_connected", "1 if connected to NATS")
+RECON_LAT = Histogram("recon_apply_seconds", "Latency to apply recon summary")
+
+
+class ReconStatusRequest(BaseModel):
+    abn: str
+    tax_type: str
+    period_id: str
+
+
+async def _get_db_conn() -> psycopg.AsyncConnection:
+    global _db_conn
+    if _db_conn and not _db_conn.closed:
+        return _db_conn
+    _db_conn = await psycopg.AsyncConnection.connect(PG_DSN)
+    return _db_conn
+
+
+async def _run_db(fn):
+    async with _db_lock:
+        conn = await _get_db_conn()
+        try:
+            result = await fn(conn)
+            await conn.commit()
+            return result
+        except Exception:
+            await conn.rollback()
+            raise
+
+
+async def _upsert_recon_input(conn: psycopg.AsyncConnection, summary: Dict[str, Any]) -> None:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO recon_inputs (abn, tax_type, period_id, expected_cents, tolerance_cents, actual_cents, updated_at)
+            VALUES (%s,%s,%s,%s,%s,%s,NOW())
+            ON CONFLICT (abn, tax_type, period_id)
+            DO UPDATE SET
+                expected_cents = EXCLUDED.expected_cents,
+                tolerance_cents = EXCLUDED.tolerance_cents,
+                actual_cents = EXCLUDED.actual_cents,
+                updated_at = NOW()
+            """,
+            (
+                summary["abn"],
+                summary["taxType"],
+                summary["period_id"],
+                summary["expectedCents"],
+                summary["toleranceCents"],
+                summary["actualCents"],
+            ),
+        )
+
+
+async def _insert_result(conn: psycopg.AsyncConnection, summary: Dict[str, Any], status: str) -> None:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO recon_results (
+                abn, tax_type, period_id,
+                expected_cents, actual_cents, delta_cents,
+                tolerance_cents, tolerance_bps, status
+            ) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)
+            """,
+            (
+                summary["abn"],
+                summary["taxType"],
+                summary["period_id"],
+                summary["expectedCents"],
+                summary["actualCents"],
+                summary["deltaCents"],
+                summary["toleranceCents"],
+                summary["toleranceBps"],
+                status,
+            ),
+        )
+
+
+async def _sync_period(conn: psycopg.AsyncConnection, summary: Dict[str, Any], status: str) -> None:
+    abn = summary["abn"]
+    tax_type = summary["taxType"]
+    period_id = summary["period_id"]
+    expected = summary["expectedCents"]
+    actual = summary["actualCents"]
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO periods (abn, tax_type, period_id, accrued_cents, final_liability_cents, credited_to_owa_cents)
+            VALUES (%s,%s,%s,%s,%s,%s)
+            ON CONFLICT (abn, tax_type, period_id)
+            DO UPDATE SET
+                accrued_cents = EXCLUDED.accrued_cents,
+                final_liability_cents = EXCLUDED.final_liability_cents,
+                credited_to_owa_cents = EXCLUDED.credited_to_owa_cents
+            """,
+            (abn, tax_type, period_id, expected, expected, actual),
+        )
+        if status == "OK":
+            await cur.execute(
+                """
+                UPDATE periods
+                   SET state='CLOSING'
+                 WHERE abn=%s AND tax_type=%s AND period_id=%s
+                   AND state IN ('OPEN','CLOSING')
+                """,
+                (abn, tax_type, period_id),
+            )
+        else:
+            await cur.execute(
+                """
+                UPDATE periods
+                   SET state='BLOCKED_DISCREPANCY'
+                 WHERE abn=%s AND tax_type=%s AND period_id=%s
+                   AND state NOT IN ('RELEASED','FINALIZED')
+                """,
+                (abn, tax_type, period_id),
+            )
+
+
+def _normalize_summary(summary: Dict[str, Any]) -> Dict[str, Any]:
+    try:
+        abn = str(summary["abn"]).strip()
+        tax_type = str(summary.get("taxType") or summary.get("tax_type")).upper()
+        period = str(summary.get("period_id") or summary.get("period")).strip()
+    except Exception as exc:
+        raise ValueError("invalid summary identifiers") from exc
+
+    expected = int(summary["expectedCents"])
+    actual = int(summary["actualCents"])
+    tolerance = int(summary.get("toleranceCents", 0))
+    tolerance_bps = int(summary.get("toleranceBps", 0))
+    delta_raw = summary.get("deltaCents")
+    delta = int(delta_raw) if delta_raw is not None else actual - expected
+
+    return {
+        "abn": abn,
+        "taxType": tax_type,
+        "period_id": period,
+        "expectedCents": expected,
+        "actualCents": actual,
+        "deltaCents": delta,
+        "toleranceCents": tolerance,
+        "toleranceBps": tolerance_bps,
+        "sourceEventId": summary.get("sourceEventId"),
+    }
+
+
+def _status_from_summary(summary: Dict[str, Any]) -> str:
+    delta = int(summary.get("deltaCents", summary["actualCents"] - summary["expectedCents"]))
+    tolerance = int(summary.get("toleranceCents", 0))
+    return "OK" if abs(delta) <= tolerance else "FAIL"
+
+
+async def _handle_summary(summary: Dict[str, Any]) -> None:
+    status = _status_from_summary(summary)
+
+    async def _work(conn: psycopg.AsyncConnection) -> None:
+        await _upsert_recon_input(conn, summary)
+        await _insert_result(conn, summary, status)
+        await _sync_period(conn, summary, status)
+
+    await _run_db(_work)
+    RECON_MESSAGES.labels(status=status).inc()
+
+
+async def _connect_nats() -> NATS:
+    backoff, max_backoff = 0.5, 8.0
+    while True:
+        try:
+            nc = NATS()
+            await nc.connect(servers=[NATS_URL])
+            NATS_CONNECTED.set(1)
+            return nc
+        except ErrNoServers:
+            NATS_CONNECTED.set(0)
+        except Exception as exc:
+            logger.warning("nats connection failed: %s", exc)
+            NATS_CONNECTED.set(0)
+        await asyncio.sleep(backoff)
+        backoff = min(max_backoff, backoff * 2)
+
+
+async def _subscribe(nc: NATS) -> None:
+    async def _on_msg(msg):
+        with RECON_LAT.time():
+            data = msg.data or b"{}"
+            try:
+                summary = orjson.loads(data)
+            except Exception:
+                RECON_ERRORS.inc()
+                logger.error("failed to decode recon summary: %s", data)
+                return
+            if not isinstance(summary, dict):
+                RECON_ERRORS.inc()
+                logger.warning("unexpected recon summary type: %s", type(summary))
+                return
+            required = {"abn", "taxType", "period_id", "expectedCents", "actualCents", "toleranceCents", "deltaCents", "toleranceBps"}
+            if not required.issubset(summary.keys()):
+                RECON_ERRORS.inc()
+                logger.warning("summary missing required keys: %s", summary)
+                return
+            try:
+                normalized = _normalize_summary(summary)
+                await _handle_summary(normalized)
+            except Exception as exc:
+                RECON_ERRORS.inc()
+                logger.error("failed to persist recon summary: %s", exc)
+
+    await nc.subscribe(SUBJECT_RECON, cb=_on_msg)
+    _ready.set()
+
+
+@app.get("/healthz")
+async def healthz() -> Dict[str, Any]:
+    await _run_db(lambda conn: conn.execute("SELECT 1"))
+    return {"ok": True, "started": _started.is_set()}
+
+
+@app.get("/readyz")
+async def readyz() -> Dict[str, Any]:
+    return {"ready": _ready.is_set()}
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    payload = generate_latest()
+    return Response(payload, media_type=CONTENT_TYPE_LATEST)
+
+
+@app.post("/recon/status")
+async def recon_status(req: ReconStatusRequest) -> Dict[str, Any]:
+    async def _fetch(conn: psycopg.AsyncConnection):
+        async with conn.cursor() as cur:
+            await cur.execute(
+                """
+                SELECT expected_cents, actual_cents, delta_cents, tolerance_cents, tolerance_bps, status, created_at
+                  FROM recon_results
+                 WHERE abn=%s AND tax_type=%s AND period_id=%s
+              ORDER BY created_at DESC
+                 LIMIT 1
+                """,
+                (req.abn, req.tax_type, req.period_id),
+            )
+            row = await cur.fetchone()
+            return row
+
+    row = await _run_db(_fetch)
+    if not row:
+        raise HTTPException(status_code=404, detail="RECON_NOT_FOUND")
+    expected, actual, delta, tolerance, tolerance_bps, status, created_at = row
+    return {
+        "abn": req.abn,
+        "tax_type": req.tax_type,
+        "period_id": req.period_id,
+        "expected_cents": int(expected),
+        "actual_cents": int(actual),
+        "delta_cents": int(delta),
+        "tolerance_cents": int(tolerance),
+        "tolerance_bps": int(tolerance_bps),
+        "status": status,
+        "as_of": created_at.isoformat() if created_at else None,
+    }
+
+
+@app.on_event("startup")
+async def startup():
+    _started.set()
+
+    async def runner():
+        global _nc
+        _nc = await _connect_nats()
+        await _subscribe(_nc)
+
+    asyncio.create_task(runner())
+
+
+@app.on_event("shutdown")
+async def shutdown():
+    global _nc, _db_conn
+    if _nc and _nc.is_connected:
+        try:
+            await _nc.drain(timeout=2)
+        except Exception:
+            pass
+        finally:
+            try:
+                await _nc.close()
+            except Exception:
+                pass
+        NATS_CONNECTED.set(0)
+    if _db_conn and not _db_conn.closed:
+        try:
+            await _db_conn.close()
+        except Exception:
+            pass

--- a/apps/services/recon/requirements.txt
+++ b/apps/services/recon/requirements.txt
@@ -1,4 +1,6 @@
-﻿fastapi==0.115.0
+fastapi==0.115.0
 uvicorn==0.30.6
 pydantic==2.9.2
-psycopg2-binary==2.9.9
+psycopg[binary]==3.2.3
+nats-py==2.11.0
+orjson==3.10.7

--- a/apps/services/tax-engine/app/main.py
+++ b/apps/services/tax-engine/app/main.py
@@ -25,13 +25,19 @@ def metrics():
 
 # --- BEGIN TAX_ENGINE_CORE_APP ---
 import asyncio
+import logging
 import os
-from typing import Optional
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
 
+import orjson
+import psycopg
 from fastapi import FastAPI, Response, status
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
 from nats.aio.client import Client as NATS
 from nats.aio.errors import ErrNoServers
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
+
+from .domains import payg_w as payg_w_mod
 
 try:
     app  # reuse if exists
@@ -40,14 +46,187 @@ except NameError:
 
 NATS_URL = os.getenv("NATS_URL", "nats://nats:4222")
 SUBJECT_INPUT = os.getenv("SUBJECT_INPUT", "apgms.normalized.v1")
-SUBJECT_OUTPUT = os.getenv("SUBJECT_OUTPUT", "apgms.tax.v1")
+SUBJECT_OUTPUT = os.getenv("SUBJECT_OUTPUT", "recon.v1.result")
 
 _nc: Optional[NATS] = None
 _started = asyncio.Event()
 _ready = asyncio.Event()
+_db_conn: Optional[psycopg.AsyncConnection] = None
+_db_lock = asyncio.Lock()
+
+if not logging.getLogger().handlers:
+    logging.basicConfig(level=getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO))
+
+logger = logging.getLogger("tax-engine")
+
+
+def _build_pg_dsn() -> str:
+    if url := os.getenv("DATABASE_URL"):
+        return url
+    host = os.getenv("PGHOST", "postgres")
+    user = os.getenv("PGUSER", "apgms")
+    password = os.getenv("PGPASSWORD", "apgms_pw")
+    database = os.getenv("PGDATABASE", "apgms")
+    port = os.getenv("PGPORT", "5432")
+    return f"postgresql://{user}:{password}@{host}:{port}/{database}"
+
+
+PG_DSN = _build_pg_dsn()
+
+
+def _load_schedules() -> Dict[str, Any]:
+    repo_root = Path(__file__).resolve().parents[4]
+    schedule_path = repo_root / "src" / "tax" / "schedules.json"
+    try:
+        data = schedule_path.read_bytes()
+        return orjson.loads(data)
+    except Exception as exc:  # pragma: no cover - fall back to defaults if missing
+        logger.warning("failed to load schedules.json (%s); using baked defaults", exc)
+        return {
+            "paygw": {
+                "tolerance_cents": 50,
+                "formula_progressive": {
+                    "brackets": [],
+                    "period": "weekly",
+                },
+            },
+            "gst": {
+                "codes": {"GST": 0.1, "GST_FREE": 0.0},
+                "tolerance_cents": 50,
+            },
+        }
+
+
+SCHEDULES = _load_schedules()
+PAYGW_RULES = SCHEDULES.get("paygw", {})
+GST_CODES = (SCHEDULES.get("gst", {}) or {}).get("codes", {})
+
+
+def _resolve_tolerance(event: Dict[str, Any], tax_type: str) -> int:
+    overrides: List[Tuple[str, Any]] = []
+    tolerances = event.get("tolerances") or event.get("tolerance") or {}
+    if isinstance(tolerances, dict):
+        overrides.extend(tolerances.items())
+    event_lower = {k.lower(): v for k, v in overrides}
+    direct_keys = [
+        f"{tax_type.lower()}_tolerance_cents",
+        f"{tax_type.lower()}ToleranceCents",
+        "tolerance_cents",
+        "toleranceCents",
+        "epsilon_cents",
+    ]
+    for key in direct_keys:
+        if key in event:
+            try:
+                return max(0, int(event[key]))
+            except Exception:
+                continue
+    for alias in (tax_type, tax_type.lower()):
+        if alias in tolerances:
+            try:
+                return max(0, int(tolerances[alias]))
+            except Exception:
+                continue
+        if alias.lower() in event_lower:
+            try:
+                return max(0, int(event_lower[alias.lower()]))
+            except Exception:
+                continue
+    default = 0
+    if tax_type.upper() == "PAYGW":
+        default = int(PAYGW_RULES.get("tolerance_cents", 0) or 0)
+    elif tax_type.upper() == "GST":
+        default = int((SCHEDULES.get("gst", {}) or {}).get("tolerance_cents", 0) or 0)
+    return max(0, default)
+
+
+async def _get_db_conn() -> psycopg.AsyncConnection:
+    global _db_conn
+    if _db_conn and not _db_conn.closed:
+        return _db_conn
+    _db_conn = await psycopg.AsyncConnection.connect(PG_DSN)
+    return _db_conn
+
+
+async def _run_db(fn):
+    async with _db_lock:
+        conn = await _get_db_conn()
+        try:
+            result = await fn(conn)
+            await conn.commit()
+            return result
+        except Exception:
+            await conn.rollback()
+            raise
+
+
+async def _select_actual(conn: psycopg.AsyncConnection, abn: str, tax_type: str, period_id: str) -> int:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            "SELECT credited_to_owa_cents FROM periods WHERE abn=%s AND tax_type=%s AND period_id=%s",
+            (abn, tax_type, period_id),
+        )
+        row = await cur.fetchone()
+        if not row:
+            return 0
+        value = row[0]
+        return int(value) if value is not None else 0
+
+
+async def _ensure_period(conn: psycopg.AsyncConnection, abn: str, tax_type: str, period_id: str, accrued: int) -> None:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO periods (abn, tax_type, period_id, accrued_cents)
+            VALUES (%s, %s, %s, %s)
+            ON CONFLICT (abn, tax_type, period_id)
+            DO UPDATE SET accrued_cents = EXCLUDED.accrued_cents
+            """,
+            (abn, tax_type, period_id, accrued),
+        )
+
+
+async def _upsert_recon_input(
+    conn: psycopg.AsyncConnection,
+    abn: str,
+    tax_type: str,
+    period_id: str,
+    expected: int,
+    tolerance: int,
+    actual: int,
+) -> None:
+    async with conn.cursor() as cur:
+        await cur.execute(
+            """
+            INSERT INTO recon_inputs (abn, tax_type, period_id, expected_cents, tolerance_cents, actual_cents, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, NOW())
+            ON CONFLICT (abn, tax_type, period_id)
+            DO UPDATE SET
+                expected_cents = EXCLUDED.expected_cents,
+                tolerance_cents = EXCLUDED.tolerance_cents,
+                actual_cents = EXCLUDED.actual_cents,
+                updated_at = NOW()
+            """,
+            (abn, tax_type, period_id, expected, tolerance, actual),
+        )
+
+
+def _gst_rate_for(code: str) -> float:
+    normalized = (code or "GST").upper()
+    if normalized in GST_CODES:
+        return float(GST_CODES[normalized])
+    if "GST" in GST_CODES:
+        return float(GST_CODES["GST"])
+    return 0.1
+
+
+def _bps(tolerance_cents: int, expected_cents: int) -> int:
+    denom = abs(expected_cents) if expected_cents else 1
+    return int(round((tolerance_cents / denom) * 10_000))
 
 TAX_REQS = Counter("tax_requests_total", "Total tax requests consumed")
 TAX_OUT = Counter("tax_results_total", "Total tax results produced")
+TAX_ERRORS = Counter("tax_results_errors_total", "Tax events that failed processing")
 NATS_CONNECTED = Gauge("taxengine_nats_connected", "1 if connected to NATS else 0")
 CALC_LAT = Histogram("taxengine_calc_seconds", "Calculate latency")
 
@@ -80,14 +259,134 @@ async def _connect_nats_with_retry() -> NATS:
         await asyncio.sleep(backoff)
         backoff = min(max_backoff, backoff * 2)
 
+def _extract_abn(event: Dict[str, Any]) -> Optional[str]:
+    for key in ("abn", "entity", "entity_id"):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _extract_period(event: Dict[str, Any]) -> Optional[str]:
+    for key in ("period_id", "period", "bas_period"):
+        value = event.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _compute_paygw(event: Dict[str, Any]) -> Optional[int]:
+    payload = event.get("payg_w") or event.get("paygw")
+    if not isinstance(payload, dict):
+        return None
+    try:
+        result = payg_w_mod.compute({"payg_w": payload}, PAYGW_RULES)
+        withholding = float(result.get("withholding", 0.0))
+        return int(round(withholding * 100))
+    except Exception as exc:
+        logger.warning("paygw compute failed: %s", exc)
+        return None
+
+
+def _compute_gst(event: Dict[str, Any]) -> Optional[int]:
+    lines = event.get("lines") or event.get("pos_lines")
+    if not isinstance(lines, list) or not lines:
+        return None
+    total = 0
+    for raw_line in lines:
+        if not isinstance(raw_line, dict):
+            continue
+        try:
+            qty = int(raw_line.get("qty", 1))
+            unit = int(raw_line.get("unit_price_cents", 0))
+        except Exception:
+            continue
+        if qty <= 0 or unit <= 0:
+            continue
+        amount_cents = qty * unit
+        rate = _gst_rate_for(str(raw_line.get("tax_code", "GST")))
+        total += int(round(amount_cents * rate))
+    return total if total else None
+
+
+async def _persist_snapshot(abn: str, tax_type: str, period_id: str, expected: int, tolerance: int) -> int:
+    async def _work(conn: psycopg.AsyncConnection) -> int:
+        await _ensure_period(conn, abn, tax_type, period_id, expected)
+        actual = await _select_actual(conn, abn, tax_type, period_id)
+        await _upsert_recon_input(conn, abn, tax_type, period_id, expected, tolerance, actual)
+        return actual
+
+    return await _run_db(_work)
+
+
 async def _subscribe_and_run(nc: NATS):
     async def _on_msg(msg):
         with CALC_LAT.time():
             TAX_REQS.inc()
             data = msg.data or b"{}"
-            # TODO: real calc -> publish real result
-            await nc.publish(SUBJECT_OUTPUT, data)
-            TAX_OUT.inc()
+            try:
+                event = orjson.loads(data)
+            except Exception:
+                TAX_ERRORS.inc()
+                logger.error("failed to decode normalized event: %s", data)
+                return
+
+            if not isinstance(event, dict):
+                TAX_ERRORS.inc()
+                logger.warning("unexpected event type: %s", type(event))
+                return
+
+            abn = _extract_abn(event)
+            period_id = _extract_period(event)
+            if not abn or not period_id:
+                TAX_ERRORS.inc()
+                logger.warning("event missing abn/period: %s", event)
+                return
+
+            tax_work: List[Tuple[str, int, int]] = []
+
+            paygw_expected = _compute_paygw(event)
+            if paygw_expected is not None:
+                tolerance = _resolve_tolerance(event, "PAYGW")
+                tax_work.append(("PAYGW", paygw_expected, tolerance))
+
+            gst_expected = _compute_gst(event)
+            if gst_expected is not None:
+                tolerance = _resolve_tolerance(event, "GST")
+                tax_work.append(("GST", gst_expected, tolerance))
+
+            if not tax_work:
+                TAX_ERRORS.inc()
+                logger.warning("event %s produced no tax liabilities", event.get("id"))
+                return
+
+            for tax_type, expected, tolerance in tax_work:
+                try:
+                    actual = await _persist_snapshot(abn, tax_type, period_id, expected, tolerance)
+                except Exception as exc:
+                    TAX_ERRORS.inc()
+                    logger.error("db failure for %s %s %s: %s", abn, tax_type, period_id, exc)
+                    continue
+
+                delta = actual - expected
+                summary = {
+                    "abn": abn,
+                    "taxType": tax_type,
+                    "period_id": period_id,
+                    "expectedCents": expected,
+                    "actualCents": actual,
+                    "deltaCents": delta,
+                    "toleranceCents": tolerance,
+                    "toleranceBps": _bps(tolerance, expected),
+                    "sourceEventId": event.get("id"),
+                }
+
+                try:
+                    await nc.publish(SUBJECT_OUTPUT, orjson.dumps(summary))
+                    TAX_OUT.inc()
+                except Exception as exc:
+                    TAX_ERRORS.inc()
+                    logger.error("failed to publish recon summary: %s", exc)
     await nc.subscribe(SUBJECT_INPUT, cb=_on_msg)
     _ready.set()
 
@@ -102,7 +401,7 @@ async def startup():
 
 @app.on_event("shutdown")
 async def shutdown():
-    global _nc
+    global _nc, _db_conn
     if _nc and _nc.is_connected:
         try:
             await _nc.drain(timeout=2)
@@ -112,6 +411,11 @@ async def shutdown():
             try: await _nc.close()
             except Exception: pass
         NATS_CONNECTED.set(0)
+    if _db_conn and not _db_conn.closed:
+        try:
+            await _db_conn.close()
+        except Exception:
+            pass
 # --- END TAX_ENGINE_CORE_APP ---
 
 # --- BEGIN READINESS_METRICS (tax-engine) ---

--- a/migrations/003_recon_inputs.sql
+++ b/migrations/003_recon_inputs.sql
@@ -1,0 +1,30 @@
+-- 003_recon_inputs.sql
+-- Recon input snapshots and reconciliation result history
+
+CREATE TABLE IF NOT EXISTS recon_inputs (
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL CHECK (tax_type IN ('PAYGW','GST')),
+  period_id TEXT NOT NULL,
+  expected_cents BIGINT NOT NULL,
+  tolerance_cents BIGINT NOT NULL,
+  actual_cents BIGINT NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (abn, tax_type, period_id)
+);
+
+CREATE TABLE IF NOT EXISTS recon_results (
+  id BIGSERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL CHECK (tax_type IN ('PAYGW','GST')),
+  period_id TEXT NOT NULL,
+  expected_cents BIGINT NOT NULL,
+  actual_cents BIGINT NOT NULL,
+  delta_cents BIGINT NOT NULL,
+  tolerance_cents BIGINT NOT NULL,
+  tolerance_bps INTEGER NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('OK','FAIL')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS recon_results_period_idx
+  ON recon_results (abn, tax_type, period_id, created_at DESC);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,15 +1,63 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
+import { getToleranceCents } from "../tax";
 import { Pool } from "pg";
 const pool = new Pool();
 
 export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const { abn, taxType, periodId, thresholds } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+
+  const { rows } = await pool.query(
+    `SELECT expected_cents, actual_cents, delta_cents, tolerance_cents, status
+       FROM recon_results
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+   ORDER BY created_at DESC
+      LIMIT 1`,
+    [abn, taxType, periodId]
+  );
+
+  if (rows.length === 0) {
+    return res.status(409).json({ error: "RECON_PENDING" });
+  }
+
+  const latest = rows[0];
+  const delta = Math.abs(Number(latest.delta_cents));
+  const tolerance = Number(latest.tolerance_cents);
+  const scheduleTolerance = getToleranceCents((String(taxType).toUpperCase() === "GST" ? "GST" : "PAYGW"));
+  const epsilon = Number.isFinite(tolerance) ? tolerance : scheduleTolerance;
+  const withinTolerance = Number.isFinite(tolerance) ? delta <= tolerance : delta <= scheduleTolerance;
+  if (latest.status !== "OK" || !withinTolerance) {
+    return res.status(409).json({
+      error: "RECON_DELTA",
+      status: latest.status,
+      delta_cents: delta,
+      tolerance_cents: epsilon
+    });
+  }
+
+  await pool.query(
+    `UPDATE periods
+        SET state='CLOSING', final_liability_cents=$4
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        AND state IN ('OPEN','CLOSING')`,
+    [abn, taxType, periodId, Number(latest.expected_cents)]
+  );
+
+  const thr = {
+    epsilon_cents: epsilon,
+    variance_ratio: 0.25,
+    dup_rate: 0.01,
+    gap_minutes: 60,
+    delta_vs_baseline: 0.2,
+    ...(thresholds || {})
+  };
+
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);

--- a/src/tax/index.ts
+++ b/src/tax/index.ts
@@ -1,0 +1,58 @@
+import schedulesJson from "./schedules.json";
+
+export type TaxType = "PAYGW" | "GST";
+
+export interface ProgressiveBracket {
+  up_to: number;
+  a: number;
+  b: number;
+  fixed: number;
+}
+
+export interface PaygwSchedule {
+  default_period: string;
+  tolerance_cents: number;
+  formula_progressive: {
+    period: string;
+    brackets: ProgressiveBracket[];
+    tax_free_threshold: boolean;
+    rounding: "HALF_UP" | "HALF_EVEN" | string;
+  };
+}
+
+export interface GstSchedule {
+  codes: Record<string, number>;
+  tolerance_cents: number;
+}
+
+export interface TaxSchedules {
+  version: string;
+  paygw: PaygwSchedule;
+  gst: GstSchedule;
+}
+
+const schedules = schedulesJson as TaxSchedules;
+
+export const taxSchedules: TaxSchedules = schedules;
+
+export function getToleranceCents(taxType: TaxType): number {
+  if (taxType === "PAYGW") {
+    return schedules.paygw.tolerance_cents;
+  }
+  if (taxType === "GST") {
+    return schedules.gst.tolerance_cents;
+  }
+  return 0;
+}
+
+export function gstRateFor(code: string): number {
+  const normalized = (code || "GST").toUpperCase();
+  if (normalized in schedules.gst.codes) {
+    return schedules.gst.codes[normalized];
+  }
+  return schedules.gst.codes["GST"] ?? 0;
+}
+
+export function allGstCodes(): string[] {
+  return Object.keys(schedules.gst.codes);
+}

--- a/src/tax/schedules.json
+++ b/src/tax/schedules.json
@@ -1,0 +1,30 @@
+{
+  "version": "2024-25",
+  "paygw": {
+    "default_period": "weekly",
+    "tolerance_cents": 50,
+    "formula_progressive": {
+      "period": "weekly",
+      "brackets": [
+        { "up_to": 359.0, "a": 0.0, "b": 0.0, "fixed": 0.0 },
+        { "up_to": 438.0, "a": 0.19, "b": 68.0, "fixed": 0.0 },
+        { "up_to": 548.0, "a": 0.234, "b": 87.82, "fixed": 0.0 },
+        { "up_to": 721.0, "a": 0.347, "b": 148.5, "fixed": 0.0 },
+        { "up_to": 865.0, "a": 0.345, "b": 147.0, "fixed": 0.0 },
+        { "up_to": 999999.0, "a": 0.39, "b": 183.0, "fixed": 0.0 }
+      ],
+      "tax_free_threshold": true,
+      "rounding": "HALF_UP"
+    }
+  },
+  "gst": {
+    "codes": {
+      "GST": 0.1,
+      "GST_FREE": 0.0,
+      "EXEMPT": 0.0,
+      "ZERO_RATED": 0.0,
+      "": 0.1
+    },
+    "tolerance_cents": 50
+  }
+}


### PR DESCRIPTION
## Summary
- load PAYGW and GST schedules from the shared tax module and reuse them in both services
- update the tax-engine consumer to calculate liabilities, upsert recon_inputs, and publish recon summaries
- add a recon subscriber that persists results, keeps period state in sync, and gate close-and-issue by delta tolerance
- create a migration for recon_inputs and recon_results tables used by the new flow

## Testing
- not run (non-interactive environment)


------
https://chatgpt.com/codex/tasks/task_e_68e2fb1aebec8327927305e63330bf93