### PR TITLE
feat: load dashboard and BAS data via react-query

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "typescript": "^5.9.3"
     },
     "dependencies": {
+        "@tanstack/react-query": "^5.59.16",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,6 @@
+export const api = {
+  periods: (abn: string) => fetch(`/api/v1/periods/${abn}`).then(r => r.json()),
+  balance: (abn: string) => fetch(`/api/v1/balance/${abn}`).then(r => r.json()),
+  evidence: (abn: string, pid: number | string) => fetch(`/api/v1/evidence/${abn}/${pid}`).then(r => r.json()),
+  gate: (abn: string, pid: number | string) => fetch(`/gate/status?abn=${abn}&period_id=${pid}`).then(r => r.json()),
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { WithQuery } from "./ui/query";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
-root.render(<App />);
+root.render(
+  <WithQuery>
+    <App />
+  </WithQuery>
+);

--- a/src/pages/BAS.tsx
+++ b/src/pages/BAS.tsx
@@ -1,15 +1,68 @@
-import React from 'react';
+import React, { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import {
+  DEFAULT_ABN,
+  buildComplianceSummary,
+  formatAmountCandidate,
+  formatDateCandidate,
+  getPeriodList,
+  getPeriodSortValue,
+  statusClass,
+  findLatestLodgedDate,
+  findNextDueDate
+} from "./complianceUtils";
 
 export default function BAS() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65, // percentage from 0 to 100
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const abn = DEFAULT_ABN;
+
+  const periodsQuery = useQuery({
+    queryKey: ["periods", abn],
+    queryFn: () => api.periods(abn)
+  });
+
+  const balanceQuery = useQuery({
+    queryKey: ["balance", abn],
+    queryFn: () => api.balance(abn)
+  });
+
+  const periods = useMemo(() => getPeriodList(periodsQuery.data), [periodsQuery.data]);
+
+  const sortedPeriods = useMemo(() => {
+    const ordered = [...periods].sort((a, b) => getPeriodSortValue(b) - getPeriodSortValue(a));
+    return ordered;
+  }, [periods]);
+
+  const activePeriod = sortedPeriods[0];
+  const activePeriodId = activePeriod && (activePeriod.period_id ?? activePeriod.periodId ?? activePeriod.id);
+
+  const gateQuery = useQuery({
+    queryKey: ["gate", abn, activePeriodId],
+    queryFn: () => api.gate(abn, activePeriodId as string),
+    enabled: Boolean(activePeriodId)
+  });
+
+  const evidenceQuery = useQuery({
+    queryKey: ["evidence", abn, activePeriodId],
+    queryFn: () => api.evidence(abn, activePeriodId as string),
+    enabled: Boolean(activePeriodId)
+  });
+
+  const summary = useMemo(
+    () => buildComplianceSummary(periodsQuery.data, balanceQuery.data, gateQuery.data, periods),
+    [periodsQuery.data, balanceQuery.data, gateQuery.data, periods]
+  );
+
+  const complianceValue = summary.complianceScore != null
+    ? Math.max(0, Math.min(100, summary.complianceScore))
+    : null;
+
+  const basEntries = useMemo(() => extractBasEntries(evidenceQuery.data), [evidenceQuery.data]);
+
+  const lastBAS = summary.lastBAS ?? formatDateCandidate(findLatestLodgedDate(periods));
+  const nextDue = summary.nextDue ?? formatDateCandidate(findNextDueDate(periods));
+
+  const reminderActive = summary.lodgments.bool === false || summary.payments.bool === false;
 
   return (
     <div className="main-card">
@@ -18,24 +71,40 @@ export default function BAS() {
         Lodge your BAS on time and accurately. Below is a summary of your current obligations.
       </p>
 
-      {!complianceStatus.lodgmentsUpToDate || !complianceStatus.paymentsUpToDate ? (
-        <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-800 p-4 rounded">
+      {periodsQuery.isLoading || balanceQuery.isLoading ? (
+        <div className="bg-card border border-dashed border-gray-300 text-gray-600 p-4 rounded mb-4">
+          Gathering compliance status…
+        </div>
+      ) : periodsQuery.isError || balanceQuery.isError ? (
+        <div className="bg-red-50 border-l-4 border-red-500 text-red-700 p-4 rounded mb-4">
+          Unable to load compliance status from the API.
+        </div>
+      ) : reminderActive ? (
+        <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-800 p-4 rounded mb-4">
           <p className="font-medium">Reminder:</p>
-          <p>Your BAS is overdue or payments are outstanding. Resolve to avoid penalties.</p>
+          <p>Your BAS has outstanding lodgments or payments. Resolve to avoid penalties.</p>
         </div>
       ) : null}
 
       <div className="bg-card p-4 rounded-xl shadow space-y-4">
-        <h2 className="text-lg font-semibold">Current Quarter</h2>
-        <ul className="list-disc pl-5 mt-2 space-y-1 text-sm">
-          <li><strong>W1:</strong> $7,500 (Gross wages)</li>
-          <li><strong>W2:</strong> $1,850 (PAYGW withheld)</li>
-          <li><strong>G1:</strong> $25,000 (Total sales)</li>
-          <li><strong>1A:</strong> $2,500 (GST on sales)</li>
-          <li><strong>1B:</strong> $450 (GST on purchases)</li>
-        </ul>
-        <button className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded">
-          Review & Lodge
+        <h2 className="text-lg font-semibold">Current Period</h2>
+        {evidenceQuery.isLoading ? (
+          <p className="text-sm text-gray-600">Loading BAS details…</p>
+        ) : evidenceQuery.isError ? (
+          <p className="text-sm text-red-600">Unable to load BAS evidence.</p>
+        ) : basEntries.length === 0 ? (
+          <p className="text-sm text-gray-600">No BAS line items reported for the selected period.</p>
+        ) : (
+          <ul className="list-disc pl-5 mt-2 space-y-1 text-sm">
+            {basEntries.map(entry => (
+              <li key={entry.code}>
+                <strong>{entry.code}:</strong> {entry.value}
+              </li>
+            ))}
+          </ul>
+        )}
+        <button className="mt-4 bg-blue-600 hover:bg-blue-700 text-white font-medium py-2 px-4 rounded" disabled={periodsQuery.isLoading || evidenceQuery.isLoading}>
+          Review &amp; Lodge
         </button>
       </div>
 
@@ -44,68 +113,84 @@ export default function BAS() {
         <div className="grid grid-cols-1 sm:grid-cols-4 gap-4 mt-3 text-sm">
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Lodgments</p>
-            <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-              {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
-            </p>
+            {periodsQuery.isLoading ? (
+              <p className="text-gray-500">Checking lodgments…</p>
+            ) : periodsQuery.isError ? (
+              <p className="text-red-600">Unable to load.</p>
+            ) : (
+              <p className={statusClass(summary.lodgments.bool)}>
+                {summary.lodgments.label ?? (summary.lodgments.bool ? "Up to date ✅" : summary.lodgments.bool === false ? "Outstanding ❌" : "Status unavailable")}
+              </p>
+            )}
           </div>
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Payments</p>
-            <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-              {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
-            </p>
+            {balanceQuery.isLoading ? (
+              <p className="text-gray-500">Checking payments…</p>
+            ) : balanceQuery.isError ? (
+              <p className="text-red-600">Unable to load.</p>
+            ) : (
+              <p className={statusClass(summary.payments.bool)}>
+                {summary.payments.label ?? (summary.payments.bool ? "All paid ✅" : summary.payments.bool === false ? "Outstanding ❌" : "Status unavailable")}
+              </p>
+            )}
           </div>
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Compliance Score</p>
             <div className="relative w-24 h-24 mx-auto">
               <svg viewBox="0 0 36 36" className="w-full h-full">
                 <path
-                  d="M18 2.0845
-                     a 15.9155 15.9155 0 0 1 0 31.831
-                     a 15.9155 15.9155 0 0 1 0 -31.831"
+                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
                   fill="none"
                   stroke="#eee"
                   strokeWidth="2"
                 />
-                <path
-                  d="M18 2.0845
-                     a 15.9155 15.9155 0 0 1 0 31.831"
-                  fill="none"
-                  stroke="url(#grad)"
-                  strokeWidth="2"
-                  strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
-                />
+                {complianceValue != null ? (
+                  <path
+                    d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831"
+                    fill="none"
+                    stroke="url(#bas-grad)"
+                    strokeWidth="2"
+                    strokeDasharray={`${complianceValue}, 100`}
+                  />
+                ) : null}
                 <defs>
-                  <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
+                  <linearGradient id="bas-grad" x1="0" y1="0" x2="1" y2="0">
                     <stop offset="0%" stopColor="red" />
                     <stop offset="50%" stopColor="yellow" />
                     <stop offset="100%" stopColor="green" />
                   </linearGradient>
                 </defs>
-                <text x="18" y="20.35" textAnchor="middle" fontSize="6">{complianceStatus.overallCompliance}%</text>
+                <text x="18" y="20.35" textAnchor="middle" fontSize="6">
+                  {complianceValue != null ? `${Math.round(complianceValue)}%` : "--"}
+                </text>
               </svg>
             </div>
           </div>
           <div className="bg-white p-3 rounded shadow">
             <p className="font-medium text-gray-700">Status</p>
             <p className="text-sm text-gray-600">
-              {complianceStatus.overallCompliance >= 90
-                ? 'Excellent compliance'
-                : complianceStatus.overallCompliance >= 70
-                ? 'Good standing'
-                : 'Needs attention'}
+              {gateQuery.isLoading
+                ? "Fetching gate status…"
+                : gateQuery.isError
+                ? "Unable to fetch gate status."
+                : summary.complianceLabel ?? "Status unavailable"}
             </p>
           </div>
         </div>
-        <p className="mt-4 text-sm text-gray-700">
-          Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>. Next BAS due by <strong>{complianceStatus.nextDue}</strong>.
-        </p>
-        <div className="mt-2 text-sm text-red-600">
-          {complianceStatus.outstandingLodgments.length > 0 && (
-            <p>Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
-          )}
-          {complianceStatus.outstandingAmounts.length > 0 && (
-            <p>Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
-          )}
+        <div className="mt-4 text-sm text-gray-700 space-y-1">
+          <p>
+            Last BAS lodged on <strong>{lastBAS ?? "—"}</strong>.
+          </p>
+          <p>
+            Next BAS due by <strong>{nextDue ?? "—"}</strong>.
+          </p>
+          {summary.outstandingLodgments.length > 0 ? (
+            <p className="text-red-600">Outstanding Lodgments: {summary.outstandingLodgments.join(", ")}</p>
+          ) : null}
+          {summary.outstandingAmounts.length > 0 ? (
+            <p className="text-red-600">Outstanding Payments: {summary.outstandingAmounts.join(", ")}</p>
+          ) : null}
         </div>
         <p className="mt-2 text-xs text-gray-500 italic">
           Staying highly compliant may help avoid audits, reduce penalties, and support eligibility for ATO support programs.
@@ -113,4 +198,40 @@ export default function BAS() {
       </div>
     </div>
   );
+}
+
+function extractBasEntries(evidence: any): Array<{ code: string; value: string }> {
+  const entries: Array<{ code: string; value: string }> = [];
+  if (!evidence) return entries;
+
+  const labelsSource = evidence?.bas_labels ?? evidence?.basLabels ?? evidence?.labels;
+  if (labelsSource && typeof labelsSource === "object") {
+    Object.entries(labelsSource as Record<string, unknown>).forEach(([code, value]) => {
+      const formatted = formatAmountCandidate(value);
+      entries.push({ code, value: formatted ?? formatFallbackValue(value) });
+    });
+  }
+
+  if (!entries.length && evidence?.period && typeof evidence.period === "object") {
+    Object.entries(evidence.period as Record<string, unknown>).forEach(([code, value]) => {
+      if (/^[A-Z0-9]+$/.test(code)) {
+        const formatted = formatAmountCandidate(value);
+        entries.push({ code, value: formatted ?? formatFallbackValue(value) });
+      }
+    });
+  }
+
+  return entries.sort((a, b) => a.code.localeCompare(b.code));
+}
+
+function formatFallbackValue(value: unknown): string {
+  if (value == null) return "—";
+  if (typeof value === "number") return value.toLocaleString();
+  if (typeof value === "string") return value;
+  if (typeof value === "object") {
+    const obj = value as Record<string, unknown>;
+    if (typeof obj.label === "string") return obj.label;
+    if (typeof obj.value === "string") return obj.value;
+  }
+  return "—";
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,24 +1,59 @@
 // src/pages/Dashboard.tsx
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "../api/client";
+import {
+  DEFAULT_ABN,
+  buildComplianceSummary,
+  getPeriodList,
+  getPeriodSortValue,
+  statusClass
+} from "./complianceUtils";
 
 export default function Dashboard() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65,
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const abn = DEFAULT_ABN;
+
+  const periodsQuery = useQuery({
+    queryKey: ["periods", abn],
+    queryFn: () => api.periods(abn)
+  });
+
+  const balanceQuery = useQuery({
+    queryKey: ["balance", abn],
+    queryFn: () => api.balance(abn)
+  });
+
+  const periods = useMemo(() => getPeriodList(periodsQuery.data), [periodsQuery.data]);
+
+  const latestPeriod = useMemo(() => {
+    const ordered = [...periods].sort((a, b) => getPeriodSortValue(b) - getPeriodSortValue(a));
+    return ordered[0];
+  }, [periods]);
+
+  const latestPeriodId = latestPeriod && (latestPeriod.period_id ?? latestPeriod.periodId ?? latestPeriod.id);
+
+  const gateQuery = useQuery({
+    queryKey: ["gate", abn, latestPeriodId],
+    queryFn: () => api.gate(abn, latestPeriodId as string),
+    enabled: Boolean(latestPeriodId)
+  });
+
+  const summary = useMemo(
+    () => buildComplianceSummary(periodsQuery.data, balanceQuery.data, gateQuery.data, periods),
+    [periodsQuery.data, balanceQuery.data, gateQuery.data, periods]
+  );
+
+  const complianceValue = summary.complianceScore != null
+    ? Math.max(0, Math.min(100, summary.complianceScore))
+    : null;
 
   return (
     <div className="main-card">
       <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
         <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
         <p className="text-sm opacity-90">
-          Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
+          Automating PAYGW &amp; GST compliance with ATO standards. Stay on track with timely lodgments and payments.
         </p>
         <div className="mt-4">
           <Link to="/wizard" className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100">
@@ -30,23 +65,35 @@ export default function Dashboard() {
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div className="bg-white p-4 rounded-xl shadow space-y-2">
           <h2 className="text-lg font-semibold">Lodgments</h2>
-          <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
-          </p>
+          {periodsQuery.isLoading ? (
+            <p className="text-gray-500">Loading lodgment status…</p>
+          ) : periodsQuery.isError ? (
+            <p className="text-red-600">Unable to load lodgment status.</p>
+          ) : (
+            <p className={statusClass(summary.lodgments.bool)}>
+              {summary.lodgments.label ?? (summary.lodgments.bool ? "Up to date ✅" : summary.lodgments.bool === false ? "Needs attention ❌" : "Status unavailable")}
+            </p>
+          )}
           <Link to="/bas" className="text-blue-600 text-sm underline">View BAS</Link>
         </div>
 
         <div className="bg-white p-4 rounded-xl shadow space-y-2">
           <h2 className="text-lg font-semibold">Payments</h2>
-          <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
-          </p>
+          {balanceQuery.isLoading ? (
+            <p className="text-gray-500">Checking payment status…</p>
+          ) : balanceQuery.isError ? (
+            <p className="text-red-600">Unable to load payment status.</p>
+          ) : (
+            <p className={statusClass(summary.payments.bool)}>
+              {summary.payments.label ?? (summary.payments.bool ? "All paid ✅" : summary.payments.bool === false ? "Outstanding ❌" : "Status unavailable")}
+            </p>
+          )}
           <Link to="/audit" className="text-blue-600 text-sm underline">View Audit</Link>
         </div>
 
         <div className="bg-white p-4 rounded-xl shadow text-center">
-          <h2 className="text-lg font-semibold mb-2">Compliance Score</h2>
-          <div className="relative w-16 h-16 mx-auto">
+          <h2 className="text-lg font-semibold mb-2">Compliance</h2>
+          <div className="relative w-20 h-20 mx-auto">
             <svg viewBox="0 0 36 36" className="w-full h-full">
               <path
                 d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
@@ -54,13 +101,15 @@ export default function Dashboard() {
                 stroke="#eee"
                 strokeWidth="2"
               />
-              <path
-                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831"
-                fill="none"
-                stroke="url(#grad)"
-                strokeWidth="2"
-                strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
-              />
+              {complianceValue != null ? (
+                <path
+                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831"
+                  fill="none"
+                  stroke="url(#grad)"
+                  strokeWidth="2"
+                  strokeDasharray={`${complianceValue}, 100`}
+                />
+              ) : null}
               <defs>
                 <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
                   <stop offset="0%" stopColor="red" />
@@ -68,27 +117,44 @@ export default function Dashboard() {
                   <stop offset="100%" stopColor="green" />
                 </linearGradient>
               </defs>
-              <text x="18" y="20.35" textAnchor="middle" fontSize="5">{complianceStatus.overallCompliance}%</text>
+              <text x="18" y="20.35" textAnchor="middle" fontSize="5">
+                {complianceValue != null ? `${Math.round(complianceValue)}%` : "--"}
+              </text>
             </svg>
           </div>
           <p className="text-sm mt-2 text-gray-600">
-            {complianceStatus.overallCompliance >= 90
-              ? 'Excellent'
-              : complianceStatus.overallCompliance >= 70
-              ? 'Good'
-              : 'Needs attention'}
+            {gateQuery.isLoading
+              ? "Fetching gate status…"
+              : gateQuery.isError
+              ? "Unable to fetch gate status."
+              : summary.complianceLabel ?? "Status unavailable"}
           </p>
         </div>
       </div>
 
       <div className="mt-6 text-sm text-gray-700">
-        <p>Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>. <Link to="/bas" className="text-blue-600 underline">Go to BAS</Link></p>
-        <p>Next BAS due by <strong>{complianceStatus.nextDue}</strong>.</p>
-        {complianceStatus.outstandingLodgments.length > 0 && (
-          <p className="text-red-600">Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
-        )}
-        {complianceStatus.outstandingAmounts.length > 0 && (
-          <p className="text-red-600">Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
+        {periodsQuery.isLoading ? (
+          <p>Loading compliance timeline…</p>
+        ) : periodsQuery.isError ? (
+          <p className="text-red-600">Unable to load compliance timeline.</p>
+        ) : (
+          <>
+            <p>
+              Last BAS lodged on <strong>{summary.lastBAS ?? "—"}</strong>. {" "}
+              <Link to="/bas" className="text-blue-600 underline">Go to BAS</Link>
+            </p>
+            <p>Next BAS due by <strong>{summary.nextDue ?? "—"}</strong>.</p>
+            {summary.outstandingLodgments.length > 0 ? (
+              <p className="text-red-600">
+                Outstanding Lodgments: {summary.outstandingLodgments.join(", ")}
+              </p>
+            ) : null}
+            {summary.outstandingAmounts.length > 0 ? (
+              <p className="text-red-600">
+                Outstanding Payments: {summary.outstandingAmounts.join(", ")}
+              </p>
+            ) : null}
+          </>
         )}
       </div>
 

--- a/src/pages/complianceUtils.ts
+++ b/src/pages/complianceUtils.ts
@@ -1,0 +1,353 @@
+export type PeriodRecord = Record<string, any>;
+
+export interface StatusInfo {
+  bool: boolean | null;
+  label: string | null;
+}
+
+export interface ComplianceSummary {
+  lodgments: StatusInfo;
+  payments: StatusInfo;
+  complianceScore: number | null;
+  complianceLabel: string | null;
+  lastBAS: string | null;
+  nextDue: string | null;
+  outstandingLodgments: string[];
+  outstandingAmounts: string[];
+}
+
+export const DEFAULT_ABN = "12345678901";
+
+export function getPeriodList(data: any): PeriodRecord[] {
+  if (!data) return [];
+  if (Array.isArray(data)) return data as PeriodRecord[];
+  if (Array.isArray(data?.periods)) return data.periods as PeriodRecord[];
+  if (Array.isArray(data?.data)) return data.data as PeriodRecord[];
+  if (Array.isArray(data?.items)) return data.items as PeriodRecord[];
+  return [];
+}
+
+export function getPeriodSortValue(period: PeriodRecord): number {
+  const due = parseDateValue(period.due_at ?? period.due_date ?? period.dueOn ?? period.next_due);
+  if (due != null) return due;
+  const end = parseDateValue(period.end_at ?? period.end_date ?? period.period_end);
+  if (end != null) return end;
+  const key = parsePeriodKey(period.period_id ?? period.periodId ?? period.id);
+  return key ?? 0;
+}
+
+export function buildComplianceSummary(
+  periodsData: any,
+  balanceData: any,
+  gateData: any,
+  periodList: PeriodRecord[]
+): ComplianceSummary {
+  const summarySource = periodsData?.summary ?? periodsData?.overview ?? periodsData?.compliance ?? periodsData;
+  const balanceSource = balanceData?.summary ?? balanceData?.data ?? balanceData;
+  const gateSource = gateData ?? {};
+
+  const outstandingLodgments = collectStrings(
+    summarySource?.outstanding_lodgments,
+    summarySource?.outstandingLodgments,
+    summarySource?.lodgments_overdue,
+    summarySource?.lodgments?.outstanding
+  );
+
+  if (outstandingLodgments.length === 0) {
+    const pending = periodList
+      .filter(item => interpretStatusValue(item.lodgment_status ?? item.lodged ?? item.state ?? item.lodgmentState).bool === false)
+      .map(item => formatPeriodLabel(item));
+    outstandingLodgments.push(...pending);
+  }
+
+  const outstandingAmounts = collectAmounts(
+    summarySource?.outstanding_amounts,
+    summarySource?.outstandingAmounts,
+    summarySource?.payments?.outstanding,
+    balanceSource?.outstanding,
+    balanceSource?.outstanding_amounts,
+    balanceSource?.outstandingAmounts
+  );
+
+  const lodgmentCandidate = summarySource?.lodgments_up_to_date ?? summarySource?.lodgment_status ?? gateSource?.lodgments_up_to_date ?? gateSource?.lodgment_status;
+  const paymentCandidate = summarySource?.payments_up_to_date ?? summarySource?.payments_status ?? balanceSource?.payments_up_to_date ?? balanceSource?.payments_status ?? gateSource?.payments_up_to_date;
+
+  const lodgments = interpretStatusValue(lodgmentCandidate);
+  const payments = interpretStatusValue(paymentCandidate);
+
+  if (lodgments.bool == null) {
+    if (outstandingLodgments.length > 0) lodgments.bool = false;
+    else if (periodList.length > 0) lodgments.bool = true;
+  }
+  if (!lodgments.label) {
+    if (lodgments.bool === true) lodgments.label = "Up to date ✅";
+    if (lodgments.bool === false) lodgments.label = "Outstanding";
+  }
+
+  if (payments.bool == null) {
+    if (outstandingAmounts.length > 0) payments.bool = false;
+    else if (balanceSource) payments.bool = true;
+  }
+  if (!payments.label) {
+    if (payments.bool === true) payments.label = "All paid ✅";
+    if (payments.bool === false) payments.label = "Outstanding";
+  }
+
+  const complianceScore = parseComplianceNumber(
+    summarySource?.overall_compliance ?? summarySource?.compliance_score ?? gateSource?.compliance_score ?? balanceSource?.overall_compliance
+  );
+
+  const complianceLabel = pickFirstString(
+    summarySource?.compliance_label,
+    summarySource?.overall_status,
+    gateSource?.status,
+    gateSource?.message,
+    balanceSource?.status
+  );
+
+  const lastBAS = pickFirstString(
+    summarySource?.last_lodged,
+    summarySource?.last_bas,
+    summarySource?.lastBAS,
+    summarySource?.lastLodged,
+    formatDateCandidate(findLatestLodgedDate(periodList))
+  );
+
+  const nextDue = pickFirstString(
+    summarySource?.next_due,
+    summarySource?.nextDue,
+    summarySource?.next_due_date,
+    summarySource?.upcoming_due,
+    formatDateCandidate(findNextDueDate(periodList))
+  );
+
+  return {
+    lodgments,
+    payments,
+    complianceScore,
+    complianceLabel,
+    lastBAS,
+    nextDue,
+    outstandingLodgments: Array.from(new Set(outstandingLodgments)),
+    outstandingAmounts: Array.from(new Set(outstandingAmounts))
+  };
+}
+
+export function statusClass(status: boolean | null): string {
+  if (status === true) return "text-green-600";
+  if (status === false) return "text-red-600";
+  return "text-gray-500";
+}
+
+export function formatAmountCandidate(value: unknown): string | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    return formatCurrency(value);
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, any>;
+    if (obj.amount_cents != null) {
+      const num = Number(obj.amount_cents);
+      if (Number.isFinite(num)) return formatCurrency(num / 100);
+    }
+    if (obj.amount != null) {
+      const num = Number(obj.amount);
+      if (Number.isFinite(num)) return formatCurrency(num);
+    }
+    if (obj.value != null) {
+      const formatted = formatAmountCandidate(obj.value);
+      if (formatted) return formatted;
+    }
+    if (typeof obj.label === "string") return obj.label;
+  }
+  return null;
+}
+
+export function formatDateCandidate(timestamp: number | null): string | null {
+  if (timestamp == null) return null;
+  const d = new Date(timestamp);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toLocaleDateString("en-AU", { year: "numeric", month: "short", day: "numeric" });
+}
+
+export function findLatestLodgedDate(periodList: PeriodRecord[]): number | null {
+  let latest: number | null = null;
+  periodList.forEach(item => {
+    const candidate = parseDateValue(item.lodged_at ?? item.lodgedAt ?? item.lodged_on ?? item.lodgment_date);
+    if (candidate != null && (latest == null || candidate > latest)) {
+      latest = candidate;
+    }
+  });
+  return latest;
+}
+
+export function findNextDueDate(periodList: PeriodRecord[]): number | null {
+  const now = Date.now();
+  let nextFuture: number | null = null;
+  let latest: number | null = null;
+  periodList.forEach(item => {
+    const due = parseDateValue(item.next_due ?? item.due_at ?? item.due_date ?? item.dueOn);
+    if (due == null) return;
+    if (due >= now && (nextFuture == null || due < nextFuture)) {
+      nextFuture = due;
+    }
+    if (latest == null || due > latest) {
+      latest = due;
+    }
+  });
+  return nextFuture ?? latest;
+}
+
+export function interpretStatusValue(value: unknown): StatusInfo {
+  const info: StatusInfo = { bool: null, label: null };
+  if (value == null) return info;
+  if (typeof value === "boolean") {
+    info.bool = value;
+    info.label = value ? "Up to date ✅" : "Needs attention ❌";
+    return info;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return info;
+    info.label = trimmed;
+    const lower = trimmed.toLowerCase();
+    const goodTokens = ["up to date", "complete", "ok", "paid", "current", "released", "ready", "clear", "passed"];
+    const badTokens = ["overdue", "outstanding", "due", "late", "blocked", "failed", "missing", "pending", "hold"];
+    if (goodTokens.some(token => lower.includes(token))) info.bool = true;
+    else if (badTokens.some(token => lower.includes(token))) info.bool = false;
+    return info;
+  }
+  if (typeof value === "number") {
+    info.label = value === 0 ? "No outstanding" : String(value);
+    if (value === 0) info.bool = true;
+    if (value > 0) info.bool = false;
+    return info;
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, any>;
+    if (obj.value != null) return interpretStatusValue(obj.value);
+    if (obj.status != null) return interpretStatusValue(obj.status);
+    if (obj.state != null) return interpretStatusValue(obj.state);
+  }
+  return info;
+}
+
+export function parseComplianceNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.\-]/g, "");
+    const num = Number(cleaned);
+    return Number.isFinite(num) ? num : null;
+  }
+  if (typeof value === "object") {
+    const obj = value as Record<string, any>;
+    if (obj.value != null) return parseComplianceNumber(obj.value);
+    if (obj.score != null) return parseComplianceNumber(obj.score);
+  }
+  return null;
+}
+
+export function pickFirstString(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}
+
+function formatPeriodLabel(period: PeriodRecord): string {
+  const label = period.label ?? period.name ?? period.title ?? period.period_id ?? period.periodId ?? period.id;
+  return typeof label === "string" ? label : String(label ?? "");
+}
+
+function collectStrings(...candidates: unknown[]): string[] {
+  const values: string[] = [];
+  candidates.forEach(candidate => {
+    if (!candidate) return;
+    if (Array.isArray(candidate)) {
+      candidate.forEach(item => {
+        const formatted = formatMaybeString(item);
+        if (formatted) values.push(formatted);
+      });
+      return;
+    }
+    const formatted = formatMaybeString(candidate);
+    if (formatted) values.push(formatted);
+  });
+  return values;
+}
+
+function collectAmounts(...candidates: unknown[]): string[] {
+  const values: string[] = [];
+  candidates.forEach(candidate => {
+    if (!candidate) return;
+    if (Array.isArray(candidate)) {
+      candidate.forEach(item => {
+        const formatted = formatAmountCandidate(item);
+        if (formatted) values.push(formatted);
+      });
+      return;
+    }
+    const formatted = formatAmountCandidate(candidate);
+    if (formatted) values.push(formatted);
+  });
+  return values;
+}
+
+function formatMaybeString(value: unknown): string | null {
+  if (!value) return null;
+  if (typeof value === "string") return value;
+  if (typeof value === "number") return String(value);
+  if (typeof value === "object") {
+    const obj = value as Record<string, any>;
+    if (typeof obj.label === "string") return obj.label;
+    if (typeof obj.name === "string") return obj.name;
+    if (typeof obj.period === "string") return obj.period;
+    if (typeof obj.period_id === "string") return obj.period_id;
+  }
+  return null;
+}
+
+function parsePeriodKey(value: unknown): number | null {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const ts = Date.parse(trimmed);
+  if (!Number.isNaN(ts)) return ts;
+  const compact = trimmed.replace(/[^0-9]/g, "");
+  if (compact.length >= 6) {
+    const year = Number(compact.slice(0, 4));
+    const month = Number(compact.slice(4, 6));
+    if (!Number.isNaN(year) && !Number.isNaN(month)) {
+      return Date.UTC(year, Math.max(0, month - 1));
+    }
+  }
+  return null;
+}
+
+function parseDateValue(value: unknown): number | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.getTime();
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const ts = Date.parse(trimmed);
+    return Number.isNaN(ts) ? null : ts;
+  }
+  return null;
+}
+
+function formatCurrency(value: number): string {
+  if (!Number.isFinite(value)) return "";
+  const formatter = new Intl.NumberFormat("en-AU", { style: "currency", currency: "AUD" });
+  return formatter.format(value);
+}

--- a/src/ui/query.tsx
+++ b/src/ui/query.tsx
@@ -1,0 +1,5 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+const qc = new QueryClient();
+export const WithQuery = ({ children }:{ children: React.ReactNode }) =>
+  <QueryClientProvider client={qc}>{children}</QueryClientProvider>;


### PR DESCRIPTION
## Summary
- add a react-query provider and API client wrapper for fetching compliance data
- load dashboard cards from live queries with loading and error states
- refactor the BAS page to consume API responses using shared compliance utilities

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e30280c2608327873475d9e4d3b3fd