### PR TITLE
Add webhook ingestion and recon pipeline

### DIFF
--- a/libs/vendor/zod/index.d.ts
+++ b/libs/vendor/zod/index.d.ts
@@ -1,0 +1,43 @@
+export type ZodIssue = { path: (string | number)[]; message: string };
+export type SafeParseSuccess<T> = { success: true; data: T };
+export type SafeParseError = { success: false; error: { issues: ZodIssue[] } };
+
+export interface ZodSchema<T> {
+  safeParse(value: unknown, path?: (string | number)[]): SafeParseSuccess<T> | SafeParseError;
+  parse(value: unknown): T;
+  refine(check: (value: T) => boolean, message?: string): ZodSchema<T>;
+  optional(): ZodSchema<T | undefined>;
+}
+
+export interface ZodString extends ZodSchema<string> {
+  min(length: number, message?: string): ZodString;
+  regex(pattern: RegExp, message?: string): ZodString;
+}
+
+export interface ZodNumber extends ZodSchema<number> {
+  int(message?: string): ZodNumber;
+  nonnegative(message?: string): ZodNumber;
+  positive(message?: string): ZodNumber;
+}
+
+export interface ZodArray<T> extends ZodSchema<T[]> {
+  min(length: number, message?: string): ZodArray<T>;
+}
+
+export type infer<T extends ZodSchema<any>> = T extends ZodSchema<infer U> ? U : never;
+
+export interface ZodObjectShape {
+  [key: string]: ZodSchema<any>;
+}
+
+export interface ZodObject<T extends ZodObjectShape> extends ZodSchema<{ [K in keyof T]: infer<T[K]> }> {}
+
+export interface ZodEnum<T extends readonly [string, ...string[]]> extends ZodSchema<T[number]> {}
+
+export const z: {
+  string(): ZodString;
+  number(): ZodNumber;
+  array<A>(inner: ZodSchema<A>): ZodArray<A>;
+  object<T extends ZodObjectShape>(shape: T): ZodObject<T>;
+  enum<T extends readonly [string, ...string[]]>(values: T): ZodEnum<T>;
+};

--- a/libs/vendor/zod/index.js
+++ b/libs/vendor/zod/index.js
@@ -1,0 +1,248 @@
+"use strict";
+function makeError(message, path) {
+  return { success: false, error: { issues: [{ message, path: path || [] }] } };
+}
+function makeSuccess(data) {
+  return { success: true, data };
+}
+function cloneChecks(checks) {
+  return checks.slice();
+}
+function buildString(checks) {
+  const schema = {
+    _checks: cloneChecks(checks),
+    safeParse(value, path) {
+      const p = path || [];
+      if (typeof value !== "string") {
+        return makeError("Expected string", p);
+      }
+      for (const check of this._checks) {
+        if (!check.fn(value)) {
+          return makeError(check.message, p);
+        }
+      }
+      return makeSuccess(value);
+    },
+    parse(value) {
+      const res = this.safeParse(value);
+      if (!res.success) {
+        const err = new Error("Invalid input");
+        err.issues = res.error.issues;
+        throw err;
+      }
+      return res.data;
+    },
+    refine(fn, message) {
+      const msg = message || "Invalid value";
+      return buildString([...this._checks, { fn, message: msg }]);
+    },
+    optional() {
+      return buildOptional(this);
+    },
+    min(len, message) {
+      const msg = message || `Must be at least ${len} characters`;
+      return this.refine((val) => val.length >= len, msg);
+    },
+    regex(re, message) {
+      const msg = message || "Invalid format";
+      return this.refine((val) => re.test(val), msg);
+    }
+  };
+  return schema;
+}
+function buildNumber(checks) {
+  const schema = {
+    _checks: cloneChecks(checks),
+    safeParse(value, path) {
+      const p = path || [];
+      if (typeof value !== "number" || Number.isNaN(value)) {
+        return makeError("Expected number", p);
+      }
+      for (const check of this._checks) {
+        if (!check.fn(value)) {
+          return makeError(check.message, p);
+        }
+      }
+      return makeSuccess(value);
+    },
+    parse(value) {
+      const res = this.safeParse(value);
+      if (!res.success) {
+        const err = new Error("Invalid input");
+        err.issues = res.error.issues;
+        throw err;
+      }
+      return res.data;
+    },
+    refine(fn, message) {
+      const msg = message || "Invalid value";
+      return buildNumber([...this._checks, { fn, message: msg }]);
+    },
+    optional() {
+      return buildOptional(this);
+    },
+    int(message) {
+      const msg = message || "Expected integer";
+      return this.refine((val) => Number.isInteger(val), msg);
+    },
+    nonnegative(message) {
+      const msg = message || "Must be non-negative";
+      return this.refine((val) => val >= 0, msg);
+    },
+    positive(message) {
+      const msg = message || "Must be positive";
+      return this.refine((val) => val > 0, msg);
+    }
+  };
+  return schema;
+}
+function buildArray(inner, checks) {
+  const schema = {
+    _checks: cloneChecks(checks),
+    safeParse(value, path) {
+      const p = path || [];
+      if (!Array.isArray(value)) {
+        return makeError("Expected array", p);
+      }
+      let issues = [];
+      const data = [];
+      value.forEach((item, idx) => {
+        const res = inner.safeParse(item, [...p, idx]);
+        if (!res.success) {
+          issues = issues.concat(res.error.issues);
+        } else {
+          data.push(res.data);
+        }
+      });
+      if (issues.length) {
+        return { success: false, error: { issues } };
+      }
+      for (const check of this._checks) {
+        if (!check.fn(data)) {
+          return makeError(check.message, p);
+        }
+      }
+      return makeSuccess(data);
+    },
+    parse(value) {
+      const res = this.safeParse(value);
+      if (!res.success) {
+        const err = new Error("Invalid input");
+        err.issues = res.error.issues;
+        throw err;
+      }
+      return res.data;
+    },
+    refine(fn, message) {
+      const msg = message || "Invalid value";
+      return buildArray(inner, [...this._checks, { fn, message: msg }]);
+    },
+    optional() {
+      return buildOptional(this);
+    },
+    min(len, message) {
+      const msg = message || `Must contain at least ${len} items`;
+      return this.refine((arr) => arr.length >= len, msg);
+    }
+  };
+  return schema;
+}
+function buildObject(shape, checks) {
+  const schema = {
+    _checks: cloneChecks(checks),
+    safeParse(value, path) {
+      const p = path || [];
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        return makeError("Expected object", p);
+      }
+      const data = {};
+      let issues = [];
+      for (const key of Object.keys(shape)) {
+        const parser = shape[key];
+        const res = parser.safeParse(value[key], [...p, key]);
+        if (!res.success) {
+          issues = issues.concat(res.error.issues);
+        } else {
+          data[key] = res.data;
+        }
+      }
+      if (issues.length) {
+        return { success: false, error: { issues } };
+      }
+      for (const check of this._checks) {
+        if (!check.fn(data)) {
+          return makeError(check.message, p);
+        }
+      }
+      return makeSuccess(data);
+    },
+    parse(value) {
+      const res = this.safeParse(value);
+      if (!res.success) {
+        const err = new Error("Invalid input");
+        err.issues = res.error.issues;
+        throw err;
+      }
+      return res.data;
+    },
+    refine(fn, message) {
+      const msg = message || "Invalid value";
+      return buildObject(shape, [...this._checks, { fn, message: msg }]);
+    },
+    optional() {
+      return buildOptional(this);
+    }
+  };
+  return schema;
+}
+function buildEnum(values) {
+  const allowed = new Set(values);
+  return buildString([{ fn: (v) => allowed.has(v), message: `Expected one of ${values.join(", ")}` }]);
+}
+function buildOptional(inner) {
+  return {
+    safeParse(value, path) {
+      if (value === undefined || value === null) {
+        return makeSuccess(undefined);
+      }
+      return inner.safeParse(value, path);
+    },
+    parse(value) {
+      const res = this.safeParse(value);
+      if (!res.success) {
+        const err = new Error("Invalid input");
+        err.issues = res.error.issues;
+        throw err;
+      }
+      return res.data;
+    },
+    refine(fn, message) {
+      const msg = message || "Invalid value";
+      return buildOptional(inner.refine((val) => val === undefined || fn(val), msg));
+    },
+    optional() {
+      return this;
+    }
+  };
+}
+const z = {
+  string() {
+    return buildString([]);
+  },
+  number() {
+    return buildNumber([]);
+  },
+  array(inner) {
+    return buildArray(inner, []);
+  },
+  object(shape) {
+    return buildObject(shape, []);
+  },
+  enum(values) {
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error("z.enum requires a non-empty array");
+    }
+    return buildEnum(values);
+  }
+};
+module.exports = { z };

--- a/libs/vendor/zod/package.json
+++ b/libs/vendor/zod/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "zod",
+  "version": "0.0.0",
+  "description": "Minimal runtime subset of Zod for offline validation",
+  "main": "index.js",
+  "types": "index.d.ts",
+  "license": "MIT"
+}

--- a/migrations/003_ingest_recon.sql
+++ b/migrations/003_ingest_recon.sql
@@ -1,0 +1,53 @@
+-- 003_ingest_recon.sql
+-- Event ingestion tables and reconciliation aggregates
+
+CREATE TABLE IF NOT EXISTS payroll_events (
+  id BIGSERIAL PRIMARY KEY,
+  source_event_id TEXT NOT NULL,
+  employer_abn TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  event_ts TIMESTAMPTZ NOT NULL,
+  gross_total_cents BIGINT NOT NULL,
+  withheld_total_cents BIGINT NOT NULL,
+  expected_withholding_cents BIGINT NOT NULL,
+  line_count INTEGER NOT NULL,
+  payload JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (source_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS payroll_events_period_idx
+  ON payroll_events (employer_abn, period_id, event_ts);
+
+CREATE TABLE IF NOT EXISTS pos_events (
+  id BIGSERIAL PRIMARY KEY,
+  source_event_id TEXT NOT NULL,
+  merchant_abn TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  event_ts TIMESTAMPTZ NOT NULL,
+  net_total_cents BIGINT NOT NULL,
+  gst_total_cents BIGINT NOT NULL,
+  expected_gst_cents BIGINT NOT NULL,
+  line_count INTEGER NOT NULL,
+  payload JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (source_event_id)
+);
+
+CREATE INDEX IF NOT EXISTS pos_events_period_idx
+  ON pos_events (merchant_abn, period_id, event_ts);
+
+CREATE TABLE IF NOT EXISTS recon_inputs (
+  abn TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  paygw_expected_cents BIGINT NOT NULL DEFAULT 0,
+  paygw_reported_cents BIGINT NOT NULL DEFAULT 0,
+  gst_expected_cents BIGINT NOT NULL DEFAULT 0,
+  gst_reported_cents BIGINT NOT NULL DEFAULT 0,
+  payroll_event_count INTEGER NOT NULL DEFAULT 0,
+  pos_event_count INTEGER NOT NULL DEFAULT 0,
+  last_payroll_event_ts TIMESTAMPTZ,
+  last_pos_event_ts TIMESTAMPTZ,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (abn, period_id)
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
                 "express": "^5.1.0",
                 "pg": "^8.16.3",
                 "tweetnacl": "^1.0.3",
-                "uuid": "^13.0.0"
+                "uuid": "^13.0.0",
+                "zod": "file:libs/vendor/zod"
             },
             "devDependencies": {
                 "@types/express": "^5.0.3",
@@ -35,6 +36,15 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/zod": {
+            "resolved": "file:libs/vendor/zod",
+            "link": true
+        },
+        "libs/vendor/zod": {
+            "name": "zod",
+            "version": "0.0.0",
+            "license": "MIT"
         },
         "node_modules/@esbuild/aix-ppc64": {
             "version": "0.25.10",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "express": "^5.1.0",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "zod": "file:libs/vendor/zod"
     }
 }

--- a/src/recon/recompute.ts
+++ b/src/recon/recompute.ts
@@ -1,0 +1,177 @@
+// src/recon/recompute.ts
+import { Pool } from "pg";
+import { appendAudit } from "../audit/appendOnly";
+
+const pool = new Pool();
+const DEFAULT_TOLERANCE = 100;
+
+function asNumber(value: unknown): number {
+  const num = Number(value ?? 0);
+  return Number.isFinite(num) ? num : 0;
+}
+
+function resolveTolerance(): number {
+  const raw = process.env.RECON_TOLERANCE_CENTS;
+  if (!raw) return DEFAULT_TOLERANCE;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : DEFAULT_TOLERANCE;
+}
+
+export interface ReconResult {
+  schema: "recon.v1.result";
+  abn: string;
+  period_id: string;
+  generated_at: string;
+  tolerance_cents: number;
+  ok: boolean;
+  state: string;
+  paygw: {
+    expected_cents: number;
+    reported_cents: number;
+    delta_cents: number;
+    event_count: number;
+  };
+  gst: {
+    expected_cents: number;
+    reported_cents: number;
+    delta_cents: number;
+    event_count: number;
+  };
+}
+
+export async function recomputeRecon(abn: string, periodId: string): Promise<ReconResult> {
+  const tolerance = resolveTolerance();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const payrollAgg = await client.query(
+      `SELECT
+         COALESCE(SUM(expected_withholding_cents),0)  AS expected_withholding_cents,
+         COALESCE(SUM(withheld_total_cents),0)       AS reported_withholding_cents,
+         COUNT(*)::bigint                            AS event_count,
+         MAX(event_ts)                               AS last_event_ts
+       FROM payroll_events
+       WHERE employer_abn = $1 AND period_id = $2`,
+      [abn, periodId]
+    );
+
+    const posAgg = await client.query(
+      `SELECT
+         COALESCE(SUM(expected_gst_cents),0) AS expected_gst_cents,
+         COALESCE(SUM(gst_total_cents),0)    AS reported_gst_cents,
+         COUNT(*)::bigint                    AS event_count,
+         MAX(event_ts)                       AS last_event_ts
+       FROM pos_events
+       WHERE merchant_abn = $1 AND period_id = $2`,
+      [abn, periodId]
+    );
+
+    const paygwExpected = asNumber(payrollAgg.rows[0]?.expected_withholding_cents);
+    const paygwReported = asNumber(payrollAgg.rows[0]?.reported_withholding_cents);
+    const paygwEvents = Number(payrollAgg.rows[0]?.event_count ?? 0);
+    const lastPayrollTs = payrollAgg.rows[0]?.last_event_ts || null;
+
+    const gstExpected = asNumber(posAgg.rows[0]?.expected_gst_cents);
+    const gstReported = asNumber(posAgg.rows[0]?.reported_gst_cents);
+    const gstEvents = Number(posAgg.rows[0]?.event_count ?? 0);
+    const lastPosTs = posAgg.rows[0]?.last_event_ts || null;
+
+    await client.query(
+      `INSERT INTO recon_inputs (
+         abn, period_id,
+         paygw_expected_cents, paygw_reported_cents,
+         gst_expected_cents, gst_reported_cents,
+         payroll_event_count, pos_event_count,
+         last_payroll_event_ts, last_pos_event_ts,
+         updated_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW())
+       ON CONFLICT (abn, period_id) DO UPDATE SET
+         paygw_expected_cents = EXCLUDED.paygw_expected_cents,
+         paygw_reported_cents = EXCLUDED.paygw_reported_cents,
+         gst_expected_cents = EXCLUDED.gst_expected_cents,
+         gst_reported_cents = EXCLUDED.gst_reported_cents,
+         payroll_event_count = EXCLUDED.payroll_event_count,
+         pos_event_count = EXCLUDED.pos_event_count,
+         last_payroll_event_ts = EXCLUDED.last_payroll_event_ts,
+         last_pos_event_ts = EXCLUDED.last_pos_event_ts,
+         updated_at = NOW()`,
+      [
+        abn,
+        periodId,
+        paygwExpected,
+        paygwReported,
+        gstExpected,
+        gstReported,
+        paygwEvents,
+        gstEvents,
+        lastPayrollTs,
+        lastPosTs
+      ]
+    );
+
+    const paygwDelta = paygwReported - paygwExpected;
+    const gstDelta = gstReported - gstExpected;
+    const paygwPass = Math.abs(paygwDelta) <= tolerance;
+    const gstPass = Math.abs(gstDelta) <= tolerance;
+    const ok = paygwPass && gstPass;
+
+    const nextState = ok ? "CLOSING" : "BLOCKED_DISCREPANCY";
+
+    await client.query(
+      `UPDATE periods
+         SET accrued_cents = $3,
+             final_liability_cents = $4,
+             state = CASE
+               WHEN state IN ('OPEN','CLOSING','BLOCKED_DISCREPANCY','BLOCKED_ANOMALY') THEN $5
+               ELSE state
+             END
+       WHERE abn = $1 AND period_id = $2 AND tax_type = 'PAYGW'`,
+      [abn, periodId, paygwExpected, paygwReported, nextState]
+    );
+
+    await client.query(
+      `UPDATE periods
+         SET accrued_cents = $3,
+             final_liability_cents = $4,
+             state = CASE
+               WHEN state IN ('OPEN','CLOSING','BLOCKED_DISCREPANCY','BLOCKED_ANOMALY') THEN $5
+               ELSE state
+             END
+       WHERE abn = $1 AND period_id = $2 AND tax_type = 'GST'`,
+      [abn, periodId, gstExpected, gstReported, nextState]
+    );
+
+    const result: ReconResult = {
+      schema: "recon.v1.result",
+      abn,
+      period_id: periodId,
+      generated_at: new Date().toISOString(),
+      tolerance_cents: tolerance,
+      ok,
+      state: nextState,
+      paygw: {
+        expected_cents: paygwExpected,
+        reported_cents: paygwReported,
+        delta_cents: paygwDelta,
+        event_count: paygwEvents
+      },
+      gst: {
+        expected_cents: gstExpected,
+        reported_cents: gstReported,
+        delta_cents: gstDelta,
+        event_count: gstEvents
+      }
+    };
+
+    await appendAudit("recon", "recon.v1.result", result);
+
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/routes/ingest.ts
+++ b/src/routes/ingest.ts
@@ -1,0 +1,197 @@
+// src/routes/ingest.ts
+import express from "express";
+import crypto from "crypto";
+import { Pool } from "pg";
+import { z } from "zod";
+import { computePaygwTotal, computeLineTotalCents, computeLineGstCents, computeGstTotal } from "../tax/engine";
+import { recomputeRecon } from "../recon/recompute";
+
+const pool = new Pool();
+const SIGNATURE_HEADER = "x-apgms-signature";
+
+interface RawBodyRequest extends express.Request {
+  rawBody?: Buffer;
+}
+
+function extractSignature(headerValue: string | undefined): string | null {
+  if (!headerValue) return null;
+  const trimmed = headerValue.trim();
+  const idx = trimmed.indexOf("=");
+  if (idx > -1) {
+    return trimmed.slice(idx + 1).trim();
+  }
+  return trimmed;
+}
+
+function verifyHmac(req: RawBodyRequest, secret: string | undefined): boolean {
+  if (!secret) {
+    throw new Error("Webhook secret is not configured");
+  }
+  const provided = extractSignature(req.header(SIGNATURE_HEADER) || undefined);
+  if (!provided) {
+    return false;
+  }
+  const rawBody = req.rawBody;
+  if (!rawBody) {
+    return false;
+  }
+  if (!/^[0-9a-fA-F]+$/.test(provided) || provided.length % 2 !== 0) {
+    return false;
+  }
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest();
+  const providedBuf = Buffer.from(provided, "hex");
+  if (providedBuf.length !== expected.length) {
+    return false;
+  }
+  return crypto.timingSafeEqual(expected, providedBuf);
+}
+
+const payrollLineSchema = z.object({
+  employee_id: z.string().min(1, "employee_id required"),
+  gross_cents: z.number().int().nonnegative(),
+  withholding_cents: z.number().int().nonnegative()
+});
+
+const stpSchema = z.object({
+  source_event_id: z.string().min(8, "source_event_id required"),
+  employer_abn: z.string().regex(/^\d{11}$/, "employer_abn must be 11 digits"),
+  period_id: z.string().min(1, "period_id required"),
+  event_timestamp: z.string().refine((val) => !Number.isNaN(Date.parse(val)), "invalid event_timestamp"),
+  payroll: z.array(payrollLineSchema).min(1, "payroll array cannot be empty")
+});
+
+const posLineSchema = z.object({
+  sku: z.string().min(1, "sku required"),
+  quantity: z.number().int().positive(),
+  unit_price_cents: z.number().int().nonnegative(),
+  tax_code: z.string().optional(),
+  tax_collected_cents: z.number().int().nonnegative().optional()
+});
+
+const posSchema = z.object({
+  source_event_id: z.string().min(8, "source_event_id required"),
+  merchant_abn: z.string().regex(/^\d{11}$/, "merchant_abn must be 11 digits"),
+  period_id: z.string().min(1, "period_id required"),
+  event_timestamp: z.string().refine((val) => !Number.isNaN(Date.parse(val)), "invalid event_timestamp"),
+  lines: z.array(posLineSchema).min(1, "lines cannot be empty")
+});
+
+export const ingestRouter = express.Router();
+
+ingestRouter.post("/stp", async (req: RawBodyRequest, res) => {
+  try {
+    const secret = process.env.STP_WEBHOOK_SECRET;
+    if (!verifyHmac(req, secret)) {
+      return res.status(401).json({ error: "INVALID_SIGNATURE" });
+    }
+
+    const parsed = stpSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "INVALID_PAYLOAD", issues: parsed.error.issues });
+    }
+    const event = parsed.data;
+
+    const payrollTotals = event.payroll.map((line) => ({ gross_cents: line.gross_cents }));
+    const grossTotal = event.payroll.reduce((sum, line) => sum + line.gross_cents, 0);
+    const reportedWithholding = event.payroll.reduce((sum, line) => sum + line.withholding_cents, 0);
+    const expectedWithholding = computePaygwTotal(payrollTotals);
+
+    const insert = await pool.query(
+      `INSERT INTO payroll_events (
+         source_event_id, employer_abn, period_id, event_ts,
+         gross_total_cents, withheld_total_cents, expected_withholding_cents,
+         line_count, payload
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       ON CONFLICT (source_event_id) DO NOTHING
+       RETURNING id`,
+      [
+        event.source_event_id,
+        event.employer_abn,
+        event.period_id,
+        new Date(event.event_timestamp).toISOString(),
+        grossTotal,
+        reportedWithholding,
+        expectedWithholding,
+        event.payroll.length,
+        event
+      ]
+    );
+
+    const duplicate = insert.rowCount === 0;
+    const recon = duplicate ? null : await recomputeRecon(event.employer_abn, event.period_id);
+
+    return res.status(duplicate ? 200 : 202).json({
+      ok: true,
+      duplicate,
+      recon
+    });
+  } catch (err: any) {
+    console.error("/ingest/stp error", err);
+    return res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
+});
+
+ingestRouter.post("/pos", async (req: RawBodyRequest, res) => {
+  try {
+    const secret = process.env.POS_WEBHOOK_SECRET;
+    if (!verifyHmac(req, secret)) {
+      return res.status(401).json({ error: "INVALID_SIGNATURE" });
+    }
+
+    const parsed = posSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({ error: "INVALID_PAYLOAD", issues: parsed.error.issues });
+    }
+    const event = parsed.data;
+
+    const normalizedLines = event.lines.map((line) => ({
+      sku: line.sku,
+      quantity: line.quantity,
+      unit_price_cents: line.unit_price_cents,
+      tax_code: line.tax_code ?? "GST",
+      tax_collected_cents: line.tax_collected_cents ?? undefined
+    }));
+
+    const netTotal = normalizedLines.reduce((sum, line) => sum + computeLineTotalCents(line), 0);
+    const expectedGst = computeGstTotal(normalizedLines);
+    const reportedGst = normalizedLines.reduce((sum, line) => {
+      if (typeof line.tax_collected_cents === "number") {
+        return sum + line.tax_collected_cents;
+      }
+      return sum + computeLineGstCents(line);
+    }, 0);
+
+    const insert = await pool.query(
+      `INSERT INTO pos_events (
+         source_event_id, merchant_abn, period_id, event_ts,
+         net_total_cents, gst_total_cents, expected_gst_cents,
+         line_count, payload
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       ON CONFLICT (source_event_id) DO NOTHING
+       RETURNING id`,
+      [
+        event.source_event_id,
+        event.merchant_abn,
+        event.period_id,
+        new Date(event.event_timestamp).toISOString(),
+        netTotal,
+        reportedGst,
+        expectedGst,
+        normalizedLines.length,
+        event
+      ]
+    );
+
+    const duplicate = insert.rowCount === 0;
+    const recon = duplicate ? null : await recomputeRecon(event.merchant_abn, event.period_id);
+
+    return res.status(duplicate ? 200 : 202).json({
+      ok: true,
+      duplicate,
+      recon
+    });
+  } catch (err: any) {
+    console.error("/ingest/pos error", err);
+    return res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
+});

--- a/src/tax/engine.ts
+++ b/src/tax/engine.ts
@@ -1,0 +1,53 @@
+// src/tax/engine.ts
+// Lightweight helpers mirroring the PAYGW/GST logic used by the Python tax-engine service.
+
+export interface PayrollLineInput {
+  gross_cents: number;
+}
+
+export interface PosLineInput {
+  quantity: number;
+  unit_price_cents: number;
+  tax_code?: string | null;
+}
+
+const GST_RATE = 0.10;
+const PAYGW_BRACKET_CENTS = 80_000;
+
+export function computePaygwWithholding(grossCents: number): number {
+  if (!Number.isFinite(grossCents) || grossCents <= 0) {
+    return 0;
+  }
+  if (grossCents <= PAYGW_BRACKET_CENTS) {
+    return Math.round(grossCents * 0.15);
+  }
+  const base = Math.round(PAYGW_BRACKET_CENTS * 0.15);
+  const excess = grossCents - PAYGW_BRACKET_CENTS;
+  return base + Math.round(excess * 0.20);
+}
+
+export function computePaygwTotal(lines: PayrollLineInput[]): number {
+  return lines.reduce((acc, line) => acc + computePaygwWithholding(line.gross_cents), 0);
+}
+
+export function computeLineTotalCents(line: PosLineInput): number {
+  const qty = Number.isFinite(line.quantity) ? line.quantity : 0;
+  const unit = Number.isFinite(line.unit_price_cents) ? line.unit_price_cents : 0;
+  return Math.round(qty * unit);
+}
+
+export function computeLineGstCents(line: PosLineInput): number {
+  const total = computeLineTotalCents(line);
+  const code = (line.tax_code || "GST").toUpperCase();
+  if (total <= 0) {
+    return 0;
+  }
+  if (code === "GST" || code === "" || code === "STANDARD") {
+    return Math.round(total * GST_RATE);
+  }
+  return 0;
+}
+
+export function computeGstTotal(lines: PosLineInput[]): number {
+  return lines.reduce((acc, line) => acc + computeLineGstCents(line), 0);
+}


### PR DESCRIPTION
## Summary
- add signed /ingest/stp and /ingest/pos webhook handlers with Zod validation and HMAC verification
- persist payroll/POS events, recompute tax expectations, and upsert recon inputs with audit emission
- wire recon state updates and create supporting SQL schema plus vendored Zod runtime for offline builds

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e30972571c8327b776e8f3af428ae9