### PR TITLE
Harden API security and validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,18 +11,25 @@
     "private": true,
     "packageManager": "pnpm@9",
     "devDependencies": {
+        "@types/cors": "^2.8.18",
         "@types/express": "^5.0.3",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^24.6.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3"
     },
     "dependencies": {
+        "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.4.0",
+        "helmet": "^7.2.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "^3.23.8"
     }
 }

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,98 @@
+import { NextFunction, Request, Response } from "express";
+import jwt, { JwtPayload, JsonWebTokenError, TokenExpiredError } from "jsonwebtoken";
+
+export type Role = "auditor" | "accountant" | "admin";
+
+export interface AuthenticatedUser extends JwtPayload {
+  sub: string;
+  role: Role;
+  email?: string;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: AuthenticatedUser;
+}
+
+interface RequireAuthOptions {
+  roles?: Role[];
+}
+
+const ROLE_ORDER: Role[] = ["auditor", "accountant", "admin"];
+
+const allowedRole = (userRole: Role, required?: Role[]): boolean => {
+  if (!required || required.length === 0) {
+    return true;
+  }
+
+  if (userRole === "admin") {
+    return true;
+  }
+
+  const userRank = ROLE_ORDER.indexOf(userRole);
+  return required.some((role) => {
+    if (role === "admin") {
+      return false;
+    }
+    const requiredRank = ROLE_ORDER.indexOf(role);
+    return requiredRank !== -1 && userRank >= requiredRank;
+  });
+};
+
+function extractBearerToken(header?: string | null): string | null {
+  if (!header) {
+    return null;
+  }
+
+  const [scheme, token] = header.split(" ");
+  if (!scheme || scheme.toLowerCase() !== "bearer" || !token) {
+    return null;
+  }
+
+  return token.trim();
+}
+
+export function requireAuth(options: RequireAuthOptions = {}) {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error("JWT_SECRET is not configured");
+  }
+
+  const { roles } = options;
+
+  return (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    try {
+      const token = extractBearerToken(req.header("Authorization"));
+      if (!token) {
+        return res.status(401).json({ error: "Missing bearer token" });
+      }
+
+      const decoded = jwt.verify(token, secret) as AuthenticatedUser;
+
+      if (!decoded || typeof decoded !== "object") {
+        return res.status(401).json({ error: "Invalid token" });
+      }
+
+      if (!decoded.role || !ROLE_ORDER.includes(decoded.role)) {
+        return res.status(403).json({ error: "Role not permitted" });
+      }
+
+      if (!allowedRole(decoded.role, roles)) {
+        return res.status(403).json({ error: "Insufficient role" });
+      }
+
+      req.user = decoded;
+
+      return next();
+    } catch (err) {
+      if (err instanceof TokenExpiredError) {
+        return res.status(401).json({ error: "Authentication failed", detail: "Token expired" });
+      }
+      if (err instanceof JsonWebTokenError) {
+        return res.status(401).json({ error: "Authentication failed", detail: err.message });
+      }
+      const message = err instanceof Error ? err.message : "Token validation failed";
+      return res.status(403).json({ error: "Authentication failed", detail: message });
+    }
+  };
+}
+

--- a/src/http/validate.ts
+++ b/src/http/validate.ts
@@ -1,0 +1,84 @@
+import { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+
+export const abnSchema = z
+  .string()
+  .regex(/^\d{11}$/u, "ABN must be 11 digits");
+
+export const closeAndIssueSchema = z.object({
+  abn: abnSchema,
+  taxType: z.string().min(1, "taxType is required"),
+  periodId: z.string().min(1, "periodId is required"),
+  thresholds: z
+    .object({
+      epsilon_cents: z.number().nonnegative().optional(),
+      variance_ratio: z.number().min(0).max(1).optional(),
+      dup_rate: z.number().min(0).max(1).optional(),
+      gap_minutes: z.number().int().nonnegative().optional(),
+      delta_vs_baseline: z.number().min(0).max(1).optional(),
+    })
+    .partial()
+    .optional(),
+});
+
+export const payAtoSchema = z.object({
+  abn: abnSchema,
+  taxType: z.string().min(1),
+  periodId: z.string().min(1),
+  rail: z.enum(["EFT", "BPAY"]),
+});
+
+export const paytoSweepSchema = z.object({
+  abn: abnSchema,
+  amount_cents: z.number().int().positive(),
+  reference: z.string().min(1),
+});
+
+export const settlementWebhookSchema = z.object({
+  csv: z.string().min(1),
+});
+
+export const evidenceQuerySchema = z.object({
+  abn: abnSchema,
+  taxType: z.string().min(1),
+  periodId: z.string().min(1),
+});
+
+export type CloseAndIssueBody = z.infer<typeof closeAndIssueSchema>;
+export type PayAtoBody = z.infer<typeof payAtoSchema>;
+export type PaytoSweepBody = z.infer<typeof paytoSweepSchema>;
+export type SettlementWebhookBody = z.infer<typeof settlementWebhookSchema>;
+export type EvidenceQuery = z.infer<typeof evidenceQuerySchema>;
+
+type AnyZod = z.ZodTypeAny;
+
+function formatZodError(error: z.ZodError) {
+  return {
+    message: "Validation failed",
+    issues: error.errors.map((issue) => ({
+      path: issue.path.join("."),
+      message: issue.message,
+    })),
+  };
+}
+
+export const validateBody = <T extends AnyZod>(schema: T) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    const parsed = schema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json(formatZodError(parsed.error));
+    }
+    req.body = parsed.data;
+    return next();
+  };
+
+export const validateQuery = <T extends AnyZod>(schema: T) =>
+  (req: Request, res: Response, next: NextFunction) => {
+    const parsed = schema.safeParse(req.query);
+    if (!parsed.success) {
+      return res.status(400).json(formatZodError(parsed.error));
+    }
+    req.query = parsed.data;
+    return next();
+  };
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,82 @@
 ﻿// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
+import helmet from "helmet";
+import cors from "cors";
+import rateLimit from "express-rate-limit";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { requireAuth } from "./http/auth";
+import {
+  closeAndIssueSchema,
+  payAtoSchema,
+  paytoSweepSchema,
+  settlementWebhookSchema,
+  evidenceQuerySchema,
+  validateBody,
+  validateQuery,
+} from "./http/validate";
 
 dotenv.config();
 
 const app = express();
+
+const allowedOrigins = (process.env.CORS_ALLOW_ORIGINS || "")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const allowedOriginSet = new Set(allowedOrigins);
+
+app.use(
+  helmet({
+    contentSecurityPolicy: {
+      directives: {
+        defaultSrc: ["'self'"],
+        scriptSrc: ["'self'"],
+        styleSrc: ["'self'", "'unsafe-inline'"],
+        imgSrc: ["'self'", "data:"],
+        connectSrc: ["'self'"],
+        frameAncestors: ["'none'"],
+        objectSrc: ["'none'"],
+        baseUri: ["'self'"],
+      },
+    },
+    hsts: {
+      maxAge: 60 * 60 * 24 * 365,
+      includeSubDomains: true,
+      preload: true,
+    },
+    crossOriginEmbedderPolicy: false,
+  })
+);
+
+app.use(
+  cors({
+    origin: (origin, callback) => {
+      if (!origin) {
+        return callback(null, true);
+      }
+      if (allowedOriginSet.has(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error("Not allowed by CORS"));
+    },
+    methods: ["GET", "POST", "OPTIONS"],
+    credentials: true,
+    allowedHeaders: ["Content-Type", "Authorization", "Idempotency-Key"],
+  })
+);
+
+app.use(rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+}));
+
 app.use(express.json({ limit: "2mb" }));
 
 // (optional) quick request logger
@@ -19,17 +86,54 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
 // Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+app.post(
+  "/api/pay",
+  requireAuth({ roles: ["accountant"] }),
+  validateBody(payAtoSchema),
+  idempotency(),
+  payAto
+);
+app.post(
+  "/api/close-issue",
+  requireAuth({ roles: ["accountant"] }),
+  validateBody(closeAndIssueSchema),
+  idempotency(),
+  closeAndIssue
+);
+app.post(
+  "/api/payto/sweep",
+  requireAuth({ roles: ["admin"] }),
+  validateBody(paytoSweepSchema),
+  idempotency(),
+  paytoSweep
+);
+app.post(
+  "/api/settlement/webhook",
+  requireAuth({ roles: ["admin"] }),
+  validateBody(settlementWebhookSchema),
+  idempotency(),
+  settlementWebhook
+);
+app.get(
+  "/api/evidence",
+  requireAuth({ roles: ["auditor"] }),
+  validateQuery(evidenceQuerySchema),
+  evidence
+);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
 
 // Existing API router(s) after
 app.use("/api", api);
+
+// Centralised CORS error handling
+app.use((err: Error, _req, res, next) => {
+  if (err.message === "Not allowed by CORS") {
+    return res.status(403).json({ error: "Origin not allowed" });
+  }
+  return next(err);
+});
 
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,16 +1,143 @@
-﻿import { Pool } from "pg";
+import { NextFunction, Request, Response } from "express";
+import { Pool } from "pg";
+
 const pool = new Pool();
-/** Express middleware for idempotency via Idempotency-Key header */
-export function idempotency() {
-  return async (req:any, res:any, next:any) => {
-    const key = req.header("Idempotency-Key");
-    if (!key) return next();
-    try {
-      await pool.query("insert into idempotency_keys(key,last_status) values(,)", [key, "INIT"]);
-      return next();
-    } catch {
-      const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+
+let schemaPromise: Promise<void> | null = null;
+
+const ensureSchema = () => {
+  if (!schemaPromise) {
+    schemaPromise = (async () => {
+      await pool.query(
+        "alter table if exists idempotency_keys add column if not exists request_payload jsonb"
+      );
+      await pool.query(
+        "alter table if exists idempotency_keys add column if not exists response_payload jsonb"
+      );
+      await pool.query(
+        "alter table if exists idempotency_keys add column if not exists status_code integer"
+      );
+    })();
+  }
+  return schemaPromise;
+};
+
+const recordResponse = (res: Response, key: string) => {
+  const locals = res.locals as Record<string, unknown>;
+  if (locals.__idempotencyHooked) {
+    return;
+  }
+  locals.__idempotencyHooked = true;
+
+  const originalJson = res.json.bind(res);
+  const originalSend = res.send.bind(res);
+
+  const capture = (payload: unknown) => {
+    locals.__idempotencyPayload = payload;
+    locals.__idempotencyStatus = res.statusCode;
+  };
+
+  res.json = ((body: unknown) => {
+    capture(body);
+    return originalJson(body);
+  }) as typeof res.json;
+
+  res.send = ((body?: unknown) => {
+    capture(body);
+    return originalSend(body);
+  }) as typeof res.send;
+
+  res.once("finish", async () => {
+    if (!("__idempotencyPayload" in locals)) {
+      return;
     }
+
+    const payload = locals.__idempotencyPayload as unknown;
+    const statusCode = (locals.__idempotencyStatus as number | undefined) ?? res.statusCode;
+    const storedPayload =
+      typeof payload === "string" ? JSON.stringify({ body: payload }) : JSON.stringify(payload ?? null);
+    const lastStatus = statusCode >= 400 ? "ERROR" : "DONE";
+
+    try {
+      await pool.query(
+        "update idempotency_keys set last_status=$2, status_code=$3, response_payload=$4::jsonb where key=$1",
+        [key, lastStatus, statusCode, storedPayload]
+      );
+    } catch (err) {
+      console.error("[idempotency] failed to persist response", err);
+    }
+  });
+};
+
+export function idempotency() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    const key = req.header("Idempotency-Key");
+    if (!key) {
+      return next();
+    }
+
+    await ensureSchema();
+
+    const requestSnapshot = JSON.stringify({
+      method: req.method,
+      path: req.originalUrl,
+      body: req.body ?? null,
+      query: req.query ?? null,
+    });
+
+    const client = await pool.connect();
+    let created = false;
+
+    try {
+      await client.query("BEGIN");
+      const existing = await client.query(
+        "select request_payload, response_payload, status_code, last_status from idempotency_keys where key=$1 for update",
+        [key]
+      );
+
+      if (existing.rowCount > 0) {
+        const row = existing.rows[0] as {
+          request_payload: unknown;
+          response_payload: unknown;
+          status_code: number | null;
+          last_status: string | null;
+        };
+
+        const storedRequest = JSON.stringify(row.request_payload ?? null);
+        if (storedRequest !== requestSnapshot) {
+          await client.query("ROLLBACK");
+          return res.status(409).json({ error: "IDEMPOTENT_PAYLOAD_MISMATCH" });
+        }
+
+        if (row.response_payload == null) {
+          await client.query("COMMIT");
+          return res.status(409).json({ error: "IDEMPOTENT_REPLAY_IN_PROGRESS" });
+        }
+
+        await client.query("COMMIT");
+        const statusCode = row.status_code ?? 200;
+        return res.status(statusCode).json(row.response_payload);
+      }
+
+      await client.query(
+        "insert into idempotency_keys(key,last_status,request_payload) values($1,$2,$3::jsonb)",
+        [key, "IN_PROGRESS", requestSnapshot]
+      );
+      await client.query("COMMIT");
+      created = true;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      console.error("[idempotency] failed to claim key", err);
+      return res.status(500).json({ error: "IDEMPOTENCY_FAILURE" });
+    } finally {
+      client.release();
+    }
+
+    if (created) {
+      recordResponse(res, key);
+    }
+
+    return next();
   };
 }
+

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,103 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { Request, Response } from "express";
+import { Pool } from "pg";
+
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import {
+  CloseAndIssueBody,
+  EvidenceQuery,
+  PayAtoBody,
+  PaytoSweepBody,
+  SettlementWebhookBody,
+} from "../http/validate";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
+export async function closeAndIssue(
+  req: Request<unknown, unknown, CloseAndIssueBody>,
+  res: Response
+) {
   const { abn, taxType, periodId, thresholds } = req.body;
   // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+  const thr =
+    thresholds || {
+      epsilon_cents: 50,
+      variance_ratio: 0.25,
+      dup_rate: 0.01,
+      gap_minutes: 60,
+      delta_vs_baseline: 0.2,
+    };
   try {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e) {
+    const error = e instanceof Error ? e.message : "Unknown error";
+    return res.status(400).json({ error });
   }
 }
 
-export async function payAto(req:any, res:any) {
+export async function payAto(
+  req: Request<unknown, unknown, PayAtoBody>,
+  res: Response
+) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) {
+    return res.status(400).json({ error: "NO_RPT" });
+  }
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    const r = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      payload.reference
+    );
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e) {
+    const error = e instanceof Error ? e.message : "Unknown error";
+    return res.status(400).json({ error });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(
+  req: Request<unknown, unknown, PaytoSweepBody>,
+  res: Response
+) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(
+  req: Request<unknown, unknown, SettlementWebhookBody>,
+  res: Response
+) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+export async function evidence(
+  req: Request<unknown, unknown, unknown, EvidenceQuery>,
+  res: Response
+) {
+  const { abn, taxType, periodId } = req.query;
+  const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+  res.json(bundle);
 }
+


### PR DESCRIPTION
## Summary
- add JWT bearer authentication middleware with role-aware checks and Zod-powered request validators
- secure the Express server with Helmet CSP/HSTS, strict CORS allow-listing, a rate limiter, and wrap sensitive routes with auth, validation, and idempotency guards
- replace the idempotency middleware with a transactional upsert that persists request/response payloads and update reconcile routes to use typed payloads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3096e4d8083279bb4f3217eb7b6f4