### PR TITLE
Add help content tooling and contextual assistance

### DIFF
--- a/docs/help/bas-operations.mdx
+++ b/docs/help/bas-operations.mdx
@@ -1,0 +1,25 @@
+---
+title: "Preparing and lodging your BAS"
+modes:
+  - bas
+  - compliance
+  - reporting
+tags:
+  - bas
+  - validation
+  - "ato lodge"
+  - "api:GET /bas/preview"
+  - "api:POST /bas/validate"
+  - "api:POST /bas/lodge"
+  - "api:POST /normalize"
+lastUpdated: "2025-10-06T00:27:34.205Z"
+---
+
+Business Activity Statements can be rehearsed and submitted programmatically:
+
+- Call `/bas/preview` to retrieve calculated PAYGW and GST totals for the current period.
+- Validate a draft with `/bas/validate` before presenting it to officers for sign-off.
+- `/bas/lodge` submits to the sandbox ATO gateway and echoes a success message when accepted.
+- `/normalize` can be used to reshape source transactions so they align with your lodgment schema before posting.
+
+Record BAS confirmations in the audit log and attach the portal reference number to your reconciliation evidence bundle.

--- a/docs/help/getting-started.mdx
+++ b/docs/help/getting-started.mdx
@@ -1,0 +1,24 @@
+---
+title: "Getting started with APGMS"
+modes:
+  - onboarding
+  - dashboard
+  - compliance
+tags:
+  - setup
+  - wizard
+  - "buffer accounts"
+  - "api:GET /health"
+  - "api:GET /dashboard/yesterday"
+  - "api:GET /metrics"
+lastUpdated: "2025-10-06T00:27:34.229Z"
+---
+
+Welcome to **APGMS**. New organisations should walk through the setup wizard to capture legal identifiers, link bank accounts, and configure the PAYGW and GST buffers before any liabilities accrue.
+
+1. Visit the **Dashboard** and confirm your next BAS due date.
+2. Launch the **Setup Wizard** to enter your ABN, trading details, and payroll providers.
+3. Link operating and buffer accounts so automated transfers can keep withheld taxes quarantined.
+4. Use the wizard's confirmation step to review compliance status and confirm everything is ready.
+
+> The `/health`, `/dashboard/yesterday`, and `/metrics` endpoints provide quick status checks for monitoring and should return 200 when the platform is ready.

--- a/docs/help/integrations-and-connections.mdx
+++ b/docs/help/integrations-and-connections.mdx
@@ -1,0 +1,27 @@
+---
+title: "Managing integrations and data feeds"
+modes:
+  - integrations
+  - automation
+  - onboarding
+tags:
+  - integrations
+  - connections
+  - payroll
+  - "api:GET /connections"
+  - "api:POST /connections/start"
+  - "api:DELETE /connections/{conn_id}"
+  - "api:GET /transactions"
+  - "api:POST /settings"
+lastUpdated: "2025-10-06T00:27:34.245Z"
+---
+
+Link payroll, POS, and banking providers so APGMS can automate compliance:
+
+- `/connections` lists active authorisations and can be polled to confirm the state after onboarding.
+- Initiate new OAuth-style handshakes with `/connections/start` and direct users to the returned URL.
+- Remove stale credentials with `/connections/{conn_id}` to enforce least-privilege access.
+- `/transactions` surfaces harmonised transactional feeds that drive GST and PAYGW calculations.
+- `/settings` persists security controls like retention windows and PII masking toggles.
+
+Ensure each provider connection is subject to multi-factor authentication and rotate secrets on a set cadence.

--- a/docs/help/monitoring-and-status.mdx
+++ b/docs/help/monitoring-and-status.mdx
@@ -1,0 +1,23 @@
+---
+title: "Monitoring status and compliance posture"
+modes:
+  - monitoring
+  - compliance
+  - engineering
+tags:
+  - monitoring
+  - status
+  - "api inventory"
+  - "api:GET /readyz"
+  - "api:GET /ato/status"
+  - "api:GET /openapi.json"
+lastUpdated: "2025-10-06T00:27:34.261Z"
+---
+
+Set up dashboards and alerts so issues are surfaced before deadlines:
+
+- `/readyz` is the liveness probe for the portal API, returning the server timestamp when healthy.
+- `/ato/status` tracks the connectivity state with the ATO digital services gateway.
+- `/openapi.json` exposes the merged contract for the public API surface; watch for drift after deploys.
+
+Combine these probes with `/metrics` from the main service to create a single source of truth for observability.

--- a/docs/help/payments-and-releases.mdx
+++ b/docs/help/payments-and-releases.mdx
@@ -1,0 +1,28 @@
+---
+title: "Managing PAYGW and GST payments"
+modes:
+  - operations
+  - compliance
+  - finance
+tags:
+  - payments
+  - release
+  - "ato remittance"
+  - "api:POST /api/pay"
+  - "api:POST /api/release"
+  - "api:POST /api/close-issue"
+  - "api:GET /api/balance"
+  - "api:GET /api/ledger"
+  - "api:POST /api/deposit"
+lastUpdated: "2025-10-06T00:27:34.273Z"
+---
+
+Keep PAYGW and GST liabilities in lockstep with payroll and sales activity:
+
+- `/api/balance` surfaces the ledger balance for a given ABN, tax type, and period.
+- `/api/ledger` returns full transaction history for audit trails.
+- `/api/deposit` records incoming PAYGW or GST funds into the quarantined buffer.
+- `/api/pay` and `/api/release` instruct the payments rail to remit funds to the ATO when a reporting period closes.
+- `/api/close-issue` finalises the RPT token and captures the compliance evidence bundle for the period.
+
+Always double check the `amountCents` sign: deposits must be positive, releases must be negative to prevent accidental overdrafts.

--- a/docs/help/settlements-and-payto.mdx
+++ b/docs/help/settlements-and-payto.mdx
@@ -1,0 +1,23 @@
+---
+title: "Settlement ingestion and PayTo sweeps"
+modes:
+  - operations
+  - banking
+  - automation
+tags:
+  - settlements
+  - payto
+  - reconciliation
+  - "api:POST /api/payto/sweep"
+  - "api:POST /api/settlement/webhook"
+  - "api:GET /api/evidence"
+lastUpdated: "2025-10-06T00:27:34.289Z"
+---
+
+Automate inbound settlement handling and evidence capture:
+
+- Use `/api/payto/sweep` when a PayTo agreement needs to sweep excess balances back to your operating account.
+- `/api/settlement/webhook` ingests settlement CSV payloads from banking partners and returns the number of rows processed.
+- `/api/evidence` composes the compliance bundle (including RPT tokens and reconciliation data) for downstream archiving.
+
+Settlement webhooks should be protected with signing middleware and replay protection to satisfy ATO audit expectations.

--- a/docs/help/support-links.mdx
+++ b/docs/help/support-links.mdx
@@ -1,0 +1,22 @@
+---
+title: "ATO resources and support"
+modes:
+  - compliance
+  - reference
+  - onboarding
+tags:
+  - support
+  - "ato guidance"
+  - lodgment
+lastUpdated: "2025-10-06T00:28:57.509Z"
+---
+
+Here are key ATO references to keep handy:
+
+- [ATO PAYGW Guide](https://www.ato.gov.au/business/payg-withholding/)
+- [ATO GST Information](https://www.ato.gov.au/business/gst/)
+- [ATO BAS Portal](https://www.ato.gov.au/business/business-activity-statements-%28bas%29/)
+- [ATO Super Obligations](https://www.ato.gov.au/business/super-for-employers/)
+- [ATO Online Services](https://www.ato.gov.au/General/Online-services/)
+
+Bookmark each link and review updates after budget announcements or legislative changes.

--- a/docs/help/whats-new/2025-09-15.mdx
+++ b/docs/help/whats-new/2025-09-15.mdx
@@ -1,0 +1,11 @@
+---
+title: "ATO connection watchdog"
+date: "2025-09-15"
+tags:
+  - "release-notes"
+  - monitoring
+summary: "ATO link status now visible in dashboards and surfaced via the /ato/status API."
+lastUpdated: "2025-10-06T00:27:34.321Z"
+---
+
+A lightweight watchdog now polls `/ato/status` to track the upstream digital services gateway. Use the new monitoring card to alert operators when the connection drifts from "Connected".

--- a/docs/help/whats-new/2025-10-05.mdx
+++ b/docs/help/whats-new/2025-10-05.mdx
@@ -1,0 +1,12 @@
+---
+title: "Automated help drawer and API coverage checks"
+date: "2025-10-05"
+tags:
+  - "release-notes"
+  - docs
+  - compliance
+summary: "Contextual help now lives inside the app and the docs build validates API coverage."
+lastUpdated: "2025-10-06T00:27:34.337Z"
+---
+
+The help experience now surfaces contextual guidance from anywhere in the console. Each help card references the underlying API endpoints and the docs pipeline validates coverage for the merged OpenAPI spec.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,15 @@
 {
     "scripts": {
         "start": "node dist/index.js",
-        "build": "echo build root",
+        "build": "npm run docs:lastUpdated && npm run docs:index && echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "docs:index": "tsx scripts/docs/buildIndex.ts",
+        "docs:lastUpdated": "tsx scripts/docs/lastUpdated.ts",
+        "docs:coverage": "tsx scripts/docs/openapiCoverage.ts",
+        "docs:links": "tsx scripts/docs/linkCheck.ts",
+        "openapi": "tsx scripts/openapi.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/schema/openapi/merged.json
+++ b/schema/openapi/merged.json
@@ -1,0 +1,258 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "APGMS merged API",
+    "version": "0.1.0",
+    "description": "Combined contract for APGMS operational and portal services"
+  },
+  "servers": [
+    {
+      "url": "https://api.apgms.local"
+    },
+    {
+      "url": "https://portal.apgms.local"
+    }
+  ],
+  "paths": {
+    "/api/balance": {
+      "get": {
+        "summary": "Fetch PAYGW or GST balance",
+        "responses": {
+          "200": {
+            "description": "Balance payload"
+          }
+        }
+      }
+    },
+    "/api/close-issue": {
+      "post": {
+        "summary": "Close reconciliation period and issue RPT token",
+        "responses": {
+          "200": {
+            "description": "Issue closed"
+          }
+        }
+      }
+    },
+    "/api/deposit": {
+      "post": {
+        "summary": "Record incoming deposit",
+        "responses": {
+          "200": {
+            "description": "Deposit recorded"
+          }
+        }
+      }
+    },
+    "/api/evidence": {
+      "get": {
+        "summary": "Retrieve compliance evidence bundle",
+        "responses": {
+          "200": {
+            "description": "Evidence returned"
+          }
+        }
+      }
+    },
+    "/api/ledger": {
+      "get": {
+        "summary": "Fetch ledger entries",
+        "responses": {
+          "200": {
+            "description": "Ledger entries"
+          }
+        }
+      }
+    },
+    "/api/pay": {
+      "post": {
+        "summary": "Trigger PAYGW payment to ATO",
+        "responses": {
+          "200": {
+            "description": "Payment accepted"
+          }
+        }
+      }
+    },
+    "/api/payto/sweep": {
+      "post": {
+        "summary": "Initiate PayTo sweep",
+        "responses": {
+          "200": {
+            "description": "Sweep triggered"
+          }
+        }
+      }
+    },
+    "/api/release": {
+      "post": {
+        "summary": "Release funds to ATO",
+        "responses": {
+          "200": {
+            "description": "Release processed"
+          }
+        }
+      }
+    },
+    "/api/settlement/webhook": {
+      "post": {
+        "summary": "Receive settlement CSV payload",
+        "responses": {
+          "200": {
+            "description": "Settlement ingested"
+          }
+        }
+      }
+    },
+    "/ato/status": {
+      "get": {
+        "summary": "Inspect upstream ATO connection",
+        "responses": {
+          "200": {
+            "description": "ATO status"
+          }
+        }
+      }
+    },
+    "/bas/lodge": {
+      "post": {
+        "summary": "Lodge BAS",
+        "responses": {
+          "200": {
+            "description": "Lodge response"
+          }
+        }
+      }
+    },
+    "/bas/preview": {
+      "get": {
+        "summary": "Preview BAS totals",
+        "responses": {
+          "200": {
+            "description": "Preview response"
+          }
+        }
+      }
+    },
+    "/bas/validate": {
+      "post": {
+        "summary": "Validate BAS draft",
+        "responses": {
+          "200": {
+            "description": "Validation outcome"
+          }
+        }
+      }
+    },
+    "/connections": {
+      "get": {
+        "summary": "List provider connections",
+        "responses": {
+          "200": {
+            "description": "Connections list"
+          }
+        }
+      }
+    },
+    "/connections/{conn_id}": {
+      "delete": {
+        "summary": "Delete provider connection",
+        "responses": {
+          "200": {
+            "description": "Connection removed"
+          }
+        }
+      }
+    },
+    "/connections/start": {
+      "post": {
+        "summary": "Start connection handshake",
+        "responses": {
+          "200": {
+            "description": "Handshake url"
+          }
+        }
+      }
+    },
+    "/dashboard/yesterday": {
+      "get": {
+        "summary": "Previous day dashboard snapshot",
+        "responses": {
+          "200": {
+            "description": "Snapshot returned"
+          }
+        }
+      }
+    },
+    "/health": {
+      "get": {
+        "summary": "Service health probe",
+        "responses": {
+          "200": {
+            "description": "Healthy"
+          }
+        }
+      }
+    },
+    "/metrics": {
+      "get": {
+        "summary": "Prometheus metrics scrape",
+        "responses": {
+          "200": {
+            "description": "Metrics exposition"
+          }
+        }
+      }
+    },
+    "/normalize": {
+      "post": {
+        "summary": "Normalize inbound payloads",
+        "responses": {
+          "200": {
+            "description": "Normalization result"
+          }
+        }
+      }
+    },
+    "/openapi.json": {
+      "get": {
+        "summary": "Expose portal OpenAPI contract",
+        "responses": {
+          "200": {
+            "description": "OpenAPI document"
+          }
+        }
+      }
+    },
+    "/readyz": {
+      "get": {
+        "summary": "Portal liveness probe",
+        "responses": {
+          "200": {
+            "description": "Portal ready"
+          }
+        }
+      }
+    },
+    "/settings": {
+      "post": {
+        "summary": "Persist portal settings",
+        "responses": {
+          "200": {
+            "description": "Settings stored"
+          }
+        }
+      }
+    },
+    "/transactions": {
+      "get": {
+        "summary": "Search harmonised transactions",
+        "responses": {
+          "200": {
+            "description": "Transactions returned"
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/docs/buildIndex.ts
+++ b/scripts/docs/buildIndex.ts
@@ -1,0 +1,170 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { parseFrontmatter } from "./frontmatter";
+
+const HELP_ROOT = path.resolve(process.cwd(), "docs/help");
+const OUTPUT_PATH = path.resolve(process.cwd(), "src/help/HelpIndex.json");
+
+interface LinkSummary {
+  href: string;
+  text: string;
+}
+
+interface BaseEntry {
+  id: string;
+  slug: string;
+  title: string;
+  tags: string[];
+  lastUpdated?: string | null;
+  summary: string;
+  body: string;
+  links: LinkSummary[];
+}
+
+interface HelpTopic extends BaseEntry {
+  modes: string[];
+}
+
+interface WhatsNewEntry extends BaseEntry {
+  date: string;
+}
+
+interface HelpIndex {
+  generatedAt: string;
+  topics: HelpTopic[];
+  whatsNew: WhatsNewEntry[];
+  tags: string[];
+  modes: string[];
+}
+
+function toPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\*\*([^*]+)\*\*/g, "$1")
+    .replace(/\*([^*]+)\*/g, "$1")
+    .replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+    .replace(/![^\s]*\((.*?)\)/g, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/^[-*+]\s+/gm, "")
+    .replace(/^#+\s+/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractLinks(markdown: string): LinkSummary[] {
+  const links: LinkSummary[] = [];
+  const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = linkRegex.exec(markdown)) !== null) {
+    links.push({ href: match[2], text: match[1] });
+  }
+  return links;
+}
+
+async function parseMdxFile(file: string) {
+  const raw = await fs.readFile(file, "utf8");
+  const parsed = parseFrontmatter(raw);
+  const trimmedContent = parsed.content.trim();
+  const paragraphs = trimmedContent.split(/\n\s*\n/).filter((p) => p.trim());
+  const summary = toPlainText(paragraphs[0] ?? "");
+  const body = toPlainText(trimmedContent);
+  const links = extractLinks(parsed.content);
+  return { data: parsed.data, summary, body, links };
+}
+
+async function buildIndex() {
+  try {
+    await fs.access(HELP_ROOT);
+  } catch (err) {
+    console.warn(`[docs:index] Help directory not found at ${HELP_ROOT}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const entries = await fs.readdir(HELP_ROOT, { withFileTypes: true });
+  const topicFiles: string[] = [];
+  const whatsNewFiles: string[] = [];
+
+  for (const entry of entries) {
+    const full = path.join(HELP_ROOT, entry.name);
+    if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      topicFiles.push(full);
+    } else if (entry.isDirectory() && entry.name === "whats-new") {
+      const wnEntries = await fs.readdir(full, { withFileTypes: true });
+      for (const wn of wnEntries) {
+        const wnPath = path.join(full, wn.name);
+        if (wn.isFile() && wn.name.endsWith(".mdx")) {
+          whatsNewFiles.push(wnPath);
+        }
+      }
+    }
+  }
+
+  const topics: HelpTopic[] = [];
+  const whatsNew: WhatsNewEntry[] = [];
+  const tagSet = new Set<string>();
+  const modeSet = new Set<string>();
+
+  for (const file of topicFiles) {
+    const { data, summary, body, links } = await parseMdxFile(file);
+    const slug = path.relative(HELP_ROOT, file).replace(/\\/g, "/").replace(/\.mdx$/, "");
+    const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
+    const modes = Array.isArray(data.modes) ? data.modes.map(String) : [];
+    const topic: HelpTopic = {
+      id: slug,
+      slug,
+      title: String(data.title ?? slug),
+      tags,
+      modes,
+      lastUpdated: data.lastUpdated ?? null,
+      summary,
+      body,
+      links,
+    };
+    tags.forEach((tag) => tagSet.add(tag));
+    modes.forEach((mode) => modeSet.add(mode));
+    topics.push(topic);
+  }
+
+  for (const file of whatsNewFiles) {
+    const { data, summary, body, links } = await parseMdxFile(file);
+    const slug = path.relative(HELP_ROOT, file).replace(/\\/g, "/").replace(/\.mdx$/, "");
+    const tags = Array.isArray(data.tags) ? data.tags.map(String) : [];
+    const entry: WhatsNewEntry = {
+      id: slug,
+      slug,
+      title: String(data.title ?? slug),
+      date: String(data.date ?? ""),
+      tags,
+      lastUpdated: data.lastUpdated ?? null,
+      summary: String(data.summary ?? summary ?? ""),
+      body,
+      links,
+    };
+    tags.forEach((tag) => tagSet.add(tag));
+    whatsNew.push(entry);
+  }
+
+  topics.sort((a, b) => a.title.localeCompare(b.title));
+  whatsNew.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0));
+
+  const index: HelpIndex = {
+    generatedAt: new Date().toISOString(),
+    topics,
+    whatsNew,
+    tags: Array.from(tagSet).sort((a, b) => a.localeCompare(b)),
+    modes: Array.from(modeSet).sort((a, b) => a.localeCompare(b)),
+  };
+
+  await fs.mkdir(path.dirname(OUTPUT_PATH), { recursive: true });
+  await fs.writeFile(OUTPUT_PATH, JSON.stringify(index, null, 2));
+  console.log(
+    `[docs:index] Wrote ${OUTPUT_PATH} with ${topics.length} topics and ${whatsNew.length} release notes.`
+  );
+}
+
+buildIndex().catch((err) => {
+  console.error(`[docs:index] Failed:`, err);
+  process.exitCode = 1;
+});

--- a/scripts/docs/frontmatter.ts
+++ b/scripts/docs/frontmatter.ts
@@ -1,0 +1,115 @@
+export interface FrontmatterResult {
+  data: Record<string, any>;
+  content: string;
+  keys: string[];
+}
+
+function parseScalar(value: string): any {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return "";
+  }
+  if (trimmed === "null") {
+    return null;
+  }
+  if ((trimmed.startsWith("\"") && trimmed.endsWith("\"")) || (trimmed.startsWith("'") && trimmed.endsWith("'"))) {
+    return trimmed.slice(1, -1);
+  }
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) {
+    return trimmed;
+  }
+  return trimmed;
+}
+
+export function parseFrontmatter(raw: string): FrontmatterResult {
+  if (!raw.startsWith("---")) {
+    return { data: {}, content: raw, keys: [] };
+  }
+
+  const closingIndex = raw.indexOf("\n---", 3);
+  if (closingIndex === -1) {
+    return { data: {}, content: raw, keys: [] };
+  }
+
+  const header = raw.slice(3, closingIndex).trim();
+  const content = raw.slice(closingIndex + 4);
+  const lines = header.split(/\r?\n/);
+
+  const data: Record<string, any> = {};
+  const keys: string[] = [];
+  let currentKey: string | null = null;
+
+  for (const line of lines) {
+    if (!line.trim()) {
+      continue;
+    }
+    const keyMatch = line.match(/^([A-Za-z0-9_]+):\s*(.*)$/);
+    if (keyMatch) {
+      const [, key, value] = keyMatch;
+      keys.push(key);
+      if (value === "") {
+        data[key] = [];
+        currentKey = key;
+      } else {
+        data[key] = parseScalar(value);
+        currentKey = null;
+      }
+      continue;
+    }
+    if (currentKey && line.trim().startsWith("-")) {
+      const item = line.trim().slice(1).trim();
+      if (!Array.isArray(data[currentKey])) {
+        data[currentKey] = [];
+      }
+      (data[currentKey] as any[]).push(parseScalar(item));
+      continue;
+    }
+  }
+
+  return { data, content, keys };
+}
+
+function formatScalar(value: any): string {
+  if (value === null) {
+    return "null";
+  }
+  if (typeof value === "string") {
+    if (value === "") {
+      return "\"\"";
+    }
+    if (/[:#\-]/.test(value) || value.includes(" ")) {
+      return `"${value.replace(/\"/g, '\\"')}"`;
+    }
+    return value;
+  }
+  return String(value);
+}
+
+export function stringifyFrontmatter(
+  data: Record<string, any>,
+  content: string,
+  keys: string[]
+): string {
+  const uniqueKeys = Array.from(new Set([...keys, ...Object.keys(data)]));
+  const lines: string[] = ["---"];
+
+  for (const key of uniqueKeys) {
+    const value = data[key];
+    if (Array.isArray(value)) {
+      lines.push(`${key}:`);
+      for (const item of value) {
+        lines.push(`  - ${formatScalar(item)}`);
+      }
+    } else {
+      lines.push(`${key}: ${formatScalar(value)}`);
+    }
+  }
+
+  lines.push("---");
+
+  if (!content.startsWith("\n")) {
+    return `${lines.join("\n")}\n\n${content}`;
+  }
+
+  return `${lines.join("\n")}${content}`;
+}

--- a/scripts/docs/lastUpdated.ts
+++ b/scripts/docs/lastUpdated.ts
@@ -1,0 +1,74 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { parseFrontmatter, stringifyFrontmatter } from "./frontmatter";
+import { execSync } from "child_process";
+
+const HELP_ROOT = path.resolve(process.cwd(), "docs/help");
+
+async function findMdxFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    entries.map(async (entry) => {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        return findMdxFiles(fullPath);
+      }
+      if (entry.isFile() && fullPath.endsWith(".mdx")) {
+        return [fullPath];
+      }
+      return [];
+    })
+  );
+  return files.flat();
+}
+
+function gitLastUpdated(file: string): string | null {
+  try {
+    const output = execSync(`git log -1 --format=%cI -- "${file}"`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (output) {
+      return output;
+    }
+  } catch (err) {
+    // fall through to fs mtime / current time
+  }
+  return null;
+}
+
+async function stampLastUpdated() {
+  try {
+    await fs.access(HELP_ROOT);
+  } catch (err) {
+    console.warn(`[docs:lastUpdated] Skipping - help directory not found at ${HELP_ROOT}`);
+    return;
+  }
+
+  const files = await findMdxFiles(HELP_ROOT);
+  let updated = 0;
+
+  for (const file of files) {
+    const raw = await fs.readFile(file, "utf8");
+    const parsed = parseFrontmatter(raw);
+    const stat = await fs.stat(file);
+    const gitDate = gitLastUpdated(file) ?? stat.mtime.toISOString();
+
+    if (parsed.data.lastUpdated !== gitDate) {
+      const next = stringifyFrontmatter(
+        { ...parsed.data, lastUpdated: gitDate },
+        parsed.content,
+        parsed.keys
+      );
+      await fs.writeFile(file, next);
+      updated += 1;
+    }
+  }
+
+  console.log(`[docs:lastUpdated] Processed ${files.length} MDX files; ${updated} updated.`);
+}
+
+stampLastUpdated().catch((err) => {
+  console.error(`[docs:lastUpdated] Failed:`, err);
+  process.exitCode = 1;
+});

--- a/scripts/docs/linkCheck.ts
+++ b/scripts/docs/linkCheck.ts
@@ -1,0 +1,97 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { parseFrontmatter } from "./frontmatter";
+
+const HELP_ROOT = path.resolve(process.cwd(), "docs/help");
+
+async function findMdxFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await findMdxFiles(full)));
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function extractLinks(markdown: string): { href: string; index: number }[] {
+  const matches: { href: string; index: number }[] = [];
+  const regex = /\[[^\]]+\]\(([^)]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(markdown)) !== null) {
+    matches.push({ href: match[1], index: match.index });
+  }
+  return matches;
+}
+
+function validateLink(href: string): string | null {
+  if (!href) {
+    return "missing href";
+  }
+  if (href.startsWith("http://") || href.startsWith("https://")) {
+    try {
+      new URL(href);
+      return null;
+    } catch (err) {
+      return "invalid URL";
+    }
+  }
+  if (href.startsWith("mailto:")) {
+    return null;
+  }
+  if (href.startsWith("#")) {
+    return null;
+  }
+  if (href.startsWith("/")) {
+    if (href.includes(" ")) {
+      return "contains spaces";
+    }
+    return null;
+  }
+  if (href.includes(" ")) {
+    return "contains spaces";
+  }
+  return null;
+}
+
+async function main() {
+  try {
+    await fs.access(HELP_ROOT);
+  } catch (err) {
+    console.warn(`[docs:links] Help directory not found at ${HELP_ROOT}`);
+    return;
+  }
+
+  const files = await findMdxFiles(HELP_ROOT);
+  const errors: string[] = [];
+
+  for (const file of files) {
+    const raw = await fs.readFile(file, "utf8");
+    const parsed = parseFrontmatter(raw);
+    const links = extractLinks(parsed.content);
+    for (const link of links) {
+      const validation = validateLink(link.href);
+      if (validation) {
+        errors.push(`${file}@${link.index} -> ${link.href} (${validation})`);
+      }
+    }
+  }
+
+  if (errors.length > 0) {
+    console.error(`[docs:links] Found ${errors.length} invalid link(s):`);
+    errors.forEach((err) => console.error(`  - ${err}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`[docs:links] All links look good across ${files.length} file(s).`);
+}
+
+main().catch((err) => {
+  console.error(`[docs:links] Failed:`, err);
+  process.exitCode = 1;
+});

--- a/scripts/docs/openapiCoverage.ts
+++ b/scripts/docs/openapiCoverage.ts
@@ -1,0 +1,92 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { parseFrontmatter } from "./frontmatter";
+
+const SPEC_PATH = path.resolve(process.cwd(), "schema/openapi/merged.json");
+const HELP_ROOT = path.resolve(process.cwd(), "docs/help");
+
+const HTTP_METHODS = new Set([
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "options",
+  "head",
+]);
+
+async function readJson(file: string) {
+  const raw = await fs.readFile(file, "utf8");
+  return JSON.parse(raw);
+}
+
+async function collectHelpTags(dir: string): Promise<Set<string>> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const tags = new Set<string>();
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      const nested = await collectHelpTags(full);
+      nested.forEach((tag) => tags.add(tag));
+    } else if (entry.isFile() && entry.name.endsWith(".mdx")) {
+      const raw = await fs.readFile(full, "utf8");
+      const parsed = parseFrontmatter(raw);
+      const frontmatterTags = Array.isArray(parsed.data.tags)
+        ? (parsed.data.tags as any[]).map(String)
+        : [];
+      for (const tag of frontmatterTags) {
+        if (tag.toLowerCase().startsWith("api:")) {
+          tags.add(tag.replace(/^api:/i, "api:").trim());
+        }
+      }
+    }
+  }
+  return tags;
+}
+
+interface OpenApiSpec {
+  paths?: Record<string, Record<string, unknown>>;
+}
+
+async function main() {
+  try {
+    await fs.access(SPEC_PATH);
+  } catch (err) {
+    console.error(`[docs:coverage] Missing OpenAPI spec at ${SPEC_PATH}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const spec = (await readJson(SPEC_PATH)) as OpenApiSpec;
+  if (!spec.paths) {
+    console.error(`[docs:coverage] Spec at ${SPEC_PATH} has no paths section.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const endpoints: string[] = [];
+  for (const [route, operations] of Object.entries(spec.paths)) {
+    for (const method of Object.keys(operations)) {
+      if (HTTP_METHODS.has(method as any)) {
+        endpoints.push(`api:${method.toUpperCase()} ${route}`);
+      }
+    }
+  }
+
+  const tags = await collectHelpTags(HELP_ROOT);
+  const missing = endpoints.filter((endpoint) => !tags.has(endpoint));
+
+  if (missing.length > 0) {
+    console.error(`[docs:coverage] Missing documentation for ${missing.length} endpoint(s):`);
+    missing.forEach((endpoint) => console.error(`  - ${endpoint}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`[docs:coverage] All ${endpoints.length} endpoints covered by help content.`);
+}
+
+main().catch((err) => {
+  console.error(`[docs:coverage] Failed:`, err);
+  process.exitCode = 1;
+});

--- a/scripts/openapi.ts
+++ b/scripts/openapi.ts
@@ -1,0 +1,69 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+const SPEC_PATH = path.resolve(process.cwd(), "schema/openapi/merged.json");
+
+interface OpenApiDocument {
+  openapi: string;
+  info?: Record<string, unknown>;
+  paths: Record<string, Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+function sortObject<T>(obj: Record<string, T>): Record<string, T> {
+  return Object.keys(obj)
+    .sort((a, b) => a.localeCompare(b))
+    .reduce<Record<string, T>>((acc, key) => {
+      acc[key] = obj[key];
+      return acc;
+    }, {});
+}
+
+async function main() {
+  try {
+    await fs.access(SPEC_PATH);
+  } catch (err) {
+    console.error(`[openapi] Spec file missing at ${SPEC_PATH}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const raw = await fs.readFile(SPEC_PATH, "utf8");
+  let spec: OpenApiDocument;
+  try {
+    spec = JSON.parse(raw);
+  } catch (err) {
+    console.error(`[openapi] Failed to parse spec JSON: ${(err as Error).message}`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!spec.openapi || typeof spec.openapi !== "string") {
+    console.error(`[openapi] Spec missing required 'openapi' version string.`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!spec.paths || typeof spec.paths !== "object") {
+    console.error(`[openapi] Spec missing 'paths' definition.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const sortedPaths: Record<string, Record<string, unknown>> = {};
+  for (const [route, operations] of Object.entries(sortObject(spec.paths))) {
+    sortedPaths[route] = sortObject(operations);
+  }
+
+  const normalized: OpenApiDocument = {
+    ...spec,
+    paths: sortedPaths,
+  };
+
+  await fs.writeFile(SPEC_PATH, JSON.stringify(normalized, null, 2) + "\n");
+  console.log(`[openapi] Normalized spec with ${Object.keys(sortedPaths).length} path(s).`);
+}
+
+main().catch((err) => {
+  console.error(`[openapi] Failed:`, err);
+  process.exitCode = 1;
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import AppLayout from "./components/AppLayout";
+import { HelpProvider } from "./help/HelpProvider";
 
 import Dashboard from "./pages/Dashboard";
 import BAS from "./pages/BAS";
@@ -14,19 +15,21 @@ import Help from "./pages/Help";
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <HelpProvider>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </HelpProvider>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import HelpDrawer from "./HelpDrawer";
+import { useHelp } from "../help/useHelp";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -14,6 +16,8 @@ const navLinks = [
 ];
 
 export default function AppLayout() {
+  const { openDrawer } = useHelp();
+
   return (
     <div>
       <header className="app-header">
@@ -42,6 +46,9 @@ export default function AppLayout() {
             </NavLink>
           ))}
         </nav>
+        <button className="help-trigger" onClick={openDrawer}>
+          Need help?
+        </button>
       </header>
 
       {/* 👇 This tells React Router where to render the child pages */}
@@ -52,6 +59,7 @@ export default function AppLayout() {
       <footer className="app-footer">
         <p>© 2025 APGMS | Compliant with Income Tax Assessment Act 1997 & GST Act 1999</p>
       </footer>
+      <HelpDrawer />
     </div>
   );
 }

--- a/src/components/HelpDrawer.tsx
+++ b/src/components/HelpDrawer.tsx
@@ -1,0 +1,174 @@
+import React from "react";
+import { useHelp } from "../help/useHelp";
+
+function formatDate(iso?: string | null) {
+  if (!iso) return "";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return "";
+  }
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export default function HelpDrawer() {
+  const {
+    isOpen,
+    closeDrawer,
+    query,
+    setQuery,
+    activeTags,
+    activeModes,
+    toggleTag,
+    toggleMode,
+    clearFilters,
+    results,
+    whatsNew,
+    index,
+  } = useHelp();
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="help-drawer-overlay" onClick={closeDrawer}>
+      <aside
+        className="help-drawer"
+        onClick={(event) => event.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Product help"
+      >
+        <header className="help-drawer__header">
+          <div>
+            <h2>Need a hand?</h2>
+            <p>Search topics, filter by workflow, or jump to release notes.</p>
+          </div>
+          <button className="help-close" type="button" onClick={closeDrawer} aria-label="Close help">
+            ×
+          </button>
+        </header>
+
+        <div className="help-search">
+          <input
+            type="search"
+            placeholder="Search help"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          {query || activeTags.length || activeModes.length ? (
+            <button className="help-clear" type="button" onClick={clearFilters}>
+              Clear filters
+            </button>
+          ) : null}
+        </div>
+
+        <section className="help-filter-section" aria-label="Modes">
+          <h3>Modes</h3>
+          <div className="help-chips">
+            {index.modes.map((mode) => {
+              const isActive = activeModes.includes(mode);
+              return (
+                <button
+                  type="button"
+                  key={mode}
+                  className={isActive ? "help-chip active" : "help-chip"}
+                  onClick={() => toggleMode(mode)}
+                >
+                  {mode}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="help-filter-section" aria-label="Tags">
+          <h3>Tags</h3>
+          <div className="help-chips">
+            {index.tags.map((tag) => {
+              const isActive = activeTags.includes(tag);
+              return (
+                <button
+                  type="button"
+                  key={tag}
+                  className={isActive ? "help-chip active" : "help-chip"}
+                  onClick={() => toggleTag(tag)}
+                >
+                  #{tag}
+                </button>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="help-whats-new" aria-label="Latest updates">
+          <h3>What’s New</h3>
+          {whatsNew.slice(0, 3).map((entry) => (
+            <article key={entry.id} className="help-card">
+              <header>
+                <h4>{entry.title}</h4>
+                <span className="help-card__date">{formatDate(entry.date)}</span>
+              </header>
+              <p>{entry.summary}</p>
+              <footer>
+                <a href={`/help#${entry.slug}`} onClick={closeDrawer}>
+                  Read more
+                </a>
+              </footer>
+            </article>
+          ))}
+        </section>
+
+        <section className="help-results" aria-label="Help topics">
+          <h3>Topics</h3>
+          {results.length === 0 ? (
+            <p className="help-empty">No topics match the current filters.</p>
+          ) : (
+            results.map((topic) => (
+              <article key={topic.id} className="help-card">
+                <header>
+                  <h4>{topic.title}</h4>
+                  <span className="help-card__date">
+                    {formatDate(topic.lastUpdated) || "Updated recently"}
+                  </span>
+                </header>
+                <p>{topic.summary}</p>
+                <div className="help-card__tags">
+                  {topic.modes.map((mode) => (
+                    <button
+                      type="button"
+                      key={`${topic.id}-mode-${mode}`}
+                      className="help-chip"
+                      onClick={() => toggleMode(mode)}
+                    >
+                      {mode}
+                    </button>
+                  ))}
+                  {topic.tags.map((tag) => (
+                    <button
+                      type="button"
+                      key={`${topic.id}-tag-${tag}`}
+                      className="help-chip"
+                      onClick={() => toggleTag(tag)}
+                    >
+                      #{tag}
+                    </button>
+                  ))}
+                </div>
+                <footer>
+                  <a href={`/help#${topic.slug}`} onClick={closeDrawer}>
+                    View details
+                  </a>
+                </footer>
+              </article>
+            ))
+          )}
+        </section>
+      </aside>
+    </div>
+  );
+}

--- a/src/components/HelpTip.tsx
+++ b/src/components/HelpTip.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { useHelp } from "../help/useHelp";
+
+interface HelpTipProps {
+  tag?: string;
+  mode?: string;
+  label?: string;
+  className?: string;
+}
+
+export default function HelpTip({ tag, mode, label = "Help", className }: HelpTipProps) {
+  const { openWithTag, openWithMode, openDrawer } = useHelp();
+
+  const handleClick = () => {
+    if (tag) {
+      openWithTag(tag);
+    } else if (mode) {
+      openWithMode(mode);
+    } else {
+      openDrawer();
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      className={`help-tip ${className ?? ""}`.trim()}
+      onClick={handleClick}
+      aria-label={label}
+    >
+      <span className="help-tip__icon">?</span>
+      <span className="help-tip__label">{label}</span>
+    </button>
+  );
+}

--- a/src/help/HelpIndex.json
+++ b/src/help/HelpIndex.json
@@ -1,0 +1,279 @@
+{
+  "generatedAt": "2025-10-06T00:29:02.881Z",
+  "topics": [
+    {
+      "id": "support-links",
+      "slug": "support-links",
+      "title": "ATO resources and support",
+      "tags": [
+        "support",
+        "ato guidance",
+        "lodgment"
+      ],
+      "modes": [
+        "compliance",
+        "reference",
+        "onboarding"
+      ],
+      "lastUpdated": "2025-10-06T00:28:57.509Z",
+      "summary": "Here are key ATO references to keep handy:",
+      "body": "Here are key ATO references to keep handy: ATO PAYGW Guide ATO GST Information ATO BAS Portal ATO Super Obligations ATO Online Services Bookmark each link and review updates after budget announcements or legislative changes.",
+      "links": [
+        {
+          "href": "https://www.ato.gov.au/business/payg-withholding/",
+          "text": "ATO PAYGW Guide"
+        },
+        {
+          "href": "https://www.ato.gov.au/business/gst/",
+          "text": "ATO GST Information"
+        },
+        {
+          "href": "https://www.ato.gov.au/business/business-activity-statements-%28bas%29/",
+          "text": "ATO BAS Portal"
+        },
+        {
+          "href": "https://www.ato.gov.au/business/super-for-employers/",
+          "text": "ATO Super Obligations"
+        },
+        {
+          "href": "https://www.ato.gov.au/General/Online-services/",
+          "text": "ATO Online Services"
+        }
+      ]
+    },
+    {
+      "id": "getting-started",
+      "slug": "getting-started",
+      "title": "Getting started with APGMS",
+      "tags": [
+        "setup",
+        "wizard",
+        "buffer accounts",
+        "api:GET /health",
+        "api:GET /dashboard/yesterday",
+        "api:GET /metrics"
+      ],
+      "modes": [
+        "onboarding",
+        "dashboard",
+        "compliance"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.229Z",
+      "summary": "Welcome to APGMS. New organisations should walk through the setup wizard to capture legal identifiers, link bank accounts, and configure the PAYGW and GST buffers before any liabilities accrue.",
+      "body": "Welcome to APGMS. New organisations should walk through the setup wizard to capture legal identifiers, link bank accounts, and configure the PAYGW and GST buffers before any liabilities accrue. 1. Visit the Dashboard and confirm your next BAS due date. 2. Launch the Setup Wizard to enter your ABN, trading details, and payroll providers. 3. Link operating and buffer accounts so automated transfers can keep withheld taxes quarantined. 4. Use the wizard's confirmation step to review compliance status and confirm everything is ready. The /health, /dashboard/yesterday, and /metrics endpoints provide quick status checks for monitoring and should return 200 when the platform is ready.",
+      "links": []
+    },
+    {
+      "id": "integrations-and-connections",
+      "slug": "integrations-and-connections",
+      "title": "Managing integrations and data feeds",
+      "tags": [
+        "integrations",
+        "connections",
+        "payroll",
+        "api:GET /connections",
+        "api:POST /connections/start",
+        "api:DELETE /connections/{conn_id}",
+        "api:GET /transactions",
+        "api:POST /settings"
+      ],
+      "modes": [
+        "integrations",
+        "automation",
+        "onboarding"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.245Z",
+      "summary": "Link payroll, POS, and banking providers so APGMS can automate compliance:",
+      "body": "Link payroll, POS, and banking providers so APGMS can automate compliance: /connections lists active authorisations and can be polled to confirm the state after onboarding. Initiate new OAuth-style handshakes with /connections/start and direct users to the returned URL. Remove stale credentials with /connections/{conn_id} to enforce least-privilege access. /transactions surfaces harmonised transactional feeds that drive GST and PAYGW calculations. /settings persists security controls like retention windows and PII masking toggles. Ensure each provider connection is subject to multi-factor authentication and rotate secrets on a set cadence.",
+      "links": []
+    },
+    {
+      "id": "payments-and-releases",
+      "slug": "payments-and-releases",
+      "title": "Managing PAYGW and GST payments",
+      "tags": [
+        "payments",
+        "release",
+        "ato remittance",
+        "api:POST /api/pay",
+        "api:POST /api/release",
+        "api:POST /api/close-issue",
+        "api:GET /api/balance",
+        "api:GET /api/ledger",
+        "api:POST /api/deposit"
+      ],
+      "modes": [
+        "operations",
+        "compliance",
+        "finance"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.273Z",
+      "summary": "Keep PAYGW and GST liabilities in lockstep with payroll and sales activity:",
+      "body": "Keep PAYGW and GST liabilities in lockstep with payroll and sales activity: /api/balance surfaces the ledger balance for a given ABN, tax type, and period. /api/ledger returns full transaction history for audit trails. /api/deposit records incoming PAYGW or GST funds into the quarantined buffer. /api/pay and /api/release instruct the payments rail to remit funds to the ATO when a reporting period closes. /api/close-issue finalises the RPT token and captures the compliance evidence bundle for the period. Always double check the amountCents sign: deposits must be positive, releases must be negative to prevent accidental overdrafts.",
+      "links": []
+    },
+    {
+      "id": "monitoring-and-status",
+      "slug": "monitoring-and-status",
+      "title": "Monitoring status and compliance posture",
+      "tags": [
+        "monitoring",
+        "status",
+        "api inventory",
+        "api:GET /readyz",
+        "api:GET /ato/status",
+        "api:GET /openapi.json"
+      ],
+      "modes": [
+        "monitoring",
+        "compliance",
+        "engineering"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.261Z",
+      "summary": "Set up dashboards and alerts so issues are surfaced before deadlines:",
+      "body": "Set up dashboards and alerts so issues are surfaced before deadlines: /readyz is the liveness probe for the portal API, returning the server timestamp when healthy. /ato/status tracks the connectivity state with the ATO digital services gateway. /openapi.json exposes the merged contract for the public API surface; watch for drift after deploys. Combine these probes with /metrics from the main service to create a single source of truth for observability.",
+      "links": []
+    },
+    {
+      "id": "bas-operations",
+      "slug": "bas-operations",
+      "title": "Preparing and lodging your BAS",
+      "tags": [
+        "bas",
+        "validation",
+        "ato lodge",
+        "api:GET /bas/preview",
+        "api:POST /bas/validate",
+        "api:POST /bas/lodge",
+        "api:POST /normalize"
+      ],
+      "modes": [
+        "bas",
+        "compliance",
+        "reporting"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.205Z",
+      "summary": "Business Activity Statements can be rehearsed and submitted programmatically:",
+      "body": "Business Activity Statements can be rehearsed and submitted programmatically: Call /bas/preview to retrieve calculated PAYGW and GST totals for the current period. Validate a draft with /bas/validate before presenting it to officers for sign-off. /bas/lodge submits to the sandbox ATO gateway and echoes a success message when accepted. /normalize can be used to reshape source transactions so they align with your lodgment schema before posting. Record BAS confirmations in the audit log and attach the portal reference number to your reconciliation evidence bundle.",
+      "links": []
+    },
+    {
+      "id": "settlements-and-payto",
+      "slug": "settlements-and-payto",
+      "title": "Settlement ingestion and PayTo sweeps",
+      "tags": [
+        "settlements",
+        "payto",
+        "reconciliation",
+        "api:POST /api/payto/sweep",
+        "api:POST /api/settlement/webhook",
+        "api:GET /api/evidence"
+      ],
+      "modes": [
+        "operations",
+        "banking",
+        "automation"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.289Z",
+      "summary": "Automate inbound settlement handling and evidence capture:",
+      "body": "Automate inbound settlement handling and evidence capture: Use /api/payto/sweep when a PayTo agreement needs to sweep excess balances back to your operating account. /api/settlement/webhook ingests settlement CSV payloads from banking partners and returns the number of rows processed. /api/evidence composes the compliance bundle (including RPT tokens and reconciliation data) for downstream archiving. Settlement webhooks should be protected with signing middleware and replay protection to satisfy ATO audit expectations.",
+      "links": []
+    }
+  ],
+  "whatsNew": [
+    {
+      "id": "whats-new/2025-10-05",
+      "slug": "whats-new/2025-10-05",
+      "title": "Automated help drawer and API coverage checks",
+      "date": "2025-10-05",
+      "tags": [
+        "release-notes",
+        "docs",
+        "compliance"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.337Z",
+      "summary": "Contextual help now lives inside the app and the docs build validates API coverage.",
+      "body": "The help experience now surfaces contextual guidance from anywhere in the console. Each help card references the underlying API endpoints and the docs pipeline validates coverage for the merged OpenAPI spec.",
+      "links": []
+    },
+    {
+      "id": "whats-new/2025-09-15",
+      "slug": "whats-new/2025-09-15",
+      "title": "ATO connection watchdog",
+      "date": "2025-09-15",
+      "tags": [
+        "release-notes",
+        "monitoring"
+      ],
+      "lastUpdated": "2025-10-06T00:27:34.321Z",
+      "summary": "ATO link status now visible in dashboards and surfaced via the /ato/status API.",
+      "body": "A lightweight watchdog now polls /ato/status to track the upstream digital services gateway. Use the new monitoring card to alert operators when the connection drifts from \"Connected\".",
+      "links": []
+    }
+  ],
+  "tags": [
+    "api inventory",
+    "api:DELETE /connections/{conn_id}",
+    "api:GET /api/balance",
+    "api:GET /api/evidence",
+    "api:GET /api/ledger",
+    "api:GET /ato/status",
+    "api:GET /bas/preview",
+    "api:GET /connections",
+    "api:GET /dashboard/yesterday",
+    "api:GET /health",
+    "api:GET /metrics",
+    "api:GET /openapi.json",
+    "api:GET /readyz",
+    "api:GET /transactions",
+    "api:POST /api/close-issue",
+    "api:POST /api/deposit",
+    "api:POST /api/pay",
+    "api:POST /api/payto/sweep",
+    "api:POST /api/release",
+    "api:POST /api/settlement/webhook",
+    "api:POST /bas/lodge",
+    "api:POST /bas/validate",
+    "api:POST /connections/start",
+    "api:POST /normalize",
+    "api:POST /settings",
+    "ato guidance",
+    "ato lodge",
+    "ato remittance",
+    "bas",
+    "buffer accounts",
+    "compliance",
+    "connections",
+    "docs",
+    "integrations",
+    "lodgment",
+    "monitoring",
+    "payments",
+    "payroll",
+    "payto",
+    "reconciliation",
+    "release",
+    "release-notes",
+    "settlements",
+    "setup",
+    "status",
+    "support",
+    "validation",
+    "wizard"
+  ],
+  "modes": [
+    "automation",
+    "banking",
+    "bas",
+    "compliance",
+    "dashboard",
+    "engineering",
+    "finance",
+    "integrations",
+    "monitoring",
+    "onboarding",
+    "operations",
+    "reference",
+    "reporting"
+  ]
+}

--- a/src/help/HelpProvider.tsx
+++ b/src/help/HelpProvider.tsx
@@ -1,0 +1,131 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+import helpIndexData from "./HelpIndex.json";
+import { HelpIndex, HelpTopic, WhatsNewEntry } from "./types";
+
+interface HelpContextValue {
+  index: HelpIndex;
+  isOpen: boolean;
+  query: string;
+  setQuery: (value: string) => void;
+  activeTags: string[];
+  activeModes: string[];
+  results: HelpTopic[];
+  whatsNew: WhatsNewEntry[];
+  openDrawer: () => void;
+  closeDrawer: () => void;
+  openWithTag: (tag: string) => void;
+  openWithMode: (mode: string) => void;
+  toggleTag: (tag: string) => void;
+  toggleMode: (mode: string) => void;
+  clearFilters: () => void;
+}
+
+const HelpContext = createContext<HelpContextValue | null>(null);
+const index = helpIndexData as HelpIndex;
+
+function normalize(value: string) {
+  return value.toLowerCase();
+}
+
+export function HelpProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [activeTags, setActiveTags] = useState<string[]>([]);
+  const [activeModes, setActiveModes] = useState<string[]>([]);
+
+  const openDrawer = useCallback(() => {
+    setIsOpen(true);
+  }, []);
+
+  const closeDrawer = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const openWithTag = useCallback((tag: string) => {
+    setActiveTags((prev) => (prev.includes(tag) ? prev : [tag]));
+    setActiveModes([]);
+    setQuery("");
+    setIsOpen(true);
+  }, []);
+
+  const openWithMode = useCallback((mode: string) => {
+    setActiveModes([mode]);
+    setActiveTags([]);
+    setQuery("");
+    setIsOpen(true);
+  }, []);
+
+  const toggleTag = useCallback((tag: string) => {
+    setActiveTags((prev) =>
+      prev.includes(tag) ? prev.filter((item) => item !== tag) : [...prev, tag]
+    );
+  }, []);
+
+  const toggleMode = useCallback((mode: string) => {
+    setActiveModes((prev) =>
+      prev.includes(mode) ? prev.filter((item) => item !== mode) : [...prev, mode]
+    );
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setActiveTags([]);
+    setActiveModes([]);
+    setQuery("");
+  }, []);
+
+  const results = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    return index.topics.filter((topic) => {
+      if (activeTags.length && !activeTags.every((tag) => topic.tags.includes(tag))) {
+        return false;
+      }
+      if (
+        activeModes.length &&
+        !activeModes.some((mode) => topic.modes.map(normalize).includes(normalize(mode)))
+      ) {
+        return false;
+      }
+      if (!normalizedQuery) {
+        return true;
+      }
+      const haystack = [
+        topic.title,
+        topic.summary,
+        topic.body,
+        topic.tags.join(" "),
+        topic.modes.join(" "),
+      ]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+  }, [query, activeTags, activeModes]);
+
+  const value: HelpContextValue = {
+    index,
+    isOpen,
+    query,
+    setQuery,
+    activeTags,
+    activeModes,
+    results,
+    whatsNew: index.whatsNew,
+    openDrawer,
+    closeDrawer,
+    openWithTag,
+    openWithMode,
+    toggleTag,
+    toggleMode,
+    clearFilters,
+  };
+
+  return <HelpContext.Provider value={value}>{children}</HelpContext.Provider>;
+}
+
+export function useHelpContext() {
+  const ctx = useContext(HelpContext);
+  if (!ctx) {
+    throw new Error("useHelpContext must be used within HelpProvider");
+  }
+  return ctx;
+}

--- a/src/help/types.ts
+++ b/src/help/types.ts
@@ -1,0 +1,36 @@
+export interface HelpLink {
+  href: string;
+  text: string;
+}
+
+export interface HelpTopic {
+  id: string;
+  slug: string;
+  title: string;
+  tags: string[];
+  modes: string[];
+  lastUpdated: string | null;
+  summary: string;
+  body: string;
+  links: HelpLink[];
+}
+
+export interface WhatsNewEntry {
+  id: string;
+  slug: string;
+  title: string;
+  date: string;
+  tags: string[];
+  lastUpdated: string | null;
+  summary: string;
+  body: string;
+  links: HelpLink[];
+}
+
+export interface HelpIndex {
+  generatedAt: string;
+  topics: HelpTopic[];
+  whatsNew: WhatsNewEntry[];
+  tags: string[];
+  modes: string[];
+}

--- a/src/help/useHelp.ts
+++ b/src/help/useHelp.ts
@@ -1,0 +1,1 @@
+export { useHelpContext as useHelp } from "./HelpProvider";

--- a/src/index.css
+++ b/src/index.css
@@ -131,6 +131,7 @@ label {
 .mb-1 { margin-bottom: 8px; }
 .mb-2 { margin-bottom: 16px; }
 .mb-3 { margin-bottom: 24px; }
+.ml-auto { margin-left: auto; }
 
 /* Button Styles */
 .button {
@@ -196,4 +197,200 @@ th {
   background: #f1f6fa;
   font-weight: 600;
   color: #00205b;
+}
+
+/* Help Drawer */
+.help-trigger {
+  margin-top: 16px;
+  background: #ffffff;
+  color: #00205b;
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border 0.2s;
+}
+
+.help-trigger:hover {
+  background: #00a99d;
+  border-color: #00a99d;
+  color: #fff;
+}
+
+.help-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 2000;
+}
+
+.help-drawer {
+  width: min(420px, 92vw);
+  background: #ffffff;
+  height: 100%;
+  overflow-y: auto;
+  box-shadow: -2px 0 16px rgba(0, 32, 91, 0.18);
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.help-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.help-drawer__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.help-drawer__header p {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: #4f5d78;
+}
+
+.help-close {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  cursor: pointer;
+  color: #4f5d78;
+}
+
+.help-close:hover {
+  color: #00205b;
+}
+
+.help-search {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+}
+
+.help-search input {
+  flex: 1;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #c9d2e2;
+  font-size: 0.95rem;
+}
+
+.help-clear {
+  border: none;
+  background: transparent;
+  color: #00716b;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.help-filter-section h3,
+.help-whats-new h3,
+.help-results h3 {
+  margin: 0 0 8px;
+  font-size: 1rem;
+  color: #00205b;
+}
+
+.help-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.help-chip {
+  border: 1px solid #d4dde9;
+  background: #f3f6fc;
+  color: #00205b;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: background 0.2s, color 0.2s, border 0.2s;
+}
+
+.help-chip.active,
+.help-chip:hover {
+  background: #00716b;
+  border-color: #00716b;
+  color: #ffffff;
+}
+
+.help-tip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: rgba(0, 113, 107, 0.12);
+  color: #005d54;
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.help-tip__icon {
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: #00716b;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+}
+
+.help-tip:hover {
+  background: rgba(0, 113, 107, 0.2);
+}
+
+.help-card {
+  border: 1px solid #e2e7f0;
+  border-radius: 14px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  background: #ffffff;
+}
+
+.help-card__date {
+  font-size: 0.75rem;
+  color: #6c7a92;
+}
+
+.help-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.help-card footer a {
+  color: #00716b;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.help-card footer a:hover {
+  text-decoration: underline;
+}
+
+.help-empty {
+  color: #6c7a92;
+  font-style: italic;
+}
+
+@media (max-width: 720px) {
+  .help-drawer {
+    width: 100%;
+  }
 }

--- a/src/pages/Audit.tsx
+++ b/src/pages/Audit.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import HelpTip from '../components/HelpTip';
 
 export default function Audit() {
   const [logs] = useState([
@@ -13,7 +14,10 @@ export default function Audit() {
 
   return (
     <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Compliance & Audit</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Compliance & Audit</h1>
+        <HelpTip tag="reconciliation" label="Audit help" />
+      </div>
       <p className="text-sm text-muted-foreground">
         Track every action in your PAYGW and GST account for compliance.
       </p>

--- a/src/pages/BAS.tsx
+++ b/src/pages/BAS.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import HelpTip from '../components/HelpTip';
 
 export default function BAS() {
   const complianceStatus = {
@@ -13,7 +14,10 @@ export default function BAS() {
 
   return (
     <div className="main-card">
-      <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
+        <HelpTip mode="bas" label="BAS guidance" />
+      </div>
       <p className="text-sm text-muted-foreground mb-4">
         Lodge your BAS on time and accurately. Below is a summary of your current obligations.
       </p>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import HelpTip from '../components/HelpTip';
 
 export default function Dashboard() {
   const complianceStatus = {
@@ -16,7 +17,10 @@ export default function Dashboard() {
   return (
     <div className="main-card">
       <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
-        <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
+          <HelpTip mode="dashboard" label="Dashboard help" />
+        </div>
         <p className="text-sm opacity-90">
           Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
         </p>

--- a/src/pages/Fraud.tsx
+++ b/src/pages/Fraud.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import HelpTip from "../components/HelpTip";
 
 export default function Fraud() {
   const [alerts] = useState([
@@ -7,7 +8,10 @@ export default function Fraud() {
   ]);
   return (
     <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
+        <HelpTip tag="settlements" label="Fraud tips" />
+      </div>
       <h3>Alerts</h3>
       <ul>
         {alerts.map((row, i) => (

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,39 +1,98 @@
-import React from 'react';
+import React from "react";
+import helpIndexData from "../help/HelpIndex.json";
+import { HelpIndex } from "../help/types";
+import { useHelp } from "../help/useHelp";
+import HelpTip from "../components/HelpTip";
+
+const helpIndex = helpIndexData as HelpIndex;
 
 export default function Help() {
+  const { openWithTag, openWithMode, openDrawer } = useHelp();
+
+  const formatDate = (value: string) => {
+    const date = new Date(value);
+    return Number.isNaN(date.getTime())
+      ? value
+      : date.toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" });
+  };
+
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Help & Guidance</h1>
-      <p className="text-sm text-muted-foreground">
-        Access support for PAYGW, GST, BAS and using this system.
-      </p>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Getting Started</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Set up your buffer accounts and payment schedule in <strong>Settings</strong>.</li>
-          <li>Use the <strong>Wizard</strong> to define PAYGW and GST split rules.</li>
-          <li>Review <strong>Dashboard</strong> for current obligations and payment alerts.</li>
-          <li>Go to <strong>BAS</strong> to lodge your Business Activity Statement each quarter.</li>
-        </ul>
+    <div className="p-6 space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Help & Guidance</h1>
+          <p className="text-sm text-muted-foreground">
+            Explore guides, compliance tips, and release notes for PAYGW, GST, and BAS operations.
+          </p>
+        </div>
+        <HelpTip label="Open drawer" />
       </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">ATO Compliance</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Use one-way tax accounts to prevent accidental use of withheld/collected funds.</li>
-          <li>Audit trail with timestamped actions supports legal protection and evidence.</li>
-          <li>Helps avoid wind-up notices, director penalties, and late lodgment fines.</li>
-        </ul>
-      </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Support Links</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/payg-withholding/">ATO PAYGW Guide</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/gst/">ATO GST Information</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/business-activity-statements-(bas)/">ATO BAS Portal</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/super-for-employers/">ATO Super Obligations</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/General/Online-services/">ATO Online Services</a></li>
-        </ul>
-      </div>
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">What’s New</h2>
+        {helpIndex.whatsNew.map((entry) => (
+          <article key={entry.id} id={entry.slug} className="bg-card p-4 rounded-xl shadow space-y-2">
+            <header className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold">{entry.title}</h3>
+              <span className="text-xs text-gray-500">{formatDate(entry.date)}</span>
+            </header>
+            <p className="text-sm text-gray-700">{entry.summary}</p>
+            <footer className="text-sm text-blue-600">
+              <button type="button" className="underline" onClick={() => openDrawer()}>
+                View in help drawer
+              </button>
+            </footer>
+          </article>
+        ))}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Topics</h2>
+        {helpIndex.topics.map((topic) => (
+          <article key={topic.id} id={topic.slug} className="bg-card p-4 rounded-xl shadow space-y-2">
+            <header className="flex items-center justify-between">
+              <h3 className="text-lg font-semibold">{topic.title}</h3>
+              <span className="text-xs text-gray-500">
+                Last updated {topic.lastUpdated ? new Date(topic.lastUpdated).toLocaleDateString() : "recently"}
+              </span>
+            </header>
+            <p className="text-sm text-gray-700">{topic.summary}</p>
+            <div className="flex flex-wrap gap-2 text-xs">
+              {topic.modes.map((mode) => (
+                <button
+                  type="button"
+                  key={`${topic.id}-mode-${mode}`}
+                  className="px-2 py-1 bg-emerald-50 text-emerald-700 rounded"
+                  onClick={() => openWithMode(mode)}
+                >
+                  {mode}
+                </button>
+              ))}
+              {topic.tags.map((tag) => (
+                <button
+                  type="button"
+                  key={`${topic.id}-tag-${tag}`}
+                  className="px-2 py-1 bg-slate-100 text-slate-700 rounded"
+                  onClick={() => openWithTag(tag)}
+                >
+                  #{tag}
+                </button>
+              ))}
+            </div>
+            {topic.links.length > 0 && (
+              <ul className="list-disc pl-5 text-sm text-blue-700">
+                {topic.links.map((link) => (
+                  <li key={`${topic.id}-${link.href}`}>
+                    <a href={link.href} target="_blank" rel="noreferrer" className="underline">
+                      {link.text}
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        ))}
+      </section>
     </div>
   );
 }

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -1,9 +1,13 @@
 import React from "react";
+import HelpTip from "../components/HelpTip";
 
 export default function Integrations() {
   return (
     <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
+        <HelpTip tag="integrations" label="Integration help" />
+      </div>
       <h3>Connect to Providers</h3>
       <ul>
         <li>MYOB (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import HelpTip from "../components/HelpTip";
 
 const tabs = [
   "Business Profile",
@@ -24,7 +25,7 @@ export default function Settings() {
 
   return (
     <div className="settings-card">
-      <div className="tabs-row">
+      <div className="tabs-row" style={{ alignItems: "center" }}>
         {tabs.map(tab => (
           <div
             key={tab}
@@ -35,6 +36,7 @@ export default function Settings() {
             {tab}
           </div>
         ))}
+        <HelpTip mode="onboarding" tag="integrations" label="Settings help" className="ml-auto" />
       </div>
 
       <div style={{ marginTop: 30 }}>

--- a/src/pages/Wizard.tsx
+++ b/src/pages/Wizard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import HelpTip from "../components/HelpTip";
 
 const steps = [
   "Business Details",
@@ -13,7 +14,10 @@ export default function Wizard() {
 
   return (
     <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Setup Wizard</h1>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Setup Wizard</h1>
+        <HelpTip mode="onboarding" tag="wizard" label="Wizard help" />
+      </div>
       <div style={{ marginBottom: 20 }}>
         <b>Step {step + 1} of {steps.length}: {steps[step]}</b>
       </div>


### PR DESCRIPTION
## Summary
- author MDX-based help topics and release notes with frontmatter metadata and generate a searchable HelpIndex.json during the docs build
- add documentation tooling for last-updated stamping, OpenAPI coverage against the merged schema, link validation, and expose normalized merged OpenAPI spec via npm scripts
- implement a contextual help drawer with HelpTip components, a What's New feed, and integrate the drawer trigger across key app pages with refreshed styles

## Testing
- npm run build
- npm run openapi
- npm run docs:coverage
- npm run docs:links

------
https://chatgpt.com/codex/tasks/task_e_68e3097baabc8327a25653deecea8e93