### PR TITLE
Implement super guarantee and SGC charge calculations

### DIFF
--- a/apps/services/tax-engine/app/engine/__init__.py
+++ b/apps/services/tax-engine/app/engine/__init__.py
@@ -1,0 +1,4 @@
+"""Computation engines for employer obligations."""
+
+from .sg import compute as compute_super_guarantee, resolve_rate_for_date, load_quarter_rules  # noqa: F401
+from .sgc import compute as compute_super_guarantee_charge  # noqa: F401

--- a/apps/services/tax-engine/app/engine/sg.py
+++ b/apps/services/tax-engine/app/engine/sg.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal, ROUND_HALF_UP
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Sequence, Tuple
+
+RULES_DIR = Path(__file__).resolve().parents[1] / "rules"
+_DECIMAL_ZERO = Decimal("0")
+_TWO_PLACES = Decimal("0.01")
+_ROADMAP: List[RoadmapEntry] = []
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return _DECIMAL_ZERO
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    return Decimal(str(value))
+
+
+def _quantize(value: Decimal) -> Decimal:
+    return value.quantize(_TWO_PLACES, rounding=ROUND_HALF_UP)
+
+
+@dataclass(frozen=True)
+class QuarterRule:
+    quarter: str
+    sg_percent: Decimal
+    max_contribution_base: Decimal
+    ote_inclusions: Tuple[str, ...]
+    ote_exclusions: Tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RoadmapEntry:
+    effective_from: date
+    sg_percent: Decimal
+
+
+@lru_cache(maxsize=1)
+def load_quarter_rules() -> Dict[str, QuarterRule]:
+    rules: Dict[str, QuarterRule] = {}
+    global _ROADMAP
+    roadmap_entries: List[RoadmapEntry] = list(_ROADMAP)
+
+    for path in sorted(RULES_DIR.glob("sg_*.json")):
+        with path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+        entries: Sequence[Mapping[str, Any]]
+        defaults: Mapping[str, Any]
+        if isinstance(payload, dict) and "quarters" in payload:
+            entries = payload.get("quarters", [])
+            defaults = {
+                "ote_inclusions": payload.get("ote_inclusions", []),
+                "ote_exclusions": payload.get("ote_exclusions", []),
+            }
+            roadmap_entries.extend(_normalise_roadmap(payload.get("roadmap", [])))
+        elif isinstance(payload, list):
+            entries = payload
+            defaults = {}
+        else:
+            continue
+        for entry in entries:
+            quarter = str(entry["quarter"]).strip()
+            sg_percent = _to_decimal(entry["sg_percent"])
+            max_contribution_base = _to_decimal(entry["max_contribution_base"])
+            ote_inclusions = tuple(entry.get("ote_inclusions", defaults.get("ote_inclusions", [])))
+            ote_exclusions = tuple(entry.get("ote_exclusions", defaults.get("ote_exclusions", [])))
+            rules[quarter] = QuarterRule(
+                quarter=quarter,
+                sg_percent=sg_percent,
+                max_contribution_base=max_contribution_base,
+                ote_inclusions=ote_inclusions,
+                ote_exclusions=ote_exclusions,
+            )
+            roadmap_entries.extend(_normalise_roadmap(entry.get("roadmap", [])))
+
+    if not rules:
+        raise FileNotFoundError("No SG rules found in rules directory")
+
+    roadmap_entries = _dedupe_roadmap(roadmap_entries)
+    _ROADMAP = roadmap_entries
+    return rules
+
+
+def _normalise_roadmap(entries: Sequence[Mapping[str, Any]]) -> List[RoadmapEntry]:
+    normalised: List[RoadmapEntry] = []
+    for entry in entries or []:
+        normalised.append(
+            RoadmapEntry(
+                effective_from=_parse_date(entry["effective_from"]),
+                sg_percent=_to_decimal(entry["sg_percent"]),
+            )
+        )
+    return normalised
+
+
+def _dedupe_roadmap(entries: Sequence[RoadmapEntry]) -> List[RoadmapEntry]:
+    unique: Dict[date, RoadmapEntry] = {}
+    for entry in entries:
+        unique[entry.effective_from] = entry
+    ordered = sorted(unique.values(), key=lambda item: item.effective_from)
+    return ordered
+
+
+def roadmap() -> Tuple[RoadmapEntry, ...]:
+    if not _ROADMAP:
+        load_quarter_rules()
+    return tuple(_ROADMAP)
+
+
+def resolve_rate_for_date(moment: date) -> Decimal:
+    schedule = roadmap()
+    if not schedule:
+        raise FileNotFoundError("SG roadmap not initialised")
+    applicable = schedule[0].sg_percent
+    for entry in schedule:
+        if moment >= entry.effective_from:
+            applicable = entry.sg_percent
+        else:
+            break
+    return applicable
+
+
+def _parse_date(value: Any) -> date:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+
+def _round_float(value: Decimal) -> float:
+    return float(_quantize(value))
+
+
+def _calculate_ote(earnings: Iterable[Mapping[str, Any]], rule: QuarterRule) -> Tuple[Decimal, List[Tuple[str, Decimal]]]:
+    include_set = set(x.lower() for x in rule.ote_inclusions)
+    exclude_set = set(x.lower() for x in rule.ote_exclusions)
+    total = _DECIMAL_ZERO
+    breakdown: List[Tuple[str, Decimal]] = []
+    for entry in earnings:
+        code_raw = str(entry.get("code", ""))
+        code = code_raw.lower()
+        amount = _to_decimal(entry.get("amount", 0))
+        if amount <= _DECIMAL_ZERO:
+            continue
+        if code in exclude_set:
+            continue
+        if include_set and code not in include_set:
+            continue
+        total += amount
+        breakdown.append((code_raw.upper(), amount))
+    return total, breakdown
+
+
+def compute(event: Mapping[str, Any]) -> Dict[str, Any]:
+    quarter = str(event.get("quarter", "")).strip()
+    if not quarter:
+        raise ValueError("quarter is required")
+    rules = load_quarter_rules()
+    if quarter not in rules:
+        raise KeyError(f"No SG rules for quarter {quarter}")
+    rule = rules[quarter]
+
+    ote_total, breakdown = _calculate_ote(event.get("earnings", []), rule)
+    ote_capped = min(ote_total, rule.max_contribution_base)
+    sg_rate = rule.sg_percent
+    required_contribution = _quantize(ote_capped * sg_rate)
+
+    sacrifice = event.get("salary_sacrifice") or {}
+    sac_pre = _quantize(_to_decimal(sacrifice.get("pre_tax", 0)))
+    sac_post = _quantize(_to_decimal(sacrifice.get("post_tax", 0)))
+    employer_recommended = _quantize(max(_DECIMAL_ZERO, required_contribution - sac_pre))
+    package_total = employer_recommended + sac_pre + sac_post
+
+    explain = [
+        f"Quarter {quarter}: OTE {ote_total:.2f} capped to {ote_capped:.2f} (MCB {rule.max_contribution_base:.2f})",
+        f"SG rate {float(sg_rate) * 100:.2f}% => required {required_contribution:.2f}",
+    ]
+    if sac_pre > _DECIMAL_ZERO or sac_post > _DECIMAL_ZERO:
+        explain.append(
+            f"Salary sacrifice pre-tax {sac_pre:.2f} post-tax {sac_post:.2f}; employer top-up {employer_recommended:.2f}"
+        )
+
+    return {
+        "quarter": quarter,
+        "sg_rate": float(sg_rate),
+        "ote": _round_float(ote_total),
+        "ote_capped": _round_float(ote_capped),
+        "max_contribution_base": _round_float(rule.max_contribution_base),
+        "required_contribution": _round_float(required_contribution),
+        "salary_sacrifice": {
+            "pre_tax": _round_float(sac_pre),
+            "post_tax": _round_float(sac_post),
+        },
+        "recommended_employer_contribution": _round_float(employer_recommended),
+        "package_total": _round_float(package_total),
+        "ote_breakdown": [
+            {"code": code, "amount": _round_float(amount)} for code, amount in breakdown
+        ],
+        "explain": explain,
+    }

--- a/apps/services/tax-engine/app/engine/sgc.py
+++ b/apps/services/tax-engine/app/engine/sgc.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Dict, Iterable, List, Mapping
+
+_SGC_RATE = Decimal("0.10")
+_ADMIN_FEE = Decimal("20.00")
+_TWO_PLACES = Decimal("0.01")
+_DECIMAL_ZERO = Decimal("0")
+
+
+def _to_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    if value is None:
+        return _DECIMAL_ZERO
+    if isinstance(value, (int, float)):
+        return Decimal(str(value))
+    return Decimal(str(value))
+
+
+def _round(value: Decimal) -> Decimal:
+    return value.quantize(_TWO_PLACES, rounding=ROUND_HALF_UP)
+
+
+def _quarter_start(quarter: str) -> date:
+    year = int(quarter[:4])
+    q = int(quarter[-1])
+    if q == 1:
+        return date(year, 7, 1)
+    if q == 2:
+        return date(year, 10, 1)
+    if q == 3:
+        return date(year + 1, 1, 1)
+    if q == 4:
+        return date(year + 1, 4, 1)
+    raise ValueError(f"Invalid quarter label: {quarter}")
+
+
+def _ensure_date(value: Any) -> date:
+    if value is None:
+        raise ValueError("A date value is required")
+    if isinstance(value, date):
+        return value
+    if isinstance(value, datetime):
+        return value.date()
+    return datetime.strptime(str(value), "%Y-%m-%d").date()
+
+
+def _sort_contributions(contributions: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    ordered: List[Dict[str, Any]] = []
+    for item in contributions:
+        ordered.append(
+            {
+                "amount": _round(_to_decimal(item.get("amount", 0))),
+                "date": _ensure_date(item.get("date")),
+                "reference": item.get("reference"),
+            }
+        )
+    ordered.sort(key=lambda entry: entry["date"])
+    return ordered
+
+
+def _sum_contributions(contributions: Iterable[Mapping[str, Any]]) -> Decimal:
+    return sum(_to_decimal(item.get("amount", 0)) for item in contributions)
+
+
+def _format_late(entries: Iterable[Mapping[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        {
+            "amount": float(entry["amount"]),
+            "date": entry["date"].isoformat(),
+            "reference": entry.get("reference"),
+        }
+        for entry in entries
+    ]
+
+
+def compute(event: Mapping[str, Any], sg_result: Mapping[str, Any]) -> Dict[str, Any]:
+    quarter = sg_result.get("quarter")
+    if not quarter:
+        raise ValueError("SG result must include quarter")
+
+    due_date = _ensure_date(event.get("due_date"))
+    calc_date = event.get("calculation_date")
+    calculation_date = _ensure_date(calc_date) if calc_date else None
+    employees = int(event.get("employees", 1) or 1)
+
+    contributions = _sort_contributions(event.get("contributions", []))
+    on_time = [c for c in contributions if c["date"] <= due_date]
+    late = [c for c in contributions if c["date"] > due_date]
+
+    required = _round(_to_decimal(sg_result.get("recommended_employer_contribution", sg_result.get("required_contribution", 0))))
+    on_time_total = _round(_sum_contributions(on_time))
+    shortfall = _round(max(_DECIMAL_ZERO, required - on_time_total))
+
+    evidence: List[str] = []
+    evidence.append(
+        f"Required SG {required:.2f}; paid on time {on_time_total:.2f}; shortfall {shortfall:.2f}"
+    )
+
+    if shortfall == _DECIMAL_ZERO:
+        return {
+            "quarter": quarter,
+            "status": "on_time",
+            "required_contribution": float(required),
+            "on_time_contributions": float(on_time_total),
+            "shortfall": 0.0,
+            "nominal_interest": 0.0,
+            "admin_fee": 0.0,
+            "sg_charge": 0.0,
+            "non_deductible_total": 0.0,
+            "evidence": evidence,
+            "late_contributions": _format_late(late),
+        }
+
+    quarter_start = _quarter_start(str(quarter))
+    outstanding = shortfall
+    interest = _DECIMAL_ZERO
+    previous_date = quarter_start
+    for payment in late:
+        payment_date = payment["date"]
+        span_days = max(0, (payment_date - previous_date).days)
+        if span_days:
+            interest += outstanding * _SGC_RATE * Decimal(span_days) / Decimal(365)
+            evidence.append(
+                f"Interest on {outstanding:.2f} for {span_days} days to {payment_date.isoformat()}"
+            )
+        amount = _round(_to_decimal(payment.get("amount", 0)))
+        outstanding = _round(max(_DECIMAL_ZERO, outstanding - amount))
+        previous_date = payment_date
+        reference = payment.get("reference")
+        ref_note = f" ({reference})" if reference else ""
+        evidence.append(
+            f"Late contribution {amount:.2f}{ref_note} received {payment_date.isoformat()} (outstanding {outstanding:.2f})"
+        )
+    final_date = calculation_date or (late[-1]["date"] if late else due_date)
+    if final_date < previous_date:
+        final_date = previous_date
+    span_days = max(0, (final_date - previous_date).days)
+    if span_days and outstanding > _DECIMAL_ZERO:
+        interest += outstanding * _SGC_RATE * Decimal(span_days) / Decimal(365)
+        evidence.append(
+            f"Interest on remaining {outstanding:.2f} for {span_days} days to {final_date.isoformat()}"
+        )
+    interest = _round(interest)
+
+    admin_fee = _round(_ADMIN_FEE * Decimal(employees))
+    sg_charge = _round(shortfall + interest + admin_fee)
+    evidence.append(f"Admin fee {admin_fee:.2f} ({employees} employee(s))")
+    evidence.append(f"SGC total {sg_charge:.2f} is non-deductible")
+
+    return {
+        "quarter": quarter,
+        "status": "late",
+        "required_contribution": float(required),
+        "on_time_contributions": float(on_time_total),
+        "shortfall": float(shortfall),
+        "nominal_interest": float(interest),
+        "admin_fee": float(admin_fee),
+        "sg_charge": float(sg_charge),
+        "non_deductible_total": float(sg_charge),
+        "evidence": evidence,
+        "late_contributions": _format_late(late),
+    }

--- a/apps/services/tax-engine/app/rules/sg_2023_24.json
+++ b/apps/services/tax-engine/app/rules/sg_2023_24.json
@@ -1,0 +1,95 @@
+{
+  "financial_year": "2023-24",
+  "ote_inclusions": [
+    "salary",
+    "allowance",
+    "bonus",
+    "leave_loading",
+    "commission"
+  ],
+  "ote_exclusions": [
+    "overtime",
+    "reimbursement",
+    "redundancy",
+    "expense_refund"
+  ],
+  "quarters": [
+    {
+      "quarter": "2023Q1",
+      "sg_percent": 0.11,
+      "max_contribution_base": 62270,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    },
+    {
+      "quarter": "2023Q2",
+      "sg_percent": 0.11,
+      "max_contribution_base": 62270,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    },
+    {
+      "quarter": "2023Q3",
+      "sg_percent": 0.11,
+      "max_contribution_base": 62270,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    },
+    {
+      "quarter": "2023Q4",
+      "sg_percent": 0.11,
+      "max_contribution_base": 62270,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    }
+  ],
+  "roadmap": [
+    {"effective_from": "2023-07-01", "sg_percent": 0.11},
+    {"effective_from": "2024-07-01", "sg_percent": 0.115},
+    {"effective_from": "2025-07-01", "sg_percent": 0.12}
+  ]
+}

--- a/apps/services/tax-engine/app/rules/sg_2024_25.json
+++ b/apps/services/tax-engine/app/rules/sg_2024_25.json
@@ -1,0 +1,94 @@
+{
+  "financial_year": "2024-25",
+  "ote_inclusions": [
+    "salary",
+    "allowance",
+    "bonus",
+    "leave_loading",
+    "commission"
+  ],
+  "ote_exclusions": [
+    "overtime",
+    "reimbursement",
+    "redundancy",
+    "expense_refund"
+  ],
+  "quarters": [
+    {
+      "quarter": "2024Q1",
+      "sg_percent": 0.115,
+      "max_contribution_base": 65070,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    },
+    {
+      "quarter": "2024Q2",
+      "sg_percent": 0.115,
+      "max_contribution_base": 65070,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    },
+    {
+      "quarter": "2024Q3",
+      "sg_percent": 0.115,
+      "max_contribution_base": 65070,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    },
+    {
+      "quarter": "2024Q4",
+      "sg_percent": 0.115,
+      "max_contribution_base": 65070,
+      "ote_inclusions": [
+        "salary",
+        "allowance",
+        "bonus",
+        "leave_loading",
+        "commission"
+      ],
+      "ote_exclusions": [
+        "overtime",
+        "reimbursement",
+        "redundancy",
+        "expense_refund"
+      ]
+    }
+  ],
+  "roadmap": [
+    {"effective_from": "2024-07-01", "sg_percent": 0.115},
+    {"effective_from": "2025-07-01", "sg_percent": 0.12}
+  ]
+}

--- a/apps/services/tax-engine/tests/test_super.py
+++ b/apps/services/tax-engine/tests/test_super.py
@@ -1,0 +1,78 @@
+from datetime import date
+from decimal import Decimal
+
+from app.engine import (
+    compute_super_guarantee,
+    compute_super_guarantee_charge,
+    load_quarter_rules,
+    resolve_rate_for_date,
+)
+
+
+def test_super_guarantee_ote_and_mcb_cap():
+    load_quarter_rules()  # ensure rules cached for consistent assertions
+    result = compute_super_guarantee(
+        {
+            "quarter": "2024Q1",
+            "earnings": [
+                {"code": "salary", "amount": 72000},
+                {"code": "bonus", "amount": 6000},
+                {"code": "allowance", "amount": 5000},
+                {"code": "overtime", "amount": 4000},  # excluded from OTE
+            ],
+            "salary_sacrifice": {"pre_tax": 2000, "post_tax": 500},
+        }
+    )
+
+    assert result["ote"] == 83000.0  # allowance, salary and bonus only
+    assert result["ote_capped"] == 65070.0
+    assert result["required_contribution"] == 7483.05
+    assert result["recommended_employer_contribution"] == 5483.05
+    assert result["salary_sacrifice"]["pre_tax"] == 2000.0
+    assert result["package_total"] == 7983.05
+    breakdown_codes = {row["code"] for row in result["ote_breakdown"]}
+    assert breakdown_codes == {"SALARY", "BONUS", "ALLOWANCE"}
+
+
+def test_sg_rate_schedule_future_increase():
+    load_quarter_rules()
+    assert resolve_rate_for_date(date(2024, 6, 30)) == Decimal("0.11")
+    assert resolve_rate_for_date(date(2024, 7, 1)) == Decimal("0.115")
+    assert resolve_rate_for_date(date(2025, 7, 1)) == Decimal("0.12")
+
+
+def test_sgc_late_payment_components_and_evidence():
+    load_quarter_rules()
+    sg_result = compute_super_guarantee(
+        {
+            "quarter": "2024Q1",
+            "earnings": [
+                {"code": "salary", "amount": 72000},
+                {"code": "bonus", "amount": 6000},
+                {"code": "allowance", "amount": 5000},
+                {"code": "overtime", "amount": 4000},
+            ],
+            "salary_sacrifice": {"pre_tax": 2000, "post_tax": 500},
+        }
+    )
+
+    sgc_result = compute_super_guarantee_charge(
+        {
+            "due_date": "2024-10-28",
+            "contributions": [
+                {"amount": 3000, "date": "2024-10-15", "reference": "on time"},
+                {"amount": 2483.05, "date": "2024-12-15", "reference": "late catch-up"},
+            ],
+        },
+        sg_result,
+    )
+
+    assert sgc_result["status"] == "late"
+    assert sgc_result["shortfall"] == 2483.05
+    assert sgc_result["nominal_interest"] == 113.61
+    assert sgc_result["admin_fee"] == 20.0
+    assert sgc_result["sg_charge"] == 2616.66
+    assert any("non-deductible" in line for line in sgc_result["evidence"])
+    assert any("late catch-up" in line for line in sgc_result["evidence"])
+    assert len(sgc_result["late_contributions"]) == 1
+    assert sgc_result["late_contributions"][0]["reference"] == "late catch-up"


### PR DESCRIPTION
## Summary
- add a super guarantee engine with OTE filtering, salary sacrifice handling and future rate roadmap
- add super guarantee charge computation covering late payments, nominal interest, admin fees and evidence output backed by new rule files
- add unit tests covering OTE capping, rate changes and a sample SGC scenario

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e375ce011c8327bcecb5b79b9cc700