### PR TITLE
Add migration tooling and CI automation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,10 @@
+node_modules
+public
+build
+dist
+coverage
+**/*.js
+**/*.d.ts
+**/*.ps1
+**/*.py
+apps/**/dist

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,32 @@
+module.exports = {
+    root: true,
+    env: {
+        node: true,
+        es2021: true,
+    },
+    parser: '@typescript-eslint/parser',
+    parserOptions: {
+        sourceType: 'module',
+        ecmaVersion: 2021,
+    },
+    plugins: ['@typescript-eslint'],
+    extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended'],
+    ignorePatterns: ['dist', 'node_modules', '**/*.js', '**/*.d.ts'],
+    rules: {
+        'no-restricted-syntax': [
+            'error',
+            {
+                selector: "NewExpression[callee.name='Pool']",
+                message: 'Use the shared pool exported from the db module.',
+            },
+        ],
+    },
+    overrides: [
+        {
+            files: ['src/db/pool.ts', 'apps/services/payments/src/db.ts', 'scripts/migrate.ts'],
+            rules: {
+                'no-restricted-syntax': 'off',
+            },
+        },
+    ],
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: apgms
+          POSTGRES_PASSWORD: apgms
+          POSTGRES_DB: apgms
+        options: >-
+          --health-cmd "pg_isready -U apgms" --health-interval 10s --health-timeout 5s --health-retries 5
+    env:
+      DATABASE_URL: postgres://apgms:apgms@localhost:5432/apgms
+    steps:
+      - uses: actions/checkout@v4
+      - name: Enable Corepack
+        run: corepack enable
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install
+      - name: Lint
+        run: pnpm lint
+      - name: Run database migrations
+        run: pnpm migrate
+      - name: Run tests
+        run: pnpm test --if-present
+      - name: Generate OpenAPI specification
+        run: pnpm openapi
+      - name: Documentation coverage
+        run: pnpm docs:coverage
+      - name: Validate documentation links
+        run: pnpm docs:links
+      - name: Upload OpenAPI artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: public/openapi.json
+      - name: Run gitleaks
+        uses: zricethezav/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+pnpm lint-staged

--- a/apps/services/payments/src/db.ts
+++ b/apps/services/payments/src/db.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+import pg from 'pg';
+
+const { Pool } = pg;
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  `postgres://${process.env.PGUSER || 'apgms'}:${encodeURIComponent(process.env.PGPASSWORD || '')}` +
+    `@${process.env.PGHOST || '127.0.0.1'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'apgms'}`;
+
+export const pool = new Pool({ connectionString });
+
+export function getPool() {
+  return pool;
+}

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -3,7 +3,6 @@ import 'dotenv/config';
 import './loadEnv.js'; // ensures .env.local is loaded when running with tsx
 
 import express from 'express';
-import pg from 'pg'; const { Pool } = pg;
 
 import { rptGate } from './middleware/rptGate.js';
 import { payAtoRelease } from './routes/payAto.js';
@@ -13,15 +12,7 @@ import { ledger } from './routes/ledger';
 
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
-
-// Prefer DATABASE_URL; else compose from PG* vars
-const connectionString =
-  process.env.DATABASE_URL ??
-  `postgres://${process.env.PGUSER || 'apgms'}:${encodeURIComponent(process.env.PGPASSWORD || '')}` +
-  `@${process.env.PGHOST || '127.0.0.1'}:${process.env.PGPORT || '5432'}/${process.env.PGDATABASE || 'apgms'}`;
-
-// Export pool for other modules
-export const pool = new Pool({ connectionString });
+export { pool } from './db.js';
 
 const app = express();
 app.use(express.json());

--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -1,11 +1,10 @@
 // apps/services/payments/src/middleware/rptGate.ts
 import { Request, Response, NextFunction } from "express";
-import pg from "pg"; const { Pool } = pg;
 import { sha256Hex } from "../utils/crypto";
 import { selectKms } from "../kms/kmsProvider";
+import { pool } from "../db.js";
 
 const kms = selectKms();
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
 export async function rptGate(req: Request, res: Response, next: NextFunction) {
   try {

--- a/apps/services/payments/src/routes/balance.ts
+++ b/apps/services/payments/src/routes/balance.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { pool } from "../index.js";
+import { pool } from "../db.js";
 
 export async function balance(req: Request, res: Response) {
   try {

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { pool } from "../index.js";
+import { pool } from "../db.js";
 import { randomUUID } from "node:crypto";
 
 export async function deposit(req: Request, res: Response) {

--- a/apps/services/payments/src/routes/ledger.ts
+++ b/apps/services/payments/src/routes/ledger.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from "express";
-import { pool } from "../index.js";
+import { pool } from "../db.js";
 
 export async function ledger(req: Request, res: Response) {
   try {

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -1,8 +1,7 @@
 ﻿// apps/services/payments/src/routes/payAto.ts
 import { Request, Response } from 'express';
 import crypto from 'crypto';
-import pg from 'pg'; const { Pool } = pg;
-import { pool } from '../index.js';
+import { pool } from '../db.js';
 
 function genUUID() {
   return crypto.randomUUID();

--- a/apps/services/payments/test/owa_constraints.test.ts
+++ b/apps/services/payments/test/owa_constraints.test.ts
@@ -1,5 +1,4 @@
-import { Pool } from "pg";
-const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+import { pool } from "../src/db.js";
 
 test("OWA deposit-only constraint", async () => {
   const c = await pool.connect();

--- a/package.json
+++ b/package.json
@@ -4,18 +4,29 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "eslint --ext .ts,.tsx scripts src \"apps/services/payments/src\" \"apps/services/payments/test\" --max-warnings=0",
+        "test": "pnpm -r --if-present test",
+        "migrate": "tsx scripts/migrate.ts",
+        "openapi": "tsx scripts/openapi.ts",
+        "docs:coverage": "tsx scripts/docs-coverage.ts",
+        "docs:links": "tsx scripts/docs-links.ts",
+        "prepare": "husky install"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.12.2",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "eslint": "^9.14.0",
+        "@typescript-eslint/parser": "^8.12.2",
+        "@typescript-eslint/eslint-plugin": "^8.12.2",
+        "husky": "^9.0.11",
+        "lint-staged": "^15.2.10"
     },
     "dependencies": {
         "csv-parse": "^6.1.0",
@@ -24,5 +35,8 @@
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
+    },
+    "lint-staged": {
+        "*.{ts,tsx}": "eslint --max-warnings=0"
     }
 }

--- a/scripts/docs-coverage.ts
+++ b/scripts/docs-coverage.ts
@@ -1,0 +1,57 @@
+import { readdir, stat, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function collectMarkdown(dir: string, acc: string[] = []): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectMarkdown(fullPath, acc);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      acc.push(fullPath);
+    }
+  }
+  return acc;
+}
+
+async function main() {
+  const docsDir = path.resolve(__dirname, '..', 'docs');
+  try {
+    await stat(docsDir);
+  } catch {
+    console.log('No docs directory present. Documentation coverage: 0/0 (100%).');
+    return;
+  }
+
+  const files = await collectMarkdown(docsDir);
+  if (!files.length) {
+    console.log('No markdown documentation files found. Coverage 0/0 (100%).');
+    return;
+  }
+
+  let documented = 0;
+  for (const file of files) {
+    const contents = await readFile(file, 'utf8');
+    if (contents.trim().length > 0) {
+      documented += 1;
+    }
+  }
+
+  const coverage = (documented / files.length) * 100;
+  const formatted = coverage.toFixed(2);
+  console.log(`Documentation coverage: ${formatted}% (${documented}/${files.length})`);
+
+  if (documented !== files.length) {
+    console.error('Some documentation files are empty.');
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error('Failed to compute documentation coverage:', error);
+  process.exitCode = 1;
+});

--- a/scripts/docs-links.ts
+++ b/scripts/docs-links.ts
@@ -1,0 +1,67 @@
+import { readdir, stat, readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function collectMarkdown(dir: string, acc: string[] = []): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      await collectMarkdown(fullPath, acc);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      acc.push(fullPath);
+    }
+  }
+  return acc;
+}
+
+function isRelativeLink(link: string) {
+  return !/^(https?:)?\/\//.test(link) && !link.startsWith('#') && !link.startsWith('mailto:') && !link.startsWith('/');
+}
+
+async function main() {
+  const docsDir = path.resolve(__dirname, '..', 'docs');
+  try {
+    await stat(docsDir);
+  } catch {
+    console.log('No docs directory present. Nothing to validate.');
+    return;
+  }
+
+  const files = await collectMarkdown(docsDir);
+  const missing: string[] = [];
+
+  const linkRegex = /\[[^\]]+\]\(([^)]+)\)/g;
+  for (const file of files) {
+    const contents = await readFile(file, 'utf8');
+    let match: RegExpExecArray | null;
+    while ((match = linkRegex.exec(contents))) {
+      const target = match[1].split('#')[0];
+      if (!target || !isRelativeLink(target)) continue;
+      const resolved = path.resolve(path.dirname(file), target);
+      try {
+        await stat(resolved);
+      } catch {
+        missing.push(`${file}: ${target}`);
+      }
+    }
+  }
+
+  if (missing.length) {
+    console.error('Broken documentation links detected:');
+    for (const m of missing) {
+      console.error(` - ${m}`);
+    }
+    process.exitCode = 1;
+  } else {
+    console.log('All documentation links resolved successfully.');
+  }
+}
+
+main().catch((error) => {
+  console.error('Failed to validate documentation links:', error);
+  process.exitCode = 1;
+});

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,115 @@
+import 'dotenv/config';
+import { access, appendFile, mkdir, readFile, readdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import crypto from 'node:crypto';
+import { Pool } from 'pg';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const migrationsDir = path.resolve(__dirname, '..', 'migrations');
+const logFile = path.join(migrationsDir, 'migrate.log');
+
+async function ensureMigrationsTable(pool: Pool) {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      id SERIAL PRIMARY KEY,
+      filename TEXT NOT NULL UNIQUE,
+      checksum TEXT NOT NULL,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+  `);
+}
+
+async function getMigrations(): Promise<string[]> {
+  const entries = await readdir(migrationsDir, { withFileTypes: true });
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.sql'))
+    .map((entry) => entry.name)
+    .sort();
+}
+
+function checksum(content: string) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+async function logLine(line: string) {
+  await appendFile(logFile, `${line}\n`);
+}
+
+async function applyMigration(pool: Pool, filename: string, content: string, hash: string) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    await client.query(content);
+    await client.query(
+      'INSERT INTO schema_migrations (filename, checksum) VALUES ($1, $2)',
+      [filename, hash]
+    );
+    await client.query('COMMIT');
+    await logLine(`${new Date().toISOString()} APPLIED ${filename} ${hash}`);
+    console.log(`Applied ${filename} (${hash})`);
+  } catch (error) {
+    await client.query('ROLLBACK');
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function verifyMigration(pool: Pool, filename: string, hash: string) {
+  const existing = await pool.query<{ checksum: string }>(
+    'SELECT checksum FROM schema_migrations WHERE filename = $1',
+    [filename]
+  );
+  if (!existing.rowCount) {
+    return false;
+  }
+  const stored = existing.rows[0].checksum;
+  if (stored !== hash) {
+    throw new Error(`Checksum mismatch for ${filename}. Expected ${stored}, got ${hash}`);
+  }
+  await logLine(`${new Date().toISOString()} SKIPPED ${filename} ${hash}`);
+  console.log(`Skipping ${filename}; already applied with checksum ${hash}`);
+  return true;
+}
+
+async function main() {
+  await mkdir(path.dirname(logFile), { recursive: true });
+  try {
+    await access(logFile);
+  } catch {
+    await writeFile(logFile, '', 'utf8');
+  }
+
+  const connectionString = process.env.DATABASE_URL;
+  const pool = new Pool(connectionString ? { connectionString } : undefined);
+
+  try {
+    await ensureMigrationsTable(pool);
+    const files = await getMigrations();
+    if (!files.length) {
+      console.log('No migrations found.');
+      return;
+    }
+
+    for (const filename of files) {
+      const fullPath = path.join(migrationsDir, filename);
+      const sql = await readFile(fullPath, 'utf8');
+      const hash = checksum(sql);
+      const alreadyApplied = await verifyMigration(pool, filename, hash);
+      if (alreadyApplied) continue;
+      await applyMigration(pool, filename, sql, hash);
+    }
+
+    console.log('Migrations complete.');
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error('Migration failed:', error);
+  process.exitCode = 1;
+});

--- a/scripts/openapi.ts
+++ b/scripts/openapi.ts
@@ -1,0 +1,246 @@
+import { writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const spec = {
+  openapi: '3.0.3',
+  info: {
+    title: 'APGMS API',
+    version: '0.1.0',
+    description: 'API surface for the Automated PAYGW & GST Management System.',
+  },
+  servers: [{ url: 'http://localhost:3000' }],
+  paths: {
+    '/health': {
+      get: {
+        summary: 'Health check',
+        responses: {
+          '200': {
+            description: 'Health check response',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { ok: { type: 'boolean' } },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/pay': {
+      post: {
+        summary: 'Release payment to ATO',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['abn', 'taxType', 'periodId', 'rail'],
+                properties: {
+                  abn: { type: 'string' },
+                  taxType: { type: 'string', enum: ['PAYGW', 'GST'] },
+                  periodId: { type: 'string' },
+                  rail: { type: 'string', enum: ['EFT', 'BPAY'] },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': {
+            description: 'Release accepted',
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+          '400': {
+            description: 'Validation error',
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+        },
+      },
+    },
+    '/api/close-issue': {
+      post: {
+        summary: 'Close period and issue RPT',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['abn', 'taxType', 'periodId'],
+                properties: {
+                  abn: { type: 'string' },
+                  taxType: { type: 'string', enum: ['PAYGW', 'GST'] },
+                  periodId: { type: 'string' },
+                  thresholds: { type: 'object', additionalProperties: { type: 'number' } },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'RPT issued' },
+          '400': { description: 'Failed to issue RPT' },
+        },
+      },
+    },
+    '/api/payto/sweep': {
+      post: {
+        summary: 'Initiate PayTo sweep',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['abn', 'amount_cents', 'reference'],
+                properties: {
+                  abn: { type: 'string' },
+                  amount_cents: { type: 'integer' },
+                  reference: { type: 'string' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'Sweep scheduled' },
+        },
+      },
+    },
+    '/api/settlement/webhook': {
+      post: {
+        summary: 'Settlement CSV ingestion webhook',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  csv: { type: 'string', description: 'Settlement CSV payload' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'Ingestion summary' },
+        },
+      },
+    },
+    '/api/evidence': {
+      get: {
+        summary: 'Retrieve evidence bundle',
+        parameters: [
+          { name: 'abn', in: 'query', required: true, schema: { type: 'string' } },
+          { name: 'taxType', in: 'query', required: true, schema: { type: 'string' } },
+          { name: 'periodId', in: 'query', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          '200': {
+            description: 'Evidence bundle',
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+        },
+      },
+    },
+    '/api/balance': {
+      get: {
+        summary: 'Retrieve ledger balance',
+        parameters: [
+          { name: 'abn', in: 'query', required: true, schema: { type: 'string' } },
+          { name: 'taxType', in: 'query', required: true, schema: { type: 'string' } },
+          { name: 'periodId', in: 'query', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          '200': { description: 'Balance response' },
+          '400': { description: 'Missing parameters' },
+        },
+      },
+    },
+    '/api/ledger': {
+      get: {
+        summary: 'Retrieve ledger entries',
+        parameters: [
+          { name: 'abn', in: 'query', required: true, schema: { type: 'string' } },
+          { name: 'taxType', in: 'query', required: true, schema: { type: 'string' } },
+          { name: 'periodId', in: 'query', required: true, schema: { type: 'string' } },
+        ],
+        responses: {
+          '200': { description: 'Ledger rows' },
+          '400': { description: 'Missing parameters' },
+        },
+      },
+    },
+    '/api/deposit': {
+      post: {
+        summary: 'Deposit funds into ledger',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['abn', 'taxType', 'periodId', 'amountCents'],
+                properties: {
+                  abn: { type: 'string' },
+                  taxType: { type: 'string' },
+                  periodId: { type: 'string' },
+                  amountCents: { type: 'integer', minimum: 1 },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'Deposit accepted' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+    '/api/release': {
+      post: {
+        summary: 'Release funds to ATO',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                required: ['abn', 'taxType', 'periodId', 'amountCents'],
+                properties: {
+                  abn: { type: 'string' },
+                  taxType: { type: 'string' },
+                  periodId: { type: 'string' },
+                  amountCents: { type: 'integer' },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          '200': { description: 'Release executed' },
+          '400': { description: 'Validation error' },
+        },
+      },
+    },
+  },
+};
+
+async function main() {
+  const outputPath = path.resolve(__dirname, '..', 'public', 'openapi.json');
+  await writeFile(outputPath, JSON.stringify(spec, null, 2));
+  console.log(`OpenAPI spec written to ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error('Failed to generate OpenAPI spec:', error);
+  process.exitCode = 1;
+});

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,6 +1,5 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import { sha256Hex } from "../crypto/merkle";
+import { pool } from "../db/pool";
 
 export async function appendAudit(actor: string, action: string, payload: any) {
   const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,17 @@
+import 'dotenv/config';
+import { Pool, PoolConfig } from 'pg';
+
+const poolConfig: PoolConfig | undefined = process.env.DATABASE_URL
+  ? { connectionString: process.env.DATABASE_URL }
+  : undefined;
+
+export const pool = new Pool(poolConfig);
+
+export async function withClient<T>(fn: (client: import('pg').PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,5 +1,4 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,5 +1,4 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
   return async (req:any, res:any, next:any) => {

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,8 +1,7 @@
-﻿import { Pool } from "pg";
+import { pool } from "../db/pool";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,10 +1,9 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
 
 export async function closeAndIssue(req:any, res:any) {
   const { abn, taxType, periodId, thresholds } = req.body;

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,8 +1,7 @@
-﻿import { Pool } from "pg";
+import { pool } from "../db/pool";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {


### PR DESCRIPTION
## Summary
- add a TypeScript migration runner with checksum logging alongside docs utilities for OpenAPI, coverage, and link validation
- centralize PostgreSQL pool usage in shared modules and enforce the pattern with ESLint, husky, and lint-staged
- wire up GitHub Actions CI to install dependencies, run linting, migrations, tests, documentation tasks, and gitleaks on a Postgres-backed build

## Testing
- npm install *(fails: registry returned 403 in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68e3096e9dd08327827a62b5f1c96bf8