### PR TITLE
Add BAS amendment handling and label mapping

### DIFF
--- a/apps/services/payments/src/bas/bas_labels.json
+++ b/apps/services/payments/src/bas/bas_labels.json
@@ -1,0 +1,18 @@
+{
+  "GST": {
+    "total_taxable_sales_cents": "G1",
+    "export_sales_cents": "G2",
+    "other_gst_free_sales_cents": "G3",
+    "capital_purchases_cents": "G10",
+    "non_capital_purchases_cents": "G11",
+    "gst_on_sales_cents": "1A",
+    "gst_on_purchases_cents": "1B"
+  },
+  "PAYGW": {
+    "gross_wages_cents": "W1",
+    "withheld_paygw_cents": "W2",
+    "instalment_income_cents": "T1",
+    "fringe_benefits_tax_cents": "F1",
+    "fringe_benefits_withheld_cents": "F2"
+  }
+}

--- a/apps/services/payments/src/bas/labels.ts
+++ b/apps/services/payments/src/bas/labels.ts
@@ -1,0 +1,100 @@
+import basLabelMap from "./bas_labels.json" assert { type: "json" };
+
+export type TaxType = "GST" | "PAYGW";
+export type DomainTotals = Record<string, number>;
+export type LabelTotals = Record<string, number>;
+
+type RawMap = Record<TaxType, Record<string, string>>;
+const mapping = basLabelMap as RawMap;
+
+export function assertTaxType(value: string): asserts value is TaxType {
+  if (value !== "GST" && value !== "PAYGW") {
+    throw new Error(`Unsupported taxType '${value}'`);
+  }
+}
+
+export function normalizeDomainTotals(taxType: TaxType, totals: Record<string, unknown>): DomainTotals {
+  const domainMap = mapping[taxType];
+  if (!domainMap) throw new Error(`No BAS mapping configured for ${taxType}`);
+  if (!totals || typeof totals !== "object") {
+    throw new Error("domainTotals must be an object");
+  }
+
+  const out: DomainTotals = {};
+  for (const key of Object.keys(domainMap)) {
+    const raw = (totals as Record<string, unknown>)[key];
+    const num = raw == null ? 0 : Number(raw);
+    if (raw != null && !Number.isFinite(num)) {
+      throw new Error(`domainTotals.${key} must be numeric`);
+    }
+    out[key] = Math.trunc(num);
+  }
+
+  for (const key of Object.keys(totals)) {
+    if (!(key in domainMap)) {
+      throw new Error(`Unknown domain total '${key}' for taxType ${taxType}`);
+    }
+  }
+
+  return out;
+}
+
+export function coerceNumericRecord(value: unknown): Record<string, number> {
+  const out: Record<string, number> = {};
+  if (!value || typeof value !== "object") return out;
+  for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+    const num = Number(raw);
+    if (Number.isFinite(num)) out[key] = Math.trunc(num);
+  }
+  return out;
+}
+
+export function projectToLabels(taxType: TaxType, domainTotals: DomainTotals): LabelTotals {
+  const domainMap = mapping[taxType];
+  const labels: LabelTotals = {};
+  for (const [domain, amount] of Object.entries(domainTotals)) {
+    const label = domainMap[domain];
+    labels[label] = (labels[label] ?? 0) + amount;
+  }
+  for (const label of Object.values(domainMap)) {
+    if (!(label in labels)) labels[label] = 0;
+  }
+  return labels;
+}
+
+export function diffTotals(before: Record<string, number>, after: Record<string, number>): Record<string, number> {
+  const keys = new Set([...Object.keys(before), ...Object.keys(after)]);
+  const out: Record<string, number> = {};
+  for (const key of keys) {
+    const prev = Number(before[key] ?? 0);
+    const next = Number(after[key] ?? 0);
+    out[key] = Math.trunc(next - prev);
+  }
+  return out;
+}
+
+export function computeNetLiability(taxType: TaxType, labels: Record<string, number>): number {
+  if (taxType === "GST") {
+    const oneA = Number(labels["1A"] ?? 0);
+    const oneB = Number(labels["1B"] ?? 0);
+    return Math.trunc(oneA - oneB);
+  }
+  if (taxType === "PAYGW") {
+    const w2 = Number(labels["W2"] ?? 0);
+    return Math.trunc(w2);
+  }
+  return 0;
+}
+
+export function buildLabelResponse(taxType: TaxType, labels: Record<string, number | null | undefined>): Record<string, number | null> {
+  const domainMap = mapping[taxType];
+  if (!domainMap) return {};
+  const result: Record<string, number | null> = {};
+  for (const label of Object.values(domainMap)) {
+    const raw = labels[label];
+    result[label] = raw == null ? null : Math.trunc(Number(raw));
+  }
+  return result;
+}
+
+export const basLabelMapping: RawMap = mapping;

--- a/apps/services/payments/src/bas/storage.ts
+++ b/apps/services/payments/src/bas/storage.ts
@@ -1,0 +1,70 @@
+import type { Pool } from "pg";
+
+let ensured = false;
+
+const ensureSql = `
+CREATE TABLE IF NOT EXISTS bas_period_totals (
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  domain_totals JSONB NOT NULL DEFAULT '{}'::jsonb,
+  label_totals JSONB NOT NULL DEFAULT '{}'::jsonb,
+  revision_seq INTEGER NOT NULL DEFAULT 0,
+  carry_forward_in JSONB,
+  carry_forward_out JSONB,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (abn, tax_type, period_id)
+);
+
+CREATE TABLE IF NOT EXISTS bas_revisions (
+  revision_id BIGSERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  revision_seq INTEGER NOT NULL,
+  submitted_by TEXT,
+  submitted_reason TEXT,
+  evidence_ref TEXT,
+  domain_totals_before JSONB NOT NULL,
+  domain_totals_after JSONB NOT NULL,
+  domain_delta JSONB NOT NULL,
+  label_totals_before JSONB NOT NULL,
+  label_totals_after JSONB NOT NULL,
+  label_delta JSONB NOT NULL,
+  net_before_cents BIGINT NOT NULL,
+  net_after_cents BIGINT NOT NULL,
+  net_delta_cents BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (abn, tax_type, period_id, revision_seq)
+);
+
+CREATE TABLE IF NOT EXISTS evidence_addenda (
+  addendum_id BIGSERIAL PRIMARY KEY,
+  bundle_id BIGINT NOT NULL REFERENCES evidence_bundles(bundle_id) ON DELETE CASCADE,
+  revision_id BIGINT NOT NULL REFERENCES bas_revisions(revision_id) ON DELETE CASCADE,
+  addendum JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (bundle_id, revision_id)
+);
+
+CREATE TABLE IF NOT EXISTS bas_carry_forward (
+  carry_id BIGSERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  from_period_id TEXT NOT NULL,
+  to_period_id TEXT NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  revision_id BIGINT NOT NULL REFERENCES bas_revisions(revision_id) ON DELETE CASCADE,
+  evidence_reference TEXT,
+  details JSONB,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (abn, tax_type, from_period_id, to_period_id)
+);
+`;
+
+export async function ensureBasTables(pool: Pool) {
+  if (ensured) return;
+  await pool.query(ensureSql);
+  ensured = true;
+}

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -10,6 +10,7 @@ import { payAtoRelease } from './routes/payAto.js';
 import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
+import { amendBas } from './routes/basAmend.js';
 
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -34,6 +35,7 @@ app.post('/deposit', deposit);
 app.post('/payAto', rptGate, payAtoRelease);
 app.get('/balance', balance);
 app.get('/ledger', ledger);
+app.post('/bas/:periodId/amend', amendBas);
 
 // 404 fallback
 app.use((_req, res) => res.status(404).send('Not found'));

--- a/apps/services/payments/src/routes/basAmend.ts
+++ b/apps/services/payments/src/routes/basAmend.ts
@@ -1,0 +1,254 @@
+import { Request, Response } from "express";
+import { pool } from "../index.js";
+import { ensureBasTables } from "../bas/storage.js";
+import {
+  assertTaxType,
+  normalizeDomainTotals,
+  projectToLabels,
+  diffTotals,
+  computeNetLiability,
+  coerceNumericRecord,
+  buildLabelResponse,
+  type TaxType
+} from "../bas/labels.js";
+
+function json(value: unknown) {
+  return JSON.stringify(value);
+}
+
+export async function amendBas(req: Request, res: Response) {
+  const { periodId } = req.params as { periodId: string };
+  const { abn, taxType, domainTotals, submittedBy, reason, evidenceRef, nextPeriodId } = req.body || {};
+
+  if (!abn || typeof abn !== "string") {
+    return res.status(400).json({ error: "abn required" });
+  }
+  if (!taxType || typeof taxType !== "string") {
+    return res.status(400).json({ error: "taxType required" });
+  }
+  if (!periodId || typeof periodId !== "string") {
+    return res.status(400).json({ error: "periodId required" });
+  }
+
+  try {
+    assertTaxType(taxType);
+  } catch (err: any) {
+    return res.status(400).json({ error: err.message || String(err) });
+  }
+
+  try {
+    await ensureBasTables(pool);
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+
+      const period = await client.query(
+        `SELECT id FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+        [abn, taxType, periodId]
+      );
+      if (period.rowCount === 0) {
+        throw new Error("PERIOD_NOT_FOUND");
+      }
+
+      const normalized = normalizeDomainTotals(taxType as TaxType, domainTotals || {});
+      const labelTotals = projectToLabels(taxType as TaxType, normalized);
+
+      const existing = await client.query(
+        `SELECT revision_seq, domain_totals, label_totals, carry_forward_in, carry_forward_out
+           FROM bas_period_totals
+          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+          FOR UPDATE`,
+        [abn, taxType, periodId]
+      );
+      const row = existing.rows[0];
+      const revisionSeq = (row?.revision_seq ?? 0) + 1;
+      const beforeDomain = coerceNumericRecord(row?.domain_totals);
+      const beforeLabels = coerceNumericRecord(row?.label_totals);
+      const carryForwardIn = row?.carry_forward_in ?? null;
+      const carryForwardOut = row?.carry_forward_out ?? null;
+
+      const domainDelta = diffTotals(beforeDomain, normalized);
+      const labelDelta = diffTotals(beforeLabels, labelTotals);
+      const beforeLabelView = buildLabelResponse(taxType as TaxType, beforeLabels);
+      const afterLabelView = buildLabelResponse(taxType as TaxType, labelTotals);
+
+      const netBefore = computeNetLiability(taxType as TaxType, beforeLabels);
+      const netAfter = computeNetLiability(taxType as TaxType, labelTotals);
+      const netDelta = netAfter - netBefore;
+
+      const revision = await client.query(
+        `INSERT INTO bas_revisions (
+           abn, tax_type, period_id, revision_seq,
+           submitted_by, submitted_reason, evidence_ref,
+           domain_totals_before, domain_totals_after, domain_delta,
+           label_totals_before, label_totals_after, label_delta,
+           net_before_cents, net_after_cents, net_delta_cents
+         ) VALUES (
+           $1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb,$10::jsonb,$11::jsonb,$12::jsonb,$13::jsonb,$14,$15,$16
+         ) RETURNING revision_id, created_at`,
+        [
+          abn,
+          taxType,
+          periodId,
+          revisionSeq,
+          submittedBy ?? null,
+          reason ?? null,
+          evidenceRef ?? null,
+          json(beforeDomain),
+          json(normalized),
+          json(domainDelta),
+          json(beforeLabels),
+          json(labelTotals),
+          json(labelDelta),
+          netBefore,
+          netAfter,
+          netDelta
+        ]
+      );
+
+      const revisionId = revision.rows[0].revision_id as number;
+      const revisionCreated = revision.rows[0].created_at as Date;
+
+      let carryForwardOutPayload = carryForwardOut ?? null;
+
+      if (netDelta < 0) {
+        if (!nextPeriodId || typeof nextPeriodId !== "string") {
+          throw new Error("NEXT_PERIOD_REQUIRED_FOR_CREDIT");
+        }
+        const creditAmount = Math.abs(netDelta);
+        const details = {
+          from_period_id: periodId,
+          to_period_id: nextPeriodId,
+          amount_cents: creditAmount,
+          revision_id: revisionId,
+          evidence_ref: evidenceRef ?? null,
+          net_before_cents: netBefore,
+          net_after_cents: netAfter
+        };
+        const carry = await client.query(
+          `INSERT INTO bas_carry_forward (
+             abn, tax_type, from_period_id, to_period_id,
+             amount_cents, revision_id, evidence_reference, details
+           ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)
+           ON CONFLICT (abn, tax_type, from_period_id, to_period_id)
+           DO UPDATE SET amount_cents=EXCLUDED.amount_cents,
+             revision_id=EXCLUDED.revision_id,
+             evidence_reference=EXCLUDED.evidence_reference,
+             details=EXCLUDED.details,
+             updated_at=now()
+           RETURNING carry_id`,
+          [abn, taxType, periodId, nextPeriodId, creditAmount, revisionId, evidenceRef ?? null, json(details)]
+        );
+        const carryId = carry.rows[0].carry_id as number;
+        carryForwardOutPayload = { ...details, carry_id: carryId };
+
+        const inboundPayload = { ...details, carry_id: carryId };
+        await client.query(
+          `INSERT INTO bas_period_totals (abn,tax_type,period_id,domain_totals,label_totals,revision_seq,carry_forward_in,carry_forward_out)
+           VALUES ($1,$2,$3,$4::jsonb,$5::jsonb,0,$6::jsonb,$7::jsonb)
+           ON CONFLICT (abn,tax_type,period_id)
+           DO UPDATE SET carry_forward_in=EXCLUDED.carry_forward_in, updated_at=now()`,
+          [abn, taxType, nextPeriodId, json({}), json({}), json(inboundPayload), json(null)]
+        );
+      } else if (carryForwardOut) {
+        const toPeriod = carryForwardOut.to_period_id ?? nextPeriodId;
+        await client.query(
+          `DELETE FROM bas_carry_forward WHERE abn=$1 AND tax_type=$2 AND from_period_id=$3 AND ($4::text IS NULL OR to_period_id=$4)`,
+          [abn, taxType, periodId, toPeriod ?? null]
+        );
+        if (toPeriod) {
+          await client.query(
+            `UPDATE bas_period_totals SET carry_forward_in=NULL, updated_at=now()
+             WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+            [abn, taxType, toPeriod]
+          );
+        }
+        carryForwardOutPayload = null;
+      }
+
+      await client.query(
+        `INSERT INTO bas_period_totals (abn,tax_type,period_id,domain_totals,label_totals,revision_seq,carry_forward_in,carry_forward_out,updated_at)
+         VALUES ($1,$2,$3,$4::jsonb,$5::jsonb,$6,$7::jsonb,$8::jsonb,now())
+         ON CONFLICT (abn,tax_type,period_id)
+         DO UPDATE SET domain_totals=EXCLUDED.domain_totals,
+           label_totals=EXCLUDED.label_totals,
+           revision_seq=EXCLUDED.revision_seq,
+           carry_forward_out=EXCLUDED.carry_forward_out,
+           updated_at=now()`,
+        [
+          abn,
+          taxType,
+          periodId,
+          json(normalized),
+          json(labelTotals),
+          revisionSeq,
+          json(carryForwardIn),
+          json(carryForwardOutPayload)
+        ]
+      );
+
+      await client.query(
+        `UPDATE periods SET final_liability_cents=$1 WHERE abn=$2 AND tax_type=$3 AND period_id=$4`,
+        [netAfter, abn, taxType, periodId]
+      );
+
+      const bundle = await client.query(
+        `SELECT bundle_id FROM evidence_bundles WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+        [abn, taxType, periodId]
+      );
+      if (bundle.rowCount) {
+        const payload = {
+          revision_seq: revisionSeq,
+          submitted_by: submittedBy ?? null,
+          reason: reason ?? null,
+          evidence_ref: evidenceRef ?? null,
+          created_at: revisionCreated instanceof Date ? revisionCreated.toISOString() : revisionCreated,
+          domain_totals: {
+            before: beforeDomain,
+            after: normalized,
+            delta: domainDelta
+          },
+          label_totals: {
+            before: beforeLabels,
+            after: labelTotals,
+            delta: labelDelta,
+            before_view: beforeLabelView,
+            after_view: afterLabelView,
+          },
+          net: {
+            before_cents: netBefore,
+            after_cents: netAfter,
+            delta_cents: netDelta
+          },
+          carry_forward_out: carryForwardOutPayload
+        };
+        await client.query(
+          `INSERT INTO evidence_addenda (bundle_id, revision_id, addendum)
+           VALUES ($1,$2,$3::jsonb)
+           ON CONFLICT (bundle_id, revision_id)
+           DO UPDATE SET addendum=EXCLUDED.addendum, created_at=now()`,
+          [bundle.rows[0].bundle_id, revisionId, json(payload)]
+        );
+      }
+
+      await client.query("COMMIT");
+
+      return res.json({
+        ok: true,
+        revision_id: revisionId,
+        revision_seq: revisionSeq,
+        net: { before_cents: netBefore, after_cents: netAfter, delta_cents: netDelta },
+        domain_delta: domainDelta,
+        label_delta: labelDelta,
+        carry_forward_out: carryForwardOutPayload
+      });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  } catch (err: any) {
+    return res.status(400).json({ error: err?.message || String(err) });
+  }
+}

--- a/apps/services/payments/test/bas_labels.test.ts
+++ b/apps/services/payments/test/bas_labels.test.ts
@@ -1,0 +1,35 @@
+import {
+  normalizeDomainTotals,
+  projectToLabels,
+  computeNetLiability,
+  diffTotals,
+} from "../src/bas/labels";
+
+describe("BAS label mapping", () => {
+  it("maps GST domain totals to label totals", () => {
+    const domain = normalizeDomainTotals("GST", {
+      total_taxable_sales_cents: 50000,
+      export_sales_cents: 1000,
+      other_gst_free_sales_cents: 200,
+      capital_purchases_cents: 1500,
+      non_capital_purchases_cents: 2500,
+      gst_on_sales_cents: 6000,
+      gst_on_purchases_cents: 3000,
+    });
+    const labels = projectToLabels("GST", domain);
+    expect(labels.G1).toBe(50000);
+    expect(labels.G2).toBe(1000);
+    expect(labels.G3).toBe(200);
+    expect(labels.G10).toBe(1500);
+    expect(labels.G11).toBe(2500);
+    expect(labels["1A"]).toBe(6000);
+    expect(labels["1B"]).toBe(3000);
+    expect(computeNetLiability("GST", labels)).toBe(3000);
+  });
+
+  it("computes deltas across totals", () => {
+    const before = { G1: 1000, G2: 0 };
+    const after = { G1: 800, G2: 50 };
+    expect(diffTotals(before, after)).toEqual({ G1: -200, G2: 50 });
+  });
+});

--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -2,6 +2,13 @@
 type Common = { abn: string; taxType: string; periodId: string };
 export type DepositArgs = Common & { amountCents: number };   // > 0
 export type ReleaseArgs = Common & { amountCents: number };   // < 0
+export type AmendArgs = Common & {
+  domainTotals: Record<string, number>;
+  submittedBy?: string;
+  reason?: string;
+  evidenceRef?: string;
+  nextPeriodId?: string;
+};
 
 // Prefer NEXT_PUBLIC_ (browser-safe), then server-only, then default
 const BASE =
@@ -47,6 +54,15 @@ export const Payments = {
     const u = new URL(`${BASE}/ledger`);
     Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
     const res = await fetch(u);
+    return handle(res);
+  },
+  async amendBas(args: AmendArgs) {
+    const { periodId, ...rest } = args;
+    const res = await fetch(`${BASE}/bas/${encodeURIComponent(periodId)}/amend`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ periodId, ...rest }),
+    });
     return handle(res);
   },
 };

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -65,3 +65,27 @@ paymentsApi.post("/release", async (req, res) => {
     res.status(400).json({ error: err?.message || "Release failed" });
   }
 });
+
+// POST /api/bas/:periodId/amend
+paymentsApi.post("/bas/:periodId/amend", async (req, res) => {
+  try {
+    const { periodId } = req.params as { periodId: string };
+    const { abn, taxType, domainTotals, submittedBy, reason, evidenceRef, nextPeriodId } = req.body || {};
+    if (!abn || !taxType || typeof domainTotals !== "object" || !periodId) {
+      return res.status(400).json({ error: "Missing amendment fields" });
+    }
+    const data = await Payments.amendBas({
+      abn,
+      taxType,
+      periodId,
+      domainTotals,
+      submittedBy,
+      reason,
+      evidenceRef,
+      nextPeriodId,
+    });
+    res.json(data);
+  } catch (err: any) {
+    res.status(400).json({ error: err?.message || "Amendment failed" });
+  }
+});

--- a/src/api/payments/index.ts
+++ b/src/api/payments/index.ts
@@ -8,6 +8,7 @@ import { ledger } from "../../../apps/services/payments/src/routes/ledger.js";
 import { deposit } from "../../../apps/services/payments/src/routes/deposit.js";
 import { rptGate } from "../../../apps/services/payments/src/middleware/rptGate.js";
 import { payAtoRelease } from "../../../apps/services/payments/src/routes/payAto.js";
+import { amendBas } from "../../../apps/services/payments/src/routes/basAmend.js";
 
 export const paymentsApi = Router();
 
@@ -18,3 +19,4 @@ paymentsApi.get("/ledger", ledger);
 // write
 paymentsApi.post("/deposit", deposit);
 paymentsApi.post("/release", rptGate, payAtoRelease);
+paymentsApi.post("/bas/:periodId/amend", amendBas);

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,141 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+import {
+  buildLabelResponse,
+  coerceNumericRecord,
+  basLabelMapping,
+  type TaxType,
+} from "../../apps/services/payments/src/bas/labels.js";
+import { ensureBasTables } from "../../apps/services/payments/src/bas/storage.js";
+
 const pool = new Pool();
 
+type LabelView = Record<string, number | null>;
+
+type CarryForward = {
+  inbound: unknown;
+  outbound: unknown;
+};
+
+function ensureLabelView(taxType: string, totals: Record<string, number>): LabelView {
+  const map = basLabelMapping[taxType as TaxType];
+  if (!map) return {};
+  return buildLabelResponse(taxType as TaxType, totals);
+}
+
+function mapLedgerRows(rows: any[]) {
+  return rows.map((row) => ({
+    id: row.id,
+    amount_cents: Number(row.amount_cents),
+    balance_after_cents: Number(row.balance_after_cents),
+    bank_receipt_hash: row.bank_receipt_hash ?? null,
+    prev_hash: row.prev_hash ?? null,
+    hash_after: row.hash_after ?? null,
+    created_at: row.created_at,
+  }));
+}
+
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
-  };
-  return bundle;
+  const client = await pool.connect();
+  try {
+    await ensureBasTables(pool);
+    const periodRes = await client.query(
+      `SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    if (periodRes.rowCount === 0) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+    const periodRow = periodRes.rows[0];
+
+    const rptRes = await client.query(
+      `SELECT payload, payload_c14n, payload_sha256, signature, created_at
+         FROM rpt_tokens
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const rptRow = rptRes.rows[0] ?? null;
+
+    const ledgerRes = await client.query(
+      `SELECT id, amount_cents, balance_after_cents, bank_receipt_hash, prev_hash, hash_after, created_at
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id ASC`,
+      [abn, taxType, periodId]
+    );
+
+    const basRes = await client.query(
+      `SELECT label_totals, domain_totals, carry_forward_in, carry_forward_out
+         FROM bas_period_totals
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    const basRow = basRes.rows[0];
+    const labelTotals = coerceNumericRecord(basRow?.label_totals);
+    const domainTotals = coerceNumericRecord(basRow?.domain_totals);
+    const carryForward: CarryForward = {
+      inbound: basRow?.carry_forward_in ?? null,
+      outbound: basRow?.carry_forward_out ?? null,
+    };
+
+    const bundleRes = await client.query(
+      `SELECT bundle_id FROM evidence_bundles WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+
+    let amendments: Array<Record<string, unknown>> = [];
+    if (bundleRes.rowCount) {
+      const addendaRes = await client.query(
+        `SELECT a.addendum, r.revision_seq
+           FROM evidence_addenda a
+           JOIN bas_revisions r ON r.revision_id = a.revision_id
+          WHERE a.bundle_id = $1
+          ORDER BY r.revision_seq ASC`,
+        [bundleRes.rows[0].bundle_id]
+      );
+      amendments = addendaRes.rows.map((row) => ({
+        revision_seq: row.revision_seq,
+        ...(row.addendum ?? {}),
+      }));
+    }
+
+    const result = {
+      meta: {
+        generated_at: new Date().toISOString(),
+        abn,
+        taxType,
+        periodId,
+      },
+      period: {
+        state: periodRow.state,
+        accrued_cents: Number(periodRow.accrued_cents ?? 0),
+        credited_to_owa_cents: Number(periodRow.credited_to_owa_cents ?? 0),
+        final_liability_cents: Number(periodRow.final_liability_cents ?? 0),
+        merkle_root: periodRow.merkle_root,
+        running_balance_hash: periodRow.running_balance_hash,
+        anomaly_vector: periodRow.anomaly_vector ?? {},
+        thresholds: periodRow.thresholds ?? {},
+      },
+      rpt: rptRow
+        ? {
+            payload: rptRow.payload,
+            payload_c14n: rptRow.payload_c14n ?? null,
+            payload_sha256: rptRow.payload_sha256 ?? null,
+            signature: rptRow.signature,
+            created_at: rptRow.created_at,
+          }
+        : null,
+      owa_ledger: mapLedgerRows(ledgerRes.rows),
+      bas_labels: ensureLabelView(taxType, labelTotals),
+      bas_domain_totals: domainTotals,
+      carry_forward,
+      amendments,
+      discrepancy_log: [],
+    };
+
+    return result;
+  } finally {
+    client.release();
+  }
 }


### PR DESCRIPTION
## Summary
- add an explicit BAS domain-to-label mapping and helper utilities for normalising totals
- implement a /bas/:periodId/amend route that records delta revisions, manages carry-forward credits, and emits evidence addenda
- update evidence bundle generation and API clients to surface BAS labels, amendments, and carry-forward metadata, plus add a mapping unit test

## Testing
- npm test -- --runTestsByPath test/bas_labels.test.ts *(fails: jest binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3760da23c83279b3ffa7f567db14d