### PR TITLE
Add error boundary and toast infrastructure for APGMS UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
                 "dotenv": "^17.2.3",
                 "express": "^5.1.0",
                 "pg": "^8.16.3",
+                "react-error-boundary": "file:src/vendor/react-error-boundary",
+                "react-hot-toast": "file:src/vendor/react-hot-toast",
                 "tweetnacl": "^1.0.3",
                 "uuid": "^13.0.0"
             },
@@ -21,6 +23,30 @@
                 "ts-node": "^10.9.2",
                 "tsx": "^4.20.6",
                 "typescript": "^5.9.3"
+            }
+        },
+        "node_modules/react-error-boundary": {
+            "version": "file:src/vendor/react-error-boundary",
+            "resolved": "src/vendor/react-error-boundary",
+            "link": true
+        },
+        "node_modules/react-hot-toast": {
+            "version": "file:src/vendor/react-hot-toast",
+            "resolved": "src/vendor/react-hot-toast",
+            "link": true
+        },
+        "src/vendor/react-error-boundary": {
+            "name": "react-error-boundary",
+            "version": "0.0.0-local",
+            "peerDependencies": {
+                "react": ">=16.8.0"
+            }
+        },
+        "src/vendor/react-hot-toast": {
+            "name": "react-hot-toast",
+            "version": "0.0.0-local",
+            "peerDependencies": {
+                "react": ">=17.0.0"
             }
         },
         "node_modules/@cspotcode/source-map-support": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
         "pg": "^8.16.3",
+        "react-error-boundary": "file:src/vendor/react-error-boundary",
+        "react-hot-toast": "file:src/vendor/react-hot-toast",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import AppLayout from "./components/AppLayout";
+import { AppErrorBoundary } from "./ui/ErrorBoundary";
 
 import Dashboard from "./pages/Dashboard";
 import BAS from "./pages/BAS";
@@ -14,19 +15,21 @@ import Help from "./pages/Help";
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <AppErrorBoundary>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </AppErrorBoundary>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
+import { Toaster } from "react-hot-toast";
 import atoLogo from "../assets/ato-logo.svg";
+import ModeBanner from "./ModeBanner";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -16,6 +18,8 @@ const navLinks = [
 export default function AppLayout() {
   return (
     <div>
+      <ModeBanner />
+      <Toaster position="top-right" />
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>

--- a/src/components/FundSecuring.tsx
+++ b/src/components/FundSecuring.tsx
@@ -1,11 +1,12 @@
 import React from "react";
+import { toast } from "react-hot-toast";
 import { transferToOneWayAccount } from "../utils/bankApi";
 
 export default function FundSecuring({ paygwDue, gstDue }: { paygwDue: number; gstDue: number }) {
   async function secureFunds() {
     await transferToOneWayAccount(paygwDue, "businessRevenueAcc", "oneWayPaygwAcc");
     await transferToOneWayAccount(gstDue, "businessRevenueAcc", "oneWayGstAcc");
-    alert("Funds secured in designated one-way accounts.");
+    toast.success("Funds secured in designated one-way accounts.");
   }
   return (
     <div className="card">

--- a/src/components/ModeBanner.tsx
+++ b/src/components/ModeBanner.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+function getModeLabel(mode: string) {
+  const normalized = mode.trim().toLowerCase();
+  switch (normalized) {
+    case "demo":
+      return "Demo environment";
+    case "staging":
+      return "Staging environment";
+    case "development":
+      return "Development build";
+    default:
+      return mode;
+  }
+}
+
+export default function ModeBanner() {
+  const mode = process.env.APP_MODE?.trim();
+
+  if (!mode || mode.toLowerCase() === "production") {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        background: "#0f172a",
+        color: "#f8fafc",
+        textAlign: "center",
+        padding: "0.35rem 1rem",
+        fontSize: "0.85rem",
+        letterSpacing: 0.4,
+        textTransform: "uppercase",
+        fontWeight: 600,
+      }}
+    >
+      {getModeLabel(mode)}
+    </div>
+  );
+}

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,9 @@ declare module "*.svg" {
   const content: string;
   export default content;
 }
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    APP_MODE?: string;
+  }
+}

--- a/src/ui/ErrorBoundary.tsx
+++ b/src/ui/ErrorBoundary.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { ErrorBoundary, FallbackProps } from "react-error-boundary";
+
+type AppErrorBoundaryProps = React.PropsWithChildren<{
+  heading?: string;
+}>;
+
+function ErrorFallback({ error, resetErrorBoundary }: FallbackProps) {
+  return (
+    <div
+      role="alert"
+      style={{
+        margin: "2rem auto",
+        maxWidth: 480,
+        borderRadius: 12,
+        padding: "1.5rem",
+        background: "#fff1f2",
+        color: "#9f1239",
+        boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
+      }}
+    >
+      <h2 style={{ fontSize: "1.25rem", fontWeight: 600, marginBottom: "0.5rem" }}>
+        Something went wrong
+      </h2>
+      <p style={{ fontSize: "0.95rem", lineHeight: 1.5, marginBottom: "1rem" }}>
+        We hit an unexpected error while rendering the application. You can try to recover by reloading the page.
+      </p>
+      <pre
+        style={{
+          background: "#fff",
+          padding: "0.75rem",
+          borderRadius: 8,
+          fontSize: "0.8rem",
+          overflowX: "auto",
+          marginBottom: "1rem",
+          color: "#881337",
+        }}
+      >
+        {error.message}
+      </pre>
+      <div style={{ display: "flex", gap: "0.75rem" }}>
+        <button
+          type="button"
+          onClick={resetErrorBoundary}
+          style={{
+            background: "#be123c",
+            color: "#fff",
+            border: "none",
+            padding: "0.6rem 1.25rem",
+            borderRadius: 9999,
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          Try again
+        </button>
+        <button
+          type="button"
+          onClick={() => window.location.reload()}
+          style={{
+            background: "transparent",
+            color: "#be123c",
+            border: "1px solid #be123c",
+            padding: "0.6rem 1.25rem",
+            borderRadius: 9999,
+            cursor: "pointer",
+            fontWeight: 600,
+          }}
+        >
+          Reload page
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function AppErrorBoundary({ children }: AppErrorBoundaryProps) {
+  return <ErrorBoundary FallbackComponent={ErrorFallback}>{children}</ErrorBoundary>;
+}

--- a/src/utils/apiClient.ts
+++ b/src/utils/apiClient.ts
@@ -1,0 +1,63 @@
+import { toast } from "react-hot-toast";
+
+export type RequestConfig = RequestInit & {
+  successMessage?: string;
+  failureMessage?: string;
+};
+
+function resolveErrorMessage(action: string, error: unknown, fallback?: string) {
+  if (error instanceof Error) {
+    return `${action} failed: ${error.message}`;
+  }
+  return fallback ?? `${action} failed`;
+}
+
+export async function apiRequest<T>(input: RequestInfo, init: RequestConfig = {}): Promise<T> {
+  const { successMessage, failureMessage, ...requestInit } = init;
+
+  try {
+    const response = await fetch(input, {
+      headers: {
+        "Content-Type": "application/json",
+        ...(requestInit.headers || {}),
+      },
+      ...requestInit,
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      const error = new Error(text || response.statusText || "Request failed");
+      throw error;
+    }
+
+    const hasBody = response.status !== 204;
+    const data = (hasBody ? await response.json() : undefined) as T;
+
+    if (successMessage) {
+      toast.success(successMessage);
+    }
+
+    return data;
+  } catch (error) {
+    const message = resolveErrorMessage("Request", error, failureMessage);
+    toast.error(message);
+    console.error("[apiRequest]", error);
+    throw error instanceof Error ? error : new Error(String(error));
+  }
+}
+
+export function withApiErrorToast<TArgs extends unknown[], TResult>(
+  action: string,
+  fn: (...args: TArgs) => Promise<TResult> | TResult
+) {
+  return async (...args: TArgs): Promise<TResult> => {
+    try {
+      return await fn(...args);
+    } catch (error) {
+      const message = resolveErrorMessage(action, error);
+      toast.error(message);
+      console.error(`[${action}]`, error);
+      throw error instanceof Error ? error : new Error(String(error));
+    }
+  };
+}

--- a/src/utils/bankApi.ts
+++ b/src/utils/bankApi.ts
@@ -1,24 +1,30 @@
-export async function submitSTPReport(data: any): Promise<boolean> {
+import { withApiErrorToast } from "./apiClient";
+
+export const submitSTPReport = withApiErrorToast("STP submission", async (data: any) => {
   console.log("Submitting STP report to ATO:", data);
   return true;
-}
+});
 
-export async function signTransaction(amount: number, account: string): Promise<string> {
-  return `SIGNED-${amount}-${account}-${Date.now()}`;
-}
+export const signTransaction = withApiErrorToast(
+  "Transaction signing",
+  async (amount: number, account: string) => `SIGNED-${amount}-${account}-${Date.now()}`
+);
 
-export async function transferToOneWayAccount(amount: number, from: string, to: string): Promise<boolean> {
-  const signature = await signTransaction(amount, to);
-  console.log(`Transfer $${amount} from ${from} to ${to} [${signature}]`);
-  return true;
-}
+export const transferToOneWayAccount = withApiErrorToast(
+  "One-way transfer",
+  async (amount: number, from: string, to: string) => {
+    const signature = await signTransaction(amount, to);
+    console.log(`Transfer $${amount} from ${from} to ${to} [${signature}]`);
+    return true;
+  }
+);
 
-export async function verifyFunds(paygwDue: number, gstDue: number): Promise<boolean> {
+export const verifyFunds = withApiErrorToast("Fund verification", async (_paygwDue: number, _gstDue: number) => {
   // For mock: always return true
   return true;
-}
+});
 
-export async function initiateTransfer(paygwDue: number, gstDue: number): Promise<boolean> {
+export const initiateTransfer = withApiErrorToast("ATO transfer", async (_paygwDue: number, _gstDue: number) => {
   // For mock: always return true
   return true;
-}
+});

--- a/src/utils/payrollApi.ts
+++ b/src/utils/payrollApi.ts
@@ -1,3 +1,13 @@
-// Placeholder for payroll API integration logic
+import { withApiErrorToast } from "./apiClient";
 
-export {};
+export interface PayrollSummary {
+  employees: number;
+  totalWages: number;
+  superAccrued: number;
+}
+
+export const fetchPayrollSummary = withApiErrorToast("Payroll summary", async (): Promise<PayrollSummary> => ({
+  employees: 0,
+  totalWages: 0,
+  superAccrued: 0,
+}));

--- a/src/utils/posApi.ts
+++ b/src/utils/posApi.ts
@@ -1,6 +1,14 @@
-// Placeholder for POS API integration logic
+import { withApiErrorToast } from "./apiClient";
 
-export {};
-// Placeholder for POS API integration logic
+export interface PosSyncResult {
+  transactionsSynced: number;
+  lastSync: string;
+}
 
-export {};
+export const syncPosTransactions = withApiErrorToast(
+  "POS sync",
+  async (): Promise<PosSyncResult> => ({
+    transactionsSynced: 0,
+    lastSync: new Date().toISOString(),
+  })
+);

--- a/src/vendor/react-error-boundary/index.d.ts
+++ b/src/vendor/react-error-boundary/index.d.ts
@@ -1,0 +1,29 @@
+import * as React from "react";
+
+export interface FallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+export interface ErrorBoundaryProps {
+  children?: React.ReactNode;
+  FallbackComponent?: React.ComponentType<FallbackProps>;
+  fallback?: React.ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  onReset?: () => void;
+  resetKeys?: ReadonlyArray<unknown>;
+}
+
+export declare class ErrorBoundary extends React.Component<ErrorBoundaryProps> {}
+
+export declare function withErrorBoundary<P>(
+  component: React.ComponentType<P>,
+  props: Omit<ErrorBoundaryProps, "children">
+): React.ComponentType<P>;
+
+export declare function useErrorHandler(initialError?: unknown): never | ((error: unknown) => void);
+
+export declare function useErrorBoundary(): {
+  ErrorBoundary: React.ComponentType<React.PropsWithChildren<Omit<ErrorBoundaryProps, "children">>>;
+  reset: () => void;
+};

--- a/src/vendor/react-error-boundary/index.tsx
+++ b/src/vendor/react-error-boundary/index.tsx
@@ -1,0 +1,136 @@
+import React, { Component, PropsWithChildren, ReactNode } from "react";
+
+export interface FallbackProps {
+  error: Error;
+  resetErrorBoundary: () => void;
+}
+
+export interface ErrorBoundaryProps {
+  children?: ReactNode;
+  FallbackComponent?: React.ComponentType<FallbackProps>;
+  fallback?: ReactNode;
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  onReset?: () => void;
+  resetKeys?: ReadonlyArray<unknown>;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+function arrayChanged(a: ReadonlyArray<unknown> | undefined, b: ReadonlyArray<unknown> | undefined) {
+  if (a === b) return false;
+  if (!a || !b) return true;
+  if (a.length !== b.length) return true;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return true;
+  }
+  return false;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    this.props.onError?.(error, info);
+  }
+
+  componentDidUpdate(prevProps: ErrorBoundaryProps): void {
+    if (this.state.error && arrayChanged(prevProps.resetKeys, this.props.resetKeys)) {
+      this.resetErrorBoundary();
+    }
+  }
+
+  resetErrorBoundary = () => {
+    this.props.onReset?.();
+    this.setState({ error: null });
+  };
+
+  render(): ReactNode {
+    const { error } = this.state;
+    const { fallback, FallbackComponent, children } = this.props;
+
+    if (error) {
+      if (React.isValidElement(fallback)) {
+        return fallback;
+      }
+
+      if (FallbackComponent) {
+        return <FallbackComponent error={error} resetErrorBoundary={this.resetErrorBoundary} />;
+      }
+
+      return null;
+    }
+
+    return children ?? null;
+  }
+}
+
+export function withErrorBoundary<P>(
+  ComponentToWrap: React.ComponentType<P>,
+  errorBoundaryProps: Omit<ErrorBoundaryProps, "children">
+) {
+  return function ErrorBoundaryWrapper(props: P) {
+    return (
+      <ErrorBoundary {...errorBoundaryProps}>
+        <ComponentToWrap {...props} />
+      </ErrorBoundary>
+    );
+  };
+}
+
+export function useErrorHandler(initialError?: unknown): never | ((error: unknown) => void) {
+  const [error, setError] = React.useState<unknown>(initialError);
+
+  if (error != null) {
+    throw error;
+  }
+
+  return setError;
+}
+
+export function useErrorBoundary() {
+  const boundaryRef = React.useRef<{ reset: () => void } | null>(null);
+
+  const reset = React.useCallback(() => {
+    boundaryRef.current?.reset();
+  }, []);
+
+  const ErrorBoundaryWithRef = React.useCallback(
+    ({ children, ...props }: PropsWithChildren<Omit<ErrorBoundaryProps, "children">>) => (
+      <InternalErrorBoundary ref={boundaryRef} {...props}>
+        {children}
+      </InternalErrorBoundary>
+    ),
+    []
+  );
+
+  return { ErrorBoundary: ErrorBoundaryWithRef, reset } as const;
+}
+
+interface InternalErrorBoundaryHandle {
+  reset: () => void;
+}
+
+const InternalErrorBoundary = React.forwardRef<InternalErrorBoundaryHandle, ErrorBoundaryProps>(
+  (props, ref) => {
+    const { children, ...rest } = props;
+    const boundaryRef = React.useRef<ErrorBoundary>(null);
+
+    React.useImperativeHandle(ref, () => ({
+      reset: () => boundaryRef.current?.resetErrorBoundary(),
+    }));
+
+    return (
+      <ErrorBoundary ref={boundaryRef} {...rest}>
+        {children}
+      </ErrorBoundary>
+    );
+  }
+);
+
+InternalErrorBoundary.displayName = "InternalErrorBoundary";

--- a/src/vendor/react-error-boundary/package.json
+++ b/src/vendor/react-error-boundary/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-error-boundary",
+  "version": "0.0.0-local",
+  "main": "index.tsx",
+  "module": "index.tsx",
+  "types": "index.d.ts",
+  "peerDependencies": {
+    "react": ">=16.8.0"
+  }
+}

--- a/src/vendor/react-hot-toast/index.d.ts
+++ b/src/vendor/react-hot-toast/index.d.ts
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+export interface ToastOptions {
+  id?: string;
+  duration?: number;
+}
+
+export interface Toast extends ToastOptions {
+  id: string;
+  message: string;
+  type: "blank" | "success" | "error";
+  createdAt: number;
+}
+
+export interface ToasterProps {
+  position?: "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right";
+}
+
+export declare function Toaster(props: ToasterProps): React.ReactElement | null;
+
+export interface ToastFunction {
+  (message: string, options?: ToastOptions): string;
+  success(message: string, options?: ToastOptions): string;
+  error(message: string, options?: ToastOptions): string;
+  dismiss(id?: string): void;
+  remove(id?: string): void;
+}
+
+export declare const toast: ToastFunction;
+
+export default toast;

--- a/src/vendor/react-hot-toast/index.tsx
+++ b/src/vendor/react-hot-toast/index.tsx
@@ -1,0 +1,150 @@
+import React from "react";
+
+type ToastType = "blank" | "success" | "error";
+
+export interface ToastOptions {
+  id?: string;
+  duration?: number;
+}
+
+export interface Toast extends ToastOptions {
+  id: string;
+  message: string;
+  type: ToastType;
+  createdAt: number;
+}
+
+type ToastListener = (toasts: Toast[]) => void;
+
+const listeners = new Set<ToastListener>();
+let toasts: Toast[] = [];
+
+const DEFAULT_DURATION = 4000;
+
+function notify() {
+  for (const listener of listeners) {
+    listener([...toasts]);
+  }
+}
+
+function scheduleRemoval(id: string, duration: number) {
+  if (duration === Infinity) return;
+  if (typeof window === "undefined") return;
+  window.setTimeout(() => dismiss(id), duration);
+}
+
+function createToast(message: string, type: ToastType, options: ToastOptions = {}) {
+  const id = options.id ?? `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const duration = options.duration ?? DEFAULT_DURATION;
+  const toast: Toast = {
+    id,
+    message,
+    type,
+    duration,
+    createdAt: Date.now(),
+  };
+
+  toasts = [...toasts.filter((item) => item.id !== id), toast];
+  notify();
+  scheduleRemoval(id, duration);
+  return id;
+}
+
+export function dismiss(id?: string) {
+  if (id) {
+    toasts = toasts.filter((toast) => toast.id !== id);
+  } else {
+    toasts = [];
+  }
+  notify();
+}
+
+function getToastColor(type: ToastType) {
+  switch (type) {
+    case "success":
+      return "#16a34a";
+    case "error":
+      return "#dc2626";
+    default:
+      return "#2563eb";
+  }
+}
+
+const POSITION_STYLE: Record<Required<ToasterProps>["position"], React.CSSProperties> = {
+  "top-left": { top: 24, left: 24 },
+  "top-center": { top: 24, left: "50%", transform: "translateX(-50%)" },
+  "top-right": { top: 24, right: 24 },
+  "bottom-left": { bottom: 24, left: 24 },
+  "bottom-center": { bottom: 24, left: "50%", transform: "translateX(-50%)" },
+  "bottom-right": { bottom: 24, right: 24 },
+};
+
+export interface ToasterProps {
+  position?: "top-left" | "top-center" | "top-right" | "bottom-left" | "bottom-center" | "bottom-right";
+}
+
+export function Toaster({ position = "top-right" }: ToasterProps) {
+  const [items, setItems] = React.useState<Toast[]>(toasts);
+
+  React.useEffect(() => {
+    const listener: ToastListener = (next) => setItems(next);
+    listeners.add(listener);
+    setItems([...toasts]);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        zIndex: 10000,
+        pointerEvents: "none",
+        maxWidth: 360,
+        width: "100%",
+        ...POSITION_STYLE[position],
+      }}
+    >
+      {items.map((toast) => (
+        <div
+          key={toast.id}
+          style={{
+            background: getToastColor(toast.type),
+            color: "#fff",
+            padding: "10px 14px",
+            borderRadius: 8,
+            marginBottom: 12,
+            boxShadow: "0 10px 25px rgba(15, 23, 42, 0.25)",
+            fontSize: 14,
+            pointerEvents: "auto",
+          }}
+        >
+          {toast.message}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export interface ToastFunction {
+  (message: string, options?: ToastOptions): string;
+  success: (message: string, options?: ToastOptions) => string;
+  error: (message: string, options?: ToastOptions) => string;
+  dismiss: typeof dismiss;
+  remove: typeof dismiss;
+}
+
+export const toast: ToastFunction = ((message: string, options?: ToastOptions) =>
+  createToast(message, "blank", options)) as ToastFunction;
+
+toast.success = (message: string, options?: ToastOptions) => createToast(message, "success", options);
+toast.error = (message: string, options?: ToastOptions) => createToast(message, "error", options);
+toast.dismiss = dismiss;
+toast.remove = dismiss;
+
+export default toast;

--- a/src/vendor/react-hot-toast/package.json
+++ b/src/vendor/react-hot-toast/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "react-hot-toast",
+  "version": "0.0.0-local",
+  "main": "index.tsx",
+  "module": "index.tsx",
+  "types": "index.d.ts",
+  "peerDependencies": {
+    "react": ">=17.0.0"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,12 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "react-error-boundary": ["src/vendor/react-error-boundary"],
+      "react-hot-toast": ["src/vendor/react-hot-toast"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add local file dependencies for `react-error-boundary` and `react-hot-toast` and wire them via TypeScript path aliases
- wrap the router with a new application error boundary and surface the environment mode banner with a mounted toaster in the root layout
- centralize toast-aware API helpers and update banking, payroll, POS, and fund securing flows to emit notifications on failure or success

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e3096b4e1483278773f71499568c7b