### PR TITLE
Adjust API routing and default payments base URL

### DIFF
--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -7,7 +7,7 @@ export type ReleaseArgs = Common & { amountCents: number };   // < 0
 const BASE =
   process.env.NEXT_PUBLIC_PAYMENTS_BASE_URL ||
   process.env.PAYMENTS_BASE_URL ||
-  "http://localhost:3001";
+  "http://localhost:8080/api/payments";
 
 async function handle(res: Response) {
   const text = await res.text();


### PR DESCRIPTION
## Summary
- wrap the API routes in a router so /api mounts first and emit the configured base path at startup
- keep payments proxy endpoints ahead of the legacy API router to avoid shadowing
- update the shared payments client to honor NEXT_PUBLIC_PAYMENTS_BASE_URL and fall back to the new gateway URL

## Testing
- npm run lint
- npx tsx apps/services/payments/src/index.ts *(fails: missing local key material for rpt gate)*

------
https://chatgpt.com/codex/tasks/task_e_68e305317b448327a91c67eb133f83fc