### PR TITLE
Add PAYGI instalment engine and planner UI

### DIFF
--- a/engine/paygi.py
+++ b/engine/paygi.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+RULES_DIR = Path(__file__).resolve().parent.parent / "rules" / "paygi"
+
+
+def _load_json(path: Path) -> Dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _normalise_quarter(quarter: str | int) -> str:
+    if isinstance(quarter, int):
+        return f"Q{quarter}"
+    q = str(quarter).upper().replace(" ", "")
+    return q if q.startswith("Q") else f"Q{q}"
+
+
+@dataclass
+class SafeHarbourResult:
+    passed: bool
+    ratio: float
+    reduction: float
+    min_ratio: float
+    max_reduction: float
+    message: str
+
+
+@dataclass
+class QuarterResult:
+    year: str
+    quarter: str
+    method: str
+    t1: float
+    t2: float
+    t3: float
+    t4: float
+    base_t4: float
+    instalment_rate: float
+    gdp_uplift: float
+    notice_amount: Optional[float] = None
+    safe_harbour: Optional[SafeHarbourResult] = None
+    evidence: Dict[str, Any] = field(default_factory=dict)
+
+
+class PaygiEngine:
+    """In-memory PAYGI calculator that tracks quarters, notices and evidence."""
+
+    def __init__(self, rules_dir: Optional[Path] = None):
+        self._rules_dir = Path(rules_dir or RULES_DIR)
+        self._variations = self._load_variations()
+        self._records: Dict[str, Dict[str, QuarterResult]] = {}
+
+    def _quarter_path(self, year: str, quarter: str | int) -> Path:
+        quarter_norm = _normalise_quarter(quarter).lower()
+        return self._rules_dir / f"paygi_{year}_{quarter_norm}.json"
+
+    def _load_quarter_rule(self, year: str, quarter: str | int) -> Dict[str, Any]:
+        path = self._quarter_path(year, quarter)
+        if not path.exists():
+            raise FileNotFoundError(f"PAYGI rules not found for {year} {quarter}: {path}")
+        return _load_json(path)
+
+    def _load_variations(self) -> Dict[str, Any]:
+        path = self._rules_dir / "paygi_variations.json"
+        if not path.exists():
+            raise FileNotFoundError(f"PAYGI variation configuration missing: {path}")
+        data = _load_json(path)
+        reasons = {r["code"]: r for r in data.get("reasons", [])}
+        safe = data.get("safe_harbour", {})
+        return {"reasons": reasons, "safe_harbour": safe}
+
+    def _safe_harbour(self, baseline: float, varied: float) -> SafeHarbourResult:
+        cfg = self._variations.get("safe_harbour", {})
+        min_ratio = float(cfg.get("min_ratio", 0.85))
+        max_reduction = float(cfg.get("max_reduction", 0.15))
+        if baseline <= 0:
+            return SafeHarbourResult(True, 1.0, 0.0, min_ratio, max_reduction, "No baseline amount to compare")
+        ratio = varied / baseline if baseline else 1.0
+        reduction = max(0.0, 1.0 - ratio)
+        passed = ratio >= min_ratio or reduction <= max_reduction
+        message = cfg.get("pass_reason" if passed else "fail_reason", "")
+        if message:
+            message = f"{message} (ratio={ratio:.2%}, reduction={reduction:.2%})"
+        else:
+            message = f"ratio={ratio:.2%}, reduction={reduction:.2%}"
+        return SafeHarbourResult(passed, ratio, reduction, min_ratio, max_reduction, message)
+
+    def calculate(
+        self,
+        *,
+        year: str,
+        quarter: str | int,
+        method: str,
+        income_base: float,
+        notice_amount: Optional[float] = None,
+        variation_amount: Optional[float] = None,
+        reason_code: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> QuarterResult:
+        method = method.lower()
+        if method not in {"rate", "amount"}:
+            raise ValueError(f"Unsupported PAYGI method: {method}")
+        q_norm = _normalise_quarter(quarter)
+        rule = self._load_quarter_rule(year, q_norm)
+        rate = float(rule.get("instalment_rate", 0.0))
+        gdp = float(rule.get("gdp_uplift", 0.0))
+        t1 = float(income_base or 0.0)
+        base_t2 = rate
+        t3 = t1 * base_t2
+        base_t4 = t3 * (1.0 + gdp)
+        applied_t4 = base_t4
+        safe_result: Optional[SafeHarbourResult] = None
+        evidence: Dict[str, Any] = {}
+
+        if method == "rate":
+            if variation_amount is not None:
+                applied_t4 = float(variation_amount)
+                safe_result = self._safe_harbour(base_t4, applied_t4)
+                if reason_code:
+                    reason = self._variations["reasons"].get(reason_code)
+                    if not reason:
+                        raise ValueError(f"Unknown variation reason: {reason_code}")
+                    evidence = {
+                        "reason_code": reason_code,
+                        "reason_label": reason.get("label"),
+                        "notes": notes or "",
+                        "hint": reason.get("hint"),
+                    }
+                elif applied_t4 != base_t4:
+                    raise ValueError("Variation amount supplied without reason code")
+            else:
+                applied_t4 = base_t4
+        else:
+            if notice_amount is None:
+                notice_amount = rule.get("base_notice_amount")
+            if notice_amount is None:
+                raise ValueError("Notice amount required for PAYGI amount method")
+            applied_t4 = float(notice_amount)
+            evidence = {
+                "reason_code": reason_code or "NOTICE",
+                "reason_label": "ATO instalment notice",
+                "notes": notes or "",
+            }
+            if reason_code and reason_code in self._variations["reasons"]:
+                reason = self._variations["reasons"][reason_code]
+                evidence["reason_label"] = reason.get("label")
+                evidence["hint"] = reason.get("hint")
+
+        return QuarterResult(
+            year=str(year),
+            quarter=q_norm,
+            method=method,
+            t1=round(t1, 2),
+            t2=round(base_t2, 6),
+            t3=round(t3, 2),
+            t4=round(applied_t4, 2),
+            base_t4=round(base_t4, 2),
+            instalment_rate=rate,
+            gdp_uplift=gdp,
+            notice_amount=float(notice_amount) if notice_amount is not None else None,
+            safe_harbour=safe_result,
+            evidence=evidence,
+        )
+
+    def record(
+        self,
+        abn: str,
+        *,
+        year: str,
+        quarter: str | int,
+        method: str,
+        income_base: float,
+        notice_amount: Optional[float] = None,
+        variation_amount: Optional[float] = None,
+        reason_code: Optional[str] = None,
+        notes: Optional[str] = None,
+    ) -> QuarterResult:
+        result = self.calculate(
+            year=year,
+            quarter=quarter,
+            method=method,
+            income_base=income_base,
+            notice_amount=notice_amount,
+            variation_amount=variation_amount,
+            reason_code=reason_code,
+            notes=notes,
+        )
+        period_key = f"{year}{_normalise_quarter(quarter)}"
+        self._records.setdefault(abn, {})[period_key] = result
+        return result
+
+    def _segments(self, records: Dict[str, QuarterResult]) -> List[Dict[str, Any]]:
+        ordered = sorted(records.items(), key=lambda item: item[0])
+        segments: List[Dict[str, Any]] = []
+        current: Optional[Dict[str, Any]] = None
+        for period_key, record in ordered:
+            if current is None or current["method"] != record.method:
+                current = {
+                    "method": record.method,
+                    "from": period_key,
+                    "to": period_key,
+                    "quarters": [period_key],
+                    "evidence": [record.evidence] if record.evidence else [],
+                }
+                segments.append(current)
+            else:
+                current["to"] = period_key
+                current["quarters"].append(period_key)
+                if record.evidence:
+                    current.setdefault("evidence", []).append(record.evidence)
+        return segments
+
+    def summary(self, abn: str) -> Dict[str, Any]:
+        records = self._records.get(abn, {})
+        ordered = [
+            {
+                "period": key,
+                "year": value.year,
+                "quarter": value.quarter,
+                "method": value.method,
+                "t1": value.t1,
+                "t2": value.t2,
+                "t3": value.t3,
+                "t4": value.t4,
+                "base_t4": value.base_t4,
+                "instalment_rate": value.instalment_rate,
+                "gdp_uplift": value.gdp_uplift,
+                "notice_amount": value.notice_amount,
+                "safe_harbour": {
+                    "passed": value.safe_harbour.passed,
+                    "ratio": value.safe_harbour.ratio,
+                    "reduction": value.safe_harbour.reduction,
+                    "min_ratio": value.safe_harbour.min_ratio,
+                    "max_reduction": value.safe_harbour.max_reduction,
+                    "message": value.safe_harbour.message,
+                }
+                if value.safe_harbour
+                else None,
+                "evidence": value.evidence,
+            }
+            for key, value in sorted(records.items(), key=lambda item: item[0])
+        ]
+        notices = {
+            key: rec.notice_amount
+            for key, rec in records.items()
+            if rec.notice_amount is not None
+        }
+        return {
+            "quarters": ordered,
+            "segments": self._segments(records),
+            "notices": notices,
+        }
+
+
+__all__ = ["PaygiEngine", "QuarterResult", "SafeHarbourResult"]

--- a/rules/paygi/paygi_2025_q1.json
+++ b/rules/paygi/paygi_2025_q1.json
@@ -1,0 +1,8 @@
+{
+  "year": "2025",
+  "quarter": "Q1",
+  "instalment_rate": 0.0425,
+  "gdp_uplift": 0.07,
+  "base_notice_amount": 4300.0,
+  "notes": "Sample data for FY25 Q1 instalments"
+}

--- a/rules/paygi/paygi_2025_q2.json
+++ b/rules/paygi/paygi_2025_q2.json
@@ -1,0 +1,8 @@
+{
+  "year": "2025",
+  "quarter": "Q2",
+  "instalment_rate": 0.044,
+  "gdp_uplift": 0.05,
+  "base_notice_amount": 4450.0,
+  "notes": "Sample data for FY25 Q2 instalments"
+}

--- a/rules/paygi/paygi_2025_q3.json
+++ b/rules/paygi/paygi_2025_q3.json
@@ -1,0 +1,8 @@
+{
+  "year": "2025",
+  "quarter": "Q3",
+  "instalment_rate": 0.043,
+  "gdp_uplift": 0.0,
+  "base_notice_amount": 4525.0,
+  "notes": "Sample data for FY25 Q3 instalments"
+}

--- a/rules/paygi/paygi_2025_q4.json
+++ b/rules/paygi/paygi_2025_q4.json
@@ -1,0 +1,8 @@
+{
+  "year": "2025",
+  "quarter": "Q4",
+  "instalment_rate": 0.045,
+  "gdp_uplift": 0.03,
+  "base_notice_amount": 4600.0,
+  "notes": "Sample data for FY25 Q4 instalments"
+}

--- a/rules/paygi/paygi_variations.json
+++ b/rules/paygi/paygi_variations.json
@@ -1,0 +1,30 @@
+{
+  "updated": "2025-03-31",
+  "reasons": [
+    {
+      "code": "VAR_REDUCED_PROFIT",
+      "label": "Reduced instalment income",
+      "predicate": "income_decline",
+      "hint": "Provide year-to-date management accounts showing the decline in instalment income."
+    },
+    {
+      "code": "VAR_CAPITAL_EXPENSE",
+      "label": "Large deductible expense",
+      "predicate": "deductible_investment",
+      "hint": "Attach evidence of the deductible capital expenditure and its timing."
+    },
+    {
+      "code": "VAR_NEW_BUSINESS",
+      "label": "New business with lower profits",
+      "predicate": "new_business",
+      "hint": "Upload business plan or forecast demonstrating the lower taxable income."
+    }
+  ],
+  "safe_harbour": {
+    "min_ratio": 0.85,
+    "max_reduction": 0.15,
+    "pass_reason": "Variation satisfies the 85% safe harbour threshold.",
+    "fail_reason": "Variation falls outside the 85% safe harbour threshold and may attract penalties.",
+    "calculation_hint": "Ensure varied instalments cover at least 85% of the baseline amount or reduce by no more than 15%."
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Audit from "./pages/Audit";
 import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
+import PAYGI from "./pages/PAYGI";
 
 export default function App() {
   return (
@@ -24,6 +25,7 @@ export default function App() {
           <Route path="/audit" element={<Audit />} />
           <Route path="/fraud" element={<Fraud />} />
           <Route path="/integrations" element={<Integrations />} />
+          <Route path="/paygi" element={<PAYGI />} />
           <Route path="/help" element={<Help />} />
         </Route>
       </Routes>

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,7 @@
+import express from "express";
+
+export const api = express.Router();
+
+api.get("/status", (_req, res) => {
+  res.json({ ok: true });
+});

--- a/src/api/paygi.ts
+++ b/src/api/paygi.ts
@@ -1,0 +1,74 @@
+import express from "express";
+import { calculatePaygi } from "../paygi/calculator";
+import { loadQuarterRule, loadVariationConfig } from "../paygi/config";
+import { paygiStore } from "../paygi/store";
+import type { PaygiCalculationInput } from "../paygi/types";
+
+export const paygiApi = express.Router();
+
+paygiApi.get("/paygi/reasons", (_req, res) => {
+  const cfg = loadVariationConfig();
+  res.json({
+    reasons: cfg.reasons,
+    safeHarbour: cfg.safeHarbour,
+  });
+});
+
+paygiApi.get("/paygi/rules/:year/:quarter", (req, res) => {
+  try {
+    const { year, quarter } = req.params;
+    const rule = loadQuarterRule(year, quarter);
+    res.json(rule);
+  } catch (error: any) {
+    res.status(404).json({ error: error?.message || "Rule not found" });
+  }
+});
+
+paygiApi.get("/paygi/summary", (req, res) => {
+  const { abn, year } = req.query as { abn?: string; year?: string };
+  if (!abn) {
+    return res.status(400).json({ error: "abn is required" });
+  }
+  res.json(paygiStore.summary(abn, year));
+});
+
+paygiApi.post("/paygi/instalments", (req, res) => {
+  try {
+    const payload = req.body as Partial<PaygiCalculationInput> & { incomeBase?: number };
+    if (!payload?.abn || !payload.year || payload.quarter === undefined || !payload.method) {
+      return res.status(400).json({ error: "abn, year, quarter and method are required" });
+    }
+    const incomeBase = Number(payload.incomeBase ?? 0);
+    const noticeAmount =
+      payload.noticeAmount === undefined || payload.noticeAmount === null
+        ? undefined
+        : Number(payload.noticeAmount);
+    const variationAmount =
+      payload.variationAmount === undefined || payload.variationAmount === null
+        ? undefined
+        : Number(payload.variationAmount);
+
+    const input: PaygiCalculationInput = {
+      abn: payload.abn,
+      year: payload.year,
+      quarter: payload.quarter,
+      method: payload.method,
+      incomeBase,
+      noticeAmount,
+      variationAmount,
+      reasonCode: payload.reasonCode,
+      notes: payload.notes,
+    };
+
+    const { result } = calculatePaygi(input);
+    paygiStore.record(payload.abn, result);
+    const summary = paygiStore.summary(payload.abn, payload.year);
+
+    res.json({
+      result,
+      summary,
+    });
+  } catch (error: any) {
+    res.status(400).json({ error: error?.message || "PAYGI calculation failed" });
+  }
+});

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -5,6 +5,7 @@ import atoLogo from "../assets/ato-logo.svg";
 const navLinks = [
   { to: "/", label: "Dashboard" },
   { to: "/bas", label: "BAS" },
+  { to: "/paygi", label: "PAYGI" },
   { to: "/settings", label: "Settings" },
   { to: "/wizard", label: "Wizard" },
   { to: "/audit", label: "Audit" },

--- a/src/components/PaygiPlanner.tsx
+++ b/src/components/PaygiPlanner.tsx
@@ -1,0 +1,410 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+type Method = "rate" | "amount";
+
+type VariationReason = {
+  code: string;
+  label: string;
+  predicate: string;
+  hint: string;
+};
+
+type SafeHarbourMeta = {
+  min_ratio: number;
+  max_reduction: number;
+  pass_reason: string;
+  fail_reason: string;
+  calculation_hint?: string;
+};
+
+type PaygiResult = {
+  period: string;
+  method: Method;
+  t1: number;
+  t2: number;
+  t3: number;
+  t4: number;
+  baseT4: number;
+  instalmentRate: number;
+  gdpUplift: number;
+  noticeAmount?: number;
+  safeHarbour?: {
+    passed: boolean;
+    ratio: number;
+    reduction: number;
+    minRatio: number;
+    maxReduction: number;
+    message: string;
+  };
+  evidence?: {
+    reasonCode?: string;
+    reasonLabel?: string;
+    notes?: string;
+    hint?: string;
+  };
+};
+
+type EvidenceSegment = {
+  method: Method;
+  from: string;
+  to: string;
+  quarters: string[];
+  evidence: { reasonCode?: string; reasonLabel?: string; notes?: string; hint?: string }[];
+};
+
+type PaygiSummary = {
+  quarters: PaygiResult[];
+  segments: EvidenceSegment[];
+  notices: Record<string, number>;
+};
+
+const quarterOptions = [
+  { value: "Q1", label: "Q1 (Jul-Sep)" },
+  { value: "Q2", label: "Q2 (Oct-Dec)" },
+  { value: "Q3", label: "Q3 (Jan-Mar)" },
+  { value: "Q4", label: "Q4 (Apr-Jun)" },
+];
+
+const defaultForm = {
+  abn: "12345678901",
+  year: "2025",
+  quarter: "Q1",
+  method: "rate" as Method,
+  incomeBase: "120000",
+  noticeAmount: "",
+  variationAmount: "",
+  reasonCode: "",
+  notes: "",
+};
+
+export default function PaygiPlanner() {
+  const [form, setForm] = useState(defaultForm);
+  const [reasons, setReasons] = useState<VariationReason[]>([]);
+  const [safeHarbour, setSafeHarbour] = useState<SafeHarbourMeta | null>(null);
+  const [result, setResult] = useState<PaygiResult | null>(null);
+  const [summary, setSummary] = useState<PaygiSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    async function loadReasons() {
+      try {
+        const res = await fetch("/api/paygi/reasons");
+        if (!res.ok) {
+          throw new Error("Unable to load PAYGI variation reasons");
+        }
+        const data = await res.json();
+        setReasons(data.reasons ?? []);
+        setSafeHarbour(data.safeHarbour ?? null);
+      } catch (err: any) {
+        setError(err?.message ?? "Failed to load PAYGI configuration");
+      }
+    }
+    loadReasons();
+  }, []);
+
+  const variationRequired = useMemo(() => {
+    if (form.method !== "rate") return false;
+    return Boolean(form.variationAmount && form.variationAmount.trim().length > 0);
+  }, [form.method, form.variationAmount]);
+
+  const reasonHint = useMemo(() => {
+    if (!form.reasonCode) return "";
+    return reasons.find((r) => r.code === form.reasonCode)?.hint ?? "";
+  }, [form.reasonCode, reasons]);
+
+  const onChange = (field: keyof typeof form) => (event: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    setForm((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const onMethodChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const method = event.target.value as Method;
+    setForm((prev) => ({
+      ...prev,
+      method,
+      variationAmount: method === "rate" ? prev.variationAmount : "",
+      reasonCode: method === "rate" ? prev.reasonCode : "",
+      notes: method === "rate" ? prev.notes : "",
+    }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const payload: Record<string, any> = {
+        abn: form.abn,
+        year: form.year,
+        quarter: form.quarter,
+        method: form.method,
+        incomeBase: Number(form.incomeBase || 0),
+      };
+      if (form.method === "amount" && form.noticeAmount) {
+        payload.noticeAmount = Number(form.noticeAmount);
+      }
+      if (form.method === "rate" && form.variationAmount) {
+        payload.variationAmount = Number(form.variationAmount);
+        payload.reasonCode = form.reasonCode || undefined;
+        payload.notes = form.notes || undefined;
+      }
+      if (form.method === "amount" && form.notes) {
+        payload.notes = form.notes;
+      }
+      const res = await fetch("/api/paygi/instalments", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || "PAYGI calculation failed");
+      }
+      const data = await res.json();
+      setResult(data.result ?? null);
+      setSummary(data.summary ?? null);
+    } catch (err: any) {
+      setError(err?.message ?? "Unable to calculate PAYGI instalment");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-white rounded-xl shadow p-6 space-y-6">
+      <div>
+        <h2 className="text-2xl font-semibold">PAYGI Planner</h2>
+        <p className="text-sm text-gray-600">
+          Calculate instalments using either the rate or amount method. Variation requests must include a valid reason code and supporting notes.
+        </p>
+        {safeHarbour?.calculation_hint && (
+          <p className="mt-2 text-xs text-blue-700">Safe harbour guidance: {safeHarbour.calculation_hint}</p>
+        )}
+      </div>
+
+      <form className="space-y-4" onSubmit={handleSubmit}>
+        <div className="grid md:grid-cols-2 gap-4">
+          <label className="block text-sm font-medium">
+            ABN
+            <input
+              className="mt-1 w-full border rounded px-3 py-2"
+              value={form.abn}
+              onChange={onChange("abn")}
+              required
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Year
+            <input
+              className="mt-1 w-full border rounded px-3 py-2"
+              value={form.year}
+              onChange={onChange("year")}
+              required
+            />
+          </label>
+          <label className="block text-sm font-medium">
+            Quarter
+            <select className="mt-1 w-full border rounded px-3 py-2" value={form.quarter} onChange={onChange("quarter")}>
+              {quarterOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block text-sm font-medium">
+            Instalment income (T1)
+            <input
+              type="number"
+              min="0"
+              step="0.01"
+              className="mt-1 w-full border rounded px-3 py-2"
+              value={form.incomeBase}
+              onChange={onChange("incomeBase")}
+              required
+            />
+          </label>
+        </div>
+
+        <fieldset className="space-y-2">
+          <legend className="text-sm font-medium">Method</legend>
+          <div className="flex space-x-4">
+            <label className="flex items-center space-x-2">
+              <input type="radio" value="rate" checked={form.method === "rate"} onChange={onMethodChange} />
+              <span>Rate (T1 × instalment rate × GDP uplift)</span>
+            </label>
+            <label className="flex items-center space-x-2">
+              <input type="radio" value="amount" checked={form.method === "amount"} onChange={onMethodChange} />
+              <span>Amount (ATO instalment notice)</span>
+            </label>
+          </div>
+        </fieldset>
+
+        {form.method === "amount" && (
+          <div className="grid md:grid-cols-2 gap-4">
+            <label className="block text-sm font-medium">
+              Notice amount (T4)
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                className="mt-1 w-full border rounded px-3 py-2"
+                value={form.noticeAmount}
+                onChange={onChange("noticeAmount")}
+                placeholder="Use notice default if blank"
+              />
+            </label>
+            <label className="block text-sm font-medium">
+              Evidence notes
+              <input
+                className="mt-1 w-full border rounded px-3 py-2"
+                value={form.notes}
+                onChange={onChange("notes")}
+                placeholder="Record notice reference"
+              />
+            </label>
+          </div>
+        )}
+
+        {form.method === "rate" && (
+          <div className="grid md:grid-cols-2 gap-4">
+            <label className="block text-sm font-medium">
+              Varied instalment amount (T4)
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                className="mt-1 w-full border rounded px-3 py-2"
+                value={form.variationAmount}
+                onChange={onChange("variationAmount")}
+                placeholder="Leave blank to use calculated amount"
+              />
+            </label>
+            <div>
+              <label className="block text-sm font-medium">
+                Variation reason code
+                <select
+                  className="mt-1 w-full border rounded px-3 py-2"
+                  value={form.reasonCode}
+                  onChange={onChange("reasonCode")}
+                  disabled={!variationRequired}
+                  required={variationRequired}
+                >
+                  <option value="">Select a reason</option>
+                  {reasons.map((reason) => (
+                    <option key={reason.code} value={reason.code}>
+                      {reason.code} — {reason.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              {reasonHint && variationRequired && (
+                <p className="text-xs text-gray-500 mt-1">Evidence hint: {reasonHint}</p>
+              )}
+            </div>
+            <label className="md:col-span-2 block text-sm font-medium">
+              Supporting notes
+              <textarea
+                className="mt-1 w-full border rounded px-3 py-2"
+                value={form.notes}
+                onChange={onChange("notes")}
+                disabled={!variationRequired}
+                required={variationRequired}
+                placeholder="Explain why the safe-harbour test is satisfied"
+                rows={3}
+              />
+            </label>
+          </div>
+        )}
+
+        <button
+          type="submit"
+          className="bg-[#00716b] text-white font-semibold px-4 py-2 rounded shadow hover:bg-[#005f59]"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "Calculating..." : "Calculate instalment"}
+        </button>
+      </form>
+
+      {error && <div className="bg-red-100 text-red-800 p-3 rounded">{error}</div>}
+
+      {result && (
+        <div className="bg-slate-50 border border-slate-200 rounded-lg p-4 space-y-3">
+          <h3 className="text-lg font-semibold">Quarter result ({result.period})</h3>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4 text-sm">
+            <div className="bg-white rounded shadow p-3">
+              <p className="text-xs uppercase text-gray-500">T1 Instalment income</p>
+              <p className="text-lg font-semibold">${result.t1.toFixed(2)}</p>
+            </div>
+            <div className="bg-white rounded shadow p-3">
+              <p className="text-xs uppercase text-gray-500">T2 Instalment rate</p>
+              <p className="text-lg font-semibold">{result.t2.toFixed(4)}</p>
+            </div>
+            <div className="bg-white rounded shadow p-3">
+              <p className="text-xs uppercase text-gray-500">T3 (T1 × T2)</p>
+              <p className="text-lg font-semibold">${result.t3.toFixed(2)}</p>
+            </div>
+            <div className="bg-white rounded shadow p-3">
+              <p className="text-xs uppercase text-gray-500">T4 PAYGI amount</p>
+              <p className="text-lg font-semibold">${result.t4.toFixed(2)}</p>
+              <p className="text-xs text-gray-500">GDP uplift applied: {(result.gdpUplift * 100).toFixed(1)}%</p>
+            </div>
+          </div>
+          {result.safeHarbour && (
+            <div
+              className={`p-3 rounded border ${
+                result.safeHarbour.passed ? "border-green-200 bg-green-50 text-green-800" : "border-red-200 bg-red-50 text-red-800"
+              }`}
+            >
+              <p className="font-medium">Safe harbour {result.safeHarbour.passed ? "met" : "failed"}</p>
+              <p className="text-sm">{result.safeHarbour.message}</p>
+              <p className="text-xs">Threshold: ≥{(result.safeHarbour.minRatio * 100).toFixed(1)}% or ≤{(result.safeHarbour.maxReduction * 100).toFixed(1)}% reduction</p>
+            </div>
+          )}
+          {result.evidence && (
+            <div className="text-sm text-gray-700">
+              <p className="font-medium">Evidence recorded</p>
+              <ul className="list-disc pl-5">
+                {result.evidence.reasonLabel && (
+                  <li>
+                    {result.evidence.reasonCode ? `${result.evidence.reasonCode}: ` : ""}
+                    {result.evidence.reasonLabel}
+                  </li>
+                )}
+                {result.evidence.notes && <li>Notes: {result.evidence.notes}</li>}
+              </ul>
+            </div>
+          )}
+        </div>
+      )}
+
+      {summary && summary.segments.length > 0 && (
+        <div className="bg-white border border-slate-200 rounded-lg p-4 space-y-3">
+          <h3 className="text-lg font-semibold">Method segments ({form.abn})</h3>
+          <ul className="space-y-2 text-sm">
+            {summary.segments.map((segment) => (
+              <li key={`${segment.method}-${segment.from}-${segment.to}`} className="bg-slate-100 rounded p-3">
+                <p className="font-medium">
+                  {segment.method.toUpperCase()} from {segment.from} to {segment.to}
+                </p>
+                {segment.evidence.length > 0 && (
+                  <ul className="list-disc pl-4 mt-1 space-y-1">
+                    {segment.evidence.map((evidence, idx) => (
+                      <li key={idx}>
+                        {evidence.reasonCode ? `${evidence.reasonCode}: ` : ""}
+                        {evidence.reasonLabel || "No label"}
+                        {evidence.notes ? ` — ${evidence.notes}` : ""}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,4 +1,5 @@
 ﻿import { Pool } from "pg";
+import { paygiStore } from "../paygi/store";
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
@@ -15,5 +16,6 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     anomaly_thresholds: p?.thresholds ?? {},
     discrepancy_log: []  // TODO: populate from recon diffs
   };
+  bundle["paygi"] = paygiStore.summary(abn);
   return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import dotenv from "dotenv";
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
+import { paygiApi } from "./api/paygi";
 import { api } from "./api";                  // your existing API router(s)
 
 dotenv.config();
@@ -27,6 +28,7 @@ app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+app.use("/api", paygiApi);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/pages/PAYGI.tsx
+++ b/src/pages/PAYGI.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import PaygiPlanner from "../components/PaygiPlanner";
+
+export default function PAYGI() {
+  return (
+    <div className="main-card space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold">PAYG Instalments (PAYGI)</h1>
+        <p className="text-sm text-gray-600">
+          Manage PAYGI instalments, record notices, and capture evidence that supports safe-harbour compliance.
+        </p>
+      </div>
+      <PaygiPlanner />
+    </div>
+  );
+}

--- a/src/paygi/calculator.ts
+++ b/src/paygi/calculator.ts
@@ -1,0 +1,108 @@
+import type {
+  PaygiCalculationInput,
+  PaygiQuarterResult,
+  QuarterEvidence,
+  SafeHarbourOutcome,
+  VariationReason,
+} from "./types";
+import { loadQuarterRule, loadVariationConfig } from "./config";
+import { evaluateSafeHarbour } from "./safeHarbour";
+
+function normaliseQuarter(value: string | number): string {
+  const raw = String(value).trim();
+  return raw.toUpperCase().startsWith("Q") ? raw.toUpperCase() : `Q${raw.toUpperCase()}`;
+}
+
+function ensureReason(code: string | undefined, notes: string | undefined, reasons: VariationReason[]): VariationReason {
+  if (!code) {
+    throw new Error("Variation reason code is required when overriding the instalment amount.");
+  }
+  const reason = reasons.find((item) => item.code === code);
+  if (!reason) {
+    throw new Error(`Unknown variation reason code: ${code}`);
+  }
+  if (!notes || !notes.trim()) {
+    throw new Error("Please provide supporting notes for the selected variation reason.");
+  }
+  return reason;
+}
+
+export function calculatePaygi(input: PaygiCalculationInput): { result: PaygiQuarterResult; safeHarbour?: SafeHarbourOutcome } {
+  const variations = loadVariationConfig();
+  const rule = loadQuarterRule(input.year, input.quarter);
+  const quarter = normaliseQuarter(input.quarter);
+  const period = `${input.year}${quarter}`;
+
+  const t1 = Number.isFinite(input.incomeBase) ? Number(input.incomeBase) : 0;
+  const instalmentRate = Number(rule.instalment_rate ?? 0);
+  const gdpUplift = Number(rule.gdp_uplift ?? 0);
+
+  let t2 = instalmentRate;
+  let t3 = t1 * instalmentRate;
+  let baseT4 = t3 * (1 + gdpUplift);
+  let appliedT4 = baseT4;
+  let safeHarbour: SafeHarbourOutcome | undefined;
+  let evidence: QuarterEvidence | undefined;
+  let noticeAmount: number | undefined;
+
+  if (input.method === "rate") {
+    if (typeof input.variationAmount === "number") {
+      appliedT4 = input.variationAmount;
+      safeHarbour = evaluateSafeHarbour(baseT4, appliedT4, variations);
+      if (Math.abs(appliedT4 - baseT4) > 0.009) {
+        const reason = ensureReason(input.reasonCode, input.notes, variations.reasons);
+        evidence = {
+          reasonCode: reason.code,
+          reasonLabel: reason.label,
+          notes: input.notes?.trim(),
+          hint: reason.hint,
+        };
+      }
+    }
+  } else {
+    const resolvedNotice =
+      typeof input.noticeAmount === "number" && !Number.isNaN(input.noticeAmount)
+        ? input.noticeAmount
+        : rule.base_notice_amount;
+    if (typeof resolvedNotice !== "number" || Number.isNaN(resolvedNotice)) {
+      throw new Error("Notice amount is required for the PAYGI amount method.");
+    }
+    noticeAmount = resolvedNotice;
+    t2 = 0;
+    t3 = 0;
+    baseT4 = noticeAmount;
+    appliedT4 = noticeAmount;
+
+    let reason: VariationReason | undefined;
+    if (input.reasonCode) {
+      reason = variations.reasons.find((item) => item.code === input.reasonCode);
+      if (!reason) {
+        throw new Error(`Unknown variation reason code: ${input.reasonCode}`);
+      }
+    }
+
+    evidence = {
+      reasonCode: reason?.code ?? "NOTICE",
+      reasonLabel: reason?.label ?? "ATO instalment notice",
+      notes: input.notes?.trim() ?? "",
+      hint: reason?.hint,
+    };
+  }
+
+  const result: PaygiQuarterResult = {
+    period,
+    method: input.method,
+    t1: Math.round(t1 * 100) / 100,
+    t2,
+    t3: Math.round(t3 * 100) / 100,
+    t4: Math.round(appliedT4 * 100) / 100,
+    baseT4: Math.round(baseT4 * 100) / 100,
+    instalmentRate,
+    gdpUplift,
+    noticeAmount,
+    safeHarbour,
+    evidence,
+  };
+
+  return { result, safeHarbour };
+}

--- a/src/paygi/config.ts
+++ b/src/paygi/config.ts
@@ -1,0 +1,49 @@
+import fs from "fs";
+import path from "path";
+import type { QuarterRule, VariationConfig } from "./types";
+
+const RULES_DIR = path.join(process.cwd(), "rules", "paygi");
+
+function readJsonFile<T>(filename: string): T {
+  const filePath = path.join(RULES_DIR, filename);
+  const raw = fs.readFileSync(filePath, "utf-8");
+  return JSON.parse(raw) as T;
+}
+
+export function loadQuarterRule(year: string, quarter: string | number): QuarterRule {
+  const q = String(quarter).toLowerCase().startsWith("q")
+    ? String(quarter).toLowerCase()
+    : `q${String(quarter).toLowerCase()}`;
+  const filename = `paygi_${year}_${q}.json`;
+  return readJsonFile<QuarterRule>(filename);
+}
+
+let variationCache: VariationConfig | null = null;
+
+export function loadVariationConfig(): VariationConfig {
+  if (!variationCache) {
+    const data = readJsonFile<{ reasons: any[]; safe_harbour: any }>("paygi_variations.json");
+    variationCache = {
+      reasons: (data.reasons || []).map((item) => ({
+        code: String(item.code),
+        label: String(item.label ?? item.code),
+        predicate: String(item.predicate ?? ""),
+        hint: String(item.hint ?? ""),
+      })),
+      safeHarbour: {
+        min_ratio: Number(data.safe_harbour?.min_ratio ?? 0.85),
+        max_reduction: Number(data.safe_harbour?.max_reduction ?? 0.15),
+        pass_reason: String(data.safe_harbour?.pass_reason ?? ""),
+        fail_reason: String(data.safe_harbour?.fail_reason ?? ""),
+        calculation_hint: data.safe_harbour?.calculation_hint
+          ? String(data.safe_harbour.calculation_hint)
+          : undefined,
+      },
+    };
+  }
+  return variationCache;
+}
+
+export function resetVariationCache() {
+  variationCache = null;
+}

--- a/src/paygi/safeHarbour.ts
+++ b/src/paygi/safeHarbour.ts
@@ -1,0 +1,27 @@
+import type { SafeHarbourOutcome, VariationConfig } from "./types";
+
+export function evaluateSafeHarbour(baseline: number, varied: number, cfg: VariationConfig): SafeHarbourOutcome {
+  const minRatio = cfg.safeHarbour.min_ratio;
+  const maxReduction = cfg.safeHarbour.max_reduction;
+
+  if (baseline <= 0) {
+    return {
+      passed: true,
+      ratio: 1,
+      reduction: 0,
+      minRatio,
+      maxReduction,
+      message: "No baseline instalment amount available; safe harbour satisfied by default.",
+    };
+  }
+
+  const ratio = varied / baseline;
+  const reduction = Math.max(0, 1 - ratio);
+  const passed = ratio >= minRatio || reduction <= maxReduction;
+  const template = passed ? cfg.safeHarbour.pass_reason : cfg.safeHarbour.fail_reason;
+  const message = template
+    ? `${template} (ratio=${(ratio * 100).toFixed(1)}%, reduction=${(reduction * 100).toFixed(1)}%)`
+    : `ratio=${(ratio * 100).toFixed(1)}%, reduction=${(reduction * 100).toFixed(1)}%`;
+
+  return { passed, ratio, reduction, minRatio, maxReduction, message };
+}

--- a/src/paygi/store.ts
+++ b/src/paygi/store.ts
@@ -1,0 +1,65 @@
+import type { EvidenceSegment, PaygiQuarterResult, PaygiSummary } from "./types";
+
+class PaygiStore {
+  private readonly storage: Map<string, Map<string, PaygiQuarterResult>> = new Map();
+
+  record(abn: string, result: PaygiQuarterResult) {
+    const quarters = this.storage.get(abn) ?? new Map<string, PaygiQuarterResult>();
+    quarters.set(result.period, result);
+    this.storage.set(abn, quarters);
+  }
+
+  private orderedQuarters(abn: string, year?: string): PaygiQuarterResult[] {
+    const quarters = this.storage.get(abn);
+    if (!quarters) {
+      return [];
+    }
+    return Array.from(quarters.values())
+      .filter((item) => (year ? item.period.startsWith(year) : true))
+      .sort((a, b) => a.period.localeCompare(b.period));
+  }
+
+  private buildSegments(records: PaygiQuarterResult[]): EvidenceSegment[] {
+    const segments: EvidenceSegment[] = [];
+    let current: EvidenceSegment | null = null;
+
+    for (const quarter of records) {
+      if (!current || current.method !== quarter.method) {
+        current = {
+          method: quarter.method,
+          from: quarter.period,
+          to: quarter.period,
+          quarters: [quarter.period],
+          evidence: quarter.evidence ? [quarter.evidence] : [],
+        };
+        segments.push(current);
+      } else {
+        current.to = quarter.period;
+        current.quarters.push(quarter.period);
+        if (quarter.evidence) {
+          current.evidence.push(quarter.evidence);
+        }
+      }
+    }
+
+    return segments;
+  }
+
+  summary(abn: string, year?: string): PaygiSummary {
+    const quarters = this.orderedQuarters(abn, year);
+    const notices = quarters.reduce<Record<string, number>>((acc, quarter) => {
+      if (typeof quarter.noticeAmount === "number") {
+        acc[quarter.period] = quarter.noticeAmount;
+      }
+      return acc;
+    }, {});
+
+    return {
+      quarters,
+      segments: this.buildSegments(quarters),
+      notices,
+    };
+  }
+}
+
+export const paygiStore = new PaygiStore();

--- a/src/paygi/types.ts
+++ b/src/paygi/types.ts
@@ -1,0 +1,85 @@
+export type PaygiMethod = "rate" | "amount";
+
+export interface QuarterRule {
+  year: string;
+  quarter: string;
+  instalment_rate: number;
+  gdp_uplift: number;
+  base_notice_amount?: number;
+  notes?: string;
+}
+
+export interface VariationReason {
+  code: string;
+  label: string;
+  predicate: string;
+  hint: string;
+}
+
+export interface VariationConfig {
+  reasons: VariationReason[];
+  safeHarbour: {
+    min_ratio: number;
+    max_reduction: number;
+    pass_reason: string;
+    fail_reason: string;
+    calculation_hint?: string;
+  };
+}
+
+export interface SafeHarbourOutcome {
+  passed: boolean;
+  ratio: number;
+  reduction: number;
+  minRatio: number;
+  maxReduction: number;
+  message: string;
+}
+
+export interface PaygiCalculationInput {
+  abn: string;
+  year: string;
+  quarter: string | number;
+  method: PaygiMethod;
+  incomeBase: number;
+  noticeAmount?: number;
+  variationAmount?: number;
+  reasonCode?: string;
+  notes?: string;
+}
+
+export interface PaygiQuarterResult {
+  period: string;
+  method: PaygiMethod;
+  t1: number;
+  t2: number;
+  t3: number;
+  t4: number;
+  baseT4: number;
+  instalmentRate: number;
+  gdpUplift: number;
+  noticeAmount?: number;
+  safeHarbour?: SafeHarbourOutcome;
+  evidence?: QuarterEvidence;
+}
+
+export interface QuarterEvidence {
+  reasonCode?: string;
+  reasonLabel?: string;
+  notes?: string;
+  hint?: string;
+}
+
+export interface PaygiSummary {
+  quarters: PaygiQuarterResult[];
+  segments: EvidenceSegment[];
+  notices: Record<string, number>;
+}
+
+export interface EvidenceSegment {
+  method: PaygiMethod;
+  from: string;
+  to: string;
+  quarters: string[];
+  evidence: QuarterEvidence[];
+}


### PR DESCRIPTION
## Summary
- add PAYGI rules with GDP uplift factors and variation configuration
- implement a PAYGI calculation engine, API endpoints, and evidence store with safe-harbour checks
- add a PAYGI planner UI that captures variation reasons and surfaces method segments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e375c4481483278e1776cbb39810dc