### PR TITLE
Return full audit log bundle

### DIFF
--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -19,6 +19,7 @@ def bundle(period_id: str):
     cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
     rpt = cur.fetchone()
     cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
-    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []
+    rows = cur.fetchall()
+    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]} for r in rows]
     cur.close(); conn.close()
     return {"period_id": period_id, "rpt": rpt[0] if rpt else None, "audit": logs}

--- a/tests/test_audit_bundle.py
+++ b/tests/test_audit_bundle.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+if "psycopg2" not in sys.modules:
+    sys.modules["psycopg2"] = types.SimpleNamespace(connect=lambda *_, **__: None)
+
+from apps.services.audit import main as audit_main
+
+
+class FakeCursor:
+    def __init__(self, rpt_row, audit_rows):
+        self._rpt_row = rpt_row
+        self._audit_rows = audit_rows
+
+    def execute(self, *_args, **_kwargs):
+        # The real cursor just runs the query; we don't need to emulate it.
+        pass
+
+    def fetchone(self):
+        return self._rpt_row
+
+    def fetchall(self):
+        return list(self._audit_rows)
+
+    def close(self):
+        pass
+
+
+class FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+    def close(self):
+        pass
+
+
+def test_bundle_returns_all_audit_rows(monkeypatch):
+    period_id = "2024-Q1"
+    rpt_row = ("{\"foo\": \"bar\"}", "signature", datetime(2024, 1, 1, 0, 0, 0))
+    audit_rows = [
+        (datetime(2024, 1, 1, 0, 0, 0), "ingest", "start"),
+        (datetime(2024, 1, 1, 1, 0, 0), "ingest", "complete"),
+    ]
+    fake_cursor = FakeCursor(rpt_row, audit_rows)
+    fake_conn = FakeConnection(fake_cursor)
+
+    monkeypatch.setattr(audit_main, "db", lambda: fake_conn)
+
+    response = audit_main.bundle(period_id)
+
+    assert response["period_id"] == period_id
+    assert response["rpt"] == rpt_row[0]
+    assert response["audit"] == [
+        {"event_time": str(row[0]), "category": row[1], "message": row[2]} for row in audit_rows
+    ]
+    assert len(response["audit"]) == 2


### PR DESCRIPTION
## Summary
- fetch all audit log rows for a bundle request and build the response from every row
- add a unit test covering multiple audit log entries for a single period id

## Testing
- pytest tests/test_audit_bundle.py

------
https://chatgpt.com/codex/tasks/task_e_68e3010d0bd48327952f8fa8f92d3330