### PR TITLE
feat: expose rules manifest and segment evidence

### DIFF
--- a/apps/services/tax-engine/CHANGELOG.md
+++ b/apps/services/tax-engine/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Tax Engine Changelog
+
+## 2025-10-05.0
+- Added rule manifest endpoint and evidence segments keyed by rule hashes.
+- Introduced regime calendars (BAS monthly/quarterly, FBT year) and enforced hash/version governance.

--- a/apps/services/tax-engine/app/engine.py
+++ b/apps/services/tax-engine/app/engine.py
@@ -1,0 +1,153 @@
+"""Core tax engine orchestration helpers."""
+from __future__ import annotations
+
+from datetime import date, timedelta
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+from .domains import payg_w
+from .rules.loader import (
+    RuleDocument,
+    build_rules_version_payload,
+    load_rule_documents,
+    load_rules_payload,
+)
+
+_PERIOD_MONTH = re.compile(r"^(?P<year>\d{4})-(?P<month>\d{2})$")
+_PERIOD_QUARTER = re.compile(r"^(?P<year>\d{4})-Q(?P<quarter>[1-4])$")
+_PERIOD_FBT = re.compile(r"^(?P<year>\d{4})-FBT$")
+
+
+def _end_of_month(year: int, month: int) -> date:
+    if month == 12:
+        return date(year, 12, 31)
+    next_month = date(year, month + 1, 1)
+    return next_month - timedelta(days=1)
+
+
+def _resolve_month(period_id: str) -> Optional[Tuple[date, date]]:
+    match = _PERIOD_MONTH.match(period_id)
+    if not match:
+        return None
+    year = int(match.group("year"))
+    month = int(match.group("month"))
+    start = date(year, month, 1)
+    end = _end_of_month(year, month)
+    return start, end
+
+
+def _resolve_quarter(period_id: str, calendars: Dict[str, Any]) -> Optional[Tuple[date, date]]:
+    match = _PERIOD_QUARTER.match(period_id)
+    if not match:
+        return None
+    quarter_key = f"Q{match.group('quarter')}"
+    year = int(match.group("year"))
+    quarter_defs = (
+        calendars.get("calendars", {})
+        .get("bas", {})
+        .get("quarterly", {})
+        .get("quarters", {})
+    )
+    cfg = quarter_defs.get(quarter_key)
+    if not cfg:
+        return None
+    start_year = year
+    end_year = year
+    start_month = int(cfg["start_month"])
+    end_month = int(cfg["end_month"])
+    if start_month > end_month:
+        # Quarter wraps the calendar year (e.g. Jan–Mar described with start_month 10)
+        end_year = year
+        start_year = year - 1
+    start = date(start_year, start_month, int(cfg.get("start_day", 1)))
+    end = date(end_year, end_month, int(cfg.get("end_day", _end_of_month(end_year, end_month).day)))
+    return start, end
+
+
+def _resolve_fbt(period_id: str, calendars: Dict[str, Any]) -> Optional[Tuple[date, date]]:
+    match = _PERIOD_FBT.match(period_id)
+    if not match:
+        return None
+    year = int(match.group("year"))
+    cfg = calendars.get("calendars", {}).get("fbt", {}).get("annual", {})
+    if not cfg:
+        return None
+    start_year = year - 1
+    start = date(start_year, int(cfg.get("start_month", 4)), int(cfg.get("start_day", 1)))
+    end = date(year, int(cfg.get("end_month", 3)), int(cfg.get("end_day", 31)))
+    return start, end
+
+
+def resolve_period_bounds(period_id: str, calendars: Optional[Dict[str, Any]] = None) -> Tuple[str, str]:
+    """Return inclusive ISO8601 bounds for a tax period."""
+
+    if calendars is None:
+        calendars = load_rules_payload("calendars.json")
+
+    period_id = period_id or ""
+    for resolver in (
+        _resolve_month,
+        lambda pid: _resolve_quarter(pid, calendars),
+        lambda pid: _resolve_fbt(pid, calendars),
+    ):
+        result = resolver(period_id)
+        if result:
+            start, end = result
+            return start.isoformat(), end.isoformat()
+
+    # Fallback: treat as instantaneous period.
+    return period_id, period_id
+
+
+def build_evidence_segments(period_id: str, rule_docs: Dict[str, RuleDocument]) -> List[Dict[str, Any]]:
+    effective_from, effective_to = resolve_period_bounds(period_id)
+    segments: List[Dict[str, Any]] = []
+    for name, doc in rule_docs.items():
+        if not name.startswith("payg_w"):
+            # Only include computation-critical rules; calendars inform period math but
+            # aren't directly part of PAYG withholding calculations.
+            continue
+        segments.append(
+            {
+                "effective_from": effective_from,
+                "effective_to": effective_to,
+                "rules_sha256": doc.sha256,
+            }
+        )
+    return segments
+
+
+def compute_payg_withholding(event: Dict[str, Any]) -> Dict[str, Any]:
+    rules_payload = load_rules_payload("payg_w_2024_25.json")
+    return payg_w.compute(event, rules_payload)
+
+
+def compute_tax_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute PAYG withholding and attach version metadata."""
+
+    rule_docs = load_rule_documents()
+    payg_result = compute_payg_withholding(event)
+    segments = build_evidence_segments(event.get("period") or "", rule_docs)
+    version_payload = build_rules_version_payload()
+
+    return {
+        "id": event.get("id"),
+        "entity": event.get("entity"),
+        "period": event.get("period"),
+        "outcome": "ok",
+        "results": {
+            "payg_w": payg_result,
+        },
+        "evidence": {
+            "segments": segments,
+        },
+        "rules": version_payload,
+    }
+
+
+__all__ = [
+    "compute_tax_event",
+    "build_evidence_segments",
+    "resolve_period_bounds",
+    "compute_payg_withholding",
+]

--- a/apps/services/tax-engine/app/rules/calendars.json
+++ b/apps/services/tax-engine/app/rules/calendars.json
@@ -1,0 +1,43 @@
+{
+  "name": "Regime calendars",
+  "version": "2025-10",
+  "notes": "Canonical tax obligation calendars used when computing evidence segments.",
+  "source_url": "https://www.ato.gov.au/businesses-and-organisations/key-dates",
+  "last_reviewed": "2025-10-05",
+  "calendars": {
+    "bas": {
+      "monthly": {
+        "regime": "BAS",
+        "frequency": "monthly",
+        "period_pattern": "^\\d{4}-\\d{2}$",
+        "start_day": 1,
+        "end": "end_of_month",
+        "description": "Business Activity Statement monthly lodgement periods"
+      },
+      "quarterly": {
+        "regime": "BAS",
+        "frequency": "quarterly",
+        "period_pattern": "^\\d{4}-Q[1-4]$",
+        "quarters": {
+          "Q1": { "start_month": 7,  "start_day": 1,  "end_month": 9,  "end_day": 30 },
+          "Q2": { "start_month": 10, "start_day": 1,  "end_month": 12, "end_day": 31 },
+          "Q3": { "start_month": 1,  "start_day": 1,  "end_month": 3,  "end_day": 31 },
+          "Q4": { "start_month": 4,  "start_day": 1,  "end_month": 6,  "end_day": 30 }
+        },
+        "description": "Business Activity Statement quarterly lodgement periods"
+      }
+    },
+    "fbt": {
+      "annual": {
+        "regime": "FBT",
+        "frequency": "annual",
+        "period_pattern": "^\\d{4}-FBT$",
+        "start_month": 4,
+        "start_day": 1,
+        "end_month": 3,
+        "end_day": 31,
+        "description": "Fringe Benefits Tax year running from 1 April to 31 March"
+      }
+    }
+  }
+}

--- a/apps/services/tax-engine/app/rules/loader.py
+++ b/apps/services/tax-engine/app/rules/loader.py
@@ -1,0 +1,118 @@
+"""Utilities for loading and validating rule documents."""
+from __future__ import annotations
+
+import json
+import hashlib
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from .version import RATES_VERSION, KNOWN_RULE_FILE_HASHES
+
+RULES_DIR = Path(__file__).resolve().parent
+
+@dataclass(frozen=True)
+class RuleDocument:
+    """Container for a single rules file."""
+
+    name: str
+    path: Path
+    sha256: str
+    payload: Dict[str, Any]
+    source_url: Optional[str]
+    last_reviewed: Optional[str]
+
+
+def _compute_sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@lru_cache(maxsize=1)
+def load_rule_documents() -> Dict[str, RuleDocument]:
+    """Return all rule documents keyed by filename."""
+
+    documents: Dict[str, RuleDocument] = {}
+    for path in sorted(RULES_DIR.glob("*.json")):
+        data = path.read_bytes()
+        payload = json.loads(data.decode("utf-8"))
+        documents[path.name] = RuleDocument(
+            name=path.name,
+            path=path,
+            sha256=_compute_sha256(data),
+            payload=payload,
+            source_url=payload.get("source_url"),
+            last_reviewed=payload.get("last_reviewed"),
+        )
+    return documents
+
+
+def load_rules_payload(name: str) -> Dict[str, Any]:
+    """Return the raw JSON payload for a named rule document."""
+
+    documents = load_rule_documents()
+    if name not in documents:
+        raise KeyError(f"Unknown rule document: {name}")
+    return documents[name].payload
+
+
+def build_rules_version_payload() -> Dict[str, Any]:
+    """Payload for the /rules/version endpoint."""
+
+    documents = load_rule_documents()
+    return {
+        "rates_version": RATES_VERSION,
+        "files": [
+            {
+                "name": doc.name,
+                "sha256": doc.sha256,
+                "source_url": doc.source_url,
+                "last_reviewed": doc.last_reviewed,
+            }
+            for doc in sorted(documents.values(), key=lambda d: d.name)
+        ],
+    }
+
+
+def validate_known_hashes() -> List[str]:
+    """Return a list of human readable mismatch messages."""
+
+    documents = load_rule_documents()
+    mismatches: List[str] = []
+    expected_files = set(KNOWN_RULE_FILE_HASHES.keys())
+    actual_files = set(documents.keys())
+
+    missing_in_expected = actual_files - expected_files
+    if missing_in_expected:
+        mismatches.append(
+            "New rules files detected: " + ", ".join(sorted(missing_in_expected))
+        )
+
+    missing_on_disk = expected_files - actual_files
+    if missing_on_disk:
+        mismatches.append(
+            "Rules files missing from disk: " + ", ".join(sorted(missing_on_disk))
+        )
+
+    for name, expected_sha in KNOWN_RULE_FILE_HASHES.items():
+        doc = documents.get(name)
+        if not doc:
+            continue
+        if doc.sha256 != expected_sha:
+            mismatches.append(
+                f"Hash mismatch for {name}: expected {expected_sha}, found {doc.sha256}"
+            )
+
+    return mismatches
+
+
+__all__ = [
+    "RuleDocument",
+    "RULES_DIR",
+    "RATES_VERSION",
+    "KNOWN_RULE_FILE_HASHES",
+    "load_rule_documents",
+    "load_rules_payload",
+    "build_rules_version_payload",
+    "validate_known_hashes",
+]

--- a/apps/services/tax-engine/app/rules/payg_w_2024_25.json
+++ b/apps/services/tax-engine/app/rules/payg_w_2024_25.json
@@ -1,6 +1,8 @@
-﻿{
+{
   "version": "2024-25",
   "notes": "Replace with ATO-published formulas/tables each 1 July before production.",
+  "source_url": "https://www.ato.gov.au/forms/tax-tables/weekly-tax-table/",
+  "last_reviewed": "2025-07-01",
   "methods_enabled": ["table_ato","formula_progressive","percent_simple","flat_plus_percent","bonus_marginal","net_to_gross"],
   "formula_progressive": {
     "period": "weekly",

--- a/apps/services/tax-engine/app/rules/version.py
+++ b/apps/services/tax-engine/app/rules/version.py
@@ -1,0 +1,16 @@
+"""Canonical versioning for published tax rules."""
+from __future__ import annotations
+
+from typing import Dict
+
+# Update this version whenever any document in ``app/rules`` changes.
+RATES_VERSION: str = "2025-10-05.0"
+
+# Expected SHA-256 digests for each rules file. The CI test ensures these stay in sync
+# with :data:`RATES_VERSION` and that a changelog entry exists for the current version.
+KNOWN_RULE_FILE_HASHES: Dict[str, str] = {
+    "calendars.json": "51b38a2c887067e45ccec5892cb2bd302aa767df30973c63348822e0c019b216",
+    "payg_w_2024_25.json": "663081afecf48c5eefa12b88c13a61d74ecd7c292fb5af12d44220cf75f23d91",
+}
+
+__all__ = ["RATES_VERSION", "KNOWN_RULE_FILE_HASHES"]

--- a/apps/services/tax-engine/pyproject.toml
+++ b/apps/services/tax-engine/pyproject.toml
@@ -16,6 +16,7 @@ alembic = "^1.13.3"
 nats-py = "^2.11.0"
 prometheus-client = "^0.21.0"
 orjson = "^3.10.7"
+jinja2 = "^3.1.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/apps/services/tax-engine/tests/test_engine.py
+++ b/apps/services/tax-engine/tests/test_engine.py
@@ -1,0 +1,37 @@
+from fastapi.testclient import TestClient
+
+from app.engine import compute_tax_event, resolve_period_bounds
+from app.rules.loader import build_rules_version_payload, load_rule_documents
+from app.main import app
+
+
+def test_resolve_period_bounds_month():
+    start, end = resolve_period_bounds("2025-09")
+    assert start == "2025-09-01"
+    assert end == "2025-09-30"
+
+
+def test_resolve_period_bounds_fbt():
+    start, end = resolve_period_bounds("2025-FBT")
+    assert start == "2024-04-01"
+    assert end == "2025-03-31"
+
+
+def test_compute_tax_event_segments_include_sha():
+    event = {"id": "test", "entity": "AUS-PTY", "period": "2025-09", "payg_w": {"method": "formula_progressive", "period": "weekly", "gross": 2000}}
+    result = compute_tax_event(event)
+    segments = result["evidence"]["segments"]
+    assert segments, "Expected at least one evidence segment"
+    rule_docs = load_rule_documents()
+    expected_shas = {doc.sha256 for name, doc in rule_docs.items() if name.startswith("payg_w")}
+    for segment in segments:
+        assert segment["rules_sha256"] in expected_shas
+        assert segment["effective_from"] <= segment["effective_to"]
+
+
+def test_rules_version_endpoint_matches_loader():
+    client = TestClient(app)
+    resp = client.get("/rules/version")
+    assert resp.status_code == 200
+    payload = resp.json()
+    assert payload == build_rules_version_payload()

--- a/apps/services/tax-engine/tests/test_rules_versioning.py
+++ b/apps/services/tax-engine/tests/test_rules_versioning.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from app.rules.loader import validate_known_hashes
+from app.rules.version import RATES_VERSION
+
+
+def test_rules_hashes_are_current():
+    mismatches = validate_known_hashes()
+    assert not mismatches, "; ".join(mismatches) or "Rules hashes must match KNOWN_RULE_FILE_HASHES"
+
+
+def test_changelog_mentions_current_rates_version():
+    changelog = Path(__file__).resolve().parents[1] / "CHANGELOG.md"
+    content = changelog.read_text("utf-8")
+    assert RATES_VERSION in content, f"Add an entry for rates version {RATES_VERSION} to CHANGELOG.md"


### PR DESCRIPTION
## Summary
- add a rules loader with regime calendars and tracked SHA-256 hashes
- expose /rules/version, compute PAYG evidence segments, and guard the UI when Jinja2 is unavailable
- enforce rates version governance with unit tests and changelog entry

## Testing
- pytest apps/services/tax-engine/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68e375f2ec6483279899fe7a80bc2297