### PR TITLE
Add versioned ATO schedules and rates tooling

### DIFF
--- a/data/ato/gst_2024-07.json
+++ b/data/ato/gst_2024-07.json
@@ -1,0 +1,12 @@
+{
+  "version": "2024-07",
+  "standardRate": 0.1,
+  "reducedRates": {
+    "basicFood": 0,
+    "exportedGoods": 0,
+    "inputTaxed": 0
+  },
+  "registrationThreshold": 75000,
+  "cashAccountingThreshold": 1000000,
+  "rounding": "standard"
+}

--- a/data/ato/paygw_2024-07.json
+++ b/data/ato/paygw_2024-07.json
@@ -1,0 +1,65 @@
+{
+  "version": "2024-07",
+  "frequencies": {
+    "weekly": {
+      "rounding": "bankers",
+      "medicareLevy": {
+        "lowerThreshold": 900,
+        "upperThreshold": 1200,
+        "fullRate": 0.02,
+        "phaseInRate": 0.08
+      },
+      "brackets": [
+        { "min": 0, "max": 350, "base": 0, "rate": 0, "offset": 0 },
+        { "min": 350, "max": 700, "base": 0, "rate": 0.19, "offset": 10 },
+        { "min": 700, "max": 1500, "base": 56.5, "rate": 0.325, "offset": 0 },
+        { "min": 1500, "max": null, "base": 316.5, "rate": 0.37, "offset": 0 }
+      ]
+    },
+    "fortnightly": {
+      "rounding": "bankers",
+      "medicareLevy": {
+        "lowerThreshold": 1800,
+        "upperThreshold": 2400,
+        "fullRate": 0.02,
+        "phaseInRate": 0.08
+      },
+      "brackets": [
+        { "min": 0, "max": 700, "base": 0, "rate": 0, "offset": 0 },
+        { "min": 700, "max": 1400, "base": 0, "rate": 0.19, "offset": 20 },
+        { "min": 1400, "max": 3000, "base": 113, "rate": 0.325, "offset": 0 },
+        { "min": 3000, "max": null, "base": 633, "rate": 0.37, "offset": 0 }
+      ]
+    },
+    "monthly": {
+      "rounding": "bankers",
+      "medicareLevy": {
+        "lowerThreshold": 3900,
+        "upperThreshold": 5200,
+        "fullRate": 0.02,
+        "phaseInRate": 0.08
+      },
+      "brackets": [
+        { "min": 0, "max": 1516.67, "base": 0, "rate": 0, "offset": 0 },
+        { "min": 1516.67, "max": 3033.33, "base": 0, "rate": 0.19, "offset": 43.33 },
+        { "min": 3033.33, "max": 6500, "base": 244.83, "rate": 0.325, "offset": 0 },
+        { "min": 6500, "max": null, "base": 1371.5, "rate": 0.37, "offset": 0 }
+      ]
+    },
+    "quarterly": {
+      "rounding": "standard",
+      "medicareLevy": {
+        "lowerThreshold": 11700,
+        "upperThreshold": 15600,
+        "fullRate": 0.02,
+        "phaseInRate": 0.08
+      },
+      "brackets": [
+        { "min": 0, "max": 4550, "base": 0, "rate": 0, "offset": 0 },
+        { "min": 4550, "max": 9100, "base": 0, "rate": 0.19, "offset": 130 },
+        { "min": 9100, "max": 19500, "base": 734.5, "rate": 0.325, "offset": 0 },
+        { "min": 19500, "max": null, "base": 4114.5, "rate": 0.37, "offset": 0 }
+      ]
+    }
+  }
+}

--- a/data/ato/penalties_2024-07.json
+++ b/data/ato/penalties_2024-07.json
@@ -1,0 +1,15 @@
+{
+  "version": "2024-07",
+  "penaltyUnitAmount": 313,
+  "gracePeriodDays": 0,
+  "tiers": [
+    { "minDays": 1, "maxDays": 28, "units": 1 },
+    { "minDays": 29, "maxDays": 56, "units": 2 },
+    { "minDays": 57, "maxDays": 84, "units": 3 },
+    { "minDays": 85, "maxDays": null, "units": 5 }
+  ],
+  "interest": {
+    "rate": 0.07,
+    "rounding": "bankers"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "rates:bump": "tsx scripts/rates-bump.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/rates-bump.ts
+++ b/scripts/rates-bump.ts
@@ -1,0 +1,85 @@
+import { promises as fs, constants as fsConstants } from "fs";
+import path from "path";
+
+const [, , requestedVersion] = process.argv;
+
+if (!requestedVersion) {
+  console.error("Usage: pnpm rates:bump <YYYY-MM>");
+  process.exit(1);
+}
+
+if (!/^\d{4}-\d{2}$/.test(requestedVersion)) {
+  console.error(`Invalid rates version "${requestedVersion}". Use the format YYYY-MM.`);
+  process.exit(1);
+}
+
+const projectRoot = process.cwd();
+const versionFile = path.join(projectRoot, "src", "tax", "ratesVersion.ts");
+const dataDir = path.join(projectRoot, "data", "ato");
+const fixtureFile = path.join(projectRoot, "tests", "fixtures", "tax", "edgeCases.json");
+
+async function readCurrentVersion(): Promise<string> {
+  const source = await fs.readFile(versionFile, "utf8");
+  const match = source.match(/RATES_VERSION\s*=\s*"([^"]+)"/);
+  if (!match) {
+    throw new Error("Unable to find RATES_VERSION in src/tax/ratesVersion.ts");
+  }
+  return match[1];
+}
+
+async function copyRateFile(baseName: string, currentVersion: string, nextVersion: string): Promise<void> {
+  const currentPath = path.join(dataDir, `${baseName}_${currentVersion}.json`);
+  const nextPath = path.join(dataDir, `${baseName}_${nextVersion}.json`);
+  await fs.access(currentPath);
+  try {
+    await fs.access(nextPath);
+    console.warn(`Skipped ${baseName}: ${nextPath} already exists.`);
+  } catch {
+    await fs.copyFile(currentPath, nextPath, fsConstants.COPYFILE_EXCL);
+    console.log(`Copied ${baseName}_${currentVersion}.json → ${baseName}_${nextVersion}.json`);
+  }
+}
+
+async function updateVersionFile(nextVersion: string): Promise<void> {
+  const source = await fs.readFile(versionFile, "utf8");
+  const updated = source.replace(/RATES_VERSION\s*=\s*"([^"]+)"/, `RATES_VERSION = "${nextVersion}"`);
+  await fs.writeFile(versionFile, `${updated.trim()}\n`);
+}
+
+async function updateFixtureVersion(nextVersion: string): Promise<void> {
+  try {
+    const raw = await fs.readFile(fixtureFile, "utf8");
+    const data = JSON.parse(raw);
+    if (!data.meta || typeof data.meta !== "object") {
+      data.meta = {};
+    }
+    data.meta.ratesVersion = nextVersion;
+    const serialized = JSON.stringify(data, null, 2);
+    await fs.writeFile(fixtureFile, `${serialized}\n`);
+    console.log(`Updated fixture rates version → ${nextVersion}`);
+  } catch (error) {
+    console.warn(`Unable to update fixture metadata: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const currentVersion = await readCurrentVersion();
+  if (currentVersion === requestedVersion) {
+    console.log(`Rates already at ${requestedVersion}. Nothing to do.`);
+    return;
+  }
+
+  const baseFiles = ["paygw", "gst", "penalties"] as const;
+  for (const base of baseFiles) {
+    await copyRateFile(base, currentVersion, requestedVersion);
+  }
+
+  await updateVersionFile(requestedVersion);
+  await updateFixtureVersion(requestedVersion);
+  console.log(`Updated RATES_VERSION ${currentVersion} → ${requestedVersion}`);
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/src/tax/atoSchedules.ts
+++ b/src/tax/atoSchedules.ts
@@ -1,0 +1,150 @@
+import { readFileSync } from "fs";
+import path from "path";
+import { RATES_VERSION } from "./ratesVersion";
+
+export type PayFrequency = "weekly" | "fortnightly" | "monthly" | "quarterly";
+export type RoundingMode = "bankers" | "standard" | "up" | "down";
+
+export interface PaygwBracket {
+  min: number;
+  max: number | null;
+  base: number;
+  rate: number;
+  offset?: number;
+}
+
+export interface MedicareLevyConfig {
+  lowerThreshold: number;
+  upperThreshold: number;
+  fullRate: number;
+  phaseInRate: number;
+}
+
+export interface PaygwFrequencySchedule {
+  rounding: RoundingMode;
+  medicareLevy?: MedicareLevyConfig;
+  brackets: PaygwBracket[];
+}
+
+export interface PaygwSchedule {
+  version: string;
+  frequencies: Record<PayFrequency, PaygwFrequencySchedule>;
+}
+
+export interface GstSchedule {
+  version: string;
+  standardRate: number;
+  reducedRates: Record<string, number>;
+  registrationThreshold: number;
+  cashAccountingThreshold: number;
+  rounding: RoundingMode;
+}
+
+export interface PenaltyTier {
+  minDays: number;
+  maxDays?: number | null;
+  units: number;
+}
+
+export interface PenaltySchedule {
+  version: string;
+  penaltyUnitAmount: number;
+  gracePeriodDays?: number;
+  tiers: PenaltyTier[];
+  interest: {
+    rate: number;
+    rounding: RoundingMode;
+  };
+}
+
+const DATA_ROOT = path.resolve(process.cwd(), "data", "ato");
+
+let paygwCache: PaygwSchedule | undefined;
+let gstCache: GstSchedule | undefined;
+let penaltyCache: PenaltySchedule | undefined;
+
+function loadJson<T>(name: string): T {
+  const filePath = path.join(DATA_ROOT, `${name}_${RATES_VERSION}.json`);
+  try {
+    const raw = readFileSync(filePath, "utf8");
+    return JSON.parse(raw) as T;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to load ${name} schedule for ${RATES_VERSION}: ${message}`);
+  }
+}
+
+export function getPaygwSchedule(): PaygwSchedule {
+  if (!paygwCache) {
+    paygwCache = loadJson<PaygwSchedule>("paygw");
+  }
+  return paygwCache;
+}
+
+export function getGstSchedule(): GstSchedule {
+  if (!gstCache) {
+    gstCache = loadJson<GstSchedule>("gst");
+  }
+  return gstCache;
+}
+
+export function getPenaltySchedule(): PenaltySchedule {
+  if (!penaltyCache) {
+    penaltyCache = loadJson<PenaltySchedule>("penalties");
+  }
+  return penaltyCache;
+}
+
+export function roundCurrency(value: number, mode: RoundingMode = "standard", digits = 2): number {
+  if (!Number.isFinite(value)) {
+    return value;
+  }
+  let rounded: number;
+  switch (mode) {
+    case "bankers":
+      rounded = bankersRound(value, digits);
+      break;
+    case "up":
+      rounded = roundUp(value, digits);
+      break;
+    case "down":
+      rounded = roundDown(value, digits);
+      break;
+    default:
+      rounded = roundStandard(value, digits);
+      break;
+  }
+  return Number(rounded.toFixed(digits));
+}
+
+function bankersRound(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  const scaled = value * factor;
+  const truncated = Math.trunc(scaled);
+  const fractional = scaled - truncated;
+  const epsilon = 1e-8;
+
+  if (Math.abs(Math.abs(fractional) - 0.5) < epsilon) {
+    const adjustment = truncated % 2 === 0 ? 0 : Math.sign(scaled);
+    return (truncated + adjustment) / factor;
+  }
+
+  return Math.round(scaled) / factor;
+}
+
+function roundStandard(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function roundUp(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  const scaled = value * factor;
+  return Math.ceil(scaled - 1e-10) / factor;
+}
+
+function roundDown(value: number, digits: number): number {
+  const factor = 10 ** digits;
+  const scaled = value * factor;
+  return Math.floor(scaled + 1e-10) / factor;
+}

--- a/src/tax/ratesVersion.ts
+++ b/src/tax/ratesVersion.ts
@@ -1,0 +1,1 @@
+export const RATES_VERSION = "2024-07";

--- a/src/utils/gst.ts
+++ b/src/utils/gst.ts
@@ -1,6 +1,10 @@
 import { GstInput } from "../types/tax";
+import { getGstSchedule, roundCurrency } from "../tax/atoSchedules";
 
 export function calculateGst({ saleAmount, exempt = false }: GstInput): number {
   if (exempt) return 0;
-  return saleAmount * 0.1;
+
+  const schedule = getGstSchedule();
+  const liability = saleAmount * schedule.standardRate;
+  return roundCurrency(liability, schedule.rounding);
 }

--- a/src/utils/paygw.ts
+++ b/src/utils/paygw.ts
@@ -1,7 +1,37 @@
 import { PaygwInput } from "../types/tax";
+import { getPaygwSchedule, roundCurrency } from "../tax/atoSchedules";
 
 export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): number {
-  const baseRate = 0.20;
-  const liability = grossIncome * baseRate - deductions - taxWithheld;
-  return Math.max(liability, 0);
+  const schedule = getPaygwSchedule();
+  const frequency = schedule.frequencies[period];
+  if (!frequency) {
+    throw new Error(`Unsupported pay frequency: ${period}`);
+  }
+
+  const bracket = frequency.brackets.find((entry) => {
+    const upperBound = entry.max ?? Number.POSITIVE_INFINITY;
+    return grossIncome >= entry.min && grossIncome <= upperBound;
+  }) ?? frequency.brackets[frequency.brackets.length - 1];
+
+  const taxablePortion = Math.max(0, grossIncome - bracket.min);
+  let liability = bracket.base + taxablePortion * bracket.rate;
+
+  if (bracket.offset) {
+    liability -= bracket.offset;
+  }
+
+  if (frequency.medicareLevy) {
+    const { lowerThreshold, upperThreshold, fullRate, phaseInRate } = frequency.medicareLevy;
+    if (grossIncome > upperThreshold) {
+      liability += grossIncome * fullRate;
+    } else if (grossIncome > lowerThreshold) {
+      liability += (grossIncome - lowerThreshold) * phaseInRate;
+    }
+  }
+
+  liability -= deductions;
+  liability -= taxWithheld;
+
+  const rounded = roundCurrency(Math.max(liability, 0), frequency.rounding);
+  return rounded;
 }

--- a/src/utils/penalties.ts
+++ b/src/utils/penalties.ts
@@ -1,5 +1,27 @@
+import { getPenaltySchedule, roundCurrency } from "../tax/atoSchedules";
+
 export function calculatePenalties(daysLate: number, amountDue: number): number {
-  const basePenalty = amountDue * 0.05;
-  const dailyInterest = amountDue * 0.0002;
-  return basePenalty + (dailyInterest * daysLate);
+  if (daysLate <= 0) {
+    return 0;
+  }
+
+  const schedule = getPenaltySchedule();
+  const gracePeriod = schedule.gracePeriodDays ?? 0;
+  const effectiveDays = Math.max(0, daysLate - gracePeriod);
+  if (effectiveDays === 0) {
+    return 0;
+  }
+
+  const tier = schedule.tiers.find((entry) => {
+    const lower = entry.minDays;
+    const upper = entry.maxDays ?? Number.POSITIVE_INFINITY;
+    return effectiveDays >= lower && effectiveDays <= upper;
+  }) ?? schedule.tiers[schedule.tiers.length - 1];
+
+  const penaltyBase = tier.units * schedule.penaltyUnitAmount;
+  const interestRate = schedule.interest.rate;
+  const interest = Math.max(amountDue, 0) * interestRate * (effectiveDays / 365);
+
+  const total = penaltyBase + interest;
+  return roundCurrency(total, schedule.interest.rounding);
 }

--- a/tests/fixtures/tax/edgeCases.json
+++ b/tests/fixtures/tax/edgeCases.json
@@ -1,0 +1,93 @@
+{
+  "meta": {
+    "ratesVersion": "2024-07"
+  },
+  "paygw": [
+    {
+      "scenario": "threshold-zero-withholding",
+      "frequency": "weekly",
+      "grossIncome": 350,
+      "taxWithheld": 0,
+      "deductions": 0,
+      "expected": 0
+    },
+    {
+      "scenario": "offset-transition",
+      "frequency": "weekly",
+      "grossIncome": 700,
+      "taxWithheld": 0,
+      "deductions": 0,
+      "expected": 56.5
+    },
+    {
+      "scenario": "bankers-rounding",
+      "frequency": "weekly",
+      "grossIncome": 700.17,
+      "taxWithheld": 0,
+      "deductions": 0,
+      "expected": 56.56
+    },
+    {
+      "scenario": "medicare-phase-in",
+      "frequency": "weekly",
+      "grossIncome": 950,
+      "taxWithheld": 0,
+      "deductions": 0,
+      "expected": 141.75
+    },
+    {
+      "scenario": "medicare-full-rate",
+      "frequency": "weekly",
+      "grossIncome": 1300,
+      "taxWithheld": 100,
+      "deductions": 50,
+      "expected": 127.5
+    },
+    {
+      "scenario": "monthly-aggregation",
+      "frequency": "monthly",
+      "grossIncome": 4000,
+      "taxWithheld": 0,
+      "deductions": 0,
+      "expected": 567
+    }
+  ],
+  "gst": [
+    {
+      "scenario": "standard-rate",
+      "saleAmount": 1000,
+      "expected": 100
+    },
+    {
+      "scenario": "rounding-check",
+      "saleAmount": 999,
+      "expected": 99.9
+    },
+    {
+      "scenario": "exempt-supply",
+      "saleAmount": 1200,
+      "exempt": true,
+      "expected": 0
+    }
+  ],
+  "penalties": [
+    {
+      "scenario": "tier-one",
+      "daysLate": 10,
+      "amountDue": 5000,
+      "expected": 322.59
+    },
+    {
+      "scenario": "tier-three",
+      "daysLate": 60,
+      "amountDue": 5000,
+      "expected": 996.53
+    },
+    {
+      "scenario": "tier-four",
+      "daysLate": 100,
+      "amountDue": 5000,
+      "expected": 1660.89
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- store PAYGW, GST, and penalty rate tables under data/ato scoped by the current RATES_VERSION and expose a loader with banker's rounding support
- update PAYGW, GST, and penalty calculators to consume the schedules and add fixtures that cover thresholds, offsets, levy treatment, and penalty tiers
- add a rates:bump helper that copies the current data files to a new version and updates the rates metadata

## Testing
- npx tsx --eval "import { calculatePaygw } from './src/utils/paygw'; console.log('weekly 350', calculatePaygw({ employeeName: 'A', grossIncome: 350, taxWithheld: 0, period: 'weekly' }));" et al.
- npx tsx scripts/rates-bump.ts 2024-07
- pnpm lint *(fails: Invalid package manager specification in package.json (pnpm@9); expected a semver version)*

------
https://chatgpt.com/codex/tasks/task_e_68e3097382ec8327a9b9639e95aff20a