### PR TITLE
Add settlement ingestion and expose enriched evidence bundles

### DIFF
--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,172 @@
-﻿import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
+
 const pool = new Pool();
 
+async function tableExists(client: PoolClient, tableName: string): Promise<boolean> {
+  const { rows } = await client.query<{ exists: string | null }>(
+    "SELECT to_regclass($1) AS exists",
+    [tableName]
+  );
+  return Boolean(rows[0]?.exists);
+}
+
+type SettlementSplit = {
+  txn_id: string;
+  gst_cents: number;
+  net_cents: number;
+  settlement_ts: string | null;
+};
+
+type SettlementMeta = {
+  reference: string;
+  amount_cents: number;
+  channel: string;
+  paid_at: string | null;
+  ledger_id: number | null;
+  transfer_uuid: string | null;
+};
+
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
-  };
-  return bundle;
+  const client = await pool.connect();
+  try {
+    const periodQ = await client.query(
+      `SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents,
+              merkle_root, running_balance_hash, anomaly_vector, thresholds
+         FROM periods
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    const period = periodQ.rows[0];
+    if (!period) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+
+    const rptQ = await client.query(
+      `SELECT payload, payload_c14n, payload_sha256, signature, created_at
+         FROM rpt_tokens
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const rpt = rptQ.rows[0] ?? null;
+
+    const ledgerQ = await client.query(
+      `SELECT id, transfer_uuid, amount_cents, balance_after_cents,
+              bank_receipt_hash, prev_hash, hash_after, created_at
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id ASC`,
+      [abn, taxType, periodId]
+    );
+    const ledger = ledgerQ.rows.map((row) => ({
+      id: Number(row.id),
+      transfer_uuid: row.transfer_uuid ?? null,
+      amount_cents: Number(row.amount_cents),
+      balance_after_cents: Number(row.balance_after_cents),
+      bank_receipt_hash: row.bank_receipt_hash ?? null,
+      prev_hash: row.prev_hash ?? null,
+      hash_after: row.hash_after ?? null,
+      created_at: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at,
+    }));
+
+    const ledgerBalance = ledger.reduce((sum, row) => sum + row.amount_cents, 0);
+    const lastLedgerHash = ledger.length ? ledger[ledger.length - 1].hash_after : null;
+
+    const hasSplits = await tableExists(client, "settlement_splits");
+    let settlementSplits: SettlementSplit[] = [];
+    if (hasSplits) {
+      const splitQ = await client.query(
+        `SELECT txn_id, gst_cents, net_cents, settlement_ts
+           FROM settlement_splits
+          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+          ORDER BY settlement_ts NULLS LAST, txn_id`,
+        [abn, taxType, periodId]
+      );
+      settlementSplits = splitQ.rows.map((row) => ({
+        txn_id: String(row.txn_id),
+        gst_cents: Number(row.gst_cents ?? 0),
+        net_cents: Number(row.net_cents ?? 0),
+        settlement_ts: row.settlement_ts instanceof Date ? row.settlement_ts.toISOString() : row.settlement_ts,
+      }));
+    }
+
+    const hasSettlementMeta = await tableExists(client, "settlements");
+    let settlements: SettlementMeta[] = [];
+    if (hasSettlementMeta) {
+      const settlementQ = await client.query(
+        `SELECT s.reference, s.amount_cents, s.channel, s.paid_at,
+                l.id AS ledger_id, l.transfer_uuid
+           FROM settlements s
+           LEFT JOIN owa_ledger l
+             ON l.abn = s.abn AND l.tax_type = s.tax_type AND l.period_id = s.period_id
+            AND l.amount_cents = -s.amount_cents
+          WHERE s.abn=$1 AND s.tax_type=$2 AND s.period_id=$3
+          ORDER BY s.paid_at DESC NULLS LAST, s.reference`,
+        [abn, taxType, periodId]
+      );
+      settlements = settlementQ.rows.map((row) => ({
+        reference: String(row.reference),
+        amount_cents: Number(row.amount_cents ?? 0),
+        channel: row.channel ?? "UNKNOWN",
+        paid_at: row.paid_at instanceof Date ? row.paid_at.toISOString() : row.paid_at,
+        ledger_id: row.ledger_id != null ? Number(row.ledger_id) : null,
+        transfer_uuid: row.transfer_uuid ?? null,
+      }));
+    }
+
+    const totalGst = settlementSplits.reduce((sum, row) => sum + row.gst_cents, 0);
+    const totalNet = settlementSplits.reduce((sum, row) => sum + row.net_cents, 0);
+    const settlementRemitted = settlements.reduce((sum, row) => sum + row.amount_cents, 0) || totalGst;
+    const liability = Number(period.final_liability_cents ?? 0);
+
+    const basLabels = {
+      W1: settlementSplits.length ? totalNet : null,
+      W2: null,
+      "1A": settlementSplits.length ? totalGst : null,
+      "1B": settlementSplits.length ? 0 : null,
+    } as const;
+
+    const discrepancyDeltas = [
+      { key: "ledger_vs_period_liability", delta_cents: ledgerBalance - liability },
+      { key: "settlement_vs_period_liability", delta_cents: settlementRemitted - liability },
+      { key: "ledger_vs_settlement", delta_cents: ledgerBalance - settlementRemitted },
+    ].filter((d) => Number.isFinite(d.delta_cents));
+
+    return {
+      meta: {
+        generated_at: new Date().toISOString(),
+        abn,
+        taxType,
+        periodId,
+      },
+      period: {
+        state: period.state,
+        accrued_cents: Number(period.accrued_cents ?? 0),
+        credited_to_owa_cents: Number(period.credited_to_owa_cents ?? 0),
+        final_liability_cents: liability,
+        merkle_root: period.merkle_root ?? null,
+        running_balance_hash: period.running_balance_hash ?? lastLedgerHash,
+        anomaly_vector: period.anomaly_vector ?? {},
+        thresholds: period.thresholds ?? {},
+      },
+      rpt: rpt
+        ? {
+            payload: rpt.payload ?? rpt.payload_c14n ?? null,
+            payload_c14n: rpt.payload_c14n ?? null,
+            payload_sha256: rpt.payload_sha256 ?? null,
+            signature: rpt.signature ?? null,
+            created_at: rpt.created_at instanceof Date ? rpt.created_at.toISOString() : rpt.created_at,
+          }
+        : null,
+      owa_ledger: ledger,
+      bas_labels: basLabels,
+      discrepancy_deltas: discrepancyDeltas,
+      discrepancy_log: discrepancyDeltas,
+      settlements,
+      settlement_splits: settlementSplits,
+    };
+  } finally {
+    client.release();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence, auditEvidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -24,6 +24,7 @@ app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
+app.get("/api/audit/evidence", auditEvidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,10 +1,44 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
+
 const pool = new Pool();
+
+async function ensureSettlementTables(client: PoolClient) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS settlement_splits (
+      id BIGSERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      txn_id TEXT NOT NULL,
+      gst_cents BIGINT NOT NULL,
+      net_cents BIGINT NOT NULL,
+      settlement_ts TIMESTAMPTZ,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (abn, tax_type, period_id, txn_id)
+    )
+  `);
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS settlements (
+      id BIGSERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      reference TEXT NOT NULL,
+      amount_cents BIGINT NOT NULL,
+      channel TEXT NOT NULL,
+      paid_at TIMESTAMPTZ NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      UNIQUE (abn, tax_type, period_id, reference)
+    )
+  `);
+}
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;
@@ -40,13 +74,110 @@ export async function paytoSweep(req:any, res:any) {
 }
 
 export async function settlementWebhook(req:any, res:any) {
-  const csvText = req.body?.csv || "";
-  const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
-  return res.json({ ingested: rows.length });
+  try {
+    const { abn, taxType, periodId, reference, channel, paidAt, amountCents } = req.body || {};
+    const csvText = req.body?.csv || "";
+    if (!abn || !taxType || !periodId) {
+      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+    }
+    if (!reference || !channel) {
+      return res.status(400).json({ error: "Missing settlement reference/channel" });
+    }
+    const rows = parseSettlementCSV(csvText);
+    if (!rows.length) {
+      return res.status(400).json({ error: "No settlement rows provided" });
+    }
+
+    const totalGst = rows.reduce((sum:number, r:any) => sum + Number(r.gst_cents || 0), 0);
+    const totalNet = rows.reduce((sum:number, r:any) => sum + Number(r.net_cents || 0), 0);
+    const settlementAmount = Number.isFinite(Number(amountCents)) ? Number(amountCents) : totalGst;
+
+    const paidAtCandidate = paidAt ? new Date(paidAt) : (rows[rows.length - 1]?.settlement_ts ? new Date(rows[rows.length - 1].settlement_ts) : new Date());
+    if (Number.isNaN(paidAtCandidate.getTime())) {
+      return res.status(400).json({ error: "Invalid paidAt timestamp" });
+    }
+    const paidAtIso = paidAtCandidate.toISOString();
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      await ensureSettlementTables(client);
+
+      const splitSql = `
+        INSERT INTO settlement_splits (abn,tax_type,period_id,txn_id,gst_cents,net_cents,settlement_ts,updated_at)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,now())
+        ON CONFLICT (abn,tax_type,period_id,txn_id)
+        DO UPDATE SET gst_cents=EXCLUDED.gst_cents, net_cents=EXCLUDED.net_cents,
+                      settlement_ts=EXCLUDED.settlement_ts, updated_at=now()
+      `;
+      for (const row of rows) {
+        const ts = row.settlement_ts ? new Date(row.settlement_ts) : null;
+        const tsVal = ts && !Number.isNaN(ts.getTime()) ? ts : null;
+        await client.query(splitSql, [
+          abn,
+          taxType,
+          periodId,
+          row.txn_id,
+          Number(row.gst_cents || 0),
+          Number(row.net_cents || 0),
+          tsVal,
+        ]);
+      }
+
+      await client.query(
+        `INSERT INTO settlements (abn,tax_type,period_id,reference,amount_cents,channel,paid_at,updated_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,now())
+         ON CONFLICT (abn,tax_type,period_id,reference)
+         DO UPDATE SET amount_cents=EXCLUDED.amount_cents,
+                       channel=EXCLUDED.channel,
+                       paid_at=EXCLUDED.paid_at,
+                       updated_at=now()`,
+        [abn, taxType, periodId, reference, settlementAmount, channel, paidAtIso]
+      );
+
+      await client.query("COMMIT");
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+
+    const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+    return res.json({
+      ok: true,
+      ingested: rows.length,
+      totals: {
+        gst_cents: totalGst,
+        net_cents: totalNet,
+      },
+      settlement: {
+        reference,
+        channel,
+        amount_cents: settlementAmount,
+        paid_at: paidAtIso,
+      },
+      bundle,
+    });
+  } catch (e:any) {
+    return res.status(500).json({ error: "settlement ingest failed", detail: String(e?.message || e) });
+  }
 }
 
 export async function evidence(req:any, res:any) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
+}
+
+export async function auditEvidence(req:any, res:any) {
+  try {
+    const { abn, taxType, periodId } = req.query as any;
+    if (!abn || !taxType || !periodId) {
+      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+    }
+    const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+    return res.json({ bundle });
+  } catch (e:any) {
+    return res.status(500).json({ error: "audit evidence failed", detail: String(e?.message || e) });
+  }
 }


### PR DESCRIPTION
## Summary
- enrich the evidence bundle builder with BAS label rollups, discrepancy deltas, settlement splits and metadata sourced from the ledger
- persist incoming settlement split CSVs and aggregate settlement metadata via the webhook so bundles reflect the latest remittance
- add an audit evidence endpoint and route registration to surface the enriched bundle

## Testing
- npm test -- --watch=false *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68e30975299c8327b32bc61f6cdaed1f