### PR TITLE
Preserve transactions filter selection after refresh

### DIFF
--- a/apps/gui/app.js
+++ b/apps/gui/app.js
@@ -224,8 +224,14 @@
           tr.innerHTML = `<td>${t.date}</td><td>${t.source}</td><td>${t.description}</td><td style="text-align:right">${t.amount.toFixed(2)}</td><td>${t.category||''}</td>`;
           tb.appendChild(tr);
         });
-        const sel = $('#filterSource'); sel.innerHTML = '<option value="">All sources</option>';
+        const sel = $('#filterSource');
+        sel.innerHTML = '<option value="">All sources</option>';
         data.sources.forEach(s=>{ const o = document.createElement('option'); o.value=s; o.textContent=s; sel.appendChild(o); });
+        if (src && data.sources.includes(src)) {
+          sel.value = src;
+        } else {
+          sel.value = '';
+        }
       }
       $('#btnRefresh').onclick = load;
       load();


### PR DESCRIPTION
## Summary
- restore the previously selected transactions source filter after refreshing the data
- fall back to the default "All sources" option when the prior source is no longer available

## Testing
- not run (not available in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68e30f16dec883278c56b6869fe0f6b4