### PR TITLE
Add codex feed ingestion API and surface preview in help page

### DIFF
--- a/src/docs/codexFeed.ts
+++ b/src/docs/codexFeed.ts
@@ -1,0 +1,148 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+interface RawManifestEntry {
+  order: number;
+  file_relative: string;
+  part: number;
+  parts: number;
+  chars: number;
+}
+
+export interface CodexManifestEntry {
+  order: number;
+  fileRelative: string;
+  part: number;
+  parts: number;
+  charCount: number;
+  fileName: string;
+}
+
+export interface CodexChunk extends CodexManifestEntry {
+  title?: string;
+  content: string;
+  preview: string;
+}
+
+const FEED_DIR = path.resolve(process.cwd(), "docs", "_codex_feed");
+const MANIFEST_PATH = path.join(FEED_DIR, "manifest.json");
+
+interface InternalManifestEntry extends CodexManifestEntry {
+  filePath: string;
+}
+
+let manifestCache: InternalManifestEntry[] | null = null;
+let manifestLookup: Map<number, InternalManifestEntry> | null = null;
+
+function ensureFeedDir() {
+  return FEED_DIR;
+}
+
+function deriveFileName(entry: RawManifestEntry): string {
+  const order = String(entry.order).padStart(4, "0");
+  const part = String(entry.part).padStart(2, "0");
+  const parts = String(entry.parts).padStart(2, "0");
+  return `${order}_${entry.file_relative}_part_${part}of${parts}.md`;
+}
+
+async function loadManifestFromDisk(): Promise<InternalManifestEntry[]> {
+  const dir = ensureFeedDir();
+  const raw = await fs.readFile(MANIFEST_PATH, "utf8");
+  const cleaned = raw.replace(/^\uFEFF/, "");
+  const parsed = JSON.parse(cleaned) as RawManifestEntry[];
+  return parsed.map((entry) => {
+    const fileName = deriveFileName(entry);
+    const filePath = path.join(dir, fileName);
+    return {
+      order: entry.order,
+      fileRelative: entry.file_relative,
+      part: entry.part,
+      parts: entry.parts,
+      charCount: entry.chars,
+      fileName,
+      filePath,
+    } satisfies InternalManifestEntry;
+  });
+}
+
+async function ensureManifestLoaded(): Promise<InternalManifestEntry[]> {
+  if (manifestCache) {
+    return manifestCache;
+  }
+  const manifest = await loadManifestFromDisk();
+  manifestCache = manifest;
+  manifestLookup = new Map(manifest.map((entry) => [entry.order, entry]));
+  return manifest;
+}
+
+function toExternal(entry: InternalManifestEntry): CodexManifestEntry {
+  const { filePath: _filePath, ...external } = entry;
+  return external;
+}
+
+function sanitizeContent(raw: string): string {
+  const withoutBom = raw.replace(/^\uFEFF/, "");
+  const codeFenceMatch = [...withoutBom.matchAll(/```([\s\S]*?)```/g)];
+  if (codeFenceMatch.length > 0) {
+    return codeFenceMatch.map((m) => m[1]).join("\n\n").trim();
+  }
+  return withoutBom.trim();
+}
+
+function extractTitle(raw: string): string | undefined {
+  const withoutBom = raw.replace(/^\uFEFF/, "");
+  const match = withoutBom.match(/^#\s+File:\s+(.+)$/m);
+  return match ? match[1].trim() : undefined;
+}
+
+function buildPreview(content: string, maxLength: number): string {
+  const normalized = content.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) {
+    return normalized;
+  }
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+export async function getManifest(): Promise<CodexManifestEntry[]> {
+  const manifest = await ensureManifestLoaded();
+  return manifest.map(toExternal);
+}
+
+export async function getChunk(order: number, previewLength = 240): Promise<CodexChunk> {
+  if (!Number.isInteger(order) || order < 1) {
+    throw new Error("ORDER_OUT_OF_RANGE");
+  }
+  await ensureManifestLoaded();
+  const entry = manifestLookup?.get(order);
+  if (!entry) {
+    throw new Error("ORDER_NOT_FOUND");
+  }
+  let raw: string;
+  try {
+    raw = await fs.readFile(entry.filePath, "utf8");
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err?.code === "ENOENT") {
+      throw new Error("CHUNK_FILE_MISSING");
+    }
+    throw error;
+  }
+  const content = sanitizeContent(raw);
+  const title = extractTitle(raw);
+  const preview = buildPreview(content, previewLength);
+  return {
+    ...toExternal(entry),
+    title,
+    content,
+    preview,
+  };
+}
+
+export async function getChunksPreview(orders: number[], previewLength = 240): Promise<CodexChunk[]> {
+  const uniqueOrders = Array.from(new Set(orders));
+  const chunks = await Promise.all(uniqueOrders.map((order) => getChunk(order, previewLength)));
+  const lookup = new Map(chunks.map((chunk) => [chunk.order, chunk]));
+  return orders
+    .map((order) => lookup.get(order))
+    .filter((chunk): chunk is CodexChunk => Boolean(chunk));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { atoCodex } from "./routes/atoCodex";
 
 dotenv.config();
 
@@ -24,6 +25,9 @@ app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
+
+// Knowledge base ingestion endpoints
+app.use("/api/ato-feed", atoCodex);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,6 +1,71 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+
+type FeedPreview = {
+  order: number;
+  fileName: string;
+  fileRelative: string;
+  title?: string;
+  preview: string;
+};
 
 export default function Help() {
+  const [feedEntries, setFeedEntries] = useState<FeedPreview[]>([]);
+  const [feedTotal, setFeedTotal] = useState<number | null>(null);
+  const [feedTruncated, setFeedTruncated] = useState(false);
+  const [feedLoading, setFeedLoading] = useState(true);
+  const [feedError, setFeedError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadFeed = async () => {
+      if (typeof fetch !== "function") {
+        if (!cancelled) {
+          setFeedError("Fetch API is not available in this environment.");
+          setFeedLoading(false);
+        }
+        return;
+      }
+
+      try {
+        const response = await fetch("/api/ato-feed/manifest?limit=5&preview=true");
+        if (!response.ok) {
+          throw new Error(`Failed to load manifest (status ${response.status})`);
+        }
+        const data = await response.json();
+        if (cancelled) return;
+
+        const entries = Array.isArray(data.entries)
+          ? (data.entries as FeedPreview[])
+          : [];
+
+        setFeedEntries(
+          entries.map((entry) => ({
+            order: entry.order,
+            fileName: entry.fileName,
+            fileRelative: entry.fileRelative,
+            title: entry.title,
+            preview: entry.preview ?? "",
+          }))
+        );
+        setFeedTotal(typeof data.total === "number" ? data.total : null);
+        setFeedTruncated(Boolean(data.truncated));
+        setFeedLoading(false);
+      } catch (error) {
+        if (!cancelled) {
+          setFeedError(error instanceof Error ? error.message : "Unknown error");
+          setFeedLoading(false);
+        }
+      }
+    };
+
+    loadFeed();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   return (
     <div className="p-6 space-y-4">
       <h1 className="text-2xl font-bold">Help & Guidance</h1>
@@ -33,6 +98,55 @@ export default function Help() {
           <li><a className="text-blue-600" href="https://www.ato.gov.au/business/super-for-employers/">ATO Super Obligations</a></li>
           <li><a className="text-blue-600" href="https://www.ato.gov.au/General/Online-services/">ATO Online Services</a></li>
         </ul>
+      </div>
+      <div className="bg-card p-4 rounded-xl shadow space-y-3">
+        <div className="space-y-1">
+          <h2 className="text-lg font-semibold">ATO Knowledge Feed</h2>
+          <p className="text-sm text-muted-foreground">
+            Live excerpts from <code>docs/_codex_feed</code> are ingested into the app for quick reference.
+          </p>
+        </div>
+        {feedLoading ? (
+          <p className="text-sm text-muted-foreground">Loading manifest…</p>
+        ) : feedError ? (
+          <p className="text-sm text-red-600">{feedError}</p>
+        ) : (
+          <div className="space-y-3">
+            <p className="text-xs text-muted-foreground">
+              Showing {feedEntries.length} of {feedTotal ?? feedEntries.length} chunks
+              {feedTruncated ? " (truncated)" : ""}.
+            </p>
+            <ul className="space-y-3">
+              {feedEntries.map((entry) => {
+                const title = entry.title || entry.fileRelative || entry.fileName;
+                return (
+                  <li
+                    key={entry.order}
+                    className="bg-card border rounded-lg p-3 space-y-2 shadow-sm"
+                  >
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="text-sm font-semibold">{title}</span>
+                      <span className="text-xs text-muted-foreground">#{entry.order}</span>
+                    </div>
+                    <p className="text-xs text-muted-foreground leading-relaxed">
+                      {entry.preview ? entry.preview : "No preview available for this chunk."}
+                    </p>
+                    <div>
+                      <a
+                        className="text-xs font-medium text-blue-600 hover:underline"
+                        href={`/api/ato-feed/chunk/${entry.order}`}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        View full chunk
+                      </a>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/routes/atoCodex.ts
+++ b/src/routes/atoCodex.ts
@@ -1,0 +1,58 @@
+import { Router } from "express";
+import { getManifest, getChunk, CodexManifestEntry, CodexChunk } from "../docs/codexFeed";
+
+export const atoCodex = Router();
+
+atoCodex.get("/manifest", async (req, res) => {
+  try {
+    const limitRaw = req.query.limit as string | undefined;
+    const includePreview = String(req.query.preview ?? "false").toLowerCase() === "true";
+    const previewLengthRaw = req.query.previewLength as string | undefined;
+
+    const limit = limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
+    const previewLength = previewLengthRaw ? Number.parseInt(previewLengthRaw, 10) : 240;
+
+    const fullManifest: CodexManifestEntry[] = await getManifest();
+    let manifest: CodexManifestEntry[] = fullManifest;
+    let truncated = false;
+
+    if (limit && Number.isFinite(limit) && limit > 0) {
+      truncated = fullManifest.length > limit;
+      manifest = fullManifest.slice(0, limit);
+    }
+
+    if (includePreview) {
+      const entriesWithPreview: CodexChunk[] = await Promise.all(
+        manifest.map((entry) => getChunk(entry.order, previewLength))
+      );
+      return res.json({ total: fullManifest.length, truncated, entries: entriesWithPreview });
+    }
+
+    return res.json({ total: fullManifest.length, truncated, entries: manifest });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "UNKNOWN_ERROR";
+    res.status(500).json({ error: message });
+  }
+});
+
+atoCodex.get("/chunk/:order", async (req, res) => {
+  try {
+    const order = Number.parseInt(req.params.order, 10);
+    const previewLengthRaw = req.query.previewLength as string | undefined;
+    const previewLength = previewLengthRaw ? Number.parseInt(previewLengthRaw, 10) : 240;
+    const chunk = await getChunk(order, previewLength);
+    res.json(chunk);
+  } catch (error) {
+    if (error instanceof Error && error.message === "ORDER_NOT_FOUND") {
+      return res.status(404).json({ error: "NOT_FOUND" });
+    }
+    if (error instanceof Error && error.message === "ORDER_OUT_OF_RANGE") {
+      return res.status(400).json({ error: "ORDER_OUT_OF_RANGE" });
+    }
+    if (error instanceof Error && error.message === "CHUNK_FILE_MISSING") {
+      return res.status(500).json({ error: "CHUNK_FILE_MISSING" });
+    }
+    const message = error instanceof Error ? error.message : "UNKNOWN_ERROR";
+    res.status(500).json({ error: message });
+  }
+});


### PR DESCRIPTION
## Summary
- add a codex feed helper that parses the manifest, caches results, and loads chunk content with previews
- expose an `/api/ato-feed` router so the app can list manifest entries or retrieve full chunk payloads on demand
- surface the ingested feed on the Help page with a live preview list that links to the new API endpoints

## Testing
- npm run typecheck
- npx tsx --eval "import { getChunk } from './src/docs/codexFeed'; (async () => { const chunk = await getChunk(1); console.log(chunk.title); console.log(chunk.preview.slice(0,60)); })();"

------
https://chatgpt.com/codex/tasks/task_e_68e364c8f35c8327af6f327c889de563