### PR TITLE
Add STP to BAS reconciliation pipeline and evidence outputs

### DIFF
--- a/apps/services/tax-engine/app/domains/stp2_map.json
+++ b/apps/services/tax-engine/app/domains/stp2_map.json
@@ -1,0 +1,28 @@
+{
+  "REG": {
+    "description": "Ordinary time earnings",
+    "bas": { "W1": "gross", "W2": "withheld" },
+    "special_tags": []
+  },
+  "ALLOWANCE": {
+    "description": "Taxable allowance",
+    "bas": { "W1": "gross", "W2": "withheld" },
+    "special_tags": []
+  },
+  "BACKPAY": {
+    "description": "Back payments reported through STP",
+    "bas": { "W1": "gross", "W2": "withheld" },
+    "special_tags": ["back_payments"]
+  },
+  "ETP-R": {
+    "description": "Employment termination payment (type R)",
+    "bas": { "W1": null, "W2": "withheld" },
+    "special_tags": ["etp"]
+  },
+  "ETP-O": {
+    "description": "Employment termination payment (type O)",
+    "bas": { "W1": null, "W2": "withheld" },
+    "special_tags": ["etp"]
+  }
+}
+

--- a/apps/services/tax-engine/app/domains/stp_bas.py
+++ b/apps/services/tax-engine/app/domains/stp_bas.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+__all__ = [
+    "STPEvent",
+    "ReconciliationError",
+    "load_stp_map",
+    "rollup_stp_to_bas",
+]
+
+@dataclass(frozen=True)
+class STPEvent:
+    """Simple representation of an STP pay event."""
+
+    stp_event_id: str
+    employee_id: str
+    earnings_code: str
+    gross_cents: int
+    tax_withheld_cents: int
+
+    @classmethod
+    def from_raw(cls, raw: Mapping[str, Any]) -> "STPEvent":
+        missing = [k for k in ("stp_event_id", "employee_id", "earnings_code") if not raw.get(k)]
+        if missing:
+            raise ValueError(f"STP event missing required fields: {', '.join(missing)}")
+        gross = int(raw.get("gross_cents", 0) or 0)
+        withheld = int(raw.get("tax_withheld_cents", 0) or 0)
+        return cls(
+            stp_event_id=str(raw["stp_event_id"]),
+            employee_id=str(raw["employee_id"]),
+            earnings_code=str(raw["earnings_code"]).upper(),
+            gross_cents=gross,
+            tax_withheld_cents=withheld,
+        )
+
+class ReconciliationError(ValueError):
+    """Raised when STP totals do not reconcile to BAS outputs."""
+
+    def __init__(self, message: str, reconciliation: Mapping[str, Any]):
+        super().__init__(message)
+        self.reconciliation: Mapping[str, Any] = reconciliation
+
+_STP_MAP: Dict[str, Dict[str, Any]] = {}
+
+def load_stp_map(path: Optional[Path] = None) -> Dict[str, Dict[str, Any]]:
+    """Load and normalise the STP earnings-code mapping."""
+
+    target = path or Path(__file__).with_name("stp2_map.json")
+    data = json.loads(target.read_text(encoding="utf-8"))
+    mapping: Dict[str, Dict[str, Any]] = {}
+
+    for code, entry in data.items():
+        norm_code = str(code).upper()
+        bas = entry.get("bas", {}) if isinstance(entry, Mapping) else {}
+        mapping[norm_code] = {
+            "description": entry.get("description", ""),
+            "bas": {
+                "W1": _normalise_source(bas.get("W1")),
+                "W2": _normalise_source(bas.get("W2")),
+            },
+            "special_tags": _normalise_tags(entry.get("special_tags", [])),
+        }
+    return mapping
+
+def _normalise_source(value: Any) -> Any:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        key = value.strip().lower()
+        if key in {"gross", "salary", "earnings"}:
+            return "gross"
+        if key in {"withheld", "tax", "w2", "tax_withheld"}:
+            return "withheld"
+        if key in {"none", "exclude", "skip", "0"}:
+            return None
+    raise ValueError(f"Unsupported mapping source: {value!r}")
+
+def _normalise_tags(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [raw]
+    if isinstance(raw, Iterable):
+        return [str(tag) for tag in raw if str(tag)]
+    return []
+
+def _ensure_map() -> Dict[str, Dict[str, Any]]:
+    global _STP_MAP
+    if not _STP_MAP:
+        _STP_MAP = load_stp_map()
+    return _STP_MAP
+
+def _amount_for_label(event: STPEvent, source: Any) -> int:
+    if source is None:
+        return 0
+    if source == "gross":
+        return event.gross_cents
+    if source == "withheld":
+        return event.tax_withheld_cents
+    if isinstance(source, (int, float)):
+        return int(round(event.gross_cents * float(source)))
+    raise ValueError(f"Unsupported BAS mapping source {source!r}")
+
+def rollup_stp_to_bas(
+    events: Sequence[Mapping[str, Any]] | Sequence[STPEvent],
+    bas_totals: Optional[Mapping[str, Any]] = None,
+    *,
+    mapping: Optional[Dict[str, Dict[str, Any]]] = None,
+    validate: bool = True,
+) -> Dict[str, Any]:
+    """Aggregate STP events into BAS label totals with traceability."""
+
+    stp_map = mapping or _ensure_map()
+    bas_labels: Dict[str, MutableMapping[str, Any]] = {
+        "W1": {"total_cents": 0, "events": []},
+        "W2": {"total_cents": 0, "events": []},
+    }
+    recon_inputs: List[Dict[str, Any]] = []
+    special_events: Dict[str, List[Dict[str, Any]]] = {}
+
+    for raw in events:
+        event = raw if isinstance(raw, STPEvent) else STPEvent.from_raw(raw)
+        code_info = stp_map.get(event.earnings_code)
+        if not code_info:
+            raise KeyError(f"Unknown earnings code: {event.earnings_code}")
+
+        base = {
+            "stp_event_id": event.stp_event_id,
+            "employee_id": event.employee_id,
+            "earnings_code": event.earnings_code,
+        }
+
+        w1_amount = _amount_for_label(event, code_info["bas"].get("W1"))
+        w2_amount = _amount_for_label(event, code_info["bas"].get("W2"))
+
+        if w1_amount:
+            bas_labels["W1"]["total_cents"] += w1_amount
+            bas_labels["W1"]["events"].append({**base, "amount_cents": w1_amount, "source": "gross"})
+        if w2_amount:
+            bas_labels["W2"]["total_cents"] += w2_amount
+            bas_labels["W2"]["events"].append({**base, "amount_cents": w2_amount, "source": "withheld"})
+
+        tags = code_info.get("special_tags", []) or []
+        for tag in tags:
+            special_events.setdefault(tag, []).append(base)
+
+        recon_inputs.append({**base, "w1_cents": w1_amount, "w2_cents": w2_amount, "special_tags": list(tags)})
+
+    for label in ("W1", "W2"):
+        events_for_label = bas_labels[label].get("events", [])
+        bas_labels[label]["stp_event_ids"] = [evt["stp_event_id"] for evt in events_for_label]
+
+    reconciliation: Optional[Dict[str, Any]] = None
+    if bas_totals is not None:
+        reconciliation = {}
+        ok = True
+        for label in ("W1", "W2"):
+            expected = int(bas_totals.get(label, 0) or 0)
+            actual = int(bas_labels[label]["total_cents"])
+            diff = actual - expected
+            reconciliation[label] = {
+                "expected_cents": expected,
+                "actual_cents": actual,
+                "difference_cents": diff,
+            }
+            if diff != 0:
+                ok = False
+        reconciliation["ok"] = ok
+        if validate and not ok:
+            raise ReconciliationError("STP totals do not reconcile with BAS outputs", reconciliation)
+
+    result: Dict[str, Any] = {
+        "bas_labels": bas_labels,
+        "recon_inputs": recon_inputs,
+        "special_events": special_events,
+    }
+    if reconciliation is not None:
+        result["reconciliation"] = reconciliation
+    return result
+

--- a/apps/services/tax-engine/tests/test_stp_bas.py
+++ b/apps/services/tax-engine/tests/test_stp_bas.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domains.stp_bas import ReconciliationError, STPEvent, rollup_stp_to_bas
+
+
+def sample_events():
+    return [
+        {
+            "stp_event_id": "EVT-001",
+            "employee_id": "EMP-001",
+            "earnings_code": "REG",
+            "gross_cents": 1_500_00,
+            "tax_withheld_cents": 450_00,
+        },
+        {
+            "stp_event_id": "EVT-002",
+            "employee_id": "EMP-001",
+            "earnings_code": "BACKPAY",
+            "gross_cents": 200_00,
+            "tax_withheld_cents": 60_00,
+        },
+        {
+            "stp_event_id": "EVT-003",
+            "employee_id": "EMP-002",
+            "earnings_code": "ALLOWANCE",
+            "gross_cents": 50_00,
+            "tax_withheld_cents": 10_00,
+        },
+        {
+            "stp_event_id": "EVT-004",
+            "employee_id": "EMP-003",
+            "earnings_code": "ETP-R",
+            "gross_cents": 1_200_00,
+            "tax_withheld_cents": 180_00,
+        },
+    ]
+
+
+def test_rollup_generates_totals_and_traceability():
+    expected_bas = {"W1": 1_750_00, "W2": 700_00}
+    result = rollup_stp_to_bas(sample_events(), expected_bas)
+
+    w1 = result["bas_labels"]["W1"]
+    w2 = result["bas_labels"]["W2"]
+
+    assert w1["total_cents"] == 1_750_00
+    assert w1["stp_event_ids"] == ["EVT-001", "EVT-002", "EVT-003"]
+    assert {evt["earnings_code"] for evt in w1["events"]} == {"REG", "BACKPAY", "ALLOWANCE"}
+
+    assert w2["total_cents"] == 700_00
+    assert w2["stp_event_ids"] == ["EVT-001", "EVT-002", "EVT-003", "EVT-004"]
+
+    assert result["special_events"]["back_payments"][0]["stp_event_id"] == "EVT-002"
+    assert result["special_events"]["etp"][0]["stp_event_id"] == "EVT-004"
+
+    recon_row = result["recon_inputs"][0]
+    assert recon_row == {
+        "stp_event_id": "EVT-001",
+        "employee_id": "EMP-001",
+        "earnings_code": "REG",
+        "w1_cents": 1_500_00,
+        "w2_cents": 450_00,
+        "special_tags": [],
+    }
+
+    assert result["reconciliation"]["ok"] is True
+
+
+def test_rollup_detects_mismatch():
+    with pytest.raises(ReconciliationError) as exc:
+        rollup_stp_to_bas(sample_events(), {"W1": 1})
+    assert exc.value.reconciliation["W1"]["difference_cents"] == 1_750_00 - 1
+
+
+def test_stp_event_from_raw_normalises_codes():
+    ev = STPEvent.from_raw(
+        {
+            "stp_event_id": "id",
+            "employee_id": "emp",
+            "earnings_code": "reg",
+            "gross_cents": "100",
+            "tax_withheld_cents": "10",
+        }
+    )
+    assert ev.earnings_code == "REG"
+    assert ev.gross_cents == 100
+    assert ev.tax_withheld_cents == 10
+

--- a/export_evidence.js
+++ b/export_evidence.js
@@ -4,6 +4,24 @@ const { Client } = require('pg');
 const fs = require('fs');
 const path = require('path');
 
+const parsePgTextArray = (raw) => {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map(String);
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    const withoutBraces = trimmed.startsWith('{') && trimmed.endsWith('}')
+      ? trimmed.slice(1, -1)
+      : trimmed;
+    if (!withoutBraces) return [];
+    return withoutBraces
+      .split(',')
+      .map(part => part.trim().replace(/^"(.*)"$/, '$1'))
+      .filter(Boolean);
+  }
+  return [];
+};
+
 async function main() {
   const {
     PGHOST='127.0.0.1', PGUSER='apgms', PGPASSWORD='apgms_pw', PGDATABASE='apgms', PGPORT='5432'
@@ -33,8 +51,70 @@ async function main() {
     [abn, taxType, periodId]
   )).rows;
 
-  // You’d normally compute BAS labels from your tax engine; placeholders here
-  const basLabels = { W1: null, W2: null, "1A": null, "1B": null };
+  let reconRows = [];
+  try {
+    const reconRes = await client.query(
+      "select stp_event_id, employee_id, earnings_code, coalesce(w1_cents,0)::bigint as w1_cents, coalesce(w2_cents,0)::bigint as w2_cents, coalesce(special_tags,'{}') as special_tags from recon_inputs where abn=$1 and tax_type=$2 and period_id=$3 order by stp_event_id",
+      [abn, taxType, periodId]
+    );
+    reconRows = reconRes.rows;
+  } catch (err) {
+    if (!(err && err.code === '42P01')) throw err;
+  }
+
+  const reconInputs = reconRows.map(row => {
+    const w1 = Number(row.w1_cents ?? 0);
+    const w2 = Number(row.w2_cents ?? 0);
+    return {
+      stp_event_id: row.stp_event_id,
+      employee_id: row.employee_id,
+      earnings_code: row.earnings_code,
+      w1_cents: w1,
+      w2_cents: w2,
+      special_tags: parsePgTextArray(row.special_tags),
+    };
+  });
+
+  const toEvent = (entry, key) => {
+    const amt = entry[key];
+    if (!amt) return null;
+    return {
+      stp_event_id: entry.stp_event_id,
+      employee_id: entry.employee_id,
+      earnings_code: entry.earnings_code,
+      amount_cents: amt,
+    };
+  };
+
+  const w1Events = reconInputs.map(entry => toEvent(entry, 'w1_cents')).filter(Boolean);
+  const w2Events = reconInputs.map(entry => toEvent(entry, 'w2_cents')).filter(Boolean);
+
+  const basLabels = {
+    W1: {
+      total_cents: w1Events.reduce((sum, evt) => sum + Number(evt.amount_cents), 0),
+      events: w1Events,
+      stp_event_ids: w1Events.map(evt => evt.stp_event_id),
+    },
+    W2: {
+      total_cents: w2Events.reduce((sum, evt) => sum + Number(evt.amount_cents), 0),
+      events: w2Events,
+      stp_event_ids: w2Events.map(evt => evt.stp_event_id),
+    },
+    "1A": null,
+    "1B": null,
+  };
+
+  const specialEvents = {};
+  for (const entry of reconInputs) {
+    for (const tag of entry.special_tags) {
+      if (!specialEvents[tag]) specialEvents[tag] = [];
+      specialEvents[tag].push({
+        stp_event_id: entry.stp_event_id,
+        employee_id: entry.employee_id,
+        earnings_code: entry.earnings_code,
+      });
+    }
+  }
 
   const bundle = {
     meta: { generated_at: new Date().toISOString(), abn, taxType, periodId },
@@ -51,6 +131,8 @@ async function main() {
     rpt: rpt ? { payload: rpt.payload, signature: rpt.signature, created_at: rpt.created_at } : null,
     owa_ledger: ledger,
     bas_labels: basLabels,
+    special_events: specialEvents,
+    stp_recon_inputs: reconInputs,
     discrepancy_log: [] // fill with your recon diffs when you build them
   };
 
@@ -62,3 +144,4 @@ async function main() {
 }
 
 main().catch(e => { console.error(e); process.exit(1); });
+

--- a/migrations/003_stp_recon.sql
+++ b/migrations/003_stp_recon.sql
@@ -1,0 +1,19 @@
+-- 003_stp_recon.sql
+
+CREATE TABLE IF NOT EXISTS recon_inputs (
+  id            bigserial PRIMARY KEY,
+  abn           text NOT NULL,
+  tax_type      text NOT NULL,
+  period_id     text NOT NULL,
+  stp_event_id  text NOT NULL,
+  employee_id   text NOT NULL,
+  earnings_code text NOT NULL,
+  w1_cents      bigint NOT NULL DEFAULT 0,
+  w2_cents      bigint NOT NULL DEFAULT 0,
+  special_tags  text[] NOT NULL DEFAULT '{}'::text[],
+  created_at    timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS recon_inputs_period_idx
+  ON recon_inputs (abn, tax_type, period_id, stp_event_id);
+

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,106 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 const pool = new Pool();
+
+const parseTags = (raw: unknown): string[] => {
+  if (!raw) return [];
+  if (Array.isArray(raw)) return raw.map((tag) => String(tag));
+  if (typeof raw === "string") {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    const withoutBraces = trimmed.startsWith("{") && trimmed.endsWith("}")
+      ? trimmed.slice(1, -1)
+      : trimmed;
+    if (!withoutBraces) return [];
+    return withoutBraces
+      .split(",")
+      .map((part) => part.trim().replace(/^"(.*)"$/, "$1"))
+      .filter(Boolean);
+  }
+  return [];
+};
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
   const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
   const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
   const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const last = deltas[deltas.length - 1];
+
+  let reconRows: any[] = [];
+  try {
+    const res = await pool.query(
+      "select stp_event_id, employee_id, earnings_code, coalesce(w1_cents,0)::bigint as w1_cents, coalesce(w2_cents,0)::bigint as w2_cents, coalesce(special_tags,'{}') as special_tags from recon_inputs where abn=$1 and tax_type=$2 and period_id=$3 order by stp_event_id",
+      [abn, taxType, periodId]
+    );
+    reconRows = res.rows;
+  } catch (err: any) {
+    if (err?.code !== "42P01") throw err;
+  }
+
+  const reconInputs = reconRows.map((row) => {
+    const w1 = Number(row.w1_cents ?? 0);
+    const w2 = Number(row.w2_cents ?? 0);
+    const tags = parseTags(row.special_tags);
+    return {
+      stp_event_id: row.stp_event_id,
+      employee_id: row.employee_id,
+      earnings_code: row.earnings_code,
+      w1_cents: w1,
+      w2_cents: w2,
+      special_tags: tags,
+    };
+  });
+
+  const toEvent = (entry: typeof reconInputs[number], amountKey: "w1_cents" | "w2_cents") => {
+    const amount = entry[amountKey];
+    if (!amount) return null;
+    return {
+      stp_event_id: entry.stp_event_id,
+      employee_id: entry.employee_id,
+      earnings_code: entry.earnings_code,
+      amount_cents: amount,
+    };
+  };
+
+  const w1Events = reconInputs.map((entry) => toEvent(entry, "w1_cents")).filter(Boolean) as Array<{ stp_event_id: string; employee_id: string; earnings_code: string; amount_cents: number }>;
+  const w2Events = reconInputs.map((entry) => toEvent(entry, "w2_cents")).filter(Boolean) as Array<{ stp_event_id: string; employee_id: string; earnings_code: string; amount_cents: number }>;
+
+  const basLabels = {
+    W1: {
+      total_cents: w1Events.reduce((sum, evt) => sum + evt.amount_cents, 0),
+      events: w1Events,
+      stp_event_ids: w1Events.map((evt) => evt.stp_event_id),
+    },
+    W2: {
+      total_cents: w2Events.reduce((sum, evt) => sum + evt.amount_cents, 0),
+      events: w2Events,
+      stp_event_ids: w2Events.map((evt) => evt.stp_event_id),
+    },
+    "1A": null,
+    "1B": null,
+  } as const;
+
+  const specialEvents: Record<string, Array<{ stp_event_id: string; employee_id: string; earnings_code: string }>> = {};
+  reconInputs.forEach((entry) => {
+    entry.special_tags.forEach((tag) => {
+      if (!specialEvents[tag]) specialEvents[tag] = [];
+      specialEvents[tag].push({
+        stp_event_id: entry.stp_event_id,
+        employee_id: entry.employee_id,
+        earnings_code: entry.earnings_code,
+      });
+    });
+  });
+
   const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
+    bas_labels: basLabels,
     rpt_payload: rpt?.payload ?? null,
     rpt_signature: rpt?.signature ?? null,
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [],
+    stp_recon_inputs: reconInputs,
+    special_events: specialEvents,
   };
   return bundle;
 }


### PR DESCRIPTION
## Summary
- add an STP earnings-code mapping and rollup helper so the tax engine can validate BAS label totals while producing recon inputs
- store STP contributions for each period and expose their totals plus traceability in the API evidence and CLI export bundles
- add a database migration and regression tests covering the STP-to-BAS aggregation flow

## Testing
- pytest apps/services/tax-engine/tests

------
https://chatgpt.com/codex/tasks/task_e_68e376058b1c8327a0b34d40cbcc0c3f