### PR TITLE
Add authentication and security middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,18 +11,26 @@
     "private": true,
     "packageManager": "pnpm@9",
     "devDependencies": {
+        "@types/cors": "^2.8.17",
         "@types/express": "^5.0.3",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^24.6.2",
+        "@types/helmet": "^7.0.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
     },
     "dependencies": {
+        "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.1.5",
+        "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "^3.23.8"
     }
 }

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,39 @@
+import { NextFunction, Request, Response } from "express";
+import jwt from "jsonwebtoken";
+
+const SECRET = process.env.API_JWT_SECRET || "dev-secret-change-me";
+
+export type Role = "auditor" | "accountant" | "admin";
+
+type JwtPayload = {
+  sub?: string;
+  roles?: Role[] | string[];
+  [key: string]: unknown;
+};
+
+export const auth = (roles?: Role[]) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    const token = (req.headers.authorization || "").replace(/^Bearer\s+/i, "");
+
+    if (!token) {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+
+    try {
+      const payload = jwt.verify(token, SECRET) as JwtPayload;
+      (req as any).user = payload;
+
+      if (roles && roles.length) {
+        const grantedRoles = Array.isArray(payload.roles) ? payload.roles : [];
+        const allowed = grantedRoles.some((role) => roles.includes(role as Role));
+
+        if (!allowed) {
+          return res.status(403).json({ error: "forbidden" });
+        }
+      }
+
+      return next();
+    } catch (error) {
+      return res.status(401).json({ error: "unauthorized" });
+    }
+  };

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,24 @@
+import { NextFunction, Request, Response } from "express";
+import { ZodError, ZodTypeAny } from "zod";
+
+export const validate = <T extends ZodTypeAny>(schema: T) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    const result = schema.safeParse(req.body);
+
+    if (!result.success) {
+      return res.status(400).json({
+        error: "invalid_body",
+        issues: formatIssues(result.error),
+      });
+    }
+
+    req.body = result.data;
+    return next();
+  };
+
+const formatIssues = (error: ZodError) =>
+  error.issues.map((issue) => ({
+    code: issue.code,
+    path: issue.path,
+    message: issue.message,
+  }));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,112 @@
 ﻿// src/index.ts
-import express from "express";
+import cors from "cors";
 import dotenv from "dotenv";
+import express from "express";
+import rateLimit from "express-rate-limit";
+import helmet from "helmet";
 
-import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { api } from "./api"; // your existing API router(s)
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { auth, Role } from "./http/auth";
+import { validate } from "./http/validate";
+import { idempotency } from "./middleware/idempotency";
+import {
+  closeAndIssue,
+  closeAndIssueSchema,
+  evidence,
+  payAto,
+  payAtoSchema,
+  paytoSweep,
+  paytoSweepSchema,
+  settlementWebhook,
+  settlementWebhookSchema,
+} from "./routes/reconcile";
 
 dotenv.config();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
 
+const allowedOrigins = (process.env.CORS_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+const corsMiddleware = cors({
+  origin: allowedOrigins.length ? allowedOrigins : undefined,
+  credentials: true,
+});
+
+if (allowedOrigins.length) {
+  app.use((req, res, next) => {
+    const origin = req.header("Origin");
+    if (origin && !allowedOrigins.includes(origin)) {
+      return res.status(403).json({ error: "origin_not_allowed" });
+    }
+    return corsMiddleware(req, res, next);
+  });
+} else {
+  app.use(corsMiddleware);
+}
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      useDefaults: true,
+    },
+    referrerPolicy: { policy: "no-referrer" },
+    hsts: { maxAge: 60 * 60 * 24 * 365, includeSubDomains: true, preload: true },
+  }),
+);
+
+app.use(
+  rateLimit({
+    windowMs: 60 * 1000,
+    max: 120,
+    standardHeaders: true,
+    legacyHeaders: false,
+  }),
+);
+
 // (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+app.use((req, _res, next) => {
+  console.log(`[app] ${req.method} ${req.url}`);
+  next();
+});
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+const accountantRoles: Role[] = ["accountant", "admin"];
+const auditorRoles: Role[] = ["auditor", "admin"];
+
+app.post(
+  "/api/pay",
+  auth(accountantRoles),
+  idempotency(),
+  validate(payAtoSchema),
+  payAto,
+);
+app.post(
+  "/api/close-issue",
+  auth(auditorRoles),
+  validate(closeAndIssueSchema),
+  closeAndIssue,
+);
+app.post(
+  "/api/payto/sweep",
+  auth(accountantRoles),
+  validate(paytoSweepSchema),
+  paytoSweep,
+);
+app.post(
+  "/api/settlement/webhook",
+  auth(auditorRoles),
+  validate(settlementWebhookSchema),
+  settlementWebhook,
+);
+app.get("/api/evidence", auth(["auditor", "accountant", "admin"]), evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,143 @@
-﻿import { issueRPT } from "../rpt/issuer";
-import { buildEvidenceBundle } from "../evidence/bundle";
-import { releasePayment, resolveDestination } from "../rails/adapter";
-import { debit as paytoDebit } from "../payto/adapter";
-import { parseSettlementCSV } from "../settlement/splitParser";
+import { Request, Response } from "express";
 import { Pool } from "pg";
+import { z } from "zod";
+
+import { buildEvidenceBundle } from "../evidence/bundle";
+import { debit as paytoDebit } from "../payto/adapter";
+import { issueRPT } from "../rpt/issuer";
+import { releasePayment, resolveDestination } from "../rails/adapter";
+import { parseSettlementCSV } from "../settlement/splitParser";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+const thresholdSchema = z
+  .object({
+    epsilon_cents: z.number().nonnegative().optional(),
+    variance_ratio: z.number().nonnegative().optional(),
+    dup_rate: z.number().nonnegative().optional(),
+    gap_minutes: z.number().nonnegative().optional(),
+    delta_vs_baseline: z.number().nonnegative().optional(),
+  })
+  .strict();
+
+export const closeAndIssueSchema = z
+  .object({
+    abn: z.string().min(1),
+    taxType: z.string().min(1),
+    periodId: z.string().min(1),
+    thresholds: thresholdSchema.partial().optional(),
+  })
+  .strict();
+
+export const payAtoSchema = z
+  .object({
+    abn: z.string().min(1),
+    taxType: z.string().min(1),
+    periodId: z.string().min(1),
+    rail: z.enum(["EFT", "BPAY"]),
+  })
+  .strict();
+
+export const paytoSweepSchema = z
+  .object({
+    abn: z.string().min(1),
+    amount_cents: z.number().int().positive(),
+    reference: z.string().min(1),
+  })
+  .strict();
+
+export const settlementWebhookSchema = z
+  .object({
+    csv: z.string().min(1),
+  })
+  .strict();
+
+type CloseAndIssueBody = z.infer<typeof closeAndIssueSchema>;
+type PayAtoBody = z.infer<typeof payAtoSchema>;
+type PaytoSweepBody = z.infer<typeof paytoSweepSchema>;
+type SettlementWebhookBody = z.infer<typeof settlementWebhookSchema>;
+
+type EvidenceQuery = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+};
+
+export async function closeAndIssue(
+  req: Request<unknown, unknown, CloseAndIssueBody>,
+  res: Response,
+) {
   const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const defaults = {
+    epsilon_cents: 50,
+    variance_ratio: 0.25,
+    dup_rate: 0.01,
+    gap_minutes: 60,
+    delta_vs_baseline: 0.2,
+  } as const;
+  const thr = { ...defaults, ...thresholds };
+
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(
+  req: Request<unknown, unknown, PayAtoBody>,
+  res: Response,
+) {
+  const { abn, taxType, periodId, rail } = req.body;
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId],
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    const r = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      payload.reference,
+    );
+    await pool.query(
+      "update periods set state='RELEASED' where abn= and tax_type= and period_id=",
+      [abn, taxType, periodId],
+    );
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(
+  req: Request<unknown, unknown, PaytoSweepBody>,
+  res: Response,
+) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
-  const rows = parseSettlementCSV(csvText);
+export async function settlementWebhook(
+  req: Request<unknown, unknown, SettlementWebhookBody>,
+  res: Response,
+) {
+  const rows = parseSettlementCSV(req.body.csv);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
+export async function evidence(
+  req: Request<unknown, unknown, unknown, EvidenceQuery>,
+  res: Response,
+) {
+  const { abn, taxType, periodId } = req.query;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }


### PR DESCRIPTION
## Summary
- add JWT authentication middleware with role-based guarding and reusable request validation
- secure the Express app with helmet, origin-restricted CORS, and rate limiting
- validate reconciliation and payment payloads with Zod schemas

## Testing
- npm install *(fails: registry returned 403 for @types/cors in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e302ad19bc8327aaf5aeab3ba4b494