### PR TITLE
Add persisted evidence bundle details for auditor view

### DIFF
--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,203 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
 const pool = new Pool();
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+let ensureEvidenceTablePromise: Promise<void> | null = null;
+
+async function ensureEvidenceTable() {
+  if (!ensureEvidenceTablePromise) {
+    ensureEvidenceTablePromise = (async () => {
+      await pool.query(`
+        CREATE TABLE IF NOT EXISTS evidence_bundles (
+          id BIGSERIAL PRIMARY KEY,
+          abn TEXT NOT NULL,
+          tax_type TEXT NOT NULL,
+          period_id TEXT NOT NULL,
+          details JSONB NOT NULL,
+          created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+      `);
+      await pool.query(`
+        CREATE UNIQUE INDEX IF NOT EXISTS ux_evidence_bundles_period
+          ON evidence_bundles (abn, tax_type, period_id)
+      `);
+    })().catch((err) => {
+      ensureEvidenceTablePromise = null;
+      throw err;
+    });
+  }
+  return ensureEvidenceTablePromise;
+}
+
+function normaliseNumber(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function fetchLatestSettlement(abn: string, taxType: string, periodId: string) {
+  const candidateTables = ["settlements", "settlement_batches", "settlement_records"];
+  for (const table of candidateTables) {
+    const reg = await pool.query("SELECT to_regclass($1) AS reg", [`public.${table}`]);
+    if (!reg.rows[0]?.reg) continue;
+    try {
+      const res = await pool.query(
+        `SELECT row_to_json(s.*) AS data FROM ${table} s WHERE s.abn=$1 AND s.tax_type=$2 AND s.period_id=$3 ORDER BY s.created_at DESC LIMIT 1`,
+        [abn, taxType, periodId]
+      );
+      if (res.rows[0]?.data) return res.rows[0].data;
+    } catch (err) {
+      const res = await pool.query(
+        `SELECT row_to_json(s.*) AS data FROM ${table} s WHERE s.abn=$1 AND s.tax_type=$2 AND s.period_id=$3 LIMIT 1`,
+        [abn, taxType, periodId]
+      );
+      if (res.rows[0]?.data) return res.rows[0].data;
+    }
+  }
+  return null;
+}
+
+export interface EvidenceBundleDetails {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  generatedAt: string;
+  labels: string[];
+  expectedCents: number | null;
+  actualCents: number | null;
+  deltaCents: number | null;
+  toleranceBps: number | null;
+  merkle_root: string | null;
+  running_balance_hash: string | null;
+  thresholds: any;
+  anomaly_vector: any;
+  rpt: {
+    payload: unknown;
+    signature: string;
+    created_at: string | null;
+  } | null;
+  owa_ledger: Array<{
+    ts: string | null;
+    amount_cents: number | null;
+    hash_after: string | null;
+    bank_receipt_hash: string | null;
+  }>;
+  settlement: unknown;
+}
+
+export interface EvidenceBundleResult {
+  id: number | null;
+  details: EvidenceBundleDetails;
+}
+
+export async function buildEvidenceBundle(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  labels: string[] = [],
+  expectedCents?: number,
+  actualCents?: number
+): Promise<EvidenceBundleResult> {
+  if (!abn || !taxType || !periodId) {
+    throw new Error("MISSING_IDENTIFIERS");
+  }
+
+  const periodQ = await pool.query(
+    "SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents, merkle_root, running_balance_hash, anomaly_vector, thresholds FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
+  const period = periodQ.rows[0];
+  if (!period) {
+    throw new Error("PERIOD_NOT_FOUND");
+  }
+
+  const rptQ = await pool.query(
+    "SELECT payload, signature, created_at FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY created_at DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
+  const rptRow = rptQ.rows[0];
+  const rpt = rptRow
+    ? {
+        payload: rptRow.payload,
+        signature: rptRow.signature,
+        created_at: rptRow.created_at instanceof Date ? rptRow.created_at.toISOString() : rptRow.created_at ?? null,
+      }
+    : null;
+
+  const ledgerQ = await pool.query(
+    "SELECT created_at AS ts, amount_cents, hash_after, bank_receipt_hash FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id",
+    [abn, taxType, periodId]
+  );
+  const ledger = ledgerQ.rows.map((row) => ({
+    ts: row.ts instanceof Date ? row.ts.toISOString() : row.ts ?? null,
+    amount_cents: normaliseNumber(row.amount_cents),
+    hash_after: row.hash_after ?? null,
+    bank_receipt_hash: row.bank_receipt_hash ?? null,
+  }));
+
+  const settlement = await fetchLatestSettlement(abn, taxType, periodId);
+
+  const expected = expectedCents ?? normaliseNumber(period.final_liability_cents);
+  const actual = actualCents ?? normaliseNumber(period.credited_to_owa_cents);
+  const delta = expected != null && actual != null ? actual - expected : null;
+
+  const thresholds = period.thresholds ?? {};
+  let toleranceBps: number | null = null;
+  const toleranceCandidates = [
+    thresholds?.tolerance_bps,
+    typeof thresholds?.variance_ratio === "number" ? thresholds.variance_ratio * 10000 : null,
+    typeof thresholds?.delta_vs_baseline === "number" ? thresholds.delta_vs_baseline * 10000 : null,
+  ];
+  for (const candidate of toleranceCandidates) {
+    let n = normaliseNumber(candidate);
+    if (n === null) continue;
+    if (Math.abs(n) <= 1) {
+      n = Math.round(n * 10000);
+    } else {
+      n = Math.round(n);
+    }
+    toleranceBps = n;
+    break;
+  }
+
+  const details: EvidenceBundleDetails = {
+    abn,
+    taxType,
+    periodId,
+    generatedAt: new Date().toISOString(),
+    labels,
+    expectedCents: expected,
+    actualCents: actual,
+    deltaCents: delta,
+    toleranceBps,
+    merkle_root: period.merkle_root ?? null,
+    running_balance_hash: period.running_balance_hash ?? null,
+    thresholds,
+    anomaly_vector: period.anomaly_vector ?? null,
+    rpt,
+    owa_ledger: ledger,
+    settlement,
   };
-  return bundle;
+
+  await ensureEvidenceTable();
+
+  const insert = await pool.query(
+    `INSERT INTO evidence_bundles (abn, tax_type, period_id, details, updated_at)
+     VALUES ($1,$2,$3,$4::jsonb, NOW())
+     ON CONFLICT (abn, tax_type, period_id) DO UPDATE
+       SET details = EXCLUDED.details,
+           updated_at = NOW()
+     RETURNING *`,
+    [abn, taxType, periodId, JSON.stringify(details)]
+  );
+
+  const row = insert.rows[0] ?? {};
+  const storedDetails =
+    typeof row.details === "string"
+      ? (JSON.parse(row.details) as EvidenceBundleDetails)
+      : (row.details as EvidenceBundleDetails) ?? details;
+  const insertedId = (row as { id?: number; bundle_id?: number }).id ?? (row as { bundle_id?: number }).bundle_id ?? null;
+
+  return { id: insertedId, details: storedDetails };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,7 @@ app.post("/api/pay", idempotency(), payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+app.get("/api/v1/evidence/:abn/:pid", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,123 @@
-﻿import { issueRPT } from "../rpt/issuer";
-import { buildEvidenceBundle } from "../evidence/bundle";
-import { releasePayment, resolveDestination } from "../rails/adapter";
-import { debit as paytoDebit } from "../payto/adapter";
-import { parseSettlementCSV } from "../settlement/splitParser";
+import type { Request, Response } from "express";
 import { Pool } from "pg";
+
+import { buildEvidenceBundle } from "../evidence/bundle";
+import { debit as paytoDebit } from "../payto/adapter";
+import { releasePayment, resolveDestination } from "../rails/adapter";
+import { issueRPT } from "../rpt/issuer";
+import { parseSettlementCSV } from "../settlement/splitParser";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
+export async function closeAndIssue(req: Request, res: Response) {
+  const { abn, taxType, periodId, thresholds } = (req.body ?? {}) as {
+    abn?: string;
+    taxType?: string;
+    periodId?: string;
+    thresholds?: Record<string, unknown>;
+  };
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_IDENTIFIERS" });
+  }
+
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message ?? "FAILED_TO_ISSUE_RPT" });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: Request, res: Response) {
+  const { abn, taxType, periodId, rail } = (req.body ?? {}) as {
+    abn?: string;
+    taxType?: string;
+    periodId?: string;
+    rail?: string;
+  }; // EFT|BPAY
+  if (!abn || !taxType || !periodId || !rail) {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query("update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message ?? "FAILED_TO_RELEASE" });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
-  const { abn, amount_cents, reference } = req.body;
+export async function paytoSweep(req: Request, res: Response) {
+  const { abn, amount_cents, reference } = (req.body ?? {}) as {
+    abn?: string;
+    amount_cents?: number;
+    reference?: string;
+  };
+  if (!abn || typeof amount_cents !== "number" || !reference) {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
+export async function settlementWebhook(req: Request, res: Response) {
+  const csvText = (req.body as { csv?: string } | undefined)?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+function parseLabels(value: unknown): string[] {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value
+      .flatMap((item) => String(item).split(","))
+      .map((v) => v.trim())
+      .filter((v) => v.length > 0);
+  }
+  return String(value)
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
+
+function parseNumberParam(value: unknown): number | undefined {
+  if (value === null || value === undefined || value === "") return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+export async function evidence(req: Request, res: Response) {
+  const { abn, pid } = req.params as { abn?: string; pid?: string };
+  if (!abn || !pid) {
+    return res.status(400).json({ error: "MISSING_IDENTIFIERS" });
+  }
+
+  const taxTypeParam = req.query.taxType;
+  const taxType = typeof taxTypeParam === "string" && taxTypeParam.length > 0 ? taxTypeParam.toUpperCase() : "GST";
+  const labels = parseLabels(req.query.labels);
+  const expected = parseNumberParam(req.query.expectedCents);
+  const actual = parseNumberParam(req.query.actualCents);
+
+  try {
+    const bundle = await buildEvidenceBundle(abn, taxType, pid, labels, expected, actual);
+    return res.json(bundle.details);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "UNKNOWN_ERROR";
+    if (message === "PERIOD_NOT_FOUND") return res.status(404).json({ error: message });
+    if (message === "MISSING_IDENTIFIERS") return res.status(400).json({ error: message });
+    console.error("[evidence]", err);
+    return res.status(500).json({ error: "FAILED_TO_BUILD_EVIDENCE" });
+  }
 }


### PR DESCRIPTION
## Summary
- persist evidence bundles in Postgres with computed deltas, tolerance, period hashes, and optional settlement information
- expose `/api/v1/evidence/:abn/:pid` that parses request parameters and returns the stored evidence details
- update evidence builder to create the backing table when missing and reuse it for repeated requests

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3054efcd88327bf6a74f6c889e3d6