### PR TITLE
Add KMS integration for RPT signing and validation

### DIFF
--- a/src/crypto/ed25519.ts
+++ b/src/crypto/ed25519.ts
@@ -1,23 +1,53 @@
-﻿import nacl from "tweetnacl";
+import nacl from "tweetnacl";
 
 export interface RptPayload {
-  entity_id: string; period_id: string; tax_type: "PAYGW"|"GST";
-  amount_cents: number; merkle_root: string; running_balance_hash: string;
-  anomaly_vector: Record<string, number>; thresholds: Record<string, number>;
-  rail_id: "EFT"|"BPAY"|"PayTo"; reference: string; expiry_ts: string; nonce: string;
+  entity_id: string;
+  period_id: string;
+  tax_type: "PAYGW" | "GST";
+  amount_cents: number;
+  merkle_root: string;
+  running_balance_hash: string;
+  anomaly_vector: Record<string, number>;
+  thresholds: Record<string, number>;
+  rail_id: "EFT" | "BPAY" | "PayTo";
+  reference: string;
+  expiry_ts: string;
+  nonce: string;
+  rates_version: string;
+}
+
+const encoder = new TextEncoder();
+
+export function canonicalizeRptPayload(payload: RptPayload): string {
+  return JSON.stringify(payload);
+}
+
+export function encodeRptPayload(payload: RptPayload): Uint8Array {
+  return encoder.encode(canonicalizeRptPayload(payload));
+}
+
+export function signDetached(message: Uint8Array, secretKey: Uint8Array): Uint8Array {
+  return nacl.sign.detached(message, secretKey);
+}
+
+export function verifyDetached(message: Uint8Array, signature: Uint8Array, publicKey: Uint8Array): boolean {
+  return nacl.sign.detached.verify(message, signature, publicKey);
 }
 
 export function signRpt(payload: RptPayload, secretKey: Uint8Array): string {
-  const msg = new TextEncoder().encode(JSON.stringify(payload));
-  const sig = nacl.sign.detached(msg, secretKey);
+  const sig = signDetached(encodeRptPayload(payload), secretKey);
   return Buffer.from(sig).toString("base64url");
 }
 
 export function verifyRpt(payload: RptPayload, signatureB64: string, publicKey: Uint8Array): boolean {
-  const msg = new TextEncoder().encode(JSON.stringify(payload));
   const sig = Buffer.from(signatureB64, "base64url");
-  return nacl.sign.detached.verify(msg, sig, publicKey);
+  return verifyDetached(encodeRptPayload(payload), sig, publicKey);
 }
 
-export function nowIso(): string { return new Date().toISOString(); }
-export function isExpired(iso: string): boolean { return Date.now() > Date.parse(iso); }
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function isExpired(iso: string): boolean {
+  return Date.now() > Date.parse(iso);
+}

--- a/src/crypto/kms.ts
+++ b/src/crypto/kms.ts
@@ -1,0 +1,213 @@
+import crypto from "crypto";
+import nacl from "tweetnacl";
+import {
+  RptPayload,
+  canonicalizeRptPayload,
+  encodeRptPayload,
+  signDetached,
+  verifyDetached,
+} from "./ed25519";
+
+export interface KmsProvider {
+  sign(message: Uint8Array): Promise<string>;
+  verify(message: Uint8Array, signature: string): Promise<boolean>;
+}
+
+function getEnv(name: string, fallback = ""): string {
+  return process.env[name] ?? fallback;
+}
+
+class LocalKmsProvider implements KmsProvider {
+  private readonly secretKey: Uint8Array;
+  private readonly publicKey?: Uint8Array;
+
+  constructor() {
+    const secretB64 = getEnv("RPT_ED25519_SECRET_BASE64");
+    if (!secretB64) {
+      throw new Error("RPT_ED25519_SECRET_BASE64 is required for local KMS");
+    }
+    this.secretKey = new Uint8Array(Buffer.from(secretB64, "base64"));
+
+    const publicB64 = getEnv("RPT_ED25519_PUBLIC_BASE64");
+    if (publicB64) {
+      this.publicKey = new Uint8Array(Buffer.from(publicB64, "base64"));
+    } else if (this.secretKey.length === 64) {
+      const { publicKey } = nacl.sign.keyPair.fromSecretKey(this.secretKey);
+      this.publicKey = publicKey;
+    }
+  }
+
+  async sign(message: Uint8Array): Promise<string> {
+    const sig = signDetached(message, this.secretKey);
+    return Buffer.from(sig).toString("base64url");
+  }
+
+  async verify(message: Uint8Array, signature: string): Promise<boolean> {
+    if (!this.publicKey) {
+      throw new Error("RPT_ED25519_PUBLIC_BASE64 is required to verify locally");
+    }
+    const sig = Buffer.from(signature, "base64url");
+    return verifyDetached(message, sig, this.publicKey);
+  }
+}
+
+class AwsKmsProvider implements KmsProvider {
+  private readonly keyId: string;
+  private readonly signingAlgorithm: string;
+  private clientPromise?: Promise<any>;
+
+  constructor() {
+    this.keyId = getEnv("AWS_KMS_KEY_ID");
+    if (!this.keyId) {
+      throw new Error("AWS_KMS_KEY_ID must be configured when FEATURE_KMS=aws");
+    }
+    this.signingAlgorithm = getEnv("AWS_KMS_SIGNING_ALGORITHM", "EDDSA");
+  }
+
+  private async getModule() {
+    try {
+      return await import("@aws-sdk/client-kms");
+    } catch (err) {
+      const error = new Error("@aws-sdk/client-kms is required when FEATURE_KMS=aws");
+      (error as any).cause = err;
+      throw error;
+    }
+  }
+
+  private async getClient() {
+    if (!this.clientPromise) {
+      this.clientPromise = this.getModule().then(({ KMSClient }) => new KMSClient({}));
+    }
+    return this.clientPromise;
+  }
+
+  async sign(message: Uint8Array): Promise<string> {
+    const [{ SignCommand }, client] = await Promise.all([
+      this.getModule(),
+      this.getClient(),
+    ]);
+    const response = await client.send(
+      new SignCommand({
+        KeyId: this.keyId,
+        Message: message,
+        MessageType: "RAW",
+        SigningAlgorithm: this.signingAlgorithm,
+      }),
+    );
+    if (!response.Signature) {
+      throw new Error("AWS KMS did not return a signature");
+    }
+    return Buffer.from(response.Signature).toString("base64url");
+  }
+
+  async verify(message: Uint8Array, signature: string): Promise<boolean> {
+    const [{ VerifyCommand }, client] = await Promise.all([
+      this.getModule(),
+      this.getClient(),
+    ]);
+    const response = await client.send(
+      new VerifyCommand({
+        KeyId: this.keyId,
+        Message: message,
+        MessageType: "RAW",
+        Signature: Buffer.from(signature, "base64url"),
+        SigningAlgorithm: this.signingAlgorithm,
+      }),
+    );
+    return Boolean(response.SignatureValid);
+  }
+}
+
+class GcpKmsProvider implements KmsProvider {
+  private readonly keyVersionName: string;
+  private clientPromise?: Promise<any>;
+  private publicKeyPromise?: Promise<crypto.KeyObject>;
+
+  constructor() {
+    this.keyVersionName = getEnv("GCP_KMS_KEY_VERSION_NAME");
+    if (!this.keyVersionName) {
+      throw new Error("GCP_KMS_KEY_VERSION_NAME must be configured when FEATURE_KMS=gcp");
+    }
+  }
+
+  private async getModule() {
+    try {
+      return await import("@google-cloud/kms");
+    } catch (err) {
+      const error = new Error("@google-cloud/kms is required when FEATURE_KMS=gcp");
+      (error as any).cause = err;
+      throw error;
+    }
+  }
+
+  private async getClient() {
+    if (!this.clientPromise) {
+      this.clientPromise = this.getModule().then(({ KeyManagementServiceClient }) => new KeyManagementServiceClient());
+    }
+    return this.clientPromise;
+  }
+
+  private async getPublicKey(): Promise<crypto.KeyObject> {
+    if (!this.publicKeyPromise) {
+      this.publicKeyPromise = (async () => {
+        const client = await this.getClient();
+        const [response] = await client.getPublicKey({ name: this.keyVersionName });
+        if (!response?.pem) {
+          throw new Error("GCP KMS public key retrieval failed");
+        }
+        return crypto.createPublicKey(response.pem);
+      })();
+    }
+    return this.publicKeyPromise;
+  }
+
+  async sign(message: Uint8Array): Promise<string> {
+    const client = await this.getClient();
+    const [result] = await client.asymmetricSign({
+      name: this.keyVersionName,
+      data: Buffer.from(message),
+    });
+    const signature = result?.signature;
+    if (!signature) {
+      throw new Error("GCP KMS did not return a signature");
+    }
+    return Buffer.from(signature).toString("base64url");
+  }
+
+  async verify(message: Uint8Array, signature: string): Promise<boolean> {
+    const keyObject = await this.getPublicKey();
+    return crypto.verify(null, Buffer.from(message), keyObject, Buffer.from(signature, "base64url"));
+  }
+}
+
+function selectProvider(): KmsProvider {
+  const mode = getEnv("FEATURE_KMS", "local").toLowerCase();
+  switch (mode) {
+    case "aws":
+      return new AwsKmsProvider();
+    case "gcp":
+      return new GcpKmsProvider();
+    case "local":
+    case "":
+    default:
+      return new LocalKmsProvider();
+  }
+}
+
+const provider = selectProvider();
+
+export function getKmsProvider(): KmsProvider {
+  return provider;
+}
+
+export async function signRpt(payload: RptPayload): Promise<string> {
+  return provider.sign(encodeRptPayload(payload));
+}
+
+export async function verifyRpt(payload: RptPayload, signature: string): Promise<boolean> {
+  return provider.verify(encodeRptPayload(payload), signature);
+}
+
+export function getCanonicalPayload(payload: RptPayload): string {
+  return canonicalizeRptPayload(payload);
+}

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,24 @@ declare module "*.svg" {
   const content: string;
   export default content;
 }
+
+declare module "@aws-sdk/client-kms" {
+  export class KMSClient {
+    constructor(config?: any);
+    send(command: any): Promise<any>;
+  }
+  export class SignCommand {
+    constructor(input: any);
+  }
+  export class VerifyCommand {
+    constructor(input: any);
+  }
+}
+
+declare module "@google-cloud/kms" {
+  export class KeyManagementServiceClient {
+    constructor(config?: any);
+    asymmetricSign(request: any): Promise<any[]>;
+    getPublicKey(request: any): Promise<any[]>;
+  }
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,59 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+import { validateRptPayload } from "../rpt/validator";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+export async function closeAndIssue(req: any, res: any) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(req: any, res: any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
-  const payload = pr.rows[0].payload;
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId],
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
+  const rpt = pr.rows[0];
   try {
-    await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
+    await validateRptPayload(rpt.payload, rpt.signature);
+    await resolveDestination(abn, rail, rpt.payload.reference);
+    const r = await releasePayment(abn, taxType, periodId, rpt.payload.amount_cents, rail, rpt.payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/src/rpt/config.ts
+++ b/src/rpt/config.ts
@@ -1,0 +1,3 @@
+export const FEATURE_ATO_TABLES = /^true$/i.test(process.env.FEATURE_ATO_TABLES ?? "");
+export const RATES_VERSION = process.env.RATES_VERSION ?? "1";
+export const RPT_TTL_SECONDS = Number(process.env.RPT_TTL_SECONDS ?? 15 * 60);

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,12 +1,22 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
-import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+import { RptPayload } from "../crypto/ed25519";
+import { getCanonicalPayload, signRpt as signRptWithKms } from "../crypto/kms";
+import { FEATURE_ATO_TABLES, RATES_VERSION, RPT_TTL_SECONDS } from "./config";
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+const pool = new Pool();
+
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>,
+) {
+  const p = await pool.query(
+    "select * from periods where abn= and tax_type= and period_id=",
+    [abn, taxType, periodId],
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
@@ -22,16 +32,39 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
+  const expiryMs = Date.now() + RPT_TTL_SECONDS * 1000;
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(expiryMs).toISOString(),
+    nonce: crypto.randomUUID(),
+    rates_version: RATES_VERSION,
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
+
+  const signature = await signRptWithKms(payload);
+  const payloadC14n = getCanonicalPayload(payload);
+  const payloadSha256 = crypto.createHash("sha256").update(payloadC14n).digest("hex");
+
+  if (FEATURE_ATO_TABLES) {
+    await pool.query(
+      "insert into rpt_tokens(abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256) values ($1,$2,$3,$4,$5,$6,$7)",
+      [abn, taxType, periodId, payload, signature, payloadC14n, payloadSha256],
+    );
+  } else {
+    await pool.query(
+      "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+      [abn, taxType, periodId, payload, signature],
+    );
+  }
+
   await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
   return { payload, signature };
 }

--- a/src/rpt/validator.ts
+++ b/src/rpt/validator.ts
@@ -1,0 +1,45 @@
+import { RptPayload, isExpired } from "../crypto/ed25519";
+import { verifyRpt as verifyRptSignature } from "../crypto/kms";
+import { FEATURE_ATO_TABLES, RATES_VERSION } from "./config";
+
+export class RptValidationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RptValidationError";
+  }
+}
+
+export async function validateRptPayload(payload: RptPayload, signature: string): Promise<boolean> {
+  if (!FEATURE_ATO_TABLES) {
+    return true;
+  }
+
+  if (!payload) {
+    throw new RptValidationError("MISSING_PAYLOAD");
+  }
+  if (!signature) {
+    throw new RptValidationError("MISSING_SIGNATURE");
+  }
+  if (payload.rates_version !== RATES_VERSION) {
+    throw new RptValidationError("RATES_VERSION_MISMATCH");
+  }
+  if (!payload.nonce) {
+    throw new RptValidationError("MISSING_NONCE");
+  }
+  if (!payload.expiry_ts) {
+    throw new RptValidationError("MISSING_EXPIRY");
+  }
+  if (Number.isNaN(Date.parse(payload.expiry_ts))) {
+    throw new RptValidationError("INVALID_EXPIRY");
+  }
+  if (isExpired(payload.expiry_ts)) {
+    throw new RptValidationError("RPT_EXPIRED");
+  }
+
+  const valid = await verifyRptSignature(payload, signature);
+  if (!valid) {
+    throw new RptValidationError("INVALID_SIGNATURE");
+  }
+
+  return true;
+}


### PR DESCRIPTION
## Summary
- add a configurable KMS abstraction with local, AWS, and GCP providers for RPT signing and verification
- include rates_version, nonce, and expiry metadata in the RPT payload and persist canonical payload hashes when issuing tokens
- introduce validator logic that enforces signature integrity and RATES_VERSION behind FEATURE_ATO_TABLES and invoke it before ATO payouts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e30970a1708327b7db2376af2b0379