### PR TITLE
Add auditor and operator runbooks

### DIFF
--- a/docs/Auditor.md
+++ b/docs/Auditor.md
@@ -1,0 +1,68 @@
+# Auditor Runbook
+
+This runbook describes how to validate Revenue Processing Transactions (RPT) that were
+produced by APGMS before they are delivered to downstream systems. It assumes that the
+operator has read-only access to the release artifacts and audit database.
+
+## 1. Inputs
+
+* **Release manifest** – JSON document emitted by `verify_rpt.js` that lists each batch and
+  associated ledger hash.
+* **Rates catalog** – The rates bundle identified by `rates_version` in the release manifest.
+* **Ledger snapshots** – Immutable hash exports written to `scan_api_out/ledger/*.json`.
+
+## 2. RPT Verification Checklist
+
+1. **Confirm manifest integrity**
+   * Validate the manifest checksum using the provided `.sha256` file.
+   * Confirm that the manifest build timestamp aligns with the expected deployment window.
+2. **Reconcile batch counts**
+   * Count the RPT rows in the staging schema and ensure the total matches the `batch_total`
+     declared in the manifest.
+   * Spot check at least one batch per tax category (PAYGW, GST) and confirm the
+     calculated withholding amounts match the manifest payload.
+3. **Cross-check submission metadata**
+   * Verify that the `submission_id` is unique for this release window.
+   * Ensure that the manifest flags (`seed`, `smoke`, `dryRun`) reflect the intended mode of
+     operation for the release.
+
+## 3. Validating `rates_version`
+
+1. Retrieve the `rates_version` string from the manifest header.
+2. Locate the matching rates bundle under `libs/rates/<rates_version>/`.
+3. Validate the bundle signature:
+   * Compare the bundle hash recorded in the manifest with the `rates.bundle.sha256` file in
+     the bundle directory.
+   * Inspect the effective date range to ensure it covers the reporting period.
+4. Perform targeted rate sampling:
+   * Choose at least one PAYGW bracket and one GST rate.
+   * Recompute the expected withholding using the published formulae and compare the
+     results to the audited RPT rows.
+
+If any of the above steps fail, reject the release and notify the operations team to re-run the
+release pipeline with a corrected rates bundle.
+
+## 4. Ledger Hash Consistency
+
+1. Extract the ledger hash map from `ledger_hashes.json` in the release bundle.
+2. For each ledger namespace:
+   * Load the corresponding snapshot from `scan_api_out/ledger/<namespace>.json`.
+   * Recompute the SHA-256 hash of the snapshot file.
+   * Compare the computed hash with the manifest entry.
+3. If a mismatch is found:
+   * Confirm that the snapshot file was not modified after the manifest was signed.
+   * Request a new release bundle; do **not** accept manual edits.
+
+When all ledger hashes match, record the verification in the audit log with the timestamp,
+operator ID, manifest checksum, and hash summary.
+
+## 5. Sign-off
+
+After completing the verification steps:
+
+1. Complete the release checklist in the audit portal.
+2. Upload the signed verification report referencing the manifest checksum and
+   `rates_version`.
+3. Transition the release state to **Approved**.
+
+Any deviations should be logged with remediation steps before approval.

--- a/docs/Operator.md
+++ b/docs/Operator.md
@@ -1,0 +1,99 @@
+# Operator Runbook
+
+This guide walks a new operator through the end-to-end APGMS release flow for both the
+prototype stack and the production ("real") environment. Follow the steps sequentially and
+record all actions in the operations log.
+
+## 1. Configuration Matrix
+
+| Mode      | Stack Alias | Flags                            | Data Sources               | Release Targets           |
+|-----------|-------------|----------------------------------|----------------------------|---------------------------|
+| Prototype | `proto`     | `SEED=1`, `SMOKE=1`, `DRY_RUN=1` | Synthetic PAYGW & GST data | Non-authoritative sandbox |
+| Real      | `prod`      | `SEED=0`, `SMOKE=0`, `DRY_RUN=0` | Authoritative customer data | Revenue authority gateway |
+
+**Tip:** The `STACK` environment variable must be set to either `proto` or `prod` before
+invoking any automation scripts. The helper `scripts/select_stack.sh` can be used to export
+the correct values in your session.
+
+## 2. Common Prerequisites
+
+1. Authenticate to the infrastructure:
+   * `aws sso login --profile apgms-<stack>` (prototype uses `apgms-proto`, production uses
+     `apgms-prod`).
+2. Pull the latest rates catalog: `make pull-rates STACK=$STACK`.
+3. Ensure Docker services are healthy: `docker compose --profile $STACK ps`.
+
+Only proceed when all services report `Up` status.
+
+## 3. Prototype (Seed/Smoke) Flow
+
+Prototype runs validate new changes using synthetic data and **must** be executed for every
+feature branch before requesting production access.
+
+1. **Seed the dataset**
+   * Run `make seed STACK=proto` to populate the sandbox ledger.
+   * Verify the seed results via `scripts/check_seed.sh proto`.
+2. **Execute smoke tests**
+   * Launch the smoke harness: `make smoke STACK=proto`.
+   * Review the output; the job should complete with `summary.status = "pass"`.
+3. **Dry run release**
+   * Invoke `node verify_rpt.js --stack proto --dry-run`.
+   * Confirm that the manifest flags include `"dryRun": true` and that no publish task is
+     queued.
+4. **Audit handoff**
+   * Package artifacts: `make package STACK=proto`.
+   * Upload the bundle to the shared prototype bucket for auditor review.
+
+If any step fails, re-run after remediation. Prototype artifacts must never be pushed to the
+revenue authority gateway.
+
+## 4. Production Flow
+
+Production runs operate on live customer data and result in submissions to the revenue
+authority.
+
+1. **Pre-flight checks**
+   * Confirm that the latest prototype run has been approved by the audit team.
+   * Set release window flag: `export RELEASE_WINDOW=$(date +%Y%m%d%H%M)`.
+2. **Disable seed/smoke flags**
+   * Ensure environment variables `SEED`, `SMOKE`, and `DRY_RUN` are unset or set to `0`.
+   * Double-check the `.env.prod` file to prevent accidental overrides.
+3. **Generate RPT bundle**
+   * Run `node verify_rpt.js --stack prod`.
+   * Review the manifest; `"dryRun"` must be `false` and `rates_version` should match the
+     auditor-approved bundle.
+4. **Ledger snapshot confirmation**
+   * Execute `make ledger-snapshot STACK=prod` and verify the resulting hash summary.
+5. **Submit to gateway**
+   * Trigger the submission: `make release STACK=prod`.
+   * Monitor the job queue until the gateway acknowledgement is received.
+6. **Post-release validation**
+   * Run `scripts/check_release.sh prod` to confirm job completion.
+   * Notify the audit team that the bundle is ready for final checks.
+
+## 5. DRY_RUN Semantics
+
+* When `DRY_RUN=1`, no data is persisted to the gateway; the manifest is generated for
+  inspection only.
+* Dry runs are required for prototype, optional (but recommended) before production
+  releases.
+* Never combine `DRY_RUN=1` with `STACK=prod` unless performing a sanctioned rehearsal.
+
+## 6. Rollback Procedure
+
+1. Identify the last known good release from the audit portal.
+2. Set `ROLLBACK_TARGET=<manifest_checksum>` in the environment.
+3. Run `make rollback STACK=prod TARGET=$ROLLBACK_TARGET`.
+4. Confirm that the ledger has been restored by running `scripts/check_ledger.sh prod`.
+5. Notify stakeholders and log the rollback in the incident tracker.
+
+Rollbacks must be accompanied by a dry run of the next corrective release before re-opening
+the deployment window.
+
+## 7. Handover to Auditors
+
+Upon completion of either flow:
+
+1. Upload the manifest and ledger hashes to the audit bucket.
+2. Provide the `rates_version` and release notes in the ticket comment.
+3. Await auditor confirmation before closing the operations ticket.


### PR DESCRIPTION
## Summary
- add an auditor runbook covering RPT verification, `rates_version` validation, and ledger hash checks
- document operator flows for prototype and production stacks with configuration matrix, environment flags, dry-run semantics, and rollback guidance

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e3097a656c8327a1b42ae515bf9326