### PR TITLE
feat: add allowance and leave loading benchmarks

### DIFF
--- a/apps/services/tax-engine/app/engine/__init__.py
+++ b/apps/services/tax-engine/app/engine/__init__.py
@@ -1,0 +1,19 @@
+"""Utility functions for allowance and leave-loading classification."""
+
+from .allowances import (
+    load_allowance_rules,
+    cents_per_km_allowance,
+    benchmark_allowance,
+)
+from .leave_loading import (
+    load_leave_loading_rules,
+    classify_leave_loading,
+)
+
+__all__ = [
+    "load_allowance_rules",
+    "cents_per_km_allowance",
+    "benchmark_allowance",
+    "load_leave_loading_rules",
+    "classify_leave_loading",
+]

--- a/apps/services/tax-engine/app/engine/allowances.py
+++ b/apps/services/tax-engine/app/engine/allowances.py
@@ -1,0 +1,245 @@
+"""Allowance calculation helpers.
+
+The helpers defined here take allowance payment inputs and return a rich
+classification of taxable versus exempt components together with the correct
+Single Touch Payroll (STP) category code that the caller should report.
+
+The module relies on JSON rule files that live alongside the tax-engine app in
+``app/rules``.  The rule data captures benchmark caps for the current financial
+year.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+import json
+
+RULES_DIR = Path(__file__).resolve().parent.parent / "rules"
+
+
+class AllowanceRuleError(ValueError):
+    """Raised when an allowance rule cannot be resolved."""
+
+
+@dataclass(frozen=True)
+class CentsPerKmRule:
+    tier: str
+    rate_cents: Decimal
+    max_kilometres: Decimal
+    stp_category: str
+    description: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "CentsPerKmRule":
+        try:
+            tier = data["tier"]
+            rate = Decimal(str(data["rate_cents"]))
+            max_km = Decimal(str(data.get("max_km", data.get("max_kilometres", 0))))
+            stp = data.get("stp_category") or "CentsPerKilometre"
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise AllowanceRuleError(f"Missing key in cents per km rule: {exc}") from exc
+        return cls(
+            tier=tier,
+            rate_cents=rate,
+            max_kilometres=max_km,
+            stp_category=stp,
+            description=data.get("description"),
+        )
+
+
+@dataclass(frozen=True)
+class BenchmarkRule:
+    tier: str
+    stp_category: str
+    metro_enabled: bool
+    remote_enabled: bool
+    caps: Dict[str, Decimal]
+    description: str | None = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BenchmarkRule":
+        try:
+            tier = data["tier"]
+            stp = data.get("stp_category") or "OtherAllowances"
+            caps_raw = data.get("caps") or {}
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise AllowanceRuleError(f"Missing key in benchmark rule: {exc}") from exc
+
+        caps = {
+            loc.lower(): Decimal(str(amount))
+            for loc, amount in caps_raw.items()
+            if amount is not None
+        }
+        return cls(
+            tier=tier,
+            stp_category=stp,
+            metro_enabled=bool(data.get("metro", True)),
+            remote_enabled=bool(data.get("remote", True)),
+            caps=caps,
+            description=data.get("description"),
+        )
+
+
+@dataclass(frozen=True)
+class AllowanceResult:
+    claimed_cents: int
+    exempt_cents: int
+    taxable_cents: int
+    stp_category: str
+    tier: str
+    notes: Iterable[str]
+
+
+def _quantize_cents(value: Decimal) -> int:
+    return int(value.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def _load_rules_file(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise AllowanceRuleError(f"Allowance rules file not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_allowance_rules(year: str | None = None) -> Dict[str, Any]:
+    """Load the allowance rules JSON for a financial year.
+
+    Parameters
+    ----------
+    year:
+        The year suffix (e.g. ``"2024_25"``).  When omitted the loader attempts
+        to use the newest file in the rules directory.
+    """
+
+    if year:
+        target = RULES_DIR / f"allowances_{year}.json"
+        return _load_rules_file(target)
+
+    candidates = sorted(RULES_DIR.glob("allowances_*.json"))
+    if not candidates:
+        raise AllowanceRuleError("No allowance rule files present")
+    return _load_rules_file(candidates[-1])
+
+
+def _resolve_cpk_rule(rules: Dict[str, Any], tier: str) -> CentsPerKmRule:
+    tier_lower = tier.lower()
+    data = rules.get("cents_per_km", {}).get("tiers", [])
+    for item in data:
+        rule = CentsPerKmRule.from_dict(item)
+        if rule.tier.lower() == tier_lower:
+            return rule
+    raise AllowanceRuleError(f"No cents-per-kilometre rule configured for tier '{tier}'")
+
+
+def _resolve_benchmark_rule(rules: Dict[str, Any], kind: str, tier: str) -> BenchmarkRule:
+    tier_lower = tier.lower()
+    kind_rules = rules.get("benchmarks", {}).get(kind.lower(), [])
+    for item in kind_rules:
+        rule = BenchmarkRule.from_dict(item)
+        if rule.tier.lower() == tier_lower:
+            return rule
+    raise AllowanceRuleError(
+        f"No benchmark rule configured for {kind!r} tier '{tier}'"
+    )
+
+
+def cents_per_km_allowance(
+    kilometres: float | Decimal,
+    rate_cents: float | Decimal,
+    *,
+    tier: str = "car",
+    year: str | None = None,
+    rules: Optional[Dict[str, Any]] = None,
+) -> AllowanceResult:
+    """Split a cents-per-kilometre allowance into taxable and exempt components."""
+
+    rules_data = rules or load_allowance_rules(year)
+    rule = _resolve_cpk_rule(rules_data, tier)
+
+    km = Decimal(str(kilometres))
+    rate = Decimal(str(rate_cents))
+    claimed = km * rate
+
+    eligible_km = min(km, rule.max_kilometres)
+    exempt_rate = min(rate, rule.rate_cents)
+    exempt_amount = eligible_km * exempt_rate
+
+    taxable_amount = claimed - exempt_amount
+
+    taxable_cents = max(_quantize_cents(taxable_amount), 0)
+    exempt_cents = max(_quantize_cents(exempt_amount), 0)
+
+    notes: list[str] = []
+    if km > rule.max_kilometres:
+        notes.append(
+            f"Only the first {rule.max_kilometres} km are concessionally treated; "
+            f"{km - rule.max_kilometres} km treated as taxable"
+        )
+    else:
+        notes.append(
+            f"Kilometres claimed within concessional cap of {rule.max_kilometres} km"
+        )
+    if rate > rule.rate_cents:
+        notes.append(
+            f"Amounts above {rule.rate_cents} cents per km are taxable"
+        )
+    else:
+        notes.append(
+            f"Rate does not exceed benchmark of {rule.rate_cents} cents per km"
+        )
+
+    return AllowanceResult(
+        claimed_cents=_quantize_cents(claimed),
+        exempt_cents=exempt_cents,
+        taxable_cents=taxable_cents,
+        stp_category=rule.stp_category,
+        tier=rule.tier,
+        notes=notes,
+    )
+
+
+def benchmark_allowance(
+    kind: str,
+    amount_cents: int,
+    *,
+    tier: str = "standard",
+    location: str = "metro",
+    year: str | None = None,
+    rules: Optional[Dict[str, Any]] = None,
+) -> AllowanceResult:
+    """Apply benchmark rules for meal, travel or tool allowances."""
+
+    rules_data = rules or load_allowance_rules(year)
+    rule = _resolve_benchmark_rule(rules_data, kind, tier)
+    location_key = location.lower()
+
+    if location_key not in rule.caps:
+        enabled_flag = "metro" if location_key == "metro" else "remote"
+        raise AllowanceRuleError(
+            f"Location '{location}' is not enabled for tier '{tier}' ({enabled_flag} not allowed)"
+        )
+
+    cap = rule.caps[location_key]
+    claimed = Decimal(amount_cents)
+    exempt_amount = min(claimed, cap)
+    taxable_amount = max(claimed - cap, Decimal("0"))
+
+    notes = [
+        f"Benchmark cap for {kind} ({tier}) in {location_key} areas is {cap} cents",
+    ]
+    if taxable_amount > 0:
+        notes.append("Excess above benchmark treated as taxable allowance")
+    else:
+        notes.append("Allowance is within benchmark and treated as exempt")
+
+    return AllowanceResult(
+        claimed_cents=int(claimed),
+        exempt_cents=_quantize_cents(exempt_amount),
+        taxable_cents=_quantize_cents(taxable_amount),
+        stp_category=rule.stp_category,
+        tier=rule.tier,
+        notes=notes,
+    )

--- a/apps/services/tax-engine/app/engine/leave_loading.py
+++ b/apps/services/tax-engine/app/engine/leave_loading.py
@@ -1,0 +1,146 @@
+"""Leave loading classification helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+import json
+
+RULES_PATH = Path(__file__).resolve().parent.parent / "rules" / "leave_loading_rules.json"
+
+
+class LeaveLoadingRuleError(ValueError):
+    """Raised when a leave loading rule cannot be determined."""
+
+
+@dataclass(frozen=True)
+class LeaveLoadingRule:
+    reference: str
+    ote: bool
+    payroll_tax: bool
+    sg: Optional[bool]
+    note: str
+    aliases: Iterable[str]
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LeaveLoadingRule":
+        try:
+            reference = data["reference"]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise LeaveLoadingRuleError("Leave loading rule requires a 'reference'") from exc
+        return cls(
+            reference=reference,
+            ote=bool(data.get("ote", True)),
+            payroll_tax=bool(data.get("payroll_tax", True)),
+            sg=data.get("sg"),
+            note=str(data.get("note", "")),
+            aliases=tuple(data.get("aliases", [])),
+        )
+
+
+@dataclass(frozen=True)
+class LeaveLoadingResult:
+    amount_cents: int
+    ote_applicable: bool
+    payroll_tax_applicable: bool
+    sg_applicable: bool
+    evidence: str
+    rule_reference: str
+
+
+def _load_rules_file(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise LeaveLoadingRuleError(f"Leave loading rules file not found: {path}")
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_leave_loading_rules() -> Dict[str, Any]:
+    """Load the leave loading rules JSON file."""
+
+    return _load_rules_file(RULES_PATH)
+
+
+def _normalise(value: str) -> str:
+    return value.strip().lower()
+
+
+def _find_rule(rules: Dict[str, Any], award_reference: Optional[str]) -> LeaveLoadingRule | None:
+    if not award_reference:
+        return None
+
+    norm_award = _normalise(award_reference)
+    for item in rules.get("rules", []):
+        rule = LeaveLoadingRule.from_dict(item)
+        candidates = [rule.reference, *rule.aliases]
+        for candidate in candidates:
+            if not candidate:
+                continue
+            norm_candidate = _normalise(candidate)
+            if norm_award == norm_candidate or norm_candidate in norm_award:
+                return rule
+    return None
+
+
+def classify_leave_loading(
+    amount_cents: int,
+    *,
+    award_reference: Optional[str] = None,
+    overrides: Optional[Dict[str, Optional[bool]]] = None,
+    rules: Optional[Dict[str, Any]] = None,
+) -> LeaveLoadingResult:
+    """Determine OTE, payroll tax and SG treatment for leave loading."""
+
+    rules_data = rules or load_leave_loading_rules()
+    overrides = overrides or {}
+
+    rule = _find_rule(rules_data, award_reference)
+    default_data = rules_data.get("default", {})
+    default_rule = LeaveLoadingRule(
+        reference=default_data.get("reference", "default"),
+        ote=bool(default_data.get("ote", True)),
+        payroll_tax=bool(default_data.get("payroll_tax", True)),
+        sg=default_data.get("sg"),
+        note=str(default_data.get("note", "")),
+        aliases=(),
+    )
+
+    applied_rule = rule or default_rule
+
+    ote = overrides.get("ote")
+    if ote is None:
+        ote = applied_rule.ote
+
+    payroll_tax = overrides.get("payroll_tax")
+    if payroll_tax is None:
+        payroll_tax = applied_rule.payroll_tax
+
+    sg = overrides.get("sg")
+    if sg is None:
+        sg = applied_rule.sg if applied_rule.sg is not None else ote
+
+    evidence_lines = []
+    if applied_rule.note:
+        evidence_lines.append(applied_rule.note)
+    if award_reference:
+        evidence_lines.append(f"Award reference considered: {award_reference}")
+    if overrides:
+        override_bits = ", ".join(
+            f"{key} set to {value}" for key, value in overrides.items() if value is not None
+        )
+        if override_bits:
+            evidence_lines.append(f"Manual overrides applied ({override_bits})")
+
+    evidence = " ".join(evidence_lines).strip()
+    if not evidence:
+        evidence = "Default leave loading treatment applied"
+
+    return LeaveLoadingResult(
+        amount_cents=int(amount_cents),
+        ote_applicable=bool(ote),
+        payroll_tax_applicable=bool(payroll_tax),
+        sg_applicable=bool(sg),
+        evidence=evidence,
+        rule_reference=applied_rule.reference,
+    )

--- a/apps/services/tax-engine/app/rules/allowances_2024_25.json
+++ b/apps/services/tax-engine/app/rules/allowances_2024_25.json
@@ -1,0 +1,98 @@
+{
+  "metadata": {
+    "financial_year": "2024-25",
+    "source": "APGMS benchmark pack v1",
+    "notes": "Illustrative rates aligned with published ATO benchmarks for cents per km and reasonable travel allowances"
+  },
+  "cents_per_km": {
+    "tiers": [
+      {
+        "tier": "car",
+        "description": "Standard car allowance for vehicles up to 1 tonne or 9 passengers",
+        "rate_cents": 85,
+        "max_km": 5000,
+        "stp_category": "CentsPerKilometre.Car"
+      },
+      {
+        "tier": "other_vehicle",
+        "description": "Motorcycle or non-standard vehicle rate",
+        "rate_cents": 45,
+        "max_km": 5000,
+        "stp_category": "CentsPerKilometre.Other"
+      }
+    ]
+  },
+  "benchmarks": {
+    "meal": [
+      {
+        "tier": "standard",
+        "description": "Overtime meal allowance benchmark",
+        "metro": true,
+        "remote": true,
+        "caps": {
+          "metro": 3200,
+          "remote": 3600
+        },
+        "stp_category": "OvertimeMeal"
+      },
+      {
+        "tier": "remote_worker",
+        "description": "Higher cap for remote operations or FIFO workers",
+        "metro": false,
+        "remote": true,
+        "caps": {
+          "remote": 4200
+        },
+        "stp_category": "OvertimeMeal"
+      }
+    ],
+    "travel": [
+      {
+        "tier": "standard",
+        "description": "Travel allowance daily benchmark for metro centres",
+        "metro": true,
+        "remote": true,
+        "caps": {
+          "metro": 18500,
+          "remote": 22000
+        },
+        "stp_category": "TravelAllowance"
+      },
+      {
+        "tier": "executive",
+        "description": "Executive or specialist tier for high cost travel",
+        "metro": true,
+        "remote": true,
+        "caps": {
+          "metro": 23500,
+          "remote": 26000
+        },
+        "stp_category": "TravelAllowance"
+      }
+    ],
+    "tool": [
+      {
+        "tier": "standard",
+        "description": "Tool allowance cap applicable across metro and remote",
+        "metro": true,
+        "remote": true,
+        "caps": {
+          "metro": 1500,
+          "remote": 1500
+        },
+        "stp_category": "ToolAllowance"
+      },
+      {
+        "tier": "specialised",
+        "description": "Higher cap where industrial instruments reference specialised equipment",
+        "metro": true,
+        "remote": true,
+        "caps": {
+          "metro": 2800,
+          "remote": 3200
+        },
+        "stp_category": "ToolAllowance"
+      }
+    ]
+  }
+}

--- a/apps/services/tax-engine/app/rules/leave_loading_rules.json
+++ b/apps/services/tax-engine/app/rules/leave_loading_rules.json
@@ -1,0 +1,39 @@
+{
+  "metadata": {
+    "financial_year": "2024-25",
+    "notes": "These settings illustrate common award treatments for annual leave loading.",
+    "source": "APGMS payroll knowledge base"
+  },
+  "default": {
+    "reference": "default",
+    "ote": true,
+    "payroll_tax": true,
+    "sg": null,
+    "note": "Default guidance – leave loading is treated as OTE and subject to payroll tax unless an award carve-out applies."
+  },
+  "rules": [
+    {
+      "reference": "award:modern:clerks:cl25",
+      "aliases": ["clerks-award", "ma000002-cl25"],
+      "ote": true,
+      "payroll_tax": true,
+      "note": "Clerks – Private Sector Award clause 25 treats the 17.5% loading as part of ordinary time earnings."
+    },
+    {
+      "reference": "award:legacy:non_ote",
+      "aliases": ["legacy-non-ote"],
+      "ote": false,
+      "payroll_tax": false,
+      "sg": false,
+      "note": "Legacy workplace agreement specifies the loading is an ex gratia payment."
+    },
+    {
+      "reference": "award:state:qld:sg-only",
+      "aliases": ["qld-state-award"],
+      "ote": false,
+      "payroll_tax": true,
+      "sg": true,
+      "note": "Queensland state instrument treats the loading as not OTE but super guarantee still applies."
+    }
+  ]
+}

--- a/apps/services/tax-engine/tests/test_allowance_engine.py
+++ b/apps/services/tax-engine/tests/test_allowance_engine.py
@@ -1,0 +1,35 @@
+from app.engine.allowances import (
+    load_allowance_rules,
+    cents_per_km_allowance,
+    benchmark_allowance,
+)
+
+
+def test_cents_per_km_above_cap():
+    rules = load_allowance_rules("2024_25")
+    result = cents_per_km_allowance(6500, 95, tier="car", rules=rules)
+    assert result.claimed_cents == 617500
+    assert result.exempt_cents == 425000
+    assert result.taxable_cents == 192500
+    assert result.stp_category == "CentsPerKilometre.Car"
+    assert any("first" in note for note in result.notes)
+
+
+def test_benchmark_meal_remote_taxable_excess():
+    rules = load_allowance_rules("2024_25")
+    result = benchmark_allowance(
+        "meal", 4000, tier="standard", location="remote", rules=rules
+    )
+    assert result.exempt_cents == 3600
+    assert result.taxable_cents == 400
+    assert result.stp_category == "OvertimeMeal"
+
+
+def test_benchmark_tool_within_cap():
+    rules = load_allowance_rules("2024_25")
+    result = benchmark_allowance(
+        "tool", 1300, tier="standard", location="metro", rules=rules
+    )
+    assert result.exempt_cents == 1300
+    assert result.taxable_cents == 0
+    assert result.stp_category == "ToolAllowance"

--- a/apps/services/tax-engine/tests/test_leave_loading_engine.py
+++ b/apps/services/tax-engine/tests/test_leave_loading_engine.py
@@ -1,0 +1,31 @@
+from app.engine.leave_loading import (
+    load_leave_loading_rules,
+    classify_leave_loading,
+)
+
+
+def test_leave_loading_default_rule():
+    rules = load_leave_loading_rules()
+    result = classify_leave_loading(100_00, award_reference=None, rules=rules)
+    assert result.ote_applicable is True
+    assert result.payroll_tax_applicable is True
+    assert result.sg_applicable is True
+    assert "Default" in result.evidence or "Default" in result.rule_reference.capitalize()
+
+
+def test_leave_loading_non_ote_rule():
+    rules = load_leave_loading_rules()
+    result = classify_leave_loading(200_00, award_reference="legacy-non-ote", rules=rules)
+    assert result.ote_applicable is False
+    assert result.payroll_tax_applicable is False
+    assert result.sg_applicable is False
+    assert "Legacy" in result.evidence
+
+
+def test_leave_loading_sg_override():
+    rules = load_leave_loading_rules()
+    result = classify_leave_loading(300_00, award_reference="qld-state-award", rules=rules)
+    assert result.ote_applicable is False
+    assert result.payroll_tax_applicable is True
+    assert result.sg_applicable is True
+    assert "Queensland" in result.evidence


### PR DESCRIPTION
## Summary
- add allowance calculators that split taxable and exempt portions and expose STP categories
- capture allowance and leave loading reference data for FY24-25
- classify leave loading for award overrides and surface evidence notes

## Testing
- pytest apps/services/tax-engine/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e375e954e88327a5a9cfbea4176752