### PR TITLE
Implement configurable rounding order for GST and PAYGW

### DIFF
--- a/apps/services/tax-engine/app/rounding.py
+++ b/apps/services/tax-engine/app/rounding.py
@@ -1,0 +1,96 @@
+"""Rounding helpers driven by the declarative rules/rounding.yaml schema."""
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_EVEN, ROUND_HALF_UP
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+_DEFAULT_MODE = "HALF_UP"
+_DEFAULT_PRECISION = "nearest_cent"
+
+_PRECISION_QUANT = {
+    "nearest_cent": Decimal("0.01"),
+    "whole_dollar": Decimal("1")
+}
+
+_ROUNDING_MODES = {
+    "HALF_UP": ROUND_HALF_UP,
+    "HALF_EVEN": ROUND_HALF_EVEN,
+}
+
+_CONFIG_PATH = Path(__file__).with_name("rules") / "rounding.yaml"
+
+
+class RoundingConfigError(RuntimeError):
+    """Raised when the rounding configuration is invalid or missing data."""
+
+
+@lru_cache(maxsize=1)
+def _load_rounding_rules() -> Dict[str, Any]:
+    if not _CONFIG_PATH.exists():
+        raise RoundingConfigError(f"rounding.yaml not found at {_CONFIG_PATH}")
+    with _CONFIG_PATH.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise RoundingConfigError("rounding.yaml must define a mapping")
+    return data
+
+
+def _normalise_rule(rule: Dict[str, Any], method_defaults: Dict[str, Any], root_defaults: Dict[str, Any]) -> Dict[str, str]:
+    mode = rule.get("mode") or method_defaults.get("mode") or root_defaults.get("mode") or _DEFAULT_MODE
+    precision = rule.get("precision") or method_defaults.get("precision") or root_defaults.get("precision") or _DEFAULT_PRECISION
+    if precision not in _PRECISION_QUANT:
+        raise RoundingConfigError(f"Unsupported precision '{precision}' in rounding.yaml")
+    if mode not in _ROUNDING_MODES:
+        raise RoundingConfigError(f"Unsupported rounding mode '{mode}' in rounding.yaml")
+    return {"mode": mode, "precision": precision}
+
+
+def get_rounding_rule(method: str, stage: str, *, period: str | None = None) -> Dict[str, str]:
+    """Return the rounding rule for a method/stage/period triple.
+
+    The schema supports:
+      * global defaults (`defaults`)
+      * method-level defaults (`methods.<method>.*`)
+      * optional per-period overrides (`methods.<method>.periods.<period>`)
+    """
+
+    cfg = _load_rounding_rules()
+    defaults = cfg.get("defaults", {})
+    methods = cfg.get("methods")
+    if not isinstance(methods, dict):
+        raise RoundingConfigError("rounding.yaml must include a 'methods' mapping")
+
+    method_cfg = methods.get(method)
+    if not isinstance(method_cfg, dict):
+        raise RoundingConfigError(f"No rounding rules configured for method '{method}'")
+
+    method_defaults = {k: v for k, v in method_cfg.items() if isinstance(v, (str, int, float))}
+    # Stage overrides
+    if period:
+        periods = method_cfg.get("periods", {})
+        if isinstance(periods, dict):
+            period_cfg = periods.get(period)
+            if isinstance(period_cfg, dict) and stage in period_cfg:
+                rule = period_cfg[stage]
+                if not isinstance(rule, dict):
+                    raise RoundingConfigError(f"Rounding rule for method '{method}' period '{period}' stage '{stage}' must be a mapping")
+                return _normalise_rule(rule, method_defaults, defaults)
+
+    stage_cfg = method_cfg.get(stage)
+    if stage_cfg is None:
+        raise RoundingConfigError(f"No rounding rule for method '{method}' stage '{stage}'")
+    if not isinstance(stage_cfg, dict):
+        raise RoundingConfigError(f"Rounding rule for method '{method}' stage '{stage}' must be a mapping")
+    return _normalise_rule(stage_cfg, method_defaults, defaults)
+
+
+def round_currency(amount: Decimal, method: str, stage: str, *, period: str | None = None) -> Decimal:
+    """Quantize a Decimal amount according to the configured rounding rule."""
+    rule = get_rounding_rule(method, stage, period=period)
+    quant = _PRECISION_QUANT[rule["precision"]]
+    rounding_mode = _ROUNDING_MODES[rule["mode"]]
+    return amount.quantize(quant, rounding=rounding_mode)

--- a/apps/services/tax-engine/app/rules/rounding.yaml
+++ b/apps/services/tax-engine/app/rules/rounding.yaml
@@ -1,0 +1,29 @@
+# Declarative rounding configuration consumed by app.rounding.
+# Methods define their line-level rounding and the final aggregation/label step.
+# GST follows the ATO instruction: round each line to cents (HALF_UP) then
+# report BAS labels in whole dollars. PAYGW uses the table-specific rounding for
+# each pay period before rounding BAS labels.
+---
+defaults:
+  mode: HALF_UP
+  precision: nearest_cent
+
+methods:
+  gst:
+    line:
+      precision: nearest_cent
+    aggregate:
+      precision: whole_dollar
+
+  paygw_table:
+    line:
+      precision: nearest_cent
+    aggregate:
+      precision: whole_dollar
+    periods:
+      weekly:
+        line:
+          precision: nearest_cent
+      monthly:
+        line:
+          precision: whole_dollar

--- a/apps/services/tax-engine/app/tax_rules.py
+++ b/apps/services/tax-engine/app/tax_rules.py
@@ -1,23 +1,107 @@
-from typing import Literal
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Dict, Iterable, Literal, Mapping
 
-GST_RATE = 0.10
+from .rounding import round_currency
 
-def gst_line_tax(amount_cents: int, tax_code: Literal["GST","GST_FREE","EXEMPT","ZERO_RATED",""] = "GST") -> int:
+GST_RATE = Decimal("0.10")
+HUNDRED = Decimal(100)
+
+
+def _decimal_from_cents(amount_cents: int) -> Decimal:
+    return Decimal(int(amount_cents)) / HUNDRED
+
+
+def _decimal_to_cents(amount: Decimal) -> int:
+    return int((amount * HUNDRED).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def gst_line_tax(amount_cents: int, tax_code: Literal["GST", "GST_FREE", "EXEMPT", "ZERO_RATED", ""] = "GST") -> int:
+    """Calculate GST for a single line item using the configured rounding order."""
+
     if amount_cents <= 0:
         return 0
-    return round(amount_cents * GST_RATE) if (tax_code or "").upper() == "GST" else 0
+    if (tax_code or "").upper() != "GST":
+        return 0
 
-def paygw_weekly(gross_cents: int) -> int:
+    # Rounding order is configured in rules/rounding.yaml (line then aggregate).
+    taxable_amount = _decimal_from_cents(amount_cents)
+    line_tax = taxable_amount * GST_RATE
+    rounded = round_currency(line_tax, method="gst", stage="line")
+    return _decimal_to_cents(rounded)
+
+
+def gst_label_totals(lines: Iterable[Mapping[str, int | str]]) -> Dict[str, Dict[str, int]]:
+    """Aggregate GST line results into BAS labels respecting the documented rounding order.
+
+    Each line should provide ``amount_cents`` (GST-exclusive) and optionally a
+    ``tax_code`` (defaults to ``GST``) and ``label`` (defaults to ``1A`` for GST).
+    The result contains the accumulated cents (line-level rounding) and the final
+    whole-dollar amount submitted on the BAS label.
     """
-    Progressive toy scale used by tests:
-      - 15% up to 80,000?
-      - 20% on the portion above 80,000?
-    """
+
+    totals: Dict[str, Dict[str, int]] = {}
+    for line in lines:
+        amount_cents = int(line.get("amount_cents", 0))
+        tax_code = str(line.get("tax_code", "GST") or "GST")
+        label = line.get("label")
+        if (tax_code or "").upper() != "GST":
+            continue
+        label = label or "1A"
+        tax_cents = gst_line_tax(amount_cents, tax_code)
+        if tax_cents == 0:
+            continue
+        bucket = totals.setdefault(label, {"cents": 0, "label": 0})
+        bucket["cents"] += tax_cents
+
+    for label, bucket in totals.items():
+        cents = bucket["cents"]
+        dollars = round_currency(_decimal_from_cents(cents), method="gst", stage="aggregate")
+        bucket["label"] = int(dollars.to_integral_value(rounding=ROUND_HALF_UP))
+
+    return totals
+
+
+_PERIOD_PARAMS: Dict[str, Dict[str, Decimal]] = {
+    "weekly": {"bracket": Decimal("800.00"), "base_rate": Decimal("0.15"), "excess_rate": Decimal("0.20")},
+    "monthly": {"bracket": Decimal("3466.67"), "base_rate": Decimal("0.15"), "excess_rate": Decimal("0.20")},
+}
+
+
+def paygw_table_withholding(gross_cents: int, period: str = "weekly") -> int:
+    """Toy progressive schedule with configurable rounding per pay period."""
+
     if gross_cents <= 0:
         return 0
-    bracket = 80_000
-    if gross_cents <= bracket:
-        return round(gross_cents * 0.15)
-    base = round(bracket * 0.15)
-    excess = gross_cents - bracket
-    return base + round(excess * 0.20)
+
+    params = _PERIOD_PARAMS.get(period, _PERIOD_PARAMS["weekly"])
+    gross = _decimal_from_cents(gross_cents)
+    bracket = params["bracket"]
+    base_rate = params["base_rate"]
+    excess_rate = params["excess_rate"]
+
+    if gross <= bracket:
+        withholding = gross * base_rate
+    else:
+        base = bracket * base_rate
+        excess = gross - bracket
+        withholding = base + excess * excess_rate
+
+    rounded = round_currency(withholding, method="paygw_table", stage="line", period=period)
+    return _decimal_to_cents(rounded)
+
+
+def paygw_label_totals(withholding_cents: Iterable[int], period: str = "weekly") -> Dict[str, int]:
+    """Aggregate PAYGW withholding amounts and round to BAS whole dollars."""
+
+    total_cents = sum(int(v) for v in withholding_cents)
+    dollars = round_currency(_decimal_from_cents(total_cents), method="paygw_table", stage="aggregate", period=period)
+    return {
+        "cents": total_cents,
+        "label": int(dollars.to_integral_value(rounding=ROUND_HALF_UP)),
+    }
+
+
+def paygw_weekly(gross_cents: int) -> int:
+    """Compatibility wrapper used by legacy tests."""
+
+    return paygw_table_withholding(gross_cents, period="weekly")

--- a/apps/services/tax-engine/app/templates/help.html
+++ b/apps/services/tax-engine/app/templates/help.html
@@ -9,5 +9,12 @@
   <li><b>Bonus (marginal)</b>: withhold bonus at marginal rate on top of regular.</li>
   <li><b>Net â†’ Gross</b>: solve gross to hit a target net using selected formula.</li>
 </ul>
+<h3>ATO rounding order</h3>
+<p>
+  Rounding rules live in <code>rules/rounding.yaml</code>. GST is rounded at the line
+  level to the nearest cent (HALF_UP) before totals are rounded to whole dollars
+  for BAS labels. PAYGW uses the per-period table rounding (weekly stays at cents,
+  monthly rounds to whole dollars) before labels are rounded to whole dollars.
+</p>
 <p><i>Disclaimer:</i> demo UI; not legal or tax advice. Validate against ATO examples before production.</p>
 {% endblock %}

--- a/apps/services/tax-engine/pyproject.toml
+++ b/apps/services/tax-engine/pyproject.toml
@@ -16,6 +16,7 @@ alembic = "^1.13.3"
 nats-py = "^2.11.0"
 prometheus-client = "^0.21.0"
 orjson = "^3.10.7"
+pyyaml = "^6.0.2"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.3"

--- a/apps/services/tax-engine/requirements.txt
+++ b/apps/services/tax-engine/requirements.txt
@@ -7,3 +7,4 @@ httpx
 orjson
 
 nats-py
+PyYAML

--- a/apps/services/tax-engine/tests/test_tax_rules.py
+++ b/apps/services/tax-engine/tests/test_tax_rules.py
@@ -1,7 +1,59 @@
-﻿from app.tax_rules import gst_line_tax, paygw_weekly
-def test_gst_line_tax():
-    assert gst_line_tax(10000,'GST')==1000
-    assert gst_line_tax(10000,'GST_FREE')==0
-def test_paygw_weekly():
-    assert paygw_weekly(50000)==7500
-    assert paygw_weekly(100000)>15000
+from app.tax_rules import (
+    gst_label_totals,
+    gst_line_tax,
+    paygw_label_totals,
+    paygw_table_withholding,
+    paygw_weekly,
+)
+
+
+def test_gst_line_tax_half_up():
+    assert gst_line_tax(10000, "GST") == 1000
+    assert gst_line_tax(5, "GST") == 1  # 0.5 cent -> rounds up to 1 cent
+    assert gst_line_tax(4, "GST") == 0  # 0.4 cent -> stays at 0
+    assert gst_line_tax(10000, "GST_FREE") == 0
+
+
+def test_gst_cash_vs_accrual_rounding_difference():
+    accrual_lines = [{"amount_cents": 5, "tax_code": "GST"} for _ in range(50)]
+    cash_lines = []
+    for _ in range(50):
+        cash_lines.append({"amount_cents": 3, "tax_code": "GST"})
+        cash_lines.append({"amount_cents": 2, "tax_code": "GST"})
+
+    accrual_totals = gst_label_totals(accrual_lines)["1A"]
+    cash_totals = gst_label_totals(cash_lines).get("1A", {"cents": 0, "label": 0})
+
+    assert accrual_totals["cents"] == 50
+    assert accrual_totals["label"] == 1
+    assert cash_totals["cents"] == 0
+    assert cash_totals["label"] == 0
+
+
+def test_gst_label_whole_dollar_rounding_boundary():
+    below = gst_label_totals([{"amount_cents": 5, "tax_code": "GST"} for _ in range(49)])["1A"]
+    above = gst_label_totals([{"amount_cents": 5, "tax_code": "GST"} for _ in range(50)])["1A"]
+
+    assert below["cents"] == 49
+    assert below["label"] == 0
+    assert above["cents"] == 50
+    assert above["label"] == 1
+
+
+def test_paygw_weekly_rounding_boundary():
+    assert paygw_weekly(5) == 1
+    assert paygw_weekly(3) == 0
+
+
+def test_paygw_period_specific_rounding():
+    weekly = paygw_weekly(12345)
+    monthly = paygw_table_withholding(12345, period="monthly")
+    assert weekly % 100 != 0  # cents precision per rounding spec
+    assert monthly % 100 == 0  # whole dollars per monthly rounding rule
+
+
+def test_paygw_label_rounding_to_whole_dollar():
+    weekly_withholding = [paygw_weekly(5) for _ in range(50)]
+    label = paygw_label_totals(weekly_withholding)
+    assert label["cents"] == 50
+    assert label["label"] == 1


### PR DESCRIPTION
## Summary
- add a declarative rounding schema and helper so GST and PAYGW use explicit line vs aggregate rules
- update GST and PAYGW calculations to honour the configured rounding order and provide BAS label aggregations
- document the rounding flow in the help UI and expand rounding-focused tests for GST and PAYGW

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e375faf2d88327aca897ee5399c202