### PR TITLE
Add tax regime goldens and drift detection

### DIFF
--- a/apps/services/tax-engine/app/rules/checksums.json
+++ b/apps/services/tax-engine/app/rules/checksums.json
@@ -1,0 +1,7 @@
+{
+  "payg_w_2024_25.json": {
+    "version": "2024-25",
+    "sha256": "d3655202868bfa4d56ca1eebfc590808aca60c4cbd7162881d1ab12cd720f53b",
+    "source": "https://www.ato.gov.au/Individuals/Tax-file-number/TFN-declaration-and-PAYG-withholding-schedules"
+  }
+}

--- a/apps/services/tax-engine/app/tax_rules.py
+++ b/apps/services/tax-engine/app/tax_rules.py
@@ -1,18 +1,71 @@
-from typing import Literal
+from __future__ import annotations
 
-GST_RATE = 0.10
+from decimal import Decimal, ROUND_HALF_UP
+from pathlib import Path
+from typing import Dict, Literal, Sequence
 
-def gst_line_tax(amount_cents: int, tax_code: Literal["GST","GST_FREE","EXEMPT","ZERO_RATED",""] = "GST") -> int:
+
+CENT = Decimal("0.01")
+HUNDRED = Decimal(100)
+
+GST_RATE = Decimal("0.10")
+SG_RATE_2024_25 = Decimal("0.115")
+SG_QUARTERLY_MAX_BASE_CENTS = 62_270 * 100
+FBT_RATE = Decimal("0.47")
+FBT_GROSS_UP_FACTORS: Dict[str, Decimal] = {
+    "type1": Decimal("2.0802"),
+    "type2": Decimal("1.8868"),
+}
+PAYROLL_TAX_DEFAULTS: Dict[str, Dict[str, Decimal | int]] = {
+    "NSW": {
+        "threshold_cents": 1_200_000 * 100,
+        "rate": Decimal("0.0545"),
+    }
+}
+
+RULES_DIR = Path(__file__).resolve().parent / "rules"
+
+
+def _decimal_to_cents(amount: Decimal) -> int:
+    quantized = amount.quantize(CENT, rounding=ROUND_HALF_UP)
+    return int((quantized * HUNDRED).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _cents_to_decimal(cents: int) -> Decimal:
+    return (Decimal(int(cents)) / HUNDRED).quantize(CENT)
+
+
+def gst_line_tax(
+    amount_cents: int,
+    tax_code: Literal["GST", "GST_FREE", "EXEMPT", "ZERO_RATED", ""] = "GST",
+) -> int:
     if amount_cents <= 0:
         return 0
-    return round(amount_cents * GST_RATE) if (tax_code or "").upper() == "GST" else 0
+    if (tax_code or "").upper() != "GST":
+        return 0
+    taxable_dollars = _cents_to_decimal(amount_cents)
+    tax = taxable_dollars * GST_RATE
+    return _decimal_to_cents(tax)
+
+
+def gst_invoice_totals(lines: Sequence[Dict[str, int | str]]) -> Dict[str, int]:
+    net_cents = 0
+    tax_cents = 0
+    for line in lines:
+        amount = int(line.get("amount_cents", 0))
+        tax_code = str(line.get("tax_code", "GST"))
+        net_cents += amount
+        tax_cents += gst_line_tax(amount, tax_code)
+    gross_cents = net_cents + tax_cents
+    return {
+        "net_cents": net_cents,
+        "tax_cents": tax_cents,
+        "gross_cents": gross_cents,
+    }
+
 
 def paygw_weekly(gross_cents: int) -> int:
-    """
-    Progressive toy scale used by tests:
-      - 15% up to 80,000?
-      - 20% on the portion above 80,000?
-    """
+    """Toy PAYGW example retained for legacy unit tests."""
     if gross_cents <= 0:
         return 0
     bracket = 80_000
@@ -21,3 +74,72 @@ def paygw_weekly(gross_cents: int) -> int:
     base = round(bracket * 0.15)
     excess = gross_cents - bracket
     return base + round(excess * 0.20)
+
+
+def paygi_instalment(
+    instalment_income_cents: int,
+    rate: float,
+    *,
+    credits_cents: int = 0,
+    adjustments_cents: int = 0,
+) -> int:
+    income = _cents_to_decimal(instalment_income_cents)
+    credits = _cents_to_decimal(credits_cents)
+    adjustments = _cents_to_decimal(adjustments_cents)
+    base = income * Decimal(str(rate))
+    liability = base - credits + adjustments
+    if liability <= 0:
+        return 0
+    return _decimal_to_cents(liability)
+
+
+def sg_quarterly_obligation(
+    ordinary_time_earnings_cents: int,
+    *,
+    rate: float | Decimal = SG_RATE_2024_25,
+    quarterly_cap_cents: int = SG_QUARTERLY_MAX_BASE_CENTS,
+) -> int:
+    capped_earnings = min(int(ordinary_time_earnings_cents), int(quarterly_cap_cents))
+    base = _cents_to_decimal(capped_earnings)
+    contribution = base * Decimal(str(rate))
+    if contribution <= 0:
+        return 0
+    return _decimal_to_cents(contribution)
+
+
+def fbt_liability(
+    taxable_value_cents: int,
+    *,
+    benefits_type: str = "type1",
+    rate: float | Decimal = FBT_RATE,
+) -> int:
+    gross_up = FBT_GROSS_UP_FACTORS.get(benefits_type.lower()) or FBT_GROSS_UP_FACTORS.get(benefits_type.upper())
+    if gross_up is None:
+        raise ValueError(f"Unknown FBT benefits_type '{benefits_type}'")
+    taxable_value = _cents_to_decimal(taxable_value_cents)
+    grossed_up = taxable_value * gross_up
+    liability = grossed_up * Decimal(str(rate))
+    if liability <= 0:
+        return 0
+    return _decimal_to_cents(liability)
+
+
+def payroll_tax_liability(
+    annual_wages_cents: int,
+    *,
+    state: str = "NSW",
+    threshold_cents: int | None = None,
+    rate: float | Decimal | None = None,
+) -> int:
+    defaults = PAYROLL_TAX_DEFAULTS.get(state.upper(), PAYROLL_TAX_DEFAULTS["NSW"])
+    threshold = int(threshold_cents if threshold_cents is not None else defaults["threshold_cents"])
+    effective_rate = Decimal(str(rate)) if rate is not None else Decimal(str(defaults["rate"]))
+    excess = max(0, int(annual_wages_cents) - threshold)
+    if excess <= 0:
+        return 0
+    liability = _cents_to_decimal(excess) * effective_rate
+    return _decimal_to_cents(liability)
+
+
+def rules_path(filename: str) -> Path:
+    return RULES_DIR / filename

--- a/apps/services/tax-engine/scripts/check_rules_drift.py
+++ b/apps/services/tax-engine/scripts/check_rules_drift.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check ATO rule payloads for drift relative to authoritative checksums."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, Tuple
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_RULES_DIR = HERE.parent / "app" / "rules"
+DEFAULT_CHECKSUMS_FILE = DEFAULT_RULES_DIR / "checksums.json"
+
+
+def _load_json(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _load_rule_json(path: Path) -> Dict[str, object]:
+    with path.open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _load_authoritative(args: argparse.Namespace) -> Dict[str, Dict[str, object]]:
+    if args.authoritative_file:
+        return _load_json(Path(args.authoritative_file))
+    if args.authoritative_url:
+        try:
+            import httpx  # type: ignore
+        except Exception as exc:  # pragma: no cover - optional dependency
+            raise SystemExit(f"httpx is required to fetch {args.authoritative_url}: {exc}") from exc
+        resp = httpx.get(args.authoritative_url, timeout=30)
+        resp.raise_for_status()
+        return resp.json()
+    return _load_json(args.checksums)
+
+
+def check_rules(
+    rules_dir: Path,
+    authoritative: Dict[str, Dict[str, object]],
+) -> Tuple[bool, str]:
+    failures: list[str] = []
+    for filename, meta in sorted(authoritative.items()):
+        rule_path = rules_dir / filename
+        if not rule_path.exists():
+            failures.append(f"Missing rule file: {filename}")
+            continue
+        expected_sha = str(meta.get("sha256", ""))
+        computed_sha = _file_sha256(rule_path)
+        data = _load_rule_json(rule_path)
+        local_version = str(data.get("version", ""))
+        expected_version = str(meta.get("version", ""))
+        if expected_version and local_version != expected_version:
+            failures.append(
+                f"{filename}: version mismatch (expected {expected_version}, found {local_version})"
+            )
+        if expected_sha and computed_sha != expected_sha:
+            failures.append(
+                f"{filename}: sha256 drift (expected {expected_sha}, found {computed_sha})"
+            )
+    ok = not failures
+    message = "\n".join(failures) if failures else "All rule checksums match authoritative sources."
+    return ok, message
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rules-dir", type=Path, default=DEFAULT_RULES_DIR)
+    parser.add_argument("--checksums", type=Path, default=DEFAULT_CHECKSUMS_FILE)
+    parser.add_argument("--authoritative-file", type=Path)
+    parser.add_argument("--authoritative-url", type=str)
+    parser.add_argument("--issue-path", type=Path)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    authoritative = _load_authoritative(args)
+    ok, message = check_rules(args.rules_dir, authoritative)
+    if not ok:
+        if args.issue_path:
+            issue_body = "# Tax rule drift detected\n\n" + message + "\n"
+            args.issue_path.write_text(issue_body, encoding="utf-8")
+        print(message, file=sys.stderr)
+        return 1
+    print(message)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/services/tax-engine/tests/test_boundaries.py
+++ b/apps/services/tax-engine/tests/test_boundaries.py
@@ -1,0 +1,48 @@
+import json
+
+import pytest
+
+from app import tax_rules
+from app.domains import payg_w
+
+
+@pytest.fixture(scope="module")
+def paygw_rules():
+    with tax_rules.rules_path("payg_w_2024_25.json").open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+
+def _withholding_cents(gross: float, rules: dict) -> int:
+    outcome = payg_w.compute(
+        {"payg_w": {"method": "formula_progressive", "period": "weekly", "gross": gross}},
+        rules,
+    )
+    return int(round(float(outcome["withholding"]) * 100))
+
+
+def test_paygw_bracket_thresholds(paygw_rules):
+    brackets = paygw_rules["formula_progressive"]["brackets"]
+    thresholds = [float(bracket["up_to"]) for bracket in brackets[:-1]]
+    previous_lower = 0.0
+    for threshold in thresholds:
+        below = max(previous_lower + 0.01, round(threshold - 0.01, 2))
+        at = round(threshold, 2)
+        above = round(threshold + 0.01, 2)
+        samples = [below, at, above]
+        values = [_withholding_cents(gross, paygw_rules) for gross in samples]
+        spread = max(values) - min(values)
+        assert spread <= 500, (
+            f"Withholding changed by more than $5.00 around threshold {threshold}: "
+            f"{list(zip(samples, values))}"
+        )
+        previous_lower = threshold
+
+
+def test_paygw_last_bracket_progression(paygw_rules):
+    start = float(paygw_rules["formula_progressive"]["brackets"][-2]["up_to"])
+    samples = [start + offset for offset in (0.01, 100.00, 200.00)]
+    values = [_withholding_cents(gross, paygw_rules) for gross in samples]
+    assert values == sorted(values), (
+        "Top bracket withholding should increase with gross income: "
+        f"{list(zip(samples, values))}"
+    )

--- a/apps/services/tax-engine/tests/test_drift.py
+++ b/apps/services/tax-engine/tests/test_drift.py
@@ -1,0 +1,42 @@
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_rules_drift.py"
+RULES_DIR = Path(__file__).resolve().parents[1] / "app" / "rules"
+CHECKSUMS = RULES_DIR / "checksums.json"
+
+
+@pytest.mark.parametrize("args,expected_rc", [([], 0)])
+def test_check_rules_drift_happy_path(args, expected_rc):
+    result = subprocess.run([sys.executable, str(SCRIPT), *map(str, args)], capture_output=True, text=True)
+    assert result.returncode == expected_rc, result.stderr
+    assert "All rule checksums" in result.stdout
+
+
+def test_check_rules_drift_detects_differences(tmp_path):
+    working_rules = tmp_path / "rules"
+    shutil.copytree(RULES_DIR, working_rules)
+    target = working_rules / "payg_w_2024_25.json"
+    data = json.loads(target.read_text(encoding="utf-8-sig"))
+    data["notes"] = "test modification"
+    target.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--rules-dir",
+            str(working_rules),
+            "--checksums",
+            str(CHECKSUMS),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "sha256 drift" in result.stderr

--- a/apps/services/tax-engine/tests/test_goldens.py
+++ b/apps/services/tax-engine/tests/test_goldens.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.domains import payg_w
+from app import tax_rules
+from app.tax_rules import (
+    fbt_liability,
+    gst_invoice_totals,
+    paygi_instalment,
+    payroll_tax_liability,
+    sg_quarterly_obligation,
+)
+
+
+def _repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if (parent / ".git").exists():
+            return parent
+    raise RuntimeError("Repository root with .git not found")
+
+
+GOLDENS_DIR = _repo_root() / "tests" / "goldens"
+GOLDEN_CASES = sorted(GOLDENS_DIR.rglob("*.json"))
+
+
+@pytest.mark.parametrize(
+    "golden_path",
+    GOLDEN_CASES,
+    ids=lambda p: str(p.relative_to(GOLDENS_DIR)),
+)
+def test_goldens(golden_path: Path) -> None:
+    data = json.loads(golden_path.read_text(encoding="utf-8"))
+    regime = data["regime"]
+    payload = data["payload"]
+    expected = data["expected"]
+
+    if regime == "gst":
+        result = gst_invoice_totals(payload["lines"])
+        assert result == expected
+        return
+
+    if regime == "paygw":
+        with tax_rules.rules_path("payg_w_2024_25.json").open("r", encoding="utf-8-sig") as fh:
+            rules = json.load(fh)
+        outcome = payg_w.compute({"payg_w": payload}, rules)
+        withholding_cents = int(round(float(outcome["withholding"]) * 100))
+        assert withholding_cents == expected["withholding_cents"]
+        return
+
+    if regime == "paygi":
+        liability = paygi_instalment(**payload)
+        assert liability == expected["instalment_cents"]
+        return
+
+    if regime == "sg":
+        contribution = sg_quarterly_obligation(**payload)
+        assert contribution == expected["contribution_cents"]
+        return
+
+    if regime == "fbt":
+        liability = fbt_liability(**payload)
+        assert liability == expected["fbt_cents"]
+        return
+
+    if regime == "payroll_tax":
+        liability = payroll_tax_liability(**payload)
+        assert liability == expected["tax_cents"]
+        return
+
+    pytest.fail(f"Unknown regime in golden case: {regime}")

--- a/apps/services/tax-engine/tests/test_properties.py
+++ b/apps/services/tax-engine/tests/test_properties.py
@@ -1,0 +1,55 @@
+import json
+from itertools import permutations
+
+import pytest
+
+from app import tax_rules
+from app.domains import payg_w
+from app.tax_rules import gst_invoice_totals
+
+
+@pytest.fixture(scope="module")
+def paygw_rules():
+    with tax_rules.rules_path("payg_w_2024_25.json").open("r", encoding="utf-8-sig") as fh:
+        return json.load(fh)
+
+
+def _withholding_cents(gross: float, rules: dict) -> int:
+    outcome = payg_w.compute(
+        {"payg_w": {"method": "formula_progressive", "period": "weekly", "gross": gross}},
+        rules,
+    )
+    return int(round(float(outcome["withholding"]) * 100))
+
+
+def test_paygw_monotonic_within_bracket(paygw_rules):
+    brackets = paygw_rules["formula_progressive"]["brackets"]
+    previous_up_to = 0.0
+    for bracket in brackets:
+        upper = float(bracket["up_to"])
+        start = previous_up_to
+        sample_limit = upper if upper < 10_000 else start + 200.0
+        start_cents = int(round(start * 100))
+        end_cents = int(round(sample_limit * 100))
+        last = None
+        for cents in range(start_cents + 1, end_cents + 1):
+            gross = cents / 100
+            current = _withholding_cents(gross, paygw_rules)
+            if last is not None:
+                assert current >= last, (
+                    f"Withholding decreased within bracket: {gross:.2f} produced {current} < {last}"
+                )
+            last = current
+        previous_up_to = upper
+
+
+def test_gst_totals_invariant_under_line_shuffle():
+    lines = [
+        {"amount_cents": 12500, "tax_code": "GST"},
+        {"amount_cents": 7600, "tax_code": "GST"},
+        {"amount_cents": 3300, "tax_code": "GST_FREE"},
+        {"amount_cents": 2400, "tax_code": "ZERO_RATED"},
+    ]
+    baseline = gst_invoice_totals(lines)
+    for perm in permutations(lines):
+        assert gst_invoice_totals(list(perm)) == baseline

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-pythonpath = apps/services/tax-engine
+pythonpath = apps/services/tax-engine libs/py-sdk .

--- a/tests/goldens/fbt/type1_example.json
+++ b/tests/goldens/fbt/type1_example.json
@@ -1,0 +1,12 @@
+{
+  "regime": "fbt",
+  "description": "Type 1 benefit gross-up at 47%",
+  "payload": {
+    "taxable_value_cents": 1000000,
+    "benefits_type": "type1",
+    "rate": 0.47
+  },
+  "expected": {
+    "fbt_cents": 977694
+  }
+}

--- a/tests/goldens/gst/basic_taxable_supply.json
+++ b/tests/goldens/gst/basic_taxable_supply.json
@@ -1,0 +1,16 @@
+{
+  "regime": "gst",
+  "description": "Single taxable supply with GST-free and exempt lines",
+  "payload": {
+    "lines": [
+      {"amount_cents": 12000, "tax_code": "GST"},
+      {"amount_cents": 3000, "tax_code": "GST_FREE"},
+      {"amount_cents": 1500, "tax_code": ""}
+    ]
+  },
+  "expected": {
+    "net_cents": 16500,
+    "tax_cents": 1200,
+    "gross_cents": 17700
+  }
+}

--- a/tests/goldens/paygi/standard_instalment.json
+++ b/tests/goldens/paygi/standard_instalment.json
@@ -1,0 +1,13 @@
+{
+  "regime": "paygi",
+  "description": "PAYG instalment with rate credits and adjustments",
+  "payload": {
+    "instalment_income_cents": 1200000,
+    "rate": 0.072,
+    "credits_cents": 20000,
+    "adjustments_cents": 5000
+  },
+  "expected": {
+    "instalment_cents": 71400
+  }
+}

--- a/tests/goldens/paygw/foreign_weekly.json
+++ b/tests/goldens/paygw/foreign_weekly.json
@@ -1,0 +1,14 @@
+{
+  "regime": "paygw",
+  "variant": "foreign",
+  "description": "Non-resident flat percentage schedule at 32.5%",
+  "payload": {
+    "method": "percent_simple",
+    "period": "weekly",
+    "gross": 900.0,
+    "percent": 0.325
+  },
+  "expected": {
+    "withholding_cents": 29250
+  }
+}

--- a/tests/goldens/paygw/resident_weekly.json
+++ b/tests/goldens/paygw/resident_weekly.json
@@ -1,0 +1,14 @@
+{
+  "regime": "paygw",
+  "variant": "resident",
+  "description": "2024-25 resident weekly withholding on $900 gross",
+  "payload": {
+    "method": "formula_progressive",
+    "period": "weekly",
+    "gross": 900.0,
+    "tax_free_threshold": true
+  },
+  "expected": {
+    "withholding_cents": 16800
+  }
+}

--- a/tests/goldens/paygw/whm_weekly.json
+++ b/tests/goldens/paygw/whm_weekly.json
@@ -1,0 +1,15 @@
+{
+  "regime": "paygw",
+  "variant": "whm",
+  "description": "Working holiday maker withholding at 15%",
+  "payload": {
+    "method": "flat_plus_percent",
+    "period": "weekly",
+    "gross": 900.0,
+    "percent": 0.15,
+    "extra": 0.0
+  },
+  "expected": {
+    "withholding_cents": 13500
+  }
+}

--- a/tests/goldens/payroll_tax/nsw_annual.json
+++ b/tests/goldens/payroll_tax/nsw_annual.json
@@ -1,0 +1,11 @@
+{
+  "regime": "payroll_tax",
+  "description": "NSW payroll tax on $1.5m annual wages",
+  "payload": {
+    "annual_wages_cents": 150000000,
+    "state": "NSW"
+  },
+  "expected": {
+    "tax_cents": 1635000
+  }
+}

--- a/tests/goldens/sg/quarterly_obligation.json
+++ b/tests/goldens/sg/quarterly_obligation.json
@@ -1,0 +1,11 @@
+{
+  "regime": "sg",
+  "description": "Quarterly super guarantee on $50,000 OTE at 11.5%",
+  "payload": {
+    "ordinary_time_earnings_cents": 5000000,
+    "rate": 0.115
+  },
+  "expected": {
+    "contribution_cents": 575000
+  }
+}


### PR DESCRIPTION
## Summary
- extend the tax engine helpers to cover GST invoices plus PAYGI, SG, FBT and payroll tax calculators
- add golden/property/boundary/drift tests with fixtures that exercise GST, PAYGW variants, PAYGI, SG, FBT and NSW payroll tax
- add rule checksum metadata and a drift checker script that fails when the PAYG-W rules change without a version bump

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3761855a48327bc6a4e029b0d97c8