### PR TITLE
Compute closing artifacts before issuing RPT

### DIFF
--- a/src/crypto/ed25519.ts
+++ b/src/crypto/ed25519.ts
@@ -5,6 +5,7 @@ export interface RptPayload {
   amount_cents: number; merkle_root: string; running_balance_hash: string;
   anomaly_vector: Record<string, number>; thresholds: Record<string, number>;
   rail_id: "EFT"|"BPAY"|"PayTo"; reference: string; expiry_ts: string; nonce: string;
+  rates_version?: string;
 }
 
 export function signRpt(payload: RptPayload, secretKey: Uint8Array): string {

--- a/src/crypto/merkle.ts
+++ b/src/crypto/merkle.ts
@@ -1,6 +1,6 @@
-﻿import { createHash } from "crypto";
+import { createHash } from "crypto";
 
-export function sha256Hex(input: Buffer | string) {
+export function sha256Hex(input: Buffer | string): string {
   const h = createHash("sha256");
   h.update(input);
   return h.digest("hex");
@@ -8,7 +8,7 @@ export function sha256Hex(input: Buffer | string) {
 
 export function merkleRootHex(leaves: string[]): string {
   if (leaves.length === 0) return sha256Hex("");
-  let level = leaves.map(x => sha256Hex(x));
+  let level = leaves.map((x) => sha256Hex(x));
   while (level.length > 1) {
     const next: string[] = [];
     for (let i = 0; i < level.length; i += 2) {
@@ -19,4 +19,8 @@ export function merkleRootHex(leaves: string[]): string {
     level = next;
   }
   return level[0];
+}
+
+export function buildMerkleRoot(payloads: string[]): string {
+  return merkleRootHex(payloads);
 }

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,10 @@
+import { Pool } from "pg";
+
+let pool: Pool | null = null;
+
+export function getPool(): Pool {
+  if (!pool) {
+    pool = new Pool();
+  }
+  return pool;
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,11 +1,27 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { getPool } from "../db/pool";
+
+const pool = getPool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const p = (
+    await pool.query(
+      "select * from periods where abn= and tax_type= and period_id=",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
+  const last = deltas[deltas.length - 1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
     rpt_payload: rpt?.payload ?? null,
@@ -13,7 +29,30 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [] // TODO: populate from recon diffs
   };
   return bundle;
+}
+
+export function buildEvidenceDetails(
+  labels: Record<string, unknown>,
+  expectedCents: number,
+  actualCents: number,
+  anomalyHash: string,
+  merkleRoot: string
+) {
+  const deltaCents = actualCents - expectedCents;
+  return {
+    merkle_root: merkleRoot,
+    running_balance_hash: anomalyHash,
+    labels,
+    discrepancies: [
+      {
+        label: "expected_vs_actual",
+        expected_cents: expectedCents,
+        actual_cents: actualCents,
+        delta_cents: deltaCents
+      }
+    ]
+  };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,24 +1,173 @@
-﻿import { issueRPT } from "../rpt/issuer";
-import { buildEvidenceBundle } from "../evidence/bundle";
+import { issueRPT } from "../rpt/issuer";
+import { buildEvidenceBundle, buildEvidenceDetails } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { buildMerkleRoot, sha256Hex } from "../crypto/merkle";
+import { getPool } from "../db/pool";
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+const pool = getPool();
+
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2
+};
+
+export async function closeAndIssue(req: any, res: any) {
+  const { abn, taxType, periodId } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_PARAMS" });
+  }
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...(req.body?.thresholds || {}) };
+
+  const client = await pool.connect();
   try {
-    const rpt = await issueRPT(abn, taxType, periodId, thr);
+    await client.query("BEGIN");
+    const periodRes = await client.query(
+      "select * from periods where abn=$1 and tax_type=$2 and period_id=$3 for update",
+      [abn, taxType, periodId]
+    );
+    if (periodRes.rowCount === 0) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+    const period = periodRes.rows[0];
+
+    const ledgerRes = await client.query(
+      "select id, amount_cents from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    );
+    const ledgerEntries = ledgerRes.rows.map((row: any) => {
+      const amt = Number(row.amount_cents) || 0;
+      return {
+        id: row.id,
+        amount_cents: amt,
+        direction: amt >= 0 ? "CREDIT" : "DEBIT"
+      };
+    });
+
+    const creditTotal = ledgerEntries
+      .filter((entry) => entry.amount_cents > 0)
+      .reduce((acc, entry) => acc + entry.amount_cents, 0);
+    const debitTotal = ledgerEntries
+      .filter((entry) => entry.amount_cents < 0)
+      .reduce((acc, entry) => acc + Math.abs(entry.amount_cents), 0);
+    const runningBalanceCents = creditTotal - debitTotal;
+    const expectedScheduleCents = Number(period.accrued_cents ?? 0);
+    const finalLiabilityCents = expectedScheduleCents - creditTotal;
+    const creditedToOwaCents = creditTotal;
+
+    const merklePayloads = ledgerEntries.map((entry) =>
+      JSON.stringify({
+        id: entry.id,
+        amount_cents: entry.amount_cents,
+        direction: entry.direction
+      })
+    );
+    const merkleRoot = buildMerkleRoot(merklePayloads);
+    let runningBalanceHash = "";
+    if (ledgerEntries.length === 0) {
+      runningBalanceHash = sha256Hex("");
+    } else {
+      for (const entry of ledgerEntries) {
+        const payload = JSON.stringify({
+          id: entry.id,
+          delta_cents: entry.amount_cents,
+          direction: entry.direction
+        });
+        runningBalanceHash = sha256Hex((runningBalanceHash || "") + payload);
+      }
+    }
+
+    const mergedThresholds = {
+      ...(period.thresholds || {}),
+      ...thresholds
+    };
+
+    const updateVals = [
+      runningBalanceHash,
+      finalLiabilityCents,
+      creditedToOwaCents,
+      merkleRoot,
+      JSON.stringify(mergedThresholds),
+      period.id
+    ];
+
+    try {
+      await client.query(
+        "update periods set state='CLOSING', hash_head=$1, running_balance_hash=$1, final_liability_cents=$2, credited_to_owa_cents=$3, merkle_root=$4, thresholds=$5::jsonb where id=$6",
+        updateVals
+      );
+    } catch (err: any) {
+      if (err?.message && /column \"hash_head\"/i.test(err.message)) {
+        await client.query(
+          "update periods set state='CLOSING', running_balance_hash=$1, final_liability_cents=$2, credited_to_owa_cents=$3, merkle_root=$4, thresholds=$5::jsonb where id=$6",
+          updateVals
+        );
+      } else {
+        throw err;
+      }
+    }
+
+    const evidenceLabels = {
+      total_entries: ledgerEntries.length,
+      credited_to_owa_cents: creditedToOwaCents,
+      debit_total_cents: debitTotal,
+      running_balance_cents: runningBalanceCents,
+      expected_schedule_cents: expectedScheduleCents,
+      final_liability_cents: finalLiabilityCents
+    };
+
+    const expectedCents = finalLiabilityCents;
+    const actualCents = runningBalanceCents;
+    const deltaCents = actualCents - expectedCents;
+    const toleranceBps = Math.round((thresholds.delta_vs_baseline ?? 0) * 10000);
+
+    const details = buildEvidenceDetails(
+      evidenceLabels,
+      expectedCents,
+      actualCents,
+      runningBalanceHash,
+      merkleRoot
+    );
+
+    await client.query(
+      `insert into evidence_bundles(abn,tax_type,period_id,delta_cents,tolerance_bps,details)
+       values ($1,$2,$3,$4,$5,$6::jsonb)
+       on conflict (abn,tax_type,period_id) do update set
+         delta_cents=excluded.delta_cents,
+         tolerance_bps=excluded.tolerance_bps,
+         details=excluded.details`,
+      [abn, taxType, periodId, deltaCents, toleranceBps, JSON.stringify(details)]
+    );
+
+    const rpt = await issueRPT(client, {
+      abn,
+      taxType,
+      periodId,
+      head: runningBalanceHash,
+      ratesVersion: process.env.RATES_VERSION || "prototype",
+      thresholds: mergedThresholds
+    });
+
+    await client.query("COMMIT");
     return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (rollbackErr) {
+      // ignore rollback errors so the original failure is surfaced
+    }
+    const status = e?.message === "PERIOD_NOT_FOUND" ? 404 : 400;
+    return res.status(status).json({ error: e?.message || String(e) });
+  } finally {
+    client.release();
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
   const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,65 @@
-﻿import { Pool } from "pg";
+import { PoolClient } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
+
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-  if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
-  const row = p.rows[0];
+export type IssueRptParams = {
+  abn: string;
+  taxType: "PAYGW" | "GST";
+  periodId: string;
+  head: string;
+  ratesVersion: string;
+  thresholds?: Record<string, number>;
+};
+
+export async function issueRPT(client: PoolClient, params: IssueRptParams) {
+  const { abn, taxType, periodId, head, ratesVersion } = params;
+  const periodQuery = await client.query(
+    "select * from periods where abn=$1 and tax_type=$2 and period_id=$3 for update",
+    [abn, taxType, periodId]
+  );
+  if (periodQuery.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
+  const row = periodQuery.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+  const persistedThresholds = row.thresholds || {};
+  const thresholds = { ...persistedThresholds, ...(params.thresholds || {}) } as Record<string, number>;
+  const anomalyVector = row.anomaly_vector || {};
+
+  if (exceeds(anomalyVector, thresholds)) {
+    await client.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
-  if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+  const epsilonLimit = thresholds["epsilon_cents"] ?? 0;
+  if (epsilon > epsilonLimit) {
+    await client.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: head || row.running_balance_hash,
+    anomaly_vector: anomalyVector,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
+    rates_version: ratesVersion
   };
+
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  await client.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await client.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }


### PR DESCRIPTION
## Summary
- compute ledger aggregates, merkle roots, and running hashes before issuing RPTs
- persist evidence bundle deltas and structured details for close-and-issue requests
- update RPT issuance to run inside the transaction and share the connection pool helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3052278f08327a1d20cb8a0c02c8c