### PR TITLE
Add recommendations for security and operations prompt tasks

### DIFF
--- a/docs/prompt_recommendations.md
+++ b/docs/prompt_recommendations.md
@@ -1,0 +1,60 @@
+# Prompt Task Recommendations
+
+This document reviews the proposed prompt tasks and provides guidance on whether to adopt them as-is, amend them, or complement them with additional efforts.
+
+## 1. MFA, Encryption, and Audit Logging (Production Grade)
+- **Recommendation:** Proceed with the task largely as written.
+- **Suggested Amendments:**
+  - Clarify how recovery codes are surfaced to users and require explicit download/acknowledgement flows.
+  - Document operational runbooks for key rotation and MFA incident handling alongside the code changes.
+  - Add a regression test that exercises the MFA step-up flow on a representative protected endpoint (e.g., allow-list update) to guard against future regressions.
+- **Additional Considerations:**
+  - Ensure the KMS abstraction supports per-environment providers (AWS, GCP, or HashiCorp Vault) through configuration rather than code changes.
+  - Include monitoring alerts for append-only audit hash discontinuities and MFA challenge anomalies.
+
+## 2. Hardened Banking Integration with Allow-Lists and Receipts
+- **Recommendation:** Adopt the task with minor clarifications.
+- **Suggested Amendments:**
+  - Define explicit SLAs for retries/backoff and document circuit breaker thresholds so operators know when manual intervention is required.
+  - Specify how idempotency keys are generated and persisted across distributed services to avoid collisions.
+  - Require integration tests that cover mTLS-enabled calls using stub certificates to ensure TLS configuration drift is detected in CI.
+- **Additional Considerations:**
+  - Add observability hooks (metrics and structured logs) for each adapter call, including latency, retry counts, and breaker state transitions.
+  - Ensure receipts are cryptographically signed or hash-linked to the audit chain for end-to-end integrity.
+
+## 3. Roadmap to EVTE-Ready Release
+- **Recommendation:** Publish the roadmap with concrete timelines and owners as proposed.
+- **Suggested Amendments:**
+  - Include risk mitigation strategies per phase (e.g., dependency on ATO data refresh cadence, KMS provisioning lead time).
+  - Add explicit Go/No-Go checklists that reference required artifacts and sign-off authorities.
+  - Establish review cadences (e.g., fortnightly steering meetings) to keep the roadmap current.
+- **Additional Considerations:**
+  - Capture key dependencies in a RACI matrix so responsibilities are clear across engineering, compliance, and operations.
+  - Plan for retrospective checkpoints after each phase to incorporate learnings into subsequent work.
+
+## 4. Operator Tooling for DLQ Replay, Anomaly Explainers, and Evidence Export
+- **Recommendation:** Move forward with the task, ensuring alignment with operator workflows.
+- **Suggested Amendments:**
+  - Define authorization scopes for operator actions (view, retry, ignore) and ensure MFA + dual-approval policies are enforced consistently.
+  - Provide UX mocks or acceptance screenshots to guarantee usability before implementation.
+  - Include rate limiting or batching constraints for DLQ retries to avoid overwhelming downstream systems.
+- **Additional Considerations:**
+  - Instrument analytics to track operator interactions and resolution times, enabling continuous improvement of tooling.
+  - Integrate anomaly explanations with an audit trail so decisions are reviewable during audits.
+
+## 5. Secrets Management, Incident Response, and Environment Hardening
+- **Recommendation:** Implement as described, with further elaboration on compliance requirements.
+- **Suggested Amendments:**
+  - Ensure the secret-fetching boot logic includes caching with automatic rotation and failure fallbacks.
+  - Add tabletop exercise templates and post-incident review forms to the incident runbook.
+  - Extend CI security scans to include container image scanning and infrastructure-as-code policy checks.
+- **Additional Considerations:**
+  - Introduce continuous compliance monitoring (e.g., AWS Config rules) aligned to the hardened posture.
+  - Provide training material for engineers on secure secret handling and incident escalation paths.
+
+## Additional Tasks to Consider
+- **Privacy Impact Assessment:** Conduct a formal privacy review covering data minimization, retention policies, and cross-border data transfers.
+- **Chaos and Resilience Testing:** Schedule quarterly resilience drills (fault injection, dependency outages) to validate recovery plans and SLOs.
+- **Customer Communication Templates:** Prepare standardized communications for security events, banking disruptions, and roadmap milestones to keep stakeholders informed.
+- **Continuous Control Monitoring:** Implement automated checks that validate MFA enforcement, log redaction, and audit chain integrity in staging and production on a daily cadence.
+


### PR DESCRIPTION
## Summary
- add a prompt review document capturing recommendations for each proposed security and operations task
- note clarifications, additional considerations, and follow-on tasks for MFA, banking integrations, roadmap, operator tooling, and hardening
- suggest supplementary initiatives such as privacy assessments, chaos drills, and continuous control monitoring

## Testing
- no tests were run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e31180d1308327aa45a30a76f0738f