### PR TITLE
Add API doc coverage scripts and help center UI

### DIFF
--- a/apps/web/console/public/help-index.json
+++ b/apps/web/console/public/help-index.json
@@ -1,0 +1,79 @@
+{
+  "generatedAt": "2025-10-06T08:30:13.667Z",
+  "docs": [
+    {
+      "slug": "close-issue",
+      "title": "Close and issue",
+      "summary": "Transition a period into READY_RPT using the close-issue API.",
+      "headings": [
+        "Close and issue"
+      ],
+      "body": "# Close and issue\n\nWhen reconciliation tasks are done, advance the period to `READY_RPT` so an RPT can be minted.\n\nInvoke `POST /api/close-issue` with the ABN, tax type and period ID. The endpoint enforces that outstanding discrepancies have\nbeen resolved before it will update the state machine.\n\nOnce the call succeeds, proceed with RPT issuance and subsequent release activity.",
+      "plainText": "Close and issue When reconciliation tasks are done, advance the period to READYRPT so an RPT can be minted. Invoke POST /api/close-issue with the ABN, tax type and period ID. The endpoint enforces that outstanding discrepancies have been resolved before it will update the state machine. Once the call succeeds, proceed with RPT issuance and subsequent release activity."
+    },
+    {
+      "slug": "evidence",
+      "title": "Evidence bundles",
+      "summary": "Download signed reconciliation evidence from the evidence endpoint.",
+      "headings": [
+        "Evidence bundles"
+      ],
+      "body": "# Evidence bundles\n\nAuditors and compliance reviewers consume the signed payload that proves the ledger matches external statements. Use\n`GET /api/evidence` with the ABN, tax type and period ID query parameters to download the ZIP archive of receipts, checksums and\nsignature manifests.\n\nThe endpoint enforces the same access control as the console. Rotate credentials that can reach `GET /api/evidence` in line with\ninternal compliance policies and alert if a bundle is requested outside your normal cadence.",
+      "plainText": "Evidence bundles Auditors and compliance reviewers consume the signed payload that proves the ledger matches external statements. Use GET /api/evidence with the ABN, tax type and period ID query parameters to download the ZIP archive of receipts, checksums and signature manifests. The endpoint enforces the same access control as the console. Rotate credentials that can reach GET /api/evidence in line with internal compliance policies and alert if a bundle is requested outside your normal cadence."
+    },
+    {
+      "slug": "health",
+      "title": "Health monitoring",
+      "summary": "Probe the lightweight health endpoint from load balancers and schedulers.",
+      "headings": [
+        "Health monitoring"
+      ],
+      "body": "# Health monitoring\n\nExpose `GET /health` to load balancers and orchestration tools so they can drain traffic if the app becomes unhealthy. The\nendpoint returns `{ \"ok\": true }` when the service loop is running.\n\nCombine the health probe with checks on dependent services such as the database, message bus and release queue to catch partial\nfailures before they impact release operations.",
+      "plainText": "Health monitoring Expose GET /health to load balancers and orchestration tools so they can drain traffic if the app becomes unhealthy. The endpoint returns { \"ok\": true } when the service loop is running. Combine the health probe with checks on dependent services such as the database, message bus and release queue to catch partial failures before they impact release operations."
+    },
+    {
+      "slug": "ledger",
+      "title": "Ledger management",
+      "summary": "Monitor balances and append deposits to one-way accounts.",
+      "headings": [
+        "Ledger management"
+      ],
+      "body": "# Ledger management\n\nThe ledger tracks every inflow and outflow for a period.\n\n- Call `GET /api/balance` to return the latest running balance. The response includes the last update timestamp so you can spot\n  staleness.\n- Use `GET /api/ledger` for the full transaction list when reconciling statement exports.\n- Credit funds with `POST /api/deposit`. The request body enforces positive `amountCents` values to protect against accidental\n  reversals.\n\nDeposits and releases appear in chronological order and power the evidence bundle that `GET /api/evidence` exports.",
+      "plainText": "Ledger management The ledger tracks every inflow and outflow for a period. - Call GET /api/balance to return the latest running balance. The response includes the last update timestamp so you can spot staleness. - Use GET /api/ledger for the full transaction list when reconciling statement exports. - Credit funds with POST /api/deposit. The request body enforces positive amountCents values to protect against accidental reversals. Deposits and releases appear in chronological order and power the evidence bundle that GET /api/evidence exports."
+    },
+    {
+      "slug": "payto",
+      "title": "PayTo sweeps",
+      "summary": "Schedule and reconcile PayTo sweeps with the webhook callbacks.",
+      "headings": [
+        "PayTo sweeps",
+        "Kick off a sweep",
+        "Track settlement"
+      ],
+      "body": "# PayTo sweeps\n\nPayTo lets APGMS prefund outgoing disbursements from linked mandate accounts. The flow combines a proactive sweep with\nasynchronous settlement notifications.\n\n## Kick off a sweep\n\nSubmit `POST /api/payto/sweep` with the ABN, debit amount and reference that matches the mandate agreement. The service will\nreserve the PayTo window and respond immediately when the sweep request is accepted by the banking rail.\n\n## Track settlement\n\nBanking partners confirm the outcome by calling `POST /api/settlement/webhook`. The webhook payload references the same\n`sweep.reference`, along with the status and timestamp so you can reconcile the release window. Store the callback data alongside\nledger entries to keep the audit trail intact.",
+      "plainText": "PayTo sweeps PayTo lets APGMS prefund outgoing disbursements from linked mandate accounts. The flow combines a proactive sweep with asynchronous settlement notifications. Kick off a sweep Submit POST /api/payto/sweep with the ABN, debit amount and reference that matches the mandate agreement. The service will reserve the PayTo window and respond immediately when the sweep request is accepted by the banking rail. Track settlement Banking partners confirm the outcome by calling POST /api/settlement/webhook. The webhook payload references the same sweep.reference, along with the status and timestamp so you can reconcile the release window. Store the callback data alongside ledger entries to keep the audit trail intact."
+    },
+    {
+      "slug": "rpt",
+      "title": "Reconciliation Pass Tokens (RPT)",
+      "summary": "How RPT issuance gates outbound releases through /api/pay and /api/release.",
+      "headings": [
+        "Reconciliation Pass Tokens (RPT)",
+        "Operational sequence",
+        "Failure handling"
+      ],
+      "body": "# Reconciliation Pass Tokens (RPT)\n\nReconciliation Pass Tokens (RPTs) are the green-light artifacts that unlock outbound flows once a period has reconciled. An RPT\ncontains the ABN, tax type, period, and an Ed25519 signature that downstream services verify before moving funds.\n\n## Operational sequence\n\n1. Close the period after resolving anomalies with `POST /api/close-issue`. This transitions the ledger to `READY_RPT` so an RPT\n   can be issued.\n2. Issue the token via the console or automation. The signed payload is persisted alongside the ledger snapshot.\n3. Present that token when invoking `POST /api/pay` for the release service or `POST /api/release` for the payments proxy. Both\n   endpoints verify signature freshness and expiry before debiting the one-way account.\n\n## Failure handling\n\nIf the RPT has expired or is missing, the release endpoints return a `400` with an explanatory error. The recovery path is to\nre-issue a fresh RPT for the same period and retry the `POST /api/pay` or `POST /api/release` call.",
+      "plainText": "Reconciliation Pass Tokens (RPT) Reconciliation Pass Tokens (RPTs) are the green-light artifacts that unlock outbound flows once a period has reconciled. An RPT contains the ABN, tax type, period, and an Ed25519 signature that downstream services verify before moving funds. Operational sequence 1. Close the period after resolving anomalies with POST /api/close-issue. This transitions the ledger to READYRPT so an RPT can be issued. 2. Issue the token via the console or automation. The signed payload is persisted alongside the ledger snapshot. 3. Present that token when invoking POST /api/pay for the release service or POST /api/release for the payments proxy. Both endpoints verify signature freshness and expiry before debiting the one-way account. Failure handling If the RPT has expired or is missing, the release endpoints return a 400 with an explanatory error. The recovery path is to re-issue a fresh RPT for the same period and retry the POST /api/pay or POST /api/release call."
+    },
+    {
+      "slug": "releases",
+      "title": "Releases",
+      "summary": "How APGMS releases draw down one-way account balances after RPT verification.",
+      "headings": [
+        "Releases"
+      ],
+      "body": "# Releases\n\nReleases move funds from the one-way account to the beneficiary after controls have cleared.\n\n- Use `POST /api/pay` when orchestrating a release directly from the console workflow. Attach the RPT, idempotency key and\n  target account metadata.\n- Use `POST /api/release` when calling through the payments proxy for service-to-service automation. The payload matches the same\n  structure and still requires a valid RPT signature.\n\nBoth endpoints debit the ledger atomically and append a release entry that is reflected by `GET /api/balance` and `GET /api/ledger`.",
+      "plainText": "Releases Releases move funds from the one-way account to the beneficiary after controls have cleared. - Use POST /api/pay when orchestrating a release directly from the console workflow. Attach the RPT, idempotency key and target account metadata. - Use POST /api/release when calling through the payments proxy for service-to-service automation. The payload matches the same structure and still requires a valid RPT signature. Both endpoints debit the ledger atomically and append a release entry that is reflected by GET /api/balance and GET /api/ledger."
+    }
+  ]
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,466 @@
-﻿import React from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
 
-function App() {
+type HelpDoc = {
+  slug: string;
+  title: string;
+  summary: string;
+  headings: string[];
+  body: string;
+  plainText: string;
+};
+
+type HelpIndexPayload = {
+  generatedAt?: string;
+  docs?: HelpDoc[];
+};
+
+type HelpTipProps = {
+  term: string;
+  slug: string;
+  onOpen: (slug: string) => void;
+};
+
+type HelpCenterProps = {
+  open: boolean;
+  query: string;
+  docs: HelpDoc[];
+  filtered: HelpDoc[];
+  activeSlug: string | null;
+  onQueryChange: (value: string) => void;
+  onClose: () => void;
+  onSelectDoc: (slug: string) => void;
+};
+
+const appStyles: React.CSSProperties = {
+  fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif",
+  padding: 24,
+  color: "#0f172a",
+  backgroundColor: "#f8fafc",
+  minHeight: "100vh"
+};
+
+const cardStyles: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  borderRadius: 12,
+  padding: 20,
+  boxShadow: "0 10px 30px rgba(15, 23, 42, 0.08)",
+  border: "1px solid #e2e8f0"
+};
+
+const helpTipStyles: React.CSSProperties = {
+  border: "none",
+  background: "none",
+  color: "#2563eb",
+  textDecoration: "underline dotted",
+  cursor: "pointer",
+  padding: 0,
+  margin: 0,
+  font: "inherit",
+  display: "inline-flex",
+  alignItems: "center",
+  gap: 6
+};
+
+const overlayStyles: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(15, 23, 42, 0.65)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 1000,
+  padding: 16
+};
+
+const dialogStyles: React.CSSProperties = {
+  backgroundColor: "#ffffff",
+  width: "min(960px, 100%)",
+  maxHeight: "90vh",
+  borderRadius: 16,
+  boxShadow: "0 30px 60px rgba(15, 23, 42, 0.25)",
+  display: "flex",
+  flexDirection: "column"
+};
+
+const searchRowStyles: React.CSSProperties = {
+  padding: "20px 24px 12px",
+  borderBottom: "1px solid #e2e8f0"
+};
+
+const helpBodyStyles: React.CSSProperties = {
+  display: "grid",
+  gridTemplateColumns: "280px 1fr",
+  gap: 0,
+  overflow: "hidden",
+  flex: 1,
+  minHeight: 0
+};
+
+const listStyles: React.CSSProperties = {
+  borderRight: "1px solid #e2e8f0",
+  overflowY: "auto"
+};
+
+const docStyles: React.CSSProperties = {
+  padding: "20px 24px",
+  overflowY: "auto",
+  backgroundColor: "#f8fafc"
+};
+
+function HelpTip({ term, slug, onOpen }: HelpTipProps) {
   return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
+    <button
+      type="button"
+      onClick={() => onOpen(slug)}
+      style={helpTipStyles}
+      aria-label={`Open help for ${term}`}
+    >
+      <span>{term}</span>
+      <span style={{ fontSize: "0.75em", color: "#1d4ed8", fontWeight: 600 }}>?</span>
+    </button>
+  );
+}
+
+function renderInline(text: string): React.ReactNode[] {
+  return text
+    .split(/(`[^`]+`)/g)
+    .filter(Boolean)
+    .map((segment, idx) => {
+      if (segment.startsWith("`") && segment.endsWith("`")) {
+        return (
+          <code key={`code-${idx}`} style={{ background: "#e2e8f0", padding: "2px 4px", borderRadius: 4 }}>
+            {segment.slice(1, -1)}
+          </code>
+        );
+      }
+      return segment;
+    });
+}
+
+function renderMarkdown(markdown: string): React.ReactNode {
+  const lines = markdown.split(/\n/);
+  const nodes: React.ReactNode[] = [];
+  let listBuffer: string[] = [];
+
+  const flushList = () => {
+    if (listBuffer.length > 0) {
+      nodes.push(
+        <ul key={`list-${nodes.length}`} style={{ margin: "12px 0", paddingLeft: 20 }}>
+          {listBuffer.map((item, idx) => (
+            <li key={`item-${idx}`} style={{ marginBottom: 6 }}>
+              {renderInline(item.trim())}
+            </li>
+          ))}
+        </ul>
+      );
+      listBuffer = [];
+    }
+  };
+
+  lines.forEach((line, index) => {
+    const trimmed = line.trim();
+    if (!trimmed) {
+      flushList();
+      return;
+    }
+    if (trimmed.startsWith("- ")) {
+      listBuffer.push(trimmed.replace(/^\-\s+/, ""));
+      return;
+    }
+    flushList();
+    if (trimmed.startsWith("#")) {
+      const level = Math.min(trimmed.match(/^#+/)?.[0].length ?? 1, 6);
+      const tag = `h${level}` as keyof JSX.IntrinsicElements;
+      nodes.push(
+        React.createElement(
+          tag,
+          { key: `heading-${index}`, style: { marginTop: level === 1 ? 0 : 18, color: "#0f172a" } },
+          renderInline(trimmed.replace(/^#+\s*/, ""))
+        )
+      );
+      return;
+    }
+    nodes.push(
+      <p key={`paragraph-${index}`} style={{ margin: "10px 0", lineHeight: 1.6 }}>
+        {renderInline(line)}
+      </p>
+    );
+  });
+
+  flushList();
+  return <>{nodes}</>;
+}
+
+function HelpCenter({ open, query, docs, filtered, activeSlug, onQueryChange, onClose, onSelectDoc }: HelpCenterProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const timer = window.setTimeout(() => inputRef.current?.focus(), 60);
+    return () => window.clearTimeout(timer);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const activeDoc = docs.find((doc) => doc.slug === activeSlug) ?? filtered[0] ?? null;
+
+  return (
+    <div
+      style={overlayStyles}
+      role="presentation"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div role="dialog" aria-modal="true" aria-label="Help Center" style={dialogStyles}>
+        <div style={searchRowStyles}>
+          <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+            <input
+              ref={inputRef}
+              type="search"
+              value={query}
+              onChange={(event) => onQueryChange(event.target.value)}
+              placeholder="Search docs by endpoint, topic or keyword"
+              style={{
+                flex: 1,
+                padding: "12px 14px",
+                borderRadius: 12,
+                border: "1px solid #cbd5f5",
+                fontSize: 16
+              }}
+            />
+            <span style={{ fontSize: 12, color: "#475569" }}>Press Esc to close</span>
+          </div>
+        </div>
+        <div style={helpBodyStyles}>
+          <div style={listStyles}>
+            {filtered.length === 0 ? (
+              <div style={{ padding: 24, color: "#64748b" }}>No matches for “{query}”.</div>
+            ) : (
+              <ul style={{ listStyle: "none", margin: 0, padding: 0 }}>
+                {filtered.map((doc) => {
+                  const isActive = doc.slug === activeDoc?.slug;
+                  return (
+                    <li key={doc.slug}>
+                      <button
+                        type="button"
+                        onClick={() => onSelectDoc(doc.slug)}
+                        style={{
+                          width: "100%",
+                          textAlign: "left",
+                          padding: "14px 18px",
+                          background: isActive ? "#e0f2fe" : "transparent",
+                          border: "none",
+                          borderBottom: "1px solid #e2e8f0",
+                          cursor: "pointer"
+                        }}
+                      >
+                        <div style={{ fontWeight: 600, color: "#0f172a", marginBottom: 4 }}>{doc.title}</div>
+                        <div style={{ fontSize: 13, color: "#475569" }}>{doc.summary}</div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+          <div style={docStyles}>
+            {activeDoc ? (
+              <article>
+                <header style={{ marginBottom: 12 }}>
+                  <h2 style={{ margin: 0, fontSize: 22 }}>{activeDoc.title}</h2>
+                  <p style={{ margin: "6px 0", color: "#475569" }}>{activeDoc.summary}</p>
+                </header>
+                <div style={{ color: "#1e293b" }}>{renderMarkdown(activeDoc.body)}</div>
+              </article>
+            ) : (
+              <div style={{ color: "#64748b" }}>Select a result to read its details.</div>
+            )}
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
+
+function App() {
+  const [helpDocs, setHelpDocs] = useState<HelpDoc[]>([]);
+  const [helpOpen, setHelpOpen] = useState(false);
+  const [helpQuery, setHelpQuery] = useState("");
+  const [activeSlug, setActiveSlug] = useState<string | null>(null);
+  const [pendingSlug, setPendingSlug] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/help-index.json")
+      .then(async (response) => {
+        if (!response.ok) {
+          throw new Error(`Failed to load help index: ${response.status}`);
+        }
+        return (await response.json()) as HelpIndexPayload;
+      })
+      .then((payload) => {
+        if (!cancelled && Array.isArray(payload.docs)) {
+          setHelpDocs(payload.docs);
+        }
+      })
+      .catch((error) => {
+        console.warn("Unable to load help index", error);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const openHelp = useCallback((slug?: string) => {
+    setHelpOpen(true);
+    setHelpQuery((current) => (slug ? "" : current));
+    setPendingSlug(slug ?? null);
+  }, []);
+
+  const closeHelp = useCallback(() => {
+    setHelpOpen(false);
+    setHelpQuery("");
+    setPendingSlug(null);
+  }, []);
+
+  const filteredDocs = useMemo(() => {
+    const query = helpQuery.trim().toLowerCase();
+    if (!query) {
+      return helpDocs;
+    }
+    return helpDocs.filter((doc) => {
+      const haystack = [doc.title, doc.summary, doc.plainText, doc.headings.join(" ")].join(" ").toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [helpDocs, helpQuery]);
+
+  useEffect(() => {
+    if (!helpOpen) return;
+    if (pendingSlug) {
+      setActiveSlug(pendingSlug);
+      setPendingSlug(null);
+      return;
+    }
+    if (activeSlug && filteredDocs.some((doc) => doc.slug === activeSlug)) {
+      return;
+    }
+    if (filteredDocs.length > 0) {
+      setActiveSlug(filteredDocs[0].slug);
+    }
+  }, [helpOpen, pendingSlug, filteredDocs, activeSlug]);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if ((event.key === "?" || (event.key === "/" && event.shiftKey)) && !event.ctrlKey && !event.metaKey && !event.altKey) {
+        event.preventDefault();
+        openHelp();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [openHelp]);
+
+  const handleSelectDoc = useCallback((slug: string) => {
+    setActiveSlug(slug);
+  }, []);
+
+  return (
+    <div style={appStyles}>
+      <header style={{ marginBottom: 32 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", flexWrap: "wrap", gap: 12 }}>
+          <div>
+            <h1 style={{ margin: 0, fontSize: 32 }}>APGMS Console</h1>
+            <p style={{ margin: "6px 0", color: "#475569" }}>
+              Orchestrate reconciliations and releases with API-level guardrails.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => openHelp()}
+            style={{
+              padding: "12px 18px",
+              borderRadius: 10,
+              border: "1px solid #2563eb",
+              background: "#2563eb",
+              color: "white",
+              fontSize: 15,
+              fontWeight: 600,
+              cursor: "pointer",
+              boxShadow: "0 10px 25px rgba(37, 99, 235, 0.2)"
+            }}
+          >
+            Open Help Center <span style={{ opacity: 0.8, marginLeft: 8 }}>(Shift + /)</span>
+          </button>
+        </div>
+      </header>
+
+      <section
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fit, minmax(260px, 1fr))",
+          gap: 20,
+          marginBottom: 32
+        }}
+      >
+        <div style={cardStyles}>
+          <h2 style={{ marginTop: 0 }}>Release readiness</h2>
+          <p style={{ lineHeight: 1.6 }}>
+            Check <HelpTip term="RPT" slug="rpt" onOpen={openHelp} /> validity before triggering releases and keep your
+            operators aligned on the current period state.
+          </p>
+        </div>
+        <div style={cardStyles}>
+          <h2 style={{ marginTop: 0 }}>Funding sweeps</h2>
+          <p style={{ lineHeight: 1.6 }}>
+            Prefund the one-way account by scheduling <HelpTip term="PayTo" slug="payto" onOpen={openHelp} /> sweeps and monitor
+            settlement webhooks for delays.
+          </p>
+        </div>
+        <div style={cardStyles}>
+          <h2 style={{ marginTop: 0 }}>Audit trail</h2>
+          <p style={{ lineHeight: 1.6 }}>
+            Keep <HelpTip term="Evidence" slug="evidence" onOpen={openHelp} /> bundles ready for auditors with snapshots of your
+            ledger movements.
+          </p>
+        </div>
+      </section>
+
+      <section style={cardStyles}>
+        <h2 style={{ marginTop: 0 }}>Next steps</h2>
+        <p style={{ lineHeight: 1.6 }}>
+          Track <HelpTip term="Releases" slug="releases" onOpen={openHelp} /> as they progress from initiation to settlement and
+          reconcile balances with upstream statements.
+        </p>
+      </section>
+
+      <HelpCenter
+        open={helpOpen}
+        query={helpQuery}
+        docs={helpDocs}
+        filtered={filteredDocs}
+        activeSlug={activeSlug}
+        onQueryChange={setHelpQuery}
+        onClose={closeHelp}
+        onSelectDoc={handleSelectDoc}
+      />
+    </div>
+  );
+}
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/docs/help/close-issue.mdx
+++ b/docs/help/close-issue.mdx
@@ -1,0 +1,14 @@
+---
+title: "Close and issue"
+slug: "close-issue"
+summary: "Transition a period into READY_RPT using the close-issue API."
+---
+
+# Close and issue
+
+When reconciliation tasks are done, advance the period to `READY_RPT` so an RPT can be minted.
+
+Invoke `POST /api/close-issue` with the ABN, tax type and period ID. The endpoint enforces that outstanding discrepancies have
+been resolved before it will update the state machine.
+
+Once the call succeeds, proceed with RPT issuance and subsequent release activity.

--- a/docs/help/evidence.mdx
+++ b/docs/help/evidence.mdx
@@ -1,0 +1,14 @@
+---
+title: "Evidence bundles"
+slug: "evidence"
+summary: "Download signed reconciliation evidence from the evidence endpoint."
+---
+
+# Evidence bundles
+
+Auditors and compliance reviewers consume the signed payload that proves the ledger matches external statements. Use
+`GET /api/evidence` with the ABN, tax type and period ID query parameters to download the ZIP archive of receipts, checksums and
+signature manifests.
+
+The endpoint enforces the same access control as the console. Rotate credentials that can reach `GET /api/evidence` in line with
+internal compliance policies and alert if a bundle is requested outside your normal cadence.

--- a/docs/help/health.mdx
+++ b/docs/help/health.mdx
@@ -1,0 +1,13 @@
+---
+title: "Health monitoring"
+slug: "health"
+summary: "Probe the lightweight health endpoint from load balancers and schedulers."
+---
+
+# Health monitoring
+
+Expose `GET /health` to load balancers and orchestration tools so they can drain traffic if the app becomes unhealthy. The
+endpoint returns `{ "ok": true }` when the service loop is running.
+
+Combine the health probe with checks on dependent services such as the database, message bus and release queue to catch partial
+failures before they impact release operations.

--- a/docs/help/ledger.mdx
+++ b/docs/help/ledger.mdx
@@ -1,0 +1,17 @@
+---
+title: "Ledger management"
+slug: "ledger"
+summary: "Monitor balances and append deposits to one-way accounts."
+---
+
+# Ledger management
+
+The ledger tracks every inflow and outflow for a period.
+
+- Call `GET /api/balance` to return the latest running balance. The response includes the last update timestamp so you can spot
+  staleness.
+- Use `GET /api/ledger` for the full transaction list when reconciling statement exports.
+- Credit funds with `POST /api/deposit`. The request body enforces positive `amountCents` values to protect against accidental
+  reversals.
+
+Deposits and releases appear in chronological order and power the evidence bundle that `GET /api/evidence` exports.

--- a/docs/help/payto.mdx
+++ b/docs/help/payto.mdx
@@ -1,0 +1,21 @@
+---
+title: "PayTo sweeps"
+slug: "payto"
+summary: "Schedule and reconcile PayTo sweeps with the webhook callbacks."
+---
+
+# PayTo sweeps
+
+PayTo lets APGMS prefund outgoing disbursements from linked mandate accounts. The flow combines a proactive sweep with
+asynchronous settlement notifications.
+
+## Kick off a sweep
+
+Submit `POST /api/payto/sweep` with the ABN, debit amount and reference that matches the mandate agreement. The service will
+reserve the PayTo window and respond immediately when the sweep request is accepted by the banking rail.
+
+## Track settlement
+
+Banking partners confirm the outcome by calling `POST /api/settlement/webhook`. The webhook payload references the same
+`sweep.reference`, along with the status and timestamp so you can reconcile the release window. Store the callback data alongside
+ledger entries to keep the audit trail intact.

--- a/docs/help/releases.mdx
+++ b/docs/help/releases.mdx
@@ -1,0 +1,16 @@
+---
+title: "Releases"
+slug: "releases"
+summary: "How APGMS releases draw down one-way account balances after RPT verification."
+---
+
+# Releases
+
+Releases move funds from the one-way account to the beneficiary after controls have cleared.
+
+- Use `POST /api/pay` when orchestrating a release directly from the console workflow. Attach the RPT, idempotency key and
+  target account metadata.
+- Use `POST /api/release` when calling through the payments proxy for service-to-service automation. The payload matches the same
+  structure and still requires a valid RPT signature.
+
+Both endpoints debit the ledger atomically and append a release entry that is reflected by `GET /api/balance` and `GET /api/ledger`.

--- a/docs/help/rpt.mdx
+++ b/docs/help/rpt.mdx
@@ -1,0 +1,23 @@
+---
+title: "Reconciliation Pass Tokens (RPT)"
+slug: "rpt"
+summary: "How RPT issuance gates outbound releases through /api/pay and /api/release."
+---
+
+# Reconciliation Pass Tokens (RPT)
+
+Reconciliation Pass Tokens (RPTs) are the green-light artifacts that unlock outbound flows once a period has reconciled. An RPT
+contains the ABN, tax type, period, and an Ed25519 signature that downstream services verify before moving funds.
+
+## Operational sequence
+
+1. Close the period after resolving anomalies with `POST /api/close-issue`. This transitions the ledger to `READY_RPT` so an RPT
+   can be issued.
+2. Issue the token via the console or automation. The signed payload is persisted alongside the ledger snapshot.
+3. Present that token when invoking `POST /api/pay` for the release service or `POST /api/release` for the payments proxy. Both
+   endpoints verify signature freshness and expiry before debiting the one-way account.
+
+## Failure handling
+
+If the RPT has expired or is missing, the release endpoints return a `400` with an explanatory error. The recovery path is to
+re-issue a fresh RPT for the same period and retry the `POST /api/pay` or `POST /api/release` call.

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,542 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "APGMS API",
+    "version": "0.1.0",
+    "description": "Programmatic surface area for APGMS payments, releases and evidence."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000",
+      "description": "Local development"
+    }
+  ],
+  "paths": {
+    "/health": {
+      "get": {
+        "summary": "Service health",
+        "description": "Returns a lightweight heartbeat so orchestrators can confirm the core service is running.",
+        "tags": [
+          "Core"
+        ],
+        "x-public": true,
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    }
+                  },
+                  "required": [
+                    "ok"
+                  ],
+                  "additionalProperties": false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pay": {
+      "post": {
+        "summary": "Submit an RPT-gated payment",
+        "description": "Releases funds via the reconciliation pipeline. Requires a valid RPT and idempotency key to guard double spends.",
+        "tags": [
+          "Releases"
+        ],
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Payment accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": {
+                      "type": "boolean"
+                    },
+                    "releaseId": {
+                      "type": "string"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Request rejected"
+          }
+        }
+      }
+    },
+    "/api/close-issue": {
+      "post": {
+        "summary": "Close and issue next period",
+        "description": "Moves an accounting period to READY_RPT after closing tasks have been completed.",
+        "tags": [
+          "Periods"
+        ],
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "abn": {
+                    "type": "string"
+                  },
+                  "taxType": {
+                    "$ref": "#/components/schemas/TaxType"
+                  },
+                  "periodId": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "abn",
+                  "taxType",
+                  "periodId"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Period closed"
+          },
+          "400": {
+            "description": "Invalid request"
+          }
+        }
+      }
+    },
+    "/api/payto/sweep": {
+      "post": {
+        "summary": "Initiate a PayTo sweep",
+        "description": "Creates a PayTo debit against the configured mandate to prefund upcoming releases.",
+        "tags": [
+          "PayTo"
+        ],
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "abn": {
+                    "type": "string"
+                  },
+                  "amountCents": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "reference": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "abn",
+                  "amountCents",
+                  "reference"
+                ],
+                "additionalProperties": false
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Sweep accepted"
+          },
+          "400": {
+            "description": "Sweep rejected"
+          }
+        }
+      }
+    },
+    "/api/settlement/webhook": {
+      "post": {
+        "summary": "Settlement status webhook",
+        "description": "Endpoint for banking rails to notify settlement outcomes for PayTo sweeps or releases.",
+        "tags": [
+          "PayTo"
+        ],
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "eventType": {
+                    "type": "string"
+                  },
+                  "reference": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string"
+                  },
+                  "occurredAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                },
+                "required": [
+                  "eventType",
+                  "reference",
+                  "status",
+                  "occurredAt"
+                ],
+                "additionalProperties": true
+              }
+            }
+          }
+        },
+        "responses": {
+          "202": {
+            "description": "Webhook accepted"
+          },
+          "400": {
+            "description": "Invalid payload"
+          }
+        }
+      }
+    },
+    "/api/evidence": {
+      "get": {
+        "summary": "Download reconciliation evidence",
+        "description": "Exports the signed evidence bundle for auditors and compliance teams.",
+        "tags": [
+          "Evidence"
+        ],
+        "x-public": true,
+        "parameters": [
+          {
+            "in": "query",
+            "name": "abn",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "taxType",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TaxType"
+            }
+          },
+          {
+            "in": "query",
+            "name": "periodId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Evidence bundle",
+            "content": {
+              "application/zip": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bundle not found"
+          }
+        }
+      }
+    },
+    "/api/balance": {
+      "get": {
+        "summary": "Current ledger balance",
+        "description": "Returns the rolling balance for a specific ABN, tax type and period.",
+        "tags": [
+          "Ledger"
+        ],
+        "x-public": true,
+        "parameters": [
+          {
+            "in": "query",
+            "name": "abn",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "taxType",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TaxType"
+            }
+          },
+          {
+            "in": "query",
+            "name": "periodId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balance response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "balanceCents": {
+                      "type": "integer"
+                    },
+                    "updatedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error"
+          }
+        }
+      }
+    },
+    "/api/ledger": {
+      "get": {
+        "summary": "Full ledger history",
+        "description": "Returns the full ledger of credits and debits for a period.",
+        "tags": [
+          "Ledger"
+        ],
+        "x-public": true,
+        "parameters": [
+          {
+            "in": "query",
+            "name": "abn",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "taxType",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TaxType"
+            }
+          },
+          {
+            "in": "query",
+            "name": "periodId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ledger entries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LedgerEntry"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/deposit": {
+      "post": {
+        "summary": "Record a deposit",
+        "description": "Credits funds into the one-way account ledger for a period.",
+        "tags": [
+          "Ledger"
+        ],
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DepositRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Deposit recorded"
+          },
+          "400": {
+            "description": "Invalid deposit"
+          }
+        }
+      }
+    },
+    "/api/release": {
+      "post": {
+        "summary": "Release funds",
+        "description": "Releases funds downstream once RPT and risk checks have passed.",
+        "tags": [
+          "Releases"
+        ],
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Release accepted"
+          },
+          "400": {
+            "description": "Release rejected"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "TaxType": {
+        "type": "string",
+        "enum": [
+          "PAYGW",
+          "GST"
+        ],
+        "description": "ATO tax type identifier"
+      },
+      "LedgerEntry": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "transferUuid": {
+            "type": "string"
+          },
+          "amountCents": {
+            "type": "integer"
+          },
+          "balanceAfterCents": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "transferUuid",
+          "amountCents",
+          "balanceAfterCents",
+          "createdAt"
+        ],
+        "additionalProperties": true
+      },
+      "DepositRequest": {
+        "type": "object",
+        "properties": {
+          "abn": {
+            "type": "string"
+          },
+          "taxType": {
+            "$ref": "#/components/schemas/TaxType"
+          },
+          "periodId": {
+            "type": "string"
+          },
+          "amountCents": {
+            "type": "integer",
+            "minimum": 1
+          }
+        },
+        "required": [
+          "abn",
+          "taxType",
+          "periodId",
+          "amountCents"
+        ],
+        "additionalProperties": false
+      },
+      "ReleaseRequest": {
+        "type": "object",
+        "properties": {
+          "abn": {
+            "type": "string"
+          },
+          "taxType": {
+            "$ref": "#/components/schemas/TaxType"
+          },
+          "periodId": {
+            "type": "string"
+          },
+          "amountCents": {
+            "type": "integer"
+          }
+        },
+        "required": [
+          "abn",
+          "taxType",
+          "periodId",
+          "amountCents"
+        ],
+        "additionalProperties": false
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "openapi": "tsx scripts/generate-openapi.ts",
+        "docs:check": "tsx scripts/check-docs.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/check-docs.ts
+++ b/scripts/check-docs.ts
@@ -1,0 +1,194 @@
+import { existsSync, mkdirSync, readFileSync, readdirSync, statSync, writeFileSync } from "node:fs";
+import { join, relative, resolve, dirname } from "node:path";
+
+import { buildOpenApiSpec } from "./openapi";
+
+const HTTP_METHODS = new Set(["get", "post", "put", "patch", "delete", "options", "head", "trace"]);
+
+interface DocRecord {
+  filePath: string;
+  slug: string;
+  title: string;
+  summary: string;
+  headings: string[];
+  body: string;
+  plainText: string;
+  links: string[];
+}
+
+function walkDocs(dir: string): string[] {
+  const entries = readdirSync(dir);
+  const results: string[] = [];
+  for (const entry of entries) {
+    const full = join(dir, entry);
+    const stats = statSync(full);
+    if (stats.isDirectory()) {
+      results.push(...walkDocs(full));
+    } else if (stats.isFile() && entry.endsWith(".mdx")) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+function parseFrontmatter(raw: string): { data: Record<string, string>; body: string } {
+  const frontmatterMatch = raw.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!frontmatterMatch) {
+    return { data: {}, body: raw.trim() };
+  }
+  const frontmatter = frontmatterMatch[1];
+  const body = raw.slice(frontmatterMatch[0].length).trim();
+  const data: Record<string, string> = {};
+  for (const line of frontmatter.split(/\n+/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const [key, ...rest] = trimmed.split(":");
+    if (!key || rest.length === 0) continue;
+    const value = rest.join(":").trim().replace(/^"|"$/g, "");
+    data[key.trim()] = value;
+  }
+  return { data, body };
+}
+
+function summarise(body: string): string {
+  const paragraphs = body
+    .split(/\n{2,}/)
+    .map((chunk) => chunk.replace(/\s+/g, " ").trim())
+    .filter(Boolean);
+  return paragraphs[0] ?? "";
+}
+
+function stripMarkdown(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/\[(.*?)\]\((.*?)\)/g, "$1")
+    .replace(/^#{1,6}\s*/gm, "")
+    .replace(/^>\s?/gm, "")
+    .replace(/[*_~]/g, "")
+    .replace(/\r/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractLinks(markdown: string): string[] {
+  const links: string[] = [];
+  const regex = /\[(?:[^\]]+)\]\(([^)]+)\)/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(markdown))) {
+    links.push(match[1]);
+  }
+  return links;
+}
+
+function loadDocs(): DocRecord[] {
+  const docsDir = resolve(process.cwd(), "docs");
+  if (!existsSync(docsDir)) {
+    throw new Error("docs directory not found");
+  }
+  const files = walkDocs(docsDir);
+  return files.map((filePath) => {
+    const raw = readFileSync(filePath, "utf8");
+    const { data, body } = parseFrontmatter(raw);
+    const title = data.title || body.split("\n")[0]?.replace(/^#+\s*/, "").trim() || relative(docsDir, filePath);
+    const slug = data.slug || title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/(^-|-$)/g, "");
+    const summary = data.summary || summarise(body);
+    const headings = body
+      .split("\n")
+      .filter((line) => line.trim().startsWith("#"))
+      .map((line) => line.replace(/^#+\s*/, "").trim());
+    const plainText = stripMarkdown(body);
+    const links = extractLinks(body);
+    return { filePath, slug, title, summary, headings, body, plainText, links };
+  });
+}
+
+interface Endpoint {
+  method: string;
+  path: string;
+}
+
+function listPublicEndpoints(): Endpoint[] {
+  const spec = buildOpenApiSpec();
+  const endpoints: Endpoint[] = [];
+  for (const [pathKey, item] of Object.entries(spec.paths ?? {})) {
+    if (!item) continue;
+    for (const [method, operation] of Object.entries(item)) {
+      if (!HTTP_METHODS.has(method)) continue;
+      if (!operation || typeof operation !== "object") continue;
+      const op: any = operation;
+      if (op["x-public"] === false) continue;
+      endpoints.push({ method: method.toUpperCase(), path: pathKey });
+    }
+  }
+  return endpoints;
+}
+
+function ensureCoverage(docs: DocRecord[], endpoints: Endpoint[]): string[] {
+  const problems: string[] = [];
+  const lowerDocs = docs.map((doc) => ({ ...doc, lower: doc.body.toLowerCase() }));
+  for (const endpoint of endpoints) {
+    const needle = `${endpoint.method} ${endpoint.path}`.toLowerCase();
+    const found = lowerDocs.some((doc) => doc.lower.includes(needle));
+    if (!found) {
+      problems.push(`Missing documentation for ${endpoint.method} ${endpoint.path}`);
+    }
+  }
+  return problems;
+}
+
+function ensureLinks(docs: DocRecord[]): string[] {
+  const problems: string[] = [];
+  for (const doc of docs) {
+    for (const link of doc.links) {
+      const clean = link.split("#")[0].split("?")[0];
+      if (!clean || /^(https?:|mailto:|tel:)/i.test(clean)) continue;
+      if (clean.startsWith("#")) continue;
+      let target: string;
+      if (clean.startsWith("/")) {
+        target = resolve(process.cwd(), clean.slice(1));
+      } else {
+        target = resolve(dirname(doc.filePath), clean);
+      }
+      if (!existsSync(target)) {
+        problems.push(`Dead link in ${relative(process.cwd(), doc.filePath)} -> ${link}`);
+      }
+    }
+  }
+  return problems;
+}
+
+function buildSearchIndex(docs: DocRecord[]) {
+  const records = docs
+    .map((doc) => ({
+      slug: doc.slug,
+      title: doc.title,
+      summary: doc.summary,
+      headings: doc.headings,
+      body: doc.body,
+      plainText: doc.plainText
+    }))
+    .sort((a, b) => a.title.localeCompare(b.title));
+  const publicDir = resolve(process.cwd(), "apps/web/console/public");
+  mkdirSync(publicDir, { recursive: true });
+  const outputPath = join(publicDir, "help-index.json");
+  writeFileSync(outputPath, JSON.stringify({ generatedAt: new Date().toISOString(), docs: records }, null, 2) + "\n");
+  console.log(`Help index written to ${relative(process.cwd(), outputPath)}`);
+}
+
+function main() {
+  const docs = loadDocs();
+  const endpoints = listPublicEndpoints();
+  const coverageIssues = ensureCoverage(docs, endpoints);
+  const linkIssues = ensureLinks(docs);
+
+  if (coverageIssues.length || linkIssues.length) {
+    [...coverageIssues, ...linkIssues].forEach((msg) => console.error(msg));
+    process.exit(1);
+  }
+
+  buildSearchIndex(docs);
+  console.log(`Documented ${endpoints.length} public endpoints across ${docs.length} pages.`);
+}
+
+main();

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,0 +1,13 @@
+import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { buildOpenApiSpec } from "./openapi";
+
+function main() {
+  const spec = buildOpenApiSpec();
+  const outputPath = resolve(process.cwd(), "openapi.json");
+  writeFileSync(outputPath, JSON.stringify(spec, null, 2) + "\n");
+  console.log(`openapi.json written to ${outputPath}`);
+}
+
+main();

--- a/scripts/openapi.ts
+++ b/scripts/openapi.ts
@@ -1,0 +1,351 @@
+type HttpMethod = "get" | "post" | "put" | "patch" | "delete" | "options" | "head" | "trace";
+
+type PathMap = {
+  [path: string]: Partial<Record<HttpMethod, Record<string, unknown> & { "x-public"?: boolean }>>;
+};
+
+type OpenAPIDocument = {
+  openapi: string;
+  info: { title: string; version: string; description: string };
+  servers: Array<{ url: string; description: string }>;
+  paths: PathMap;
+  components: { schemas: Record<string, unknown> };
+};
+
+export function buildOpenApiSpec(): OpenAPIDocument {
+  const paths: PathMap = {
+    "/health": {
+      get: {
+        summary: "Service health",
+        description: "Returns a lightweight heartbeat so orchestrators can confirm the core service is running.",
+        tags: ["Core"],
+        "x-public": true,
+        responses: {
+          200: {
+            description: "Service is healthy",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    ok: { type: "boolean" }
+                  },
+                  required: ["ok"],
+                  additionalProperties: false
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/pay": {
+      post: {
+        summary: "Submit an RPT-gated payment",
+        description:
+          "Releases funds via the reconciliation pipeline. Requires a valid RPT and idempotency key to guard double spends.",
+        tags: ["Releases"],
+        "x-public": true,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ReleaseRequest"
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: "Payment accepted",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    ok: { type: "boolean" },
+                    releaseId: { type: "string" }
+                  },
+                  additionalProperties: true
+                }
+              }
+            }
+          },
+          400: { description: "Request rejected" }
+        }
+      }
+    },
+    "/api/close-issue": {
+      post: {
+        summary: "Close and issue next period",
+        description: "Moves an accounting period to READY_RPT after closing tasks have been completed.",
+        tags: ["Periods"],
+        "x-public": true,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  abn: { type: "string" },
+                  taxType: { $ref: "#/components/schemas/TaxType" },
+                  periodId: { type: "string" }
+                },
+                required: ["abn", "taxType", "periodId"],
+                additionalProperties: false
+              }
+            }
+          }
+        },
+        responses: {
+          200: { description: "Period closed" },
+          400: { description: "Invalid request" }
+        }
+      }
+    },
+    "/api/payto/sweep": {
+      post: {
+        summary: "Initiate a PayTo sweep",
+        description: "Creates a PayTo debit against the configured mandate to prefund upcoming releases.",
+        tags: ["PayTo"],
+        "x-public": true,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  abn: { type: "string" },
+                  amountCents: { type: "integer", minimum: 1 },
+                  reference: { type: "string" }
+                },
+                required: ["abn", "amountCents", "reference"],
+                additionalProperties: false
+              }
+            }
+          }
+        },
+        responses: {
+          200: { description: "Sweep accepted" },
+          400: { description: "Sweep rejected" }
+        }
+      }
+    },
+    "/api/settlement/webhook": {
+      post: {
+        summary: "Settlement status webhook",
+        description: "Endpoint for banking rails to notify settlement outcomes for PayTo sweeps or releases.",
+        tags: ["PayTo"],
+        "x-public": true,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  eventType: { type: "string" },
+                  reference: { type: "string" },
+                  status: { type: "string" },
+                  occurredAt: { type: "string", format: "date-time" }
+                },
+                required: ["eventType", "reference", "status", "occurredAt"],
+                additionalProperties: true
+              }
+            }
+          }
+        },
+        responses: {
+          202: { description: "Webhook accepted" },
+          400: { description: "Invalid payload" }
+        }
+      }
+    },
+    "/api/evidence": {
+      get: {
+        summary: "Download reconciliation evidence",
+        description: "Exports the signed evidence bundle for auditors and compliance teams.",
+        tags: ["Evidence"],
+        "x-public": true,
+        parameters: [
+          { in: "query", name: "abn", required: true, schema: { type: "string" } },
+          { in: "query", name: "taxType", required: true, schema: { $ref: "#/components/schemas/TaxType" } },
+          { in: "query", name: "periodId", required: true, schema: { type: "string" } }
+        ],
+        responses: {
+          200: {
+            description: "Evidence bundle",
+            content: {
+              "application/zip": {
+                schema: { type: "string", format: "binary" }
+              }
+            }
+          },
+          404: { description: "Bundle not found" }
+        }
+      }
+    },
+    "/api/balance": {
+      get: {
+        summary: "Current ledger balance",
+        description: "Returns the rolling balance for a specific ABN, tax type and period.",
+        tags: ["Ledger"],
+        "x-public": true,
+        parameters: [
+          { in: "query", name: "abn", required: true, schema: { type: "string" } },
+          { in: "query", name: "taxType", required: true, schema: { $ref: "#/components/schemas/TaxType" } },
+          { in: "query", name: "periodId", required: true, schema: { type: "string" } }
+        ],
+        responses: {
+          200: {
+            description: "Balance response",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    balanceCents: { type: "integer" },
+                    updatedAt: { type: "string", format: "date-time" }
+                  },
+                  additionalProperties: true
+                }
+              }
+            }
+          },
+          400: { description: "Validation error" }
+        }
+      }
+    },
+    "/api/ledger": {
+      get: {
+        summary: "Full ledger history",
+        description: "Returns the full ledger of credits and debits for a period.",
+        tags: ["Ledger"],
+        "x-public": true,
+        parameters: [
+          { in: "query", name: "abn", required: true, schema: { type: "string" } },
+          { in: "query", name: "taxType", required: true, schema: { $ref: "#/components/schemas/TaxType" } },
+          { in: "query", name: "periodId", required: true, schema: { type: "string" } }
+        ],
+        responses: {
+          200: {
+            description: "Ledger entries",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "array",
+                  items: { $ref: "#/components/schemas/LedgerEntry" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/deposit": {
+      post: {
+        summary: "Record a deposit",
+        description: "Credits funds into the one-way account ledger for a period.",
+        tags: ["Ledger"],
+        "x-public": true,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/DepositRequest"
+              }
+            }
+          }
+        },
+        responses: {
+          200: { description: "Deposit recorded" },
+          400: { description: "Invalid deposit" }
+        }
+      }
+    },
+    "/api/release": {
+      post: {
+        summary: "Release funds",
+        description: "Releases funds downstream once RPT and risk checks have passed.",
+        tags: ["Releases"],
+        "x-public": true,
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/ReleaseRequest"
+              }
+            }
+          }
+        },
+        responses: {
+          200: { description: "Release accepted" },
+          400: { description: "Release rejected" }
+        }
+      }
+    }
+  };
+
+  const spec: OpenAPIDocument = {
+    openapi: "3.1.0",
+    info: {
+      title: "APGMS API",
+      version: "0.1.0",
+      description: "Programmatic surface area for APGMS payments, releases and evidence." 
+    },
+    servers: [
+      { url: "http://localhost:3000", description: "Local development" }
+    ],
+    paths,
+    components: {
+      schemas: {
+        TaxType: {
+          type: "string",
+          enum: ["PAYGW", "GST"],
+          description: "ATO tax type identifier"
+        },
+        LedgerEntry: {
+          type: "object",
+          properties: {
+            id: { type: "integer" },
+            transferUuid: { type: "string" },
+            amountCents: { type: "integer" },
+            balanceAfterCents: { type: "integer" },
+            createdAt: { type: "string", format: "date-time" }
+          },
+          required: ["id", "transferUuid", "amountCents", "balanceAfterCents", "createdAt"],
+          additionalProperties: true
+        },
+        DepositRequest: {
+          type: "object",
+          properties: {
+            abn: { type: "string" },
+            taxType: { $ref: "#/components/schemas/TaxType" },
+            periodId: { type: "string" },
+            amountCents: { type: "integer", minimum: 1 }
+          },
+          required: ["abn", "taxType", "periodId", "amountCents"],
+          additionalProperties: false
+        },
+        ReleaseRequest: {
+          type: "object",
+          properties: {
+            abn: { type: "string" },
+            taxType: { $ref: "#/components/schemas/TaxType" },
+            periodId: { type: "string" },
+            amountCents: { type: "integer" }
+          },
+          required: ["abn", "taxType", "periodId", "amountCents"],
+          additionalProperties: false
+        }
+      }
+    }
+  };
+
+  return spec;
+}


### PR DESCRIPTION
## Summary
- generate an OpenAPI specification from source and script the docs coverage check that also produces the help search index
- build a Shift+/ driven help center with search and inline HelpTip links for RPT, PayTo, Evidence, and Releases
- document all public endpoints in new MDX pages to keep the help library current

## Testing
- npx tsx scripts/generate-openapi.ts
- npx tsx scripts/check-docs.ts

------
https://chatgpt.com/codex/tasks/task_e_68e37ba1f8c88327b55e2716c6a8e6e9