### PR TITLE
Add FBT calculation engine and BAS aggregation utilities

### DIFF
--- a/bas_fbt.py
+++ b/bas_fbt.py
@@ -1,0 +1,117 @@
+"""BAS reporting helpers for FBT instalments and annual reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Dict, List, Literal, Optional
+
+from engine.fbt_calc import FBTCarBenefitResult, load_rules
+from engine.fbt_calendar import FBTCalendar, FBTPeriod
+
+
+@dataclass
+class PeriodTotals:
+    """Stores totals for a BAS period."""
+
+    period: FBTPeriod
+    actual_type1: float = 0.0
+    actual_type2: float = 0.0
+    instalment_type1: float = 0.0
+    instalment_type2: float = 0.0
+
+    def as_row(self, year_label: int) -> Dict[str, object]:
+        return {
+            "period": self.period.label(year_label),
+            "start": self.period.start,
+            "end": self.period.end,
+            "F1": round(self.actual_type1, 2),
+            "F2": round(self.actual_type2, 2),
+            "instalment_F1": round(self.instalment_type1, 2),
+            "instalment_F2": round(self.instalment_type2, 2),
+        }
+
+
+class FBTBASCalculator:
+    """Aggregates FBT fringe benefits into BAS reporting lines."""
+
+    def __init__(
+        self,
+        fbt_year: int | str,
+        *,
+        frequency: Literal["monthly", "quarterly"] = "quarterly",
+        rules: Optional[Dict[str, object]] = None,
+    ) -> None:
+        self.fbt_year = FBTCalendar.for_year(fbt_year)
+        self.frequency = frequency
+        self.rules = rules or load_rules(self.fbt_year.label)
+        self.periods: List[PeriodTotals] = [
+            PeriodTotals(period=period)
+            for period in FBTCalendar.iter_periods(self.fbt_year.label, frequency=frequency)
+        ]
+
+    def record_benefit(
+        self,
+        when: date,
+        benefit: FBTCarBenefitResult | float,
+        *,
+        has_gst_credit: Optional[bool] = None,
+    ) -> None:
+        """Record a fringe benefit for the BAS period that includes ``when``."""
+
+        if FBTCalendar.from_date(when).label != self.fbt_year.label:
+            raise ValueError("benefit date does not fall within configured FBT year")
+        period_index = FBTCalendar.period_index(when, frequency=self.frequency)
+        if period_index >= len(self.periods):
+            raise ValueError("date outside configured BAS schedule")
+        period = self.periods[period_index]
+
+        if isinstance(benefit, FBTCarBenefitResult):
+            has_credit = benefit.has_gst_credit if has_gst_credit is None else has_gst_credit
+            amount = benefit.grossed_up_value
+            if benefit.ev_exempt:
+                return
+        else:
+            if has_gst_credit is None:
+                raise ValueError("has_gst_credit must be provided for raw taxable values")
+            has_credit = has_gst_credit
+            factor = float(self.rules["gross_up_factors"]["type1" if has_credit else "type2"])  # type: ignore[index]
+            amount = float(benefit) * factor
+
+        if has_credit:
+            period.actual_type1 += amount
+        else:
+            period.actual_type2 += amount
+
+    def set_instalment(self, period_index: int, *, F1: Optional[float] = None, F2: Optional[float] = None) -> None:
+        """Override the instalment amount reported for the supplied period index."""
+
+        period = self.periods[period_index]
+        if F1 is not None:
+            period.instalment_type1 = float(F1)
+        if F2 is not None:
+            period.instalment_type2 = float(F2)
+
+    def period_report(self) -> List[Dict[str, object]]:
+        """Return BAS-ready rows for each configured period."""
+
+        return [period.as_row(self.fbt_year.label) for period in self.periods]
+
+    def annual_reconciliation(self) -> Dict[str, Dict[str, float]]:
+        """Compare total instalments with actual FBT liability for the year."""
+
+        actual_f1 = sum(period.actual_type1 for period in self.periods)
+        actual_f2 = sum(period.actual_type2 for period in self.periods)
+        instalments_f1 = sum(period.instalment_type1 for period in self.periods)
+        instalments_f2 = sum(period.instalment_type2 for period in self.periods)
+
+        variance_f1 = actual_f1 - instalments_f1
+        variance_f2 = actual_f2 - instalments_f2
+
+        return {
+            "actual": {"F1": round(actual_f1, 2), "F2": round(actual_f2, 2)},
+            "instalments": {"F1": round(instalments_f1, 2), "F2": round(instalments_f2, 2)},
+            "variance": {"F1": round(variance_f1, 2), "F2": round(variance_f2, 2)},
+            "net_payable": round(variance_f1 + variance_f2, 2),
+        }
+

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,19 @@
+"""Utilities for Fringe Benefits Tax calculations."""
+
+from .fbt_calendar import FBTCalendar, FBTPeriod, FBTYear
+from .fbt_calc import (
+    CarBenefitInput,
+    FBTCarBenefitResult,
+    calculate_car_benefit,
+    compare_car_methods,
+)
+
+__all__ = [
+    "FBTCalendar",
+    "FBTYear",
+    "FBTPeriod",
+    "CarBenefitInput",
+    "FBTCarBenefitResult",
+    "calculate_car_benefit",
+    "compare_car_methods",
+]

--- a/engine/fbt_calc.py
+++ b/engine/fbt_calc.py
@@ -1,0 +1,189 @@
+"""Core calculations for Australian Fringe Benefits Tax (FBT)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Literal, Optional
+
+from .fbt_calendar import FBTCalendar
+
+RulesDict = Dict[str, object]
+
+
+@dataclass
+class CarBenefitInput:
+    """Input payload describing a car fringe benefit scenario."""
+
+    base_value: float
+    acquisition_date: date
+    days_available: int = 365
+    employee_contribution: float = 0.0
+    operating_costs: Optional[Dict[str, float]] = None
+    business_use_percentage: float = 0.0
+    has_gst_credit: bool = True
+    is_electric: bool = False
+    co2_emissions: Optional[float] = None
+    purchase_price: Optional[float] = None
+
+    def private_use_percentage(self) -> float:
+        business = max(0.0, min(1.0, self.business_use_percentage))
+        return 1.0 - business
+
+
+@dataclass
+class FBTCarBenefitResult:
+    """Result bundle for a car fringe benefit calculation."""
+
+    method: Literal["statutory", "operating"]
+    taxable_value: float
+    gross_up_type: Literal["type1", "type2"]
+    grossed_up_value: float
+    reportable_amount: float
+    ev_exempt: bool
+    details: Dict[str, float] = field(default_factory=dict)
+
+    @property
+    def has_gst_credit(self) -> bool:
+        return self.gross_up_type == "type1"
+
+
+def calculate_car_benefit(
+    payload: CarBenefitInput, fbt_year: int | str, method: Literal["statutory", "operating"]
+) -> FBTCarBenefitResult:
+    """Calculate the taxable value and RFBA for the supplied car fringe benefit."""
+
+    rules = load_rules(fbt_year)
+    ev_exempt = _is_ev_exempt(payload, rules, fbt_year)
+    if ev_exempt:
+        return FBTCarBenefitResult(
+            method=method,
+            taxable_value=0.0,
+            gross_up_type="type1" if payload.has_gst_credit else "type2",
+            grossed_up_value=0.0,
+            reportable_amount=0.0,
+            ev_exempt=True,
+            details={"base_value": payload.base_value, "reduced_base_value": 0.0},
+        )
+
+    base_value = _reduced_base_value(payload, rules, fbt_year)
+    if method == "statutory":
+        taxable = _statutory_taxable_value(payload, rules, base_value)
+    elif method == "operating":
+        taxable = _operating_taxable_value(payload, rules, base_value)
+    else:
+        raise ValueError("method must be 'statutory' or 'operating'")
+
+    gross_up_type = "type1" if payload.has_gst_credit else "type2"
+    gross_up_factor = float(rules["gross_up_factors"][gross_up_type])  # type: ignore[index]
+    grossed_up_value = taxable * gross_up_factor
+
+    rfba_threshold = float(rules["thresholds"]["rfba_minimum"])  # type: ignore[index]
+    rfba_factor = float(rules["gross_up_factors"]["type2"])  # type: ignore[index]
+    reportable_amount = taxable * rfba_factor if taxable > rfba_threshold else 0.0
+
+    return FBTCarBenefitResult(
+        method=method,
+        taxable_value=round(taxable, 2),
+        gross_up_type=gross_up_type,
+        grossed_up_value=round(grossed_up_value, 2),
+        reportable_amount=round(reportable_amount, 2),
+        ev_exempt=False,
+        details={
+            "base_value": round(payload.base_value, 2),
+            "reduced_base_value": round(base_value, 2),
+            "private_use_percentage": round(payload.private_use_percentage(), 4),
+        },
+    )
+
+
+def compare_car_methods(payload: CarBenefitInput, fbt_year: int | str) -> Dict[str, FBTCarBenefitResult]:
+    """Evaluate the car fringe benefit under both statutory and operating cost methods."""
+
+    return {
+        "statutory": calculate_car_benefit(payload, fbt_year, method="statutory"),
+        "operating": calculate_car_benefit(payload, fbt_year, method="operating"),
+    }
+
+
+def _statutory_taxable_value(payload: CarBenefitInput, rules: RulesDict, base_value: float) -> float:
+    car_rules = rules["car_benefit"]  # type: ignore[index]
+    statutory_fraction = float(car_rules["statutory_fraction"])  # type: ignore[index]
+    days_in_year = int(car_rules["days_in_year"])  # type: ignore[index]
+    days_available = max(0, min(payload.days_available, days_in_year))
+    taxable = base_value * statutory_fraction * (days_available / days_in_year)
+    taxable -= payload.employee_contribution
+    return max(0.0, taxable)
+
+
+def _operating_taxable_value(payload: CarBenefitInput, rules: RulesDict, base_value: float) -> float:
+    operating_costs = payload.operating_costs or {}
+    total_costs = sum(float(value) for value in operating_costs.values())
+    base_reduction = payload.base_value - base_value
+    if base_reduction > 0 and operating_costs:
+        depreciation_key = next(
+            (key for key in operating_costs.keys() if "depr" in key.lower()),
+            None,
+        )
+        if depreciation_key is not None:
+            depreciation = float(operating_costs[depreciation_key])
+            adjusted_depreciation = max(0.0, depreciation - base_reduction)
+            total_costs = total_costs - depreciation + adjusted_depreciation
+        else:
+            total_costs = max(0.0, total_costs - min(total_costs, base_reduction))
+    private_use = payload.private_use_percentage()
+    taxable = total_costs * private_use
+    taxable -= payload.employee_contribution
+    return max(0.0, taxable)
+
+
+def _reduced_base_value(payload: CarBenefitInput, rules: RulesDict, fbt_year: int | str) -> float:
+    car_rules = rules["car_benefit"]  # type: ignore[index]
+    reduction_wait = int(car_rules["base_value_reduction_years"])  # type: ignore[index]
+    max_reductions = int(car_rules.get("maximum_reductions", 3))
+    acquisition_year = FBTCalendar.from_date(payload.acquisition_date).label
+    current_year = int(fbt_year)
+    years_elapsed = max(0, current_year - acquisition_year)
+    reductions = max(0, years_elapsed - reduction_wait)
+    reductions = min(reductions, max_reductions)
+    reduction_fraction = 1 - (reductions / 3)
+    reduction_fraction = max(0.0, reduction_fraction)
+    return payload.base_value * reduction_fraction
+
+
+def _is_ev_exempt(payload: CarBenefitInput, rules: RulesDict, fbt_year: int | str) -> bool:
+    config = rules.get("ev_exemption", {})  # type: ignore[assignment]
+    if not config or not bool(config.get("enabled", False)):
+        return False
+    first_year = int(config.get("first_applicable_year", fbt_year))
+    if int(fbt_year) < first_year:
+        return False
+    if not payload.is_electric:
+        return False
+    threshold = config.get("lct_threshold")
+    if threshold is not None and payload.purchase_price is not None:
+        if payload.purchase_price > float(threshold):
+            return False
+    co2_threshold = config.get("co2_threshold")
+    if co2_threshold is not None and payload.co2_emissions is not None:
+        if payload.co2_emissions > float(co2_threshold):
+            return False
+    zero_required = config.get("ev_zero_emissions_required", False)
+    if zero_required and payload.co2_emissions not in (None, 0, 0.0):
+        return False
+    return True
+
+
+@lru_cache(maxsize=8)
+def load_rules(year: int | str) -> RulesDict:
+    """Load the JSON rule set for the requested FBT year."""
+
+    label = int(year)
+    rules_path = Path(__file__).resolve().parent.parent / "rules" / f"fbt_{label}.json"
+    data = rules_path.read_text(encoding="utf-8")
+    import json
+
+    return json.loads(data)
+

--- a/engine/fbt_calendar.py
+++ b/engine/fbt_calendar.py
@@ -1,0 +1,115 @@
+"""FBT year calendar utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date, timedelta
+from typing import Iterator, Literal
+
+
+@dataclass(frozen=True)
+class FBTYear:
+    """Represents the Australian FBT year (1 April – 31 March)."""
+
+    label: int
+    start: date
+    end: date
+
+    def contains(self, target: date) -> bool:
+        return self.start <= target <= self.end
+
+    def period_label(self) -> str:
+        """Return a display label for the FBT year."""
+
+        return f"FBT {self.start.year}-{self.end.year}"
+
+
+@dataclass(frozen=True)
+class FBTPeriod:
+    """Represents a reporting period within an FBT year."""
+
+    index: int
+    start: date
+    end: date
+    frequency: Literal["monthly", "quarterly"]
+
+    def label(self, year_label: int) -> str:
+        prefix = "M" if self.frequency == "monthly" else "Q"
+        return f"{year_label}-{prefix}{self.index:02d}"
+
+
+class FBTCalendar:
+    """Calendar helper that models the Australian FBT year."""
+
+    @staticmethod
+    def for_year(year: int | str) -> FBTYear:
+        """Return the :class:`FBTYear` instance for the supplied FBT year label."""
+
+        label = int(year)
+        start = date(label - 1, 4, 1)
+        end = date(label, 3, 31)
+        return FBTYear(label=label, start=start, end=end)
+
+    @staticmethod
+    def from_date(target: date) -> FBTYear:
+        """Return the FBT year that contains *target*."""
+
+        if target.month >= 4:
+            label = target.year + 1
+        else:
+            label = target.year
+        return FBTCalendar.for_year(label)
+
+    @staticmethod
+    def iter_periods(
+        year: int | str, frequency: Literal["monthly", "quarterly"] = "quarterly"
+    ) -> Iterator[FBTPeriod]:
+        """Yield period objects for the requested frequency within the supplied year."""
+
+        fbt_year = FBTCalendar.for_year(year)
+        if frequency not in {"monthly", "quarterly"}:
+            raise ValueError("frequency must be 'monthly' or 'quarterly'")
+
+        step = 1 if frequency == "monthly" else 3
+        current = fbt_year.start
+        index = 1
+        while current <= fbt_year.end:
+            period_end = FBTCalendar._period_end(current, step)
+            period_end = min(period_end, fbt_year.end)
+            yield FBTPeriod(index=index, start=current, end=period_end, frequency=frequency)
+            current = period_end + timedelta(days=1)
+            index += 1
+
+    @staticmethod
+    def period_index(target: date, frequency: Literal["monthly", "quarterly"] = "quarterly") -> int:
+        """Return the 0-based period index for *target* within the FBT year."""
+
+        fbt_year = FBTCalendar.from_date(target)
+        if not fbt_year.contains(target):
+            raise ValueError("target date outside FBT year")
+
+        if frequency == "monthly":
+            months = (target.year - fbt_year.start.year) * 12 + target.month - 4
+            return months
+        if frequency == "quarterly":
+            months = (target.year - fbt_year.start.year) * 12 + target.month - 4
+            return months // 3
+        raise ValueError("frequency must be 'monthly' or 'quarterly'")
+
+    @staticmethod
+    def _period_end(start: date, months: int) -> date:
+        """Return the inclusive period end date for a span of *months*."""
+
+        month = start.month + months - 1
+        year = start.year + (month - 1) // 12
+        month = ((month - 1) % 12) + 1
+        last_day = FBTCalendar._last_day_of_month(year, month)
+        return date(year, month, last_day)
+
+    @staticmethod
+    def _last_day_of_month(year: int, month: int) -> int:
+        if month == 12:
+            return 31
+        next_month = date(year, month + 1, 1)
+        return (next_month - timedelta(days=1)).day
+

--- a/rules/fbt_2025.json
+++ b/rules/fbt_2025.json
@@ -1,0 +1,26 @@
+{
+  "year": "2025",
+  "period_start": "2024-04-01",
+  "period_end": "2025-03-31",
+  "gross_up_factors": {
+    "type1": 2.0802,
+    "type2": 1.8868
+  },
+  "thresholds": {
+    "rfba_minimum": 2000.0,
+    "ev_luxury_car_threshold": 89732.0,
+    "ev_zero_emissions_required": true
+  },
+  "car_benefit": {
+    "statutory_fraction": 0.2,
+    "days_in_year": 365,
+    "base_value_reduction_years": 4,
+    "maximum_reductions": 3
+  },
+  "ev_exemption": {
+    "enabled": true,
+    "first_applicable_year": "2024",
+    "lct_threshold": 89732.0,
+    "co2_threshold": 0.0
+  }
+}

--- a/tests/test_fbt.py
+++ b/tests/test_fbt.py
@@ -1,0 +1,105 @@
+import math
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from bas_fbt import FBTBASCalculator
+from engine.fbt_calc import CarBenefitInput, calculate_car_benefit, compare_car_methods
+from engine.fbt_calendar import FBTCalendar
+
+
+@pytest.fixture(scope="module")
+def sample_payload():
+    return CarBenefitInput(
+        base_value=42000,
+        acquisition_date=date(2019, 7, 1),
+        days_available=365,
+        employee_contribution=1500,
+        operating_costs={"fuel": 2800, "maintenance": 1400, "depreciation": 6000},
+        business_use_percentage=0.55,
+        has_gst_credit=True,
+    )
+
+
+def test_car_benefit_methods(sample_payload):
+    results = compare_car_methods(sample_payload, 2025)
+    statutory = results["statutory"]
+    operating = results["operating"]
+
+    assert statutory.method == "statutory"
+    assert operating.method == "operating"
+    # Statutory method should generally produce a higher taxable value when private use is moderate.
+    assert statutory.taxable_value > operating.taxable_value
+    # Reduced base value should reflect 1/3 reduction (car held more than 4 full FBT years).
+    assert math.isclose(statutory.details["reduced_base_value"], 28000.0, rel_tol=1e-4)
+    assert statutory.reportable_amount > 0
+
+
+def test_electric_vehicle_exemption():
+    ev_payload = CarBenefitInput(
+        base_value=68000,
+        acquisition_date=date(2024, 5, 10),
+        is_electric=True,
+        purchase_price=70000,
+        co2_emissions=0,
+    )
+    result = calculate_car_benefit(ev_payload, 2025, method="statutory")
+    assert result.ev_exempt is True
+    assert result.taxable_value == 0
+    assert result.reportable_amount == 0
+
+
+def test_rfba_threshold_application(sample_payload):
+    high_private_use = CarBenefitInput(
+        base_value=52000,
+        acquisition_date=date(2020, 8, 30),
+        employee_contribution=0,
+        business_use_percentage=0.1,
+        has_gst_credit=False,
+    )
+    result = calculate_car_benefit(high_private_use, 2025, method="statutory")
+    assert result.gross_up_type == "type2"
+    assert result.reportable_amount > 0
+    # Taxable value exceeds threshold and should be reflected in RFBA.
+    assert result.reportable_amount == pytest.approx(result.taxable_value * 1.8868, rel=1e-4)
+
+
+def test_bas_instalments_and_washup(sample_payload):
+    calc = FBTBASCalculator(2025, frequency="quarterly")
+    periods = list(FBTCalendar.iter_periods(2025))
+
+    first_quarter_date = periods[0].start
+    second_quarter_date = periods[1].start
+    third_quarter_date = periods[2].start
+
+    stat_result = calculate_car_benefit(sample_payload, 2025, method="statutory")
+    op_result = calculate_car_benefit(sample_payload, 2025, method="operating")
+
+    calc.record_benefit(first_quarter_date, stat_result)
+    calc.record_benefit(second_quarter_date, op_result)
+    calc.record_benefit(third_quarter_date, 1500.0, has_gst_credit=False)
+
+    calc.set_instalment(0, F1=5000)
+    calc.set_instalment(1, F1=4500)
+    calc.set_instalment(2, F2=2000)
+
+    report = calc.period_report()
+    assert report[0]["F1"] > 0
+    assert report[1]["F1"] > 0
+    assert report[2]["F2"] > 0
+
+    reconciliation = calc.annual_reconciliation()
+    assert reconciliation["actual"]["F1"] >= report[0]["F1"] + report[1]["F1"]
+    assert reconciliation["variance"]["F1"] == pytest.approx(
+        reconciliation["actual"]["F1"] - (5000 + 4500), rel=1e-4
+    )
+    assert reconciliation["variance"]["F2"] == pytest.approx(
+        reconciliation["actual"]["F2"] - 2000, rel=1e-4
+    )
+


### PR DESCRIPTION
## Summary
- add a 2025 FBT ruleset covering gross-up factors, EV thresholds, and car benefit settings
- implement an FBT calendar and car fringe benefit calculator supporting statutory and operating methods plus EV exemptions
- introduce BAS instalment aggregation with annual reconciliation and accompanying automated tests

## Testing
- pytest tests/test_fbt.py

------
https://chatgpt.com/codex/tasks/task_e_68e375d7e2b48327bcae3d5e00e4e2cc