### PR TITLE
feat: implement gst attribution and reporting engine

### DIFF
--- a/apps/services/tax-engine/app/engine/__init__.py
+++ b/apps/services/tax-engine/app/engine/__init__.py
@@ -1,0 +1,23 @@
+"""GST engine exports."""
+
+from .gst_attribution import attribute_period, initial_bas_summary, load_basis_rules, load_cross_border_rules
+from .gst_adjust import apply_adjustments, load_adjustment_rules
+from .dgst import apply_dgst, load_dgst_rules
+from .ritc import apply_ritc, load_ritc_rules
+from .wet_lct import apply_wet_lct, load_wet_rules, load_lct_rules
+
+__all__ = [
+    "attribute_period",
+    "initial_bas_summary",
+    "load_basis_rules",
+    "load_cross_border_rules",
+    "apply_adjustments",
+    "load_adjustment_rules",
+    "apply_dgst",
+    "load_dgst_rules",
+    "apply_ritc",
+    "load_ritc_rules",
+    "apply_wet_lct",
+    "load_wet_rules",
+    "load_lct_rules",
+]

--- a/apps/services/tax-engine/app/engine/dgst.py
+++ b/apps/services/tax-engine/app/engine/dgst.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+DGST_FILE_TEMPLATE = "gst_dgst_{year}.json"
+DEFAULT_YEAR = 2025
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value or "0")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def load_dgst_rules(year: int = DEFAULT_YEAR, path: Path | None = None) -> Dict:
+    rules_path = path or RULES_DIR / DGST_FILE_TEMPLATE.format(year=year)
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def apply_dgst(
+    bas_summary: Dict[str, Decimal],
+    imports: Iterable[Dict],
+    *,
+    rules: Optional[Dict] = None,
+) -> Tuple[Dict[str, Decimal], List[Dict]]:
+    rules = rules or load_dgst_rules()
+    labels = rules.get("labels", {})
+    dgst_label = labels.get("dgst", "7")
+    gst_label = labels.get("gst", "1A")
+    bas_summary.setdefault(dgst_label, Decimal("0.00"))
+    bas_summary.setdefault(gst_label, Decimal("0.00"))
+
+    evidence: List[Dict] = []
+    for entry in imports:
+        amount = _to_decimal(entry.get("deferred_gst"))
+        if not amount:
+            continue
+        bas_summary[dgst_label] += amount
+        bas_summary[gst_label] += amount
+        evidence.append(
+            {
+                "import_declaration": entry.get("import_declaration"),
+                "period": entry.get("period"),
+                "amount": amount,
+                "labels": {"dgst": dgst_label, "gst": gst_label},
+                "rule_hash": rules.get("rule_hash"),
+            }
+        )
+    return bas_summary, evidence

--- a/apps/services/tax-engine/app/engine/gst_adjust.py
+++ b/apps/services/tax-engine/app/engine/gst_adjust.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+ADJUSTMENTS_FILE = RULES_DIR / "gst_adjustments.json"
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value or "0")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def load_adjustment_rules(path: Path | None = None) -> Dict:
+    rules_path = path or ADJUSTMENTS_FILE
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def apply_adjustments(
+    bas_summary: Dict[str, Decimal],
+    adjustments: Iterable[Dict],
+    *,
+    rules: Optional[Dict] = None,
+) -> Tuple[Dict[str, Decimal], List[Dict]]:
+    rules = rules or load_adjustment_rules()
+    triggers = rules.get("triggers", {})
+    evidence: List[Dict] = []
+
+    for adj in adjustments:
+        trigger = adj.get("trigger")
+        direction = (adj.get("direction") or "").lower()
+        applies_to = (adj.get("applies_to") or "sales").lower()
+        bucket = triggers.get(trigger)
+        if not bucket:
+            raise ValueError(f"Unsupported adjustment trigger: {trigger}")
+        detail = bucket.get(applies_to)
+        if not detail:
+            raise ValueError(f"Unsupported adjustment scope '{applies_to}' for trigger '{trigger}'")
+        labels = detail.get("labels", {})
+        amount_label = labels.get("amount")
+        gst_label = labels.get("gst")
+        if not amount_label or not gst_label:
+            raise ValueError(f"Missing BAS labels for trigger '{trigger}' scope '{applies_to}'")
+        sign = 1 if direction.startswith("increas") else -1
+        amount = _to_decimal(adj.get("amount"))
+        gst_amount = _to_decimal(adj.get("gst") or adj.get("gst_amount"))
+
+        bas_summary.setdefault(amount_label, Decimal("0.00"))
+        bas_summary.setdefault(gst_label, Decimal("0.00"))
+        bas_summary[amount_label] += sign * amount
+        bas_summary[gst_label] += sign * gst_amount
+
+        evidence.append(
+            {
+                "trigger": trigger,
+                "direction": direction or "increasing",
+                "applies_to": applies_to,
+                "amount": amount,
+                "gst": gst_amount,
+                "labels": labels,
+                "rule_hash": detail.get("rule_hash") or bucket.get("rule_hash"),
+            }
+        )
+
+    return bas_summary, evidence

--- a/apps/services/tax-engine/app/engine/gst_attribution.py
+++ b/apps/services/tax-engine/app/engine/gst_attribution.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+BASIS_RULES_FILE = RULES_DIR / "gst_basis.json"
+CROSS_BORDER_RULES_FILE = RULES_DIR / "gst_cross_border_2025.json"
+
+BAS_LABELS = ["G1", "G2", "G3", "G10", "G11", "1A", "1B", "7", "1C", "1E"]
+
+
+def _as_date(value: date | datetime | str) -> date:
+    if isinstance(value, date) and not isinstance(value, datetime):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return datetime.fromisoformat(str(value)).date()
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value or "0")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+@dataclass
+class Segment:
+    basis: str
+    start: date
+    end: date
+    rule_hash: str
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "basis": self.basis,
+            "effective_from": self.start.isoformat(),
+            "effective_to": self.end.isoformat(),
+            "rule_hash": self.rule_hash,
+        }
+
+
+def load_basis_rules(path: Path | None = None) -> Dict:
+    rules_path = path or BASIS_RULES_FILE
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_cross_border_rules(path: Path | None = None) -> Dict:
+    rules_path = path or CROSS_BORDER_RULES_FILE
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def initial_bas_summary() -> Dict[str, Decimal]:
+    return {label: Decimal("0.00") for label in BAS_LABELS}
+
+
+def _determine_segments(
+    period_start: date,
+    period_end: date,
+    basis_schedule: Sequence[Dict[str, str]],
+    rules: Dict,
+) -> List[Segment]:
+    if not basis_schedule:
+        raise ValueError("basis_schedule must include at least one entry")
+
+    sorted_schedule = sorted(
+        (
+            {
+                "basis": entry["basis"].lower(),
+                "effective_from": _as_date(entry["effective_from"]),
+            }
+            for entry in basis_schedule
+        ),
+        key=lambda item: item["effective_from"],
+    )
+
+    current_basis: Optional[str] = None
+    current_start: Optional[date] = None
+    segments: List[Segment] = []
+
+    for entry in sorted_schedule:
+        basis = entry["basis"]
+        eff = entry["effective_from"]
+        if eff <= period_start:
+            current_basis = basis
+            current_start = period_start
+        elif eff <= period_end:
+            if current_basis is None:
+                current_basis = basis
+                current_start = eff
+            else:
+                if current_start is None:
+                    current_start = eff
+                seg_end = eff - timedelta(days=1)
+                segments.append(
+                    Segment(current_basis, current_start, seg_end, rules[current_basis]["rule_hash"])
+                )
+                current_basis = basis
+                current_start = eff
+    if current_basis is None:
+        # default to earliest basis if no effective before period start
+        first = sorted_schedule[0]
+        current_basis = first["basis"]
+        current_start = max(period_start, first["effective_from"])
+    if current_start is None:
+        current_start = period_start
+    segments.append(Segment(current_basis, current_start, period_end, rules[current_basis]["rule_hash"]))
+
+    # merge any consecutive segments with same basis
+    merged: List[Segment] = []
+    for seg in segments:
+        if merged and merged[-1].basis == seg.basis and merged[-1].end >= seg.start - timedelta(days=1):
+            merged[-1].end = seg.end
+        else:
+            merged.append(seg)
+    return merged
+
+
+def _recognition_date(tx: Dict, basis: str) -> Optional[date]:
+    if basis == "cash":
+        cash_keys = ["payment_date", "received_date", "cash_date"]
+        for key in cash_keys:
+            if key in tx and tx[key]:
+                return _as_date(tx[key])
+        if "invoice_date" in tx:
+            return _as_date(tx["invoice_date"])
+    else:
+        accrual_keys = ["invoice_date", "supply_date", "accrual_date"]
+        for key in accrual_keys:
+            if key in tx and tx[key]:
+                return _as_date(tx[key])
+        if "payment_date" in tx:
+            return _as_date(tx["payment_date"])
+    return None
+
+
+def _apply_cross_border_overrides(
+    tx: Dict,
+    amount_label: str,
+    gst_label: str,
+    cross_border_rules: Dict,
+) -> tuple[str, str]:
+    scheme = (tx.get("scheme") or tx.get("cross_border"))
+    if not scheme:
+        return amount_label, gst_label
+    scheme = scheme.lower()
+    rule = cross_border_rules.get(scheme)
+    if not rule:
+        return amount_label, gst_label
+
+    labels = rule.get("labels", {})
+    amount_label = labels.get(tx.get("type", "sale"), labels.get("sale", amount_label))
+    gst_label = labels.get("gst", gst_label)
+
+    if scheme == "lvig":
+        threshold = Decimal(str(rule.get("threshold", "0")))
+        amount = _to_decimal(tx.get("amount", "0"))
+        if threshold and amount > threshold:
+            return amount_label, gst_label
+    if scheme == "marketplace" and not tx.get("marketplace_collected", True):
+        return amount_label, gst_label
+    return amount_label, gst_label
+
+
+def attribute_period(
+    period_start: date | str,
+    period_end: date | str,
+    transactions: Iterable[Dict],
+    basis_schedule: Sequence[Dict[str, str]],
+    *,
+    rules: Optional[Dict] = None,
+    cross_border_rules: Optional[Dict] = None,
+) -> tuple[Dict[str, Decimal], Dict[str, List[Dict[str, str]]]]:
+    start = _as_date(period_start)
+    end = _as_date(period_end)
+    rules = rules or load_basis_rules()
+    cross_border_rules = cross_border_rules or load_cross_border_rules()
+
+    segments = _determine_segments(start, end, basis_schedule, rules)
+    bas_summary = initial_bas_summary()
+
+    for segment in segments:
+        for tx in transactions:
+            recognition = _recognition_date(tx, segment.basis)
+            if recognition is None:
+                continue
+            if not (segment.start <= recognition <= segment.end):
+                continue
+            amount = _to_decimal(tx.get("amount", "0"))
+            gst_amount = _to_decimal(tx.get("gst", "0"))
+            tax_code = (tx.get("tax_code") or "GST").upper()
+            tx_type = tx.get("type", "sale").lower()
+
+            amount_label = "G1" if tx_type == "sale" else "G11"
+            gst_label = "1A" if tx_type == "sale" else "1B"
+
+            if tx_type == "import":
+                amount_label = "G10"
+                gst_label = "1B"
+            elif tx_type == "export":
+                amount_label = "G2"
+                gst_label = "1A"
+
+            amount_label, gst_label = _apply_cross_border_overrides(
+                tx, amount_label, gst_label, cross_border_rules
+            )
+
+            if tax_code in {"GST_FREE", "ZERO_RATED"}:
+                gst_amount = Decimal("0.00")
+                if tx_type == "sale":
+                    amount_label = "G3" if tax_code == "GST_FREE" else "G2"
+            elif tax_code in {"EXEMPT", "INPUT_TAXED"}:
+                gst_amount = Decimal("0.00")
+            bas_summary.setdefault(amount_label, Decimal("0.00"))
+            bas_summary.setdefault(gst_label, Decimal("0.00"))
+
+            bas_summary[amount_label] += amount
+            if gst_amount:
+                bas_summary[gst_label] += gst_amount
+
+    evidence = {
+        "segments": [segment.to_dict() for segment in segments],
+        "adjustments": [],
+        "dgst": [],
+        "ritc": [],
+        "wet_lct": [],
+    }
+    return bas_summary, evidence

--- a/apps/services/tax-engine/app/engine/ritc.py
+++ b/apps/services/tax-engine/app/engine/ritc.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+RITC_FILE_TEMPLATE = "gst_ritc_{year}.json"
+DEFAULT_YEAR = 2025
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value or "0")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def load_ritc_rules(year: int = DEFAULT_YEAR, path: Path | None = None) -> Dict:
+    rules_path = path or RULES_DIR / RITC_FILE_TEMPLATE.format(year=year)
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def apply_ritc(
+    bas_summary: Dict[str, Decimal],
+    purchases: Iterable[Dict],
+    *,
+    rules: Optional[Dict] = None,
+) -> Tuple[Dict[str, Decimal], List[Dict]]:
+    rules = rules or load_ritc_rules()
+    categories = rules.get("categories", {})
+    evidence: List[Dict] = []
+    bas_summary.setdefault("1B", Decimal("0.00"))
+
+    for item in purchases:
+        category = (item.get("category") or "").lower()
+        schedule = categories.get(category)
+        if not schedule:
+            raise ValueError(f"Unsupported RITC category: {category}")
+        percentage = Decimal(str(schedule.get("percentage", 0)))
+        gst_amount = _to_decimal(item.get("gst_amount"))
+        allowed = (gst_amount * percentage).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        reduction = (gst_amount - allowed).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        if reduction:
+            bas_summary["1B"] -= reduction
+        evidence.append(
+            {
+                "category": category,
+                "gst_amount": gst_amount,
+                "percentage": float(percentage),
+                "reduction": reduction,
+                "rule_hash": schedule.get("rule_hash") or rules.get("rule_hash"),
+            }
+        )
+    return bas_summary, evidence

--- a/apps/services/tax-engine/app/engine/wet_lct.py
+++ b/apps/services/tax-engine/app/engine/wet_lct.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Tuple
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+WET_FILE_TEMPLATE = "wet_{year}.json"
+LCT_FILE_TEMPLATE = "lct_{year}.json"
+DEFAULT_YEAR = 2025
+
+
+def _to_decimal(value) -> Decimal:
+    return Decimal(str(value or "0")).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def load_wet_rules(year: int = DEFAULT_YEAR, path: Path | None = None) -> Dict:
+    rules_path = path or RULES_DIR / WET_FILE_TEMPLATE.format(year=year)
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def load_lct_rules(year: int = DEFAULT_YEAR, path: Path | None = None) -> Dict:
+    rules_path = path or RULES_DIR / LCT_FILE_TEMPLATE.format(year=year)
+    with open(rules_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def apply_wet_lct(
+    bas_summary: Dict[str, Decimal],
+    wet_items: Optional[Iterable[Dict]] = None,
+    lct_items: Optional[Iterable[Dict]] = None,
+    *,
+    wet_rules: Optional[Dict] = None,
+    lct_rules: Optional[Dict] = None,
+) -> Tuple[Dict[str, Decimal], List[Dict]]:
+    wet_rules = wet_rules or load_wet_rules()
+    lct_rules = lct_rules or load_lct_rules()
+
+    evidence: List[Dict] = []
+
+    wet_label = wet_rules.get("bas_label", "1C")
+    lct_label = lct_rules.get("bas_label", "1E")
+    bas_summary.setdefault(wet_label, Decimal("0.00"))
+    bas_summary.setdefault(lct_label, Decimal("0.00"))
+
+    if wet_items:
+        rate = Decimal(str(wet_rules.get("rate", 0)))
+        rebate_cap = _to_decimal(wet_rules.get("rebate_cap")) if wet_rules.get("rebate_cap") else None
+        for item in wet_items:
+            taxable_value = _to_decimal(item.get("wholesale_value"))
+            wet_amount = (taxable_value * rate).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+            if rebate_cap and wet_amount > rebate_cap:
+                wet_amount = rebate_cap
+            bas_summary[wet_label] += wet_amount
+            evidence.append(
+                {
+                    "type": "wet",
+                    "reference": item.get("reference"),
+                    "amount": wet_amount,
+                    "rule_hash": wet_rules.get("rule_hash"),
+                }
+            )
+
+    if lct_items:
+        thresholds = lct_rules.get("thresholds", {})
+        default_threshold = thresholds.get("other", {})
+        for item in lct_items:
+            fuel_flag = item.get("fuel_efficient")
+            if fuel_flag is None:
+                if "fuel_efficiency_test_l_per_100km" in item:
+                    fuel_flag = item["fuel_efficiency_test_l_per_100km"] <= thresholds.get("fuel_efficient", {}).get("fuel_efficiency_test_l_per_100km", 0)
+            schedule = thresholds.get("fuel_efficient" if fuel_flag else "other", default_threshold)
+            threshold_value = Decimal(str(schedule.get("threshold", default_threshold.get("threshold", 0))))
+            rate = Decimal(str(schedule.get("rate", default_threshold.get("rate", 0))))
+            taxable_value = _to_decimal(item.get("luxury_value"))
+            if taxable_value <= threshold_value:
+                continue
+            lct_amount = ((taxable_value - threshold_value) * rate).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+            bas_summary[lct_label] += lct_amount
+            evidence.append(
+                {
+                    "type": "lct",
+                    "reference": item.get("reference"),
+                    "amount": lct_amount,
+                    "rule_hash": schedule.get("rule_hash") or lct_rules.get("rule_hash"),
+                }
+            )
+
+    return bas_summary, evidence

--- a/apps/services/tax-engine/app/rules/gst_adjustments.json
+++ b/apps/services/tax-engine/app/rules/gst_adjustments.json
@@ -1,0 +1,62 @@
+{
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "2c30cd217c2793eaa0ba269fee50ce30840a8d2aaf1620dcb198023118ec2dd8",
+    "source_url": "https://www.ato.gov.au/business/gst/in-detail/adjustments/"
+  },
+  "triggers": {
+    "bad_debt": {
+      "purchases": {
+        "labels": {
+          "amount": "G11",
+          "gst": "1B"
+        }
+      },
+      "rule_hash": "6448d24ea12bca75f166eae6aac29d14594338bc5139b7b1f83b1791bdff0347",
+      "sales": {
+        "labels": {
+          "amount": "G1",
+          "gst": "1A"
+        }
+      }
+    },
+    "error_correction": {
+      "imports": {
+        "labels": {
+          "amount": "G10",
+          "gst": "1B"
+        }
+      },
+      "purchases": {
+        "labels": {
+          "amount": "G11",
+          "gst": "1B"
+        }
+      },
+      "rule_hash": "0ffe3e2fd719d60e1b0e9e82e74d6c84abdd8efc85d3ff2eaf3b0969c1fbab93",
+      "sales": {
+        "labels": {
+          "amount": "G1",
+          "gst": "1A"
+        }
+      }
+    },
+    "price_change": {
+      "exports": {
+        "labels": {
+          "amount": "G2",
+          "gst": "1A"
+        }
+      },
+      "rule_hash": "dcdc648b1b3b50b3cb18f3dc6a50476861ac39aa44562cd36a4da5015b8b99be",
+      "sales": {
+        "labels": {
+          "amount": "G1",
+          "gst": "1A"
+        }
+      }
+    }
+  }
+}

--- a/apps/services/tax-engine/app/rules/gst_basis.json
+++ b/apps/services/tax-engine/app/rules/gst_basis.json
@@ -1,0 +1,37 @@
+{
+  "accrual": {
+    "description": "Recognise GST on the earlier of invoice issue or consideration.",
+    "labels": {
+      "purchase_amount": "G11",
+      "purchase_gst": "1B",
+      "sale_amount": "G1",
+      "sale_gst": "1A"
+    },
+    "recognition": "invoice_date",
+    "rule_hash": "72932b7341663fbee174ebd9de0a6c6a2676e1a3d4e83f6d7ad8d44f8b6990b6"
+  },
+  "cash": {
+    "description": "Recognise GST when consideration is received or paid.",
+    "labels": {
+      "purchase_amount": "G11",
+      "purchase_gst": "1B",
+      "sale_amount": "G1",
+      "sale_gst": "1A"
+    },
+    "recognition": "payment_date",
+    "rule_hash": "0e9459beeaa4eff21f6928138368ece0458d24c9c4bd7c8a682c0d3d5151a00b"
+  },
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "d886c6c7c1380025537b9a4c75c7981c39d9b4af180675f93ec56087769e7003",
+    "source_url": "https://www.ato.gov.au/business/gst/accounting-for-gst/choose-an-accounting-method/"
+  },
+  "switch_rules": {
+    "description": "Split tax periods into segments when a basis change occurs mid-period.",
+    "notice_period_days": 14,
+    "rule_hash": "bdb77b47c666ecf8e967634183f8fdc9070ac4959204ef121ee3ce5efac43f9f",
+    "segment_method": "calendar_split"
+  }
+}

--- a/apps/services/tax-engine/app/rules/gst_cross_border_2025.json
+++ b/apps/services/tax-engine/app/rules/gst_cross_border_2025.json
@@ -1,0 +1,35 @@
+{
+  "lvig": {
+    "description": "Low value imported goods deemed supplies to Australian consumers.",
+    "labels": {
+      "gst": "1A",
+      "sale": "G3"
+    },
+    "rule_hash": "41830270d377be44bf95737ab15d11fee03470ee0f73e51a2398deefbe602805",
+    "threshold": 1000
+  },
+  "marketplace": {
+    "deemed_supplier": true,
+    "description": "Electronic distribution platforms responsible for GST on supplies.",
+    "labels": {
+      "gst": "1A",
+      "sale": "G1"
+    },
+    "rule_hash": "c7877d1a5c815c18fab3671679b02fd9df5fa6f1985de8764c874576e9f0c56b"
+  },
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "31b00061fa437d2c867e957bf36ff1d7b1aa531e43c55f8d6ba3c744c5f60d69",
+    "source_url": "https://www.ato.gov.au/business/gst/in-detail/non-residents-and-gst/"
+  },
+  "simplified": {
+    "description": "Simplified GST for non-residents providing digital products or services.",
+    "labels": {
+      "gst": "1A",
+      "sale": "G2"
+    },
+    "rule_hash": "922805bde4a55fa1cc80fe313327703759e88e5794b0fb76fcaa69ebe38adeca"
+  }
+}

--- a/apps/services/tax-engine/app/rules/gst_dgst_2025.json
+++ b/apps/services/tax-engine/app/rules/gst_dgst_2025.json
@@ -1,0 +1,14 @@
+{
+  "labels": {
+    "dgst": "7",
+    "gst": "1A"
+  },
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "6289528333438e71c17e2aa5aedc72521bb8a11722e07fb17b8a986e26d918f6",
+    "source_url": "https://www.ato.gov.au/business/gst/in-detail/importing-goods/paying-gst-and-import-processing-charges/"
+  },
+  "rule_hash": "79052d5010767361c001bd62bb4ea64901e8ad41e37fffbfdb9aaeb4d3c371dd"
+}

--- a/apps/services/tax-engine/app/rules/gst_ritc_2025.json
+++ b/apps/services/tax-engine/app/rules/gst_ritc_2025.json
@@ -1,0 +1,23 @@
+{
+  "categories": {
+    "financial_supplies": {
+      "percentage": 0.75,
+      "rule_hash": "06640696fae035777ccc2464a46f2e9ce859f52eb7d75206d5df81f26f025a1b"
+    },
+    "managed_investment": {
+      "percentage": 0.55,
+      "rule_hash": "905312413dde23f543ab6cae223940a9560628277c7bf5a29343bf09cdabbb1b"
+    },
+    "residential_rent": {
+      "percentage": 0.0,
+      "rule_hash": "87c870277544861fa66220afdcdd905c9174b65a8806279a709cfb33848c8457"
+    }
+  },
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "37a0442856bfbdfb5c9f0551b8aaefb63f5987e0656bfc461dcf82684018a6de",
+    "source_url": "https://www.ato.gov.au/business/gst/in-detail/financial-services-and-insurance/reduced-input-tax-credits/"
+  }
+}

--- a/apps/services/tax-engine/app/rules/lct_2025.json
+++ b/apps/services/tax-engine/app/rules/lct_2025.json
@@ -1,0 +1,24 @@
+{
+  "bas_label": "1E",
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "95edc6b73a95a10dbb096090d7a6de7ff0f8f2b73d161dcf0b6450c32038da4d",
+    "source_url": "https://www.ato.gov.au/business/luxury-car-tax/"
+  },
+  "rule_hash": "a13eead1426b1f14453d46ef434ae4ab228455fd6ba32e0ca4da336220930f2f",
+  "thresholds": {
+    "fuel_efficient": {
+      "fuel_efficiency_test_l_per_100km": 7.0,
+      "rate": 0.33,
+      "rule_hash": "a5c32e59129f7e19267171593eb62e59859a7896862074aaa0d6a194cd1f636d",
+      "threshold": 91507
+    },
+    "other": {
+      "rate": 0.33,
+      "rule_hash": "fa1c043bd8dbec01355c36a0db60a703b283d1168af5621889a41e0430c61d68",
+      "threshold": 76901
+    }
+  }
+}

--- a/apps/services/tax-engine/app/rules/wet_2025.json
+++ b/apps/services/tax-engine/app/rules/wet_2025.json
@@ -1,0 +1,13 @@
+{
+  "bas_label": "1C",
+  "metadata": {
+    "effective_from": "2025-07-01",
+    "effective_to": null,
+    "last_reviewed": "2025-07-01",
+    "sha256": "436c37fcc2b736c4f1c567e96a2a1123450c26dbe54563cb177f89da578f1872",
+    "source_url": "https://www.ato.gov.au/business/wine-equalisation-tax/"
+  },
+  "rate": 0.29,
+  "rebate_cap": 100000,
+  "rule_hash": "b73325a137990c18235d256ebd94f0a479af9738cda08d65dcef8e87d4868cae"
+}

--- a/apps/services/tax-engine/tests/test_gst_engine.py
+++ b/apps/services/tax-engine/tests/test_gst_engine.py
@@ -1,0 +1,233 @@
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.engine import (
+    apply_adjustments,
+    apply_dgst,
+    apply_ritc,
+    apply_wet_lct,
+    attribute_period,
+    initial_bas_summary,
+    load_adjustment_rules,
+    load_basis_rules,
+    load_cross_border_rules,
+    load_dgst_rules,
+    load_lct_rules,
+    load_ritc_rules,
+    load_wet_rules,
+)
+
+
+@pytest.fixture(scope="module")
+def basis_rules():
+    return load_basis_rules()
+
+
+@pytest.fixture(scope="module")
+def cross_border_rules():
+    return load_cross_border_rules()
+
+
+def test_cash_vs_accrual_attribution(basis_rules, cross_border_rules):
+    transactions = [
+        {
+            "type": "sale",
+            "amount": 1100,
+            "gst": 100,
+            "invoice_date": "2025-07-05",
+            "payment_date": "2025-08-02",
+        },
+        {
+            "type": "purchase",
+            "amount": 550,
+            "gst": 50,
+            "invoice_date": "2025-07-07",
+            "payment_date": "2025-07-10",
+        },
+    ]
+
+    accrual_schedule = [{"basis": "accrual", "effective_from": "2025-07-01"}]
+    bas_accrual, evidence_accrual = attribute_period(
+        date(2025, 7, 1),
+        date(2025, 7, 31),
+        transactions,
+        accrual_schedule,
+        rules=basis_rules,
+        cross_border_rules=cross_border_rules,
+    )
+
+    assert bas_accrual["G1"] == Decimal("1100.00")
+    assert bas_accrual["1A"] == Decimal("100.00")
+    assert bas_accrual["G11"] == Decimal("550.00")
+    assert bas_accrual["1B"] == Decimal("50.00")
+    assert evidence_accrual["segments"][0]["rule_hash"] == basis_rules["accrual"]["rule_hash"]
+
+    cash_schedule = [{"basis": "cash", "effective_from": "2025-07-01"}]
+    bas_cash, _ = attribute_period(
+        "2025-07-01",
+        "2025-07-31",
+        transactions,
+        cash_schedule,
+        rules=basis_rules,
+        cross_border_rules=cross_border_rules,
+    )
+    assert bas_cash["1A"] == Decimal("0.00")
+    assert bas_cash["G1"] == Decimal("0.00")
+    assert bas_cash["1B"] == Decimal("50.00")
+    assert bas_cash["G11"] == Decimal("550.00")
+
+
+def test_basis_switch_segments(basis_rules, cross_border_rules):
+    transactions = [
+        {
+            "type": "sale",
+            "amount": 220,
+            "gst": 20,
+            "invoice_date": "2025-07-02",
+            "payment_date": "2025-07-05",
+        },
+        {
+            "type": "sale",
+            "amount": 330,
+            "gst": 30,
+            "invoice_date": "2025-07-20",
+            "payment_date": "2025-07-25",
+        },
+    ]
+    schedule = [
+        {"basis": "cash", "effective_from": "2025-07-01"},
+        {"basis": "accrual", "effective_from": "2025-07-15"},
+    ]
+    bas, evidence = attribute_period(
+        date(2025, 7, 1),
+        date(2025, 7, 31),
+        transactions,
+        schedule,
+        rules=basis_rules,
+        cross_border_rules=cross_border_rules,
+    )
+
+    assert bas["G1"] == Decimal("550.00")
+    assert bas["1A"] == Decimal("50.00")
+    assert len(evidence["segments"]) == 2
+    bases = {segment["basis"] for segment in evidence["segments"]}
+    assert bases == {"cash", "accrual"}
+    for segment in evidence["segments"]:
+        expected_hash = basis_rules[segment["basis"]]["rule_hash"]
+        assert segment["rule_hash"] == expected_hash
+
+
+def test_adjustments_feed_into_evidence():
+    bas = initial_bas_summary()
+    adjustments = [
+        {
+            "trigger": "bad_debt",
+            "direction": "decreasing",
+            "applies_to": "sales",
+            "amount": 550,
+            "gst": 50,
+        }
+    ]
+    rules = load_adjustment_rules()
+    bas, evidence = apply_adjustments(bas, adjustments, rules=rules)
+    assert bas["G1"] == Decimal("-550.00")
+    assert bas["1A"] == Decimal("-50.00")
+    assert evidence[0]["rule_hash"] == rules["triggers"]["bad_debt"]["rule_hash"]
+
+
+def test_dgst_application():
+    bas = initial_bas_summary()
+    rules = load_dgst_rules()
+    bas, evidence = apply_dgst(
+        bas,
+        [
+            {
+                "import_declaration": "12345",
+                "period": "2025-07",
+                "deferred_gst": 1200,
+            }
+        ],
+        rules=rules,
+    )
+    assert bas["7"] == Decimal("1200.00")
+    assert bas["1A"] == Decimal("1200.00")
+    assert evidence[0]["rule_hash"] == rules["rule_hash"]
+
+
+def test_ritc_reduces_1b():
+    bas = initial_bas_summary()
+    bas["1B"] = Decimal("200.00")
+    rules = load_ritc_rules()
+    bas, evidence = apply_ritc(
+        bas,
+        [
+            {"category": "financial_supplies", "gst_amount": 100},
+            {"category": "managed_investment", "gst_amount": 80},
+        ],
+        rules=rules,
+    )
+    # 25 and 36 reductions respectively
+    assert bas["1B"] == Decimal("200.00") - Decimal("25.00") - Decimal("36.00")
+    assert len(evidence) == 2
+    assert evidence[0]["rule_hash"] == rules["categories"]["financial_supplies"]["rule_hash"]
+
+
+def test_cross_border_rules(basis_rules, cross_border_rules):
+    transactions = [
+        {
+            "type": "sale",
+            "amount": 900,
+            "gst": 90,
+            "invoice_date": "2025-07-10",
+            "scheme": "lvig",
+        },
+        {
+            "type": "sale",
+            "amount": 1200,
+            "gst": 120,
+            "invoice_date": "2025-07-12",
+            "scheme": "marketplace",
+            "marketplace_collected": True,
+        },
+        {
+            "type": "sale",
+            "amount": 1500,
+            "gst": 150,
+            "invoice_date": "2025-07-18",
+            "scheme": "simplified",
+        },
+    ]
+    schedule = [{"basis": "accrual", "effective_from": "2025-07-01"}]
+    bas, _ = attribute_period(
+        date(2025, 7, 1),
+        date(2025, 7, 31),
+        transactions,
+        schedule,
+        rules=basis_rules,
+        cross_border_rules=cross_border_rules,
+    )
+    assert bas["G3"] == Decimal("900.00")
+    assert bas["G1"] == Decimal("1200.00")
+    assert bas["G2"] == Decimal("1500.00")
+    assert bas["1A"] == Decimal("360.00")
+
+
+def test_wet_lct_application():
+    bas = initial_bas_summary()
+    wet_rules = load_wet_rules()
+    lct_rules = load_lct_rules()
+    bas, evidence = apply_wet_lct(
+        bas,
+        wet_items=[{"reference": "W001", "wholesale_value": 50000}],
+        lct_items=[{"reference": "L001", "luxury_value": 100000, "fuel_efficient": False}],
+        wet_rules=wet_rules,
+        lct_rules=lct_rules,
+    )
+    assert bas[wet_rules["bas_label"]] == Decimal("14500.00")
+    assert bas[lct_rules["bas_label"]] == Decimal("7622.67")
+    types = {entry["type"] for entry in evidence}
+    assert types == {"wet", "lct"}
+    assert evidence[0]["rule_hash"] in {wet_rules["rule_hash"], lct_rules["rule_hash"], lct_rules["thresholds"]["other"]["rule_hash"]}
+


### PR DESCRIPTION
## Summary
- implement GST attribution engine with cash/accrual basis support and cross-border handling
- add adjustment, DGST, RITC, and WET/LCT calculators with evidence outputs
- codify GST governance rules via JSON schedules and golden tests

## Testing
- pytest apps/services/tax-engine/tests/test_gst_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68e375b1225883278bd57c551d08c204