### PR TITLE
Add Codex feed loader utilities and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,16 @@ Build for Production
 
 npm run build
 
+Codex feed utilities
+--------------------
+
+The repository ships with a loader for the chunked ingestion located in `docs/_codex_feed`.
+
+* `src/utils/codexFeed.ts` exposes helpers that return manifest entries, chunk contents, or the stitched text for each original source file.
+* `npm run codex:dump -- <filter>` prints the reconstructed files to stdout, optionally filtering by the original file name fragment.
+
+Example: `npm run codex:dump -- chunk_000123` will show the text that originated from `chunk_000123.txt`.
+
 Project Structure
 apgms/
 ├── public/ # Static assets and HTML

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "codex:dump": "tsx scripts/dumpCodexFeed.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/dumpCodexFeed.ts
+++ b/scripts/dumpCodexFeed.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env tsx
+import type { CodexManifestEntry } from '../src/utils/codexFeed';
+import { loadFiles } from '../src/utils/codexFeed';
+
+async function main() {
+  const [, , ...args] = process.argv;
+  const [needle] = args;
+
+  let filter: ((entry: CodexManifestEntry) => boolean) | undefined;
+
+  if (needle) {
+    console.error(`Filtering manifest entries containing: ${needle}`);
+    const lowerNeedle = needle.toLowerCase();
+    filter = (entry) => entry.file_relative.toLowerCase().includes(lowerNeedle);
+  }
+
+  const files = await loadFiles({ filter });
+
+  console.log(`Loaded ${files.length} file(s) from the Codex feed${needle ? ` matching "${needle}"` : ''}.`);
+
+  for (const file of files) {
+    console.log(`\n# ${file.fileRelative}`);
+    console.log(`Language: ${file.language ?? 'n/a'} | Parts: ${file.parts} | Characters: ${file.chars}`);
+    console.log('---');
+    console.log(file.text.trim());
+  }
+}
+
+main().catch((error) => {
+  console.error('Failed to read Codex feed:', error);
+  process.exitCode = 1;
+});

--- a/src/utils/codexFeed.ts
+++ b/src/utils/codexFeed.ts
@@ -1,0 +1,118 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface CodexManifestEntry {
+  order: number;
+  file_relative: string;
+  part: number;
+  parts: number;
+  md_path: string;
+  language: string;
+  chars: number;
+}
+
+export interface CodexChunk {
+  entry: CodexManifestEntry;
+  text: string;
+  path: string;
+}
+
+export interface CodexFile {
+  fileRelative: string;
+  language?: string;
+  chars: number;
+  parts: number;
+  text: string;
+  order: number;
+}
+
+export interface LoadOptions {
+  manifestPath?: string;
+  feedRoot?: string;
+  filter?: (entry: CodexManifestEntry) => boolean;
+}
+
+const DEFAULT_FEED_ROOT = path.resolve(process.cwd(), 'docs/_codex_feed');
+const DEFAULT_MANIFEST = path.join(DEFAULT_FEED_ROOT, 'manifest.json');
+
+const BOM = '\uFEFF';
+
+async function readManifest(manifestPath: string = DEFAULT_MANIFEST): Promise<CodexManifestEntry[]> {
+  try {
+    const contents = await fs.readFile(manifestPath, 'utf8');
+    const normalized = contents.startsWith(BOM) ? contents.slice(1) : contents;
+    const entries = JSON.parse(normalized) as CodexManifestEntry[];
+    return entries;
+  } catch (error) {
+    throw new Error(`Unable to read Codex manifest at ${manifestPath}: ${(error as Error).message}`);
+  }
+}
+
+function chunkFileName(entry: CodexManifestEntry): string {
+  const order = entry.order.toString().padStart(4, '0');
+  const part = entry.part.toString().padStart(2, '0');
+  const parts = entry.parts.toString().padStart(2, '0');
+  return `${order}_${entry.file_relative}_part_${part}of${parts}.md`;
+}
+
+async function readChunk(entry: CodexManifestEntry, feedRoot: string = DEFAULT_FEED_ROOT): Promise<CodexChunk> {
+  const relativeName = chunkFileName(entry);
+  const chunkPath = path.join(feedRoot, relativeName);
+  try {
+    const text = await fs.readFile(chunkPath, 'utf8');
+    return {
+      entry,
+      text,
+      path: chunkPath,
+    };
+  } catch (error) {
+    throw new Error(`Unable to read Codex chunk ${relativeName}: ${(error as Error).message}`);
+  }
+}
+
+export async function loadChunks(options: LoadOptions = {}): Promise<CodexChunk[]> {
+  const manifestPath = options.manifestPath ?? DEFAULT_MANIFEST;
+  const feedRoot = options.feedRoot ?? DEFAULT_FEED_ROOT;
+  const entries = await readManifest(manifestPath);
+  const filtered = options.filter ? entries.filter(options.filter) : entries;
+  const chunks = await Promise.all(filtered.map((entry) => readChunk(entry, feedRoot)));
+  return chunks;
+}
+
+export async function loadFiles(options: LoadOptions = {}): Promise<CodexFile[]> {
+  const chunks = await loadChunks(options);
+  const grouped = new Map<string, CodexFile>();
+
+  for (const chunk of chunks) {
+    const key = chunk.entry.file_relative;
+    if (!grouped.has(key)) {
+      grouped.set(key, {
+        fileRelative: key,
+        language: chunk.entry.language || undefined,
+        chars: chunk.entry.chars,
+        parts: chunk.entry.parts,
+        text: chunk.text,
+        order: chunk.entry.order,
+      });
+      continue;
+    }
+
+    const existing = grouped.get(key)!;
+    existing.text += chunk.text;
+    existing.parts = Math.max(existing.parts, chunk.entry.parts);
+    existing.chars += chunk.entry.chars;
+    existing.order = Math.min(existing.order, chunk.entry.order);
+  }
+
+  return Array.from(grouped.values()).sort((a, b) => a.order - b.order);
+}
+
+export async function loadCombinedText(options: LoadOptions = {}): Promise<string> {
+  const feedRoot = options.feedRoot ?? DEFAULT_FEED_ROOT;
+  const combinedPath = path.join(feedRoot, 'combined_all.md');
+  try {
+    return await fs.readFile(combinedPath, 'utf8');
+  } catch (error) {
+    throw new Error(`Unable to read combined Codex feed at ${combinedPath}: ${(error as Error).message}`);
+  }
+}


### PR DESCRIPTION
## Summary
- add utilities for parsing the Codex manifest, chunk files, and combined feed text
- provide a tsx CLI that reconstructs and prints chunked source files
- document the new workflow and npm script in the README

## Testing
- npm run codex:dump -- chunk_000000

------
https://chatgpt.com/codex/tasks/task_e_68e36a21baf88327b8950dacda9bbeb1