### PR TITLE
Handle JSON parse errors in GUI upload

### DIFF
--- a/apps/gui/app.js
+++ b/apps/gui/app.js
@@ -180,7 +180,15 @@
       $('#btnUpload')?.addEventListener('click', async () => {
         const f = $('#file').files[0], out = $('#normOut'); if(!f){ alert('Choose a file'); return; }
         const text = await f.text();
-        const payload = text.trim().startsWith('{') || text.trim().startsWith('[') ? JSON.parse(text) : { csv: text };
+        let payload;
+        try {
+          const trimmed = text.trim();
+          payload = trimmed.startsWith('{') || trimmed.startsWith('[') ? JSON.parse(trimmed) : { csv: text };
+        } catch (err) {
+          console.error('Failed to parse upload payload', err);
+          out.textContent = 'Upload failed: invalid JSON content.';
+          return;
+        }
         out.textContent = 'Uploading...';
         try {
           const res = await api('/normalize', { method:'POST', body: JSON.stringify(payload) });


### PR DESCRIPTION
## Summary
- wrap the GUI upload JSON parsing in a try/catch so malformed files are handled locally
- surface a validation message and log the parse error instead of calling the normalize API

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e30f1714a88327a90527002dfb0bef