### PR TITLE
Add payroll tax engine and state rules

### DIFF
--- a/engine/payroll_tax.py
+++ b/engine/payroll_tax.py
@@ -1,0 +1,234 @@
+"""Payroll tax computation engine.
+
+This module loads state rules from JSON descriptions and computes monthly
+liabilities, grouped wage aggregates, and annual reconciliations. The
+implementation intentionally keeps the rule format simple so that new
+levies and rates can be introduced through the JSON definitions without
+modifying code.
+"""
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal, ROUND_HALF_UP, getcontext
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+
+getcontext().prec = 28
+
+_BASE_DIR = Path(__file__).resolve().parents[1]
+_RULES_DIR = _BASE_DIR / "rules"
+
+
+class RuleNotFoundError(FileNotFoundError):
+    """Raised when a payroll tax rule file cannot be located."""
+
+
+def load_rules(state: str, year: int) -> Dict[str, Any]:
+    """Load the payroll tax rules for a given state and year."""
+    state_key = state.lower()
+    rules_path = _RULES_DIR / f"payroll_tax_{state_key}_{year}.json"
+    if not rules_path.exists():
+        raise RuleNotFoundError(f"No payroll tax rules for {state.upper()} {year} at {rules_path}")
+
+    with rules_path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def aggregate_group_wages(wage_records: Iterable[Mapping[str, Any]], state: str) -> Dict[str, Decimal]:
+    """Aggregate wages for the provided state grouped by the supplied group keys."""
+    state_upper = state.upper()
+    grouped: Dict[str, Decimal] = {}
+    for record in wage_records:
+        nexus = record.get("nexus", state_upper)
+        if nexus and str(nexus).upper() != state_upper:
+            continue
+        wages = _to_decimal(record.get("wages", 0))
+        if wages <= 0:
+            continue
+        group_key = record.get("group") or record.get("entity") or "default"
+        grouped[group_key] = grouped.get(group_key, Decimal("0")) + wages
+    return grouped
+
+
+def compute_monthly_liability(
+    state: str,
+    year: int,
+    wage_records: Iterable[Mapping[str, Any]],
+    pay_date: date | datetime | str,
+) -> Dict[str, Any]:
+    """Compute the monthly payroll tax liability for the given state.
+
+    The function returns a dictionary describing the computation so that tests can
+    assert against both the totals and the intermediate grouping calculations.
+    """
+
+    rules = load_rules(state, year)
+    pay_date = _coerce_date(pay_date)
+
+    group_totals = aggregate_group_wages(wage_records, state)
+    total_wages = sum(group_totals.values(), start=Decimal("0"))
+
+    monthly_threshold = _to_decimal(rules.get("thresholds", {}).get("monthly", 0))
+    grouping_rules = rules.get("grouping", {})
+    shared_threshold = grouping_rules.get("shared_threshold", True)
+
+    taxable_by_group: Dict[str, Decimal] = {}
+    if shared_threshold:
+        for group, wages in group_totals.items():
+            taxable_by_group[group] = _positive(wages - monthly_threshold)
+    else:
+        # If the threshold is not shared, apply it to each entity (or record) individually.
+        for group, wages in group_totals.items():
+            taxable_by_group[group] = _positive(wages - monthly_threshold)
+
+    taxable_wages = sum(taxable_by_group.values(), start=Decimal("0"))
+    tax_amount = _apply_rates(taxable_wages, rules.get("rates", []))
+
+    levies: Dict[str, Decimal] = {}
+    for levy in rules.get("levies", []):
+        if _levy_active(levy, pay_date):
+            base_selector = levy.get("apply_on", "taxable").lower()
+            if base_selector == "total":
+                base_amount = total_wages
+            else:
+                base_amount = taxable_wages
+            levies[levy["name"]] = base_amount * _to_decimal(levy.get("rate", 0))
+
+    total_liability = tax_amount + sum(levies.values(), start=Decimal("0"))
+
+    return {
+        "state": state.upper(),
+        "period": pay_date.strftime("%Y-%m"),
+        "total_wages": _round_currency(total_wages),
+        "group_totals": {group: _round_currency(amount) for group, amount in group_totals.items()},
+        "taxable_wages": _round_currency(taxable_wages),
+        "taxable_wages_by_group": {group: _round_currency(amount) for group, amount in taxable_by_group.items()},
+        "tax": _round_currency(tax_amount),
+        "levies": {name: _round_currency(amount) for name, amount in levies.items()},
+        "total_liability": _round_currency(total_liability),
+    }
+
+
+def annual_reconciliation(
+    state: str,
+    year: int,
+    monthly_liabilities: Iterable[Mapping[str, Any]],
+) -> Dict[str, Any]:
+    """Perform a simple annual reconciliation based on monthly liabilities."""
+
+    rules = load_rules(state, year)
+    annual_threshold = _to_decimal(rules.get("thresholds", {}).get("annual", 0))
+
+    total_wages = sum((_to_decimal(item.get("total_wages", 0)) for item in monthly_liabilities), start=Decimal("0"))
+    taxable_wages = _positive(total_wages - annual_threshold)
+    annual_tax = _apply_rates(taxable_wages, rules.get("rates", []))
+
+    tax_paid = sum((_to_decimal(item.get("tax", 0)) for item in monthly_liabilities), start=Decimal("0"))
+    levies_paid = sum(
+        (
+            _to_decimal(value)
+            for item in monthly_liabilities
+            for value in item.get("levies", {}).values()
+        ),
+        start=Decimal("0"),
+    )
+
+    balance = annual_tax - tax_paid
+
+    return {
+        "state": state.upper(),
+        "year": year,
+        "total_wages": _round_currency(total_wages),
+        "taxable_wages": _round_currency(taxable_wages),
+        "annual_tax": _round_currency(annual_tax),
+        "tax_paid": _round_currency(tax_paid),
+        "levies_paid": _round_currency(levies_paid),
+        "balance": _round_currency(balance),
+    }
+
+
+def _coerce_date(value: date | datetime | str) -> date:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        return datetime.fromisoformat(value).date()
+    raise TypeError(f"Unsupported date value: {value!r}")
+
+
+def _levy_active(levy: Mapping[str, Any], pay_date: date) -> bool:
+    start_raw = levy.get("effective_from")
+    end_raw = levy.get("effective_to")
+
+    start = datetime.fromisoformat(start_raw).date() if start_raw else date.min
+    end = datetime.fromisoformat(end_raw).date() if end_raw else date.max
+
+    return start <= pay_date <= end
+
+
+def _apply_rates(amount: Decimal, rates: List[Mapping[str, Any]]) -> Decimal:
+    amount = _to_decimal(amount)
+    if amount <= 0 or not rates:
+        return Decimal("0")
+
+    ordered = sorted(
+        rates,
+        key=lambda r: _to_decimal(r.get("threshold")) if r.get("threshold") is not None else Decimal("Infinity"),
+    )
+
+    tax = Decimal("0")
+    previous_limit = Decimal("0")
+
+    for bracket in ordered:
+        rate = _to_decimal(bracket.get("rate", 0))
+        threshold = bracket.get("threshold")
+        if threshold is None:
+            slice_amount = amount - previous_limit
+        else:
+            limit = _to_decimal(threshold)
+            if amount <= previous_limit:
+                slice_amount = Decimal("0")
+            else:
+                slice_amount = min(amount, limit) - previous_limit
+        if slice_amount <= 0:
+            if threshold is not None:
+                previous_limit = _to_decimal(threshold)
+            continue
+        tax += slice_amount * rate
+        if threshold is None:
+            break
+        previous_limit = _to_decimal(threshold)
+        if amount <= previous_limit:
+            break
+    return tax
+
+
+def _positive(value: Decimal) -> Decimal:
+    value = _to_decimal(value)
+    return value if value > 0 else Decimal("0")
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    if value is None:
+        return Decimal("0")
+    return Decimal(str(value))
+
+
+def _round_currency(value: Decimal) -> float:
+    value = _to_decimal(value)
+    return float(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
+__all__ = [
+    "RuleNotFoundError",
+    "load_rules",
+    "aggregate_group_wages",
+    "compute_monthly_liability",
+    "annual_reconciliation",
+]

--- a/rules/payroll_tax_nsw_2024.json
+++ b/rules/payroll_tax_nsw_2024.json
@@ -1,0 +1,34 @@
+{
+  "state": "NSW",
+  "year": 2024,
+  "thresholds": {
+    "annual": 1200000,
+    "monthly": 100000
+  },
+  "rates": [
+    { "threshold": null, "rate": 0.0485 }
+  ],
+  "grouping": {
+    "shared_threshold": true,
+    "threshold_application": "Group wages are aggregated across related employers and the monthly threshold is applied once to the combined amount.",
+    "rules": [
+      "Related corporations and commonly controlled employers form a group and must share the NSW threshold.",
+      "Businesses with substantially common employees or shared control are grouped for payroll tax purposes."
+    ]
+  },
+  "nexus": [
+    "Wages paid or payable in NSW for services performed in NSW.",
+    "Wages paid outside NSW where the employee performs NSW duties for more than 10 days in the month.",
+    "Wages paid by NSW employers to contractors that have been deemed wages under NSW nexus provisions."
+  ],
+  "levies": [
+    {
+      "name": "Mental Health Levy",
+      "rate": 0.001,
+      "apply_on": "taxable",
+      "effective_from": "2023-07-01",
+      "effective_to": "2024-06-30",
+      "notes": "Applied to taxable wages while the NSW mental health levy is in effect."
+    }
+  ]
+}

--- a/rules/payroll_tax_qld_2024.json
+++ b/rules/payroll_tax_qld_2024.json
@@ -1,0 +1,35 @@
+{
+  "state": "QLD",
+  "year": 2024,
+  "thresholds": {
+    "annual": 1300000,
+    "monthly": 108333
+  },
+  "rates": [
+    { "threshold": 6250000, "rate": 0.0449 },
+    { "threshold": null, "rate": 0.0475 }
+  ],
+  "grouping": {
+    "shared_threshold": true,
+    "threshold_application": "Queensland applies a single threshold to grouped employers; the higher rate applies once taxable wages exceed the first tier.",
+    "rules": [
+      "Corporations related through control or ownership share the Queensland threshold.",
+      "Businesses with interdependent operations may be grouped under commissioner discretion."
+    ]
+  },
+  "nexus": [
+    "Wages for services performed in Queensland.",
+    "Wages paid in Queensland for employees who mainly work in the state.",
+    "Deemed wages to contractors connected to Queensland."
+  ],
+  "levies": [
+    {
+      "name": "Health Services Levy",
+      "rate": 0.0005,
+      "apply_on": "taxable",
+      "effective_from": "2024-01-01",
+      "effective_to": "2024-03-31",
+      "notes": "Illustrative levy to demonstrate toggling based on effective dates."
+    }
+  ]
+}

--- a/rules/payroll_tax_vic_2024.json
+++ b/rules/payroll_tax_vic_2024.json
@@ -1,0 +1,34 @@
+{
+  "state": "VIC",
+  "year": 2024,
+  "thresholds": {
+    "annual": 700000,
+    "monthly": 58333
+  },
+  "rates": [
+    { "threshold": null, "rate": 0.0465 }
+  ],
+  "grouping": {
+    "shared_threshold": true,
+    "threshold_application": "Victorian groups apply the threshold once to total grouped wages each month.",
+    "rules": [
+      "Related corporations form a payroll tax group.",
+      "Employers using common employees or that are commonly controlled are grouped."
+    ]
+  },
+  "nexus": [
+    "Wages paid in Victoria for services performed in the state.",
+    "Wages paid outside Victoria when the employee is based in Victoria and duties are mainly performed there.",
+    "Deemed wages paid to contractors with a Victorian nexus."
+  ],
+  "levies": [
+    {
+      "name": "Mental Health and Wellbeing Surcharge",
+      "rate": 0.005,
+      "apply_on": "total",
+      "effective_from": "2021-07-01",
+      "effective_to": null,
+      "notes": "Applies to large employers on Victorian wages. For illustration this levy applies to all wages in tests."
+    }
+  ]
+}

--- a/tests/test_payroll_tax.py
+++ b/tests/test_payroll_tax.py
@@ -1,0 +1,109 @@
+import calendar
+from datetime import date
+from pathlib import Path
+import sys
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from engine.payroll_tax import (
+    annual_reconciliation,
+    compute_monthly_liability,
+    load_rules,
+)
+
+
+@pytest.mark.parametrize(
+    "state",
+    ["nsw", "NSW"],
+)
+def test_load_rules_case_insensitive(state):
+    rules = load_rules(state, 2024)
+    assert rules["state"] == "NSW"
+
+
+def test_monthly_liability_nsw_with_levy():
+    wage_records = [
+        {"entity": "Alpha", "group": "GroupNSW", "wages": 75000, "nexus": "NSW"},
+        {"entity": "Beta", "group": "GroupNSW", "wages": 80000, "nexus": "NSW"},
+    ]
+    result = compute_monthly_liability("NSW", 2024, wage_records, "2024-05-31")
+
+    assert result["total_wages"] == pytest.approx(155000.0, abs=0.01)
+    assert result["taxable_wages"] == pytest.approx(55000.0, abs=0.01)
+    assert result["tax"] == pytest.approx(2667.5, abs=0.01)
+    assert result["levies"]["Mental Health Levy"] == pytest.approx(55.0, abs=0.01)
+    assert result["total_liability"] == pytest.approx(2722.5, abs=0.01)
+
+
+def test_monthly_liability_nsw_levy_expired():
+    wage_records = [
+        {"entity": "Alpha", "group": "GroupNSW", "wages": 75000, "nexus": "NSW"},
+        {"entity": "Beta", "group": "GroupNSW", "wages": 80000, "nexus": "NSW"},
+    ]
+    result = compute_monthly_liability("NSW", 2024, wage_records, "2024-07-31")
+
+    assert "Mental Health Levy" not in result["levies"]
+    assert result["tax"] == pytest.approx(2667.5, abs=0.01)
+    assert result["total_liability"] == pytest.approx(2667.5, abs=0.01)
+
+
+def test_monthly_liability_vic_filters_nexus_and_applies_levy():
+    wage_records = [
+        {"entity": "VicCoA", "group": "VicGroup", "wages": 40000, "nexus": "VIC"},
+        {"entity": "VicCoB", "group": "VicGroup", "wages": 30000, "nexus": "VIC"},
+        {"entity": "NSWCo", "group": "VicGroup", "wages": 50000, "nexus": "NSW"},
+    ]
+    result = compute_monthly_liability("VIC", 2024, wage_records, date(2024, 3, 31))
+
+    assert result["total_wages"] == pytest.approx(70000.0, abs=0.01)
+    assert result["taxable_wages"] == pytest.approx(11667.0, abs=1.0)
+    assert result["tax"] == pytest.approx(542.52, abs=0.1)
+    assert result["levies"]["Mental Health and Wellbeing Surcharge"] == pytest.approx(350.0, abs=0.01)
+    assert result["total_liability"] == pytest.approx(892.52, abs=0.5)
+
+
+def test_grouping_and_multi_tier_rates_for_qld():
+    wage_records = [
+        {"entity": "QLD1", "group": "GroupA", "wages": 90000, "nexus": "QLD"},
+        {"entity": "QLD2", "group": "GroupA", "wages": 30000, "nexus": "QLD"},
+        {"entity": "QLD3", "group": "GroupB", "wages": 50000, "nexus": "QLD"},
+    ]
+    result = compute_monthly_liability("QLD", 2024, wage_records, date(2024, 2, 29))
+
+    assert result["group_totals"]["GroupA"] == pytest.approx(120000.0, abs=0.01)
+    assert result["taxable_wages_by_group"]["GroupA"] == pytest.approx(11667.0, abs=1.0)
+    assert result["taxable_wages_by_group"].get("GroupB", 0.0) == pytest.approx(0.0, abs=0.01)
+    assert result["tax"] == pytest.approx(523.0, abs=1.0)
+    assert result["levies"]["Health Services Levy"] == pytest.approx(5.83, abs=0.1)
+
+
+def test_levy_turns_off_after_effective_date_for_qld():
+    wage_records = [
+        {"entity": "QLD1", "group": "GroupA", "wages": 90000, "nexus": "QLD"},
+        {"entity": "QLD2", "group": "GroupA", "wages": 30000, "nexus": "QLD"},
+    ]
+    result = compute_monthly_liability("QLD", 2024, wage_records, date(2024, 4, 30))
+
+    assert result["tax"] == pytest.approx(523.0, abs=1.0)
+    assert result["levies"] == {}
+
+
+def test_annual_reconciliation_nsw():
+    wage_records = [{"entity": "Alpha", "group": "GroupNSW", "wages": 130000, "nexus": "NSW"}]
+    monthly_results = [
+        compute_monthly_liability("NSW", 2024, wage_records, date(2024, month, calendar.monthrange(2024, month)[1]))
+        for month in range(1, 13)
+    ]
+
+    reconciliation = annual_reconciliation("NSW", 2024, monthly_results)
+
+    assert reconciliation["total_wages"] == pytest.approx(1560000.0, abs=0.1)
+    assert reconciliation["taxable_wages"] == pytest.approx(360000.0, abs=0.1)
+    assert reconciliation["annual_tax"] == pytest.approx(17460.0, abs=0.1)
+    assert reconciliation["tax_paid"] == pytest.approx(17460.0, abs=0.1)
+    assert reconciliation["levies_paid"] == pytest.approx(180.0, abs=0.1)
+    assert reconciliation["balance"] == pytest.approx(0.0, abs=0.1)


### PR DESCRIPTION
## Summary
- add structured payroll tax rule definitions for NSW, VIC, and QLD including thresholds, rates, nexus guidance, and levies
- implement a payroll tax engine that loads rules to compute monthly liabilities, levies, grouping aggregation, and annual reconciliation
- add pytest coverage for state scenarios, grouping aggregation, levy effective windows, and annual reconciliation

## Testing
- pytest tests/test_payroll_tax.py

------
https://chatgpt.com/codex/tasks/task_e_68e375e09af88327a2a4882955f1ee5b