### PR TITLE
Add evidence bundle endpoints and UI evidence drawer

### DIFF
--- a/migrations/003_evidence_bundles.sql
+++ b/migrations/003_evidence_bundles.sql
@@ -1,0 +1,15 @@
+-- 003_evidence_bundles.sql
+-- Evidence bundle storage for auditor exports
+
+CREATE TABLE IF NOT EXISTS evidence_bundles (
+  id BIGSERIAL PRIMARY KEY,
+  abn TEXT NOT NULL,
+  tax_type TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  details JSONB NOT NULL,
+  UNIQUE (abn, tax_type, period_id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_evidence_bundles_created_at
+  ON evidence_bundles (created_at DESC);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Audit from "./pages/Audit";
 import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
+import PeriodDetail from "./pages/PeriodDetail";
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
           <Route path="/fraud" element={<Fraud />} />
           <Route path="/integrations" element={<Integrations />} />
           <Route path="/help" element={<Help />} />
+          <Route path="/periods/:periodId" element={<PeriodDetail />} />
         </Route>
       </Routes>
     </Router>

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,237 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { Pool } from "pg";
+import { EvidenceBundle, EvidenceReceipt, LedgerEntry, PeriodSummary } from "../types/evidence";
 
-export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+const pool = new Pool();
+const DEFAULT_RATES_VERSION = process.env.ATO_RATES_VERSION || "ATO-2024.07";
+const DEFAULT_PUBLIC_KEY_ID =
+  process.env.RPT_PUBLIC_KEY_ID || process.env.RPT_ED25519_KEY_ID || "ed25519:primary";
+const DEFAULT_LABELS: Record<string, number | null> = { W1: null, W2: null, "1A": null, "1B": null };
+const LEDGER_SAMPLE_SIZE = 10;
+
+let tableEnsured = false;
+
+async function ensureEvidenceTable() {
+  if (tableEnsured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS evidence_bundles (
+      id BIGSERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+      details JSONB NOT NULL,
+      UNIQUE (abn, tax_type, period_id)
+    )
+  `);
+  tableEnsured = true;
+}
+
+function safeIso(value: any): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string") {
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) return parsed.toISOString();
+  }
+  if (value && typeof value.toISOString === "function") return value.toISOString();
+  return new Date().toISOString();
+}
+
+function extractBasLabels(periodRow: any): Record<string, number | null> {
+  const candidate = (periodRow?.bas_labels ?? periodRow?.thresholds?.bas_labels) as
+    | Record<string, number | null>
+    | undefined;
+  if (candidate && typeof candidate === "object") {
+    return { ...DEFAULT_LABELS, ...candidate };
+  }
+  return { ...DEFAULT_LABELS };
+}
+
+function determineRatesVersion(periodRow: any): string {
+  const fromPeriod =
+    (periodRow?.rates_version as string | undefined) ||
+    (periodRow?.thresholds?.rates_version as string | undefined) ||
+    (periodRow?.thresholds?.ratesVersion as string | undefined);
+  if (fromPeriod && fromPeriod.trim().length > 0) {
+    return fromPeriod;
+  }
+  return DEFAULT_RATES_VERSION;
+}
+
+function normaliseLedgerEntries(rows: any[]): LedgerEntry[] {
+  return rows.map((row) => ({
+    id: Number(row.id),
+    transfer_uuid: row.transfer_uuid ?? null,
+    amount_cents: Number(row.amount_cents ?? 0),
+    balance_after_cents: Number(row.balance_after_cents ?? 0),
+    bank_receipt_hash: row.bank_receipt_hash ?? null,
+    prev_hash: row.prev_hash ?? null,
+    hash_after: row.hash_after ?? null,
+    created_at: safeIso(row.created_at),
+  }));
+}
+
+function centsFromPayload(payload: Record<string, unknown> | undefined, fallback: number): number {
+  if (!payload) return fallback;
+  const value = payload["amount_cents"];
+  if (typeof value === "number") return value;
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function formatReceipt(
+  ledgerEntry: LedgerEntry | undefined,
+  payload: Record<string, unknown> | undefined,
+  periodId: string,
+  finalLiabilityCents: number,
+  generatedAt: string
+): EvidenceReceipt {
+  const channel = (payload?.["rail_id"] as string | undefined) || null;
+  const providerRef = ledgerEntry?.bank_receipt_hash ?? null;
+  const transferId = ledgerEntry?.transfer_uuid ?? null;
+  const amountCents = ledgerEntry
+    ? Math.abs(ledgerEntry.amount_cents)
+    : Math.abs(centsFromPayload(payload, finalLiabilityCents));
+  const lines = [
+    "APGMS Bank Receipt",
+    `Generated: ${generatedAt}`,
+    `Period: ${periodId}`,
+    `Channel: ${channel ?? "UNKNOWN"}`,
+    `Provider Reference: ${providerRef ?? "N/A"}`,
+    `Transfer UUID: ${transferId ?? "N/A"}`,
+    `Amount (AUD): ${(amountCents / 100).toFixed(2)}`,
+    `Dry Run: ${ledgerEntry ? "false" : "true"}`,
+  ];
+
+  return {
+    id: transferId,
+    channel,
+    provider_ref: providerRef,
+    dry_run: !ledgerEntry,
+    raw: lines.join("\n"),
   };
+}
+
+async function persistBundle(abn: string, taxType: string, periodId: string, bundle: EvidenceBundle) {
+  await ensureEvidenceTable();
+  await pool.query(
+    `
+      INSERT INTO evidence_bundles (abn, tax_type, period_id, details)
+      VALUES ($1, $2, $3, $4::jsonb)
+      ON CONFLICT (abn, tax_type, period_id)
+      DO UPDATE SET details = EXCLUDED.details, created_at = now()
+    `,
+    [abn, taxType, periodId, JSON.stringify(bundle)]
+  );
+}
+
+export async function buildEvidenceBundle(
+  abn: string,
+  taxType: string,
+  periodId: string
+): Promise<EvidenceBundle> {
+  const periodRes = await pool.query(
+    `
+      SELECT state, accrued_cents, credited_to_owa_cents, final_liability_cents,
+             merkle_root, running_balance_hash, anomaly_vector, thresholds
+        FROM periods
+       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
+    `,
+    [abn, taxType, periodId]
+  );
+
+  if (periodRes.rowCount === 0) {
+    throw new Error("PERIOD_NOT_FOUND");
+  }
+
+  const periodRow = periodRes.rows[0];
+  const generatedAt = new Date().toISOString();
+  const ratesVersion = determineRatesVersion(periodRow);
+  const periodSummary: PeriodSummary = {
+    state: String(periodRow.state ?? "UNKNOWN"),
+    totals: {
+      accrued_cents: Number(periodRow.accrued_cents ?? 0),
+      credited_to_owa_cents: Number(periodRow.credited_to_owa_cents ?? 0),
+      final_liability_cents: Number(periodRow.final_liability_cents ?? 0),
+    },
+    labels: extractBasLabels(periodRow),
+    anomaly_vector: (periodRow.anomaly_vector ?? {}) as Record<string, unknown>,
+    thresholds: (periodRow.thresholds ?? {}) as Record<string, unknown>,
+    rates_version: ratesVersion,
+  };
+
+  const ledgerRes = await pool.query(
+    `
+      SELECT id, transfer_uuid, amount_cents, balance_after_cents,
+             bank_receipt_hash, prev_hash, hash_after, created_at
+        FROM owa_ledger
+       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
+       ORDER BY id DESC
+       LIMIT $4
+    `,
+    [abn, taxType, periodId, LEDGER_SAMPLE_SIZE * 3]
+  );
+
+  const ledgerEntries = normaliseLedgerEntries(ledgerRes.rows).sort((a, b) => a.id - b.id);
+  const sampleEntries = ledgerEntries.slice(-LEDGER_SAMPLE_SIZE);
+  const lastEntry = sampleEntries[sampleEntries.length - 1] || ledgerEntries[ledgerEntries.length - 1];
+
+  const rptRes = await pool.query(
+    `
+      SELECT payload, signature
+        FROM rpt_tokens
+       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
+       ORDER BY created_at DESC
+       LIMIT 1
+    `,
+    [abn, taxType, periodId]
+  );
+
+  const rptRow = rptRes.rows[0] ?? null;
+  const rpt = rptRow
+    ? {
+        payload: (rptRow.payload ?? {}) as Record<string, unknown>,
+        signature: String(rptRow.signature ?? ""),
+        public_key_id: DEFAULT_PUBLIC_KEY_ID,
+      }
+    : null;
+
+  if (!rpt) {
+    throw new Error("RPT_NOT_FOUND");
+  }
+
+  const receiptSource = [...ledgerEntries].reverse().find((entry) => entry.amount_cents < 0);
+  const receipt = formatReceipt(
+    receiptSource,
+    rpt.payload,
+    periodId,
+    periodSummary.totals.final_liability_cents,
+    generatedAt
+  );
+
+  const ledgerProof = {
+    merkle_root: (periodRow.merkle_root as string | null) ?? lastEntry?.hash_after ?? null,
+    running_balance_hash:
+      (periodRow.running_balance_hash as string | null) ?? lastEntry?.hash_after ?? null,
+    entry_count: ledgerEntries.length,
+    entries: sampleEntries,
+  };
+
+  const bundle: EvidenceBundle = {
+    abn,
+    tax_type: taxType,
+    period_id: periodId,
+    generated_at: generatedAt,
+    rates_version: ratesVersion,
+    period_summary: periodSummary,
+    ledger_proof: ledgerProof,
+    rpt,
+    receipt,
+  };
+
+  await persistBundle(abn, taxType, periodId, bundle);
+
   return bundle;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -197,3 +197,227 @@ th {
   font-weight: 600;
   color: #00205b;
 }
+
+/* Evidence drawer styles */
+.evidence-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 32, 91, 0.38);
+  display: flex;
+  justify-content: flex-end;
+  z-index: 1000;
+}
+
+.evidence-drawer {
+  width: min(520px, 100vw);
+  background: #fff;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -6px 0 20px rgba(0, 32, 91, 0.2);
+}
+
+.drawer-header {
+  padding: 24px;
+  border-bottom: 1px solid #e3e8f0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.drawer-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.drawer-body {
+  padding: 24px;
+  overflow-y: auto;
+  flex: 1;
+  background: #f7f9fc;
+}
+
+.drawer-close {
+  background: none;
+  border: none;
+  color: #00716b;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.drawer-section {
+  margin-bottom: 28px;
+}
+
+.drawer-section h3 {
+  margin: 0 0 12px 0;
+  font-size: 1.05rem;
+  color: #00205b;
+}
+
+.hash-value {
+  font-family: "Menlo", "Fira Mono", monospace;
+  display: inline-block;
+  background: #eef3fb;
+  padding: 4px 8px;
+  border-radius: 8px;
+  word-break: break-word;
+  font-size: 0.85rem;
+}
+
+.download-buttons {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 20px;
+}
+
+.download-button {
+  background: #00205b;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 10px 20px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 4px 12px rgba(0, 32, 91, 0.16);
+}
+
+.download-button.secondary {
+  background: #00716b;
+}
+
+.download-button:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.receipt-card {
+  background: #f2f8f8;
+  border: 1px solid #d7e8e8;
+  border-radius: 12px;
+  padding: 12px 16px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  font-size: 0.9rem;
+}
+
+.receipt-raw,
+.evidence-json {
+  background: #0a162b;
+  color: #e4f2ff;
+  padding: 18px;
+  border-radius: 12px;
+  font-family: "Menlo", "Fira Mono", monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  overflow-x: auto;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.ledger-entries {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.ledger-entry {
+  background: #ffffff;
+  border: 1px solid #dbe5f5;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-size: 0.85rem;
+  box-shadow: 0 2px 6px rgba(0, 32, 91, 0.08);
+}
+
+.error-banner {
+  background: #fef2f2;
+  border: 1px solid #f9b5b5;
+  color: #a42525;
+  padding: 12px 16px;
+  border-radius: 12px;
+}
+
+.period-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.period-summary-grid .card {
+  background: #fff;
+  border: 1px solid #e2e8f5;
+  border-radius: 12px;
+  padding: 18px;
+  box-shadow: 0 2px 8px rgba(0, 32, 91, 0.08);
+}
+
+.period-summary-grid .value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: #00205b;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #e6f4f1;
+  color: #00716b;
+  font-size: 0.78rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.status-pill.released {
+  background: #e8f5e9;
+  color: #2e7d32;
+}
+
+.status-pill.ready_rpt {
+  background: #fff3e0;
+  color: #ef6c00;
+}
+
+.status-pill.blocked_discrepancy,
+.status-pill.blocked_anomaly {
+  background: #fdecea;
+  color: #c62828;
+}
+
+.period-table code {
+  font-family: "Menlo", "Fira Mono", monospace;
+  font-size: 0.82rem;
+}
+
+.period-table td.actions {
+  text-align: right;
+}
+
+.period-table td.actions a {
+  color: #00716b;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .evidence-drawer {
+    width: 100vw;
+  }
+
+  .drawer-body {
+    padding: 18px;
+  }
+
+  .download-buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { closeAndIssue, payAto, paytoSweep, settlementWebhook } from "./routes/reconcile";
+import { getEvidenceJson, getEvidenceZip } from "./routes/evidence";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -23,7 +24,9 @@ app.post("/api/pay", idempotency(), payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+
+app.get("/evidence/:periodId.json", getEvidenceJson);
+app.get("/evidence/:periodId.zip", getEvidenceZip);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,12 @@ export default function Dashboard() {
     outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
   };
 
+  const abn = '12345678901';
+  const periods = [
+    { id: '2025-09', taxType: 'GST', state: 'RELEASED', merkleRoot: 'merkle_demo_root' },
+    { id: '2025-06', taxType: 'PAYGW', state: 'READY_RPT', merkleRoot: 'pending_merkle' },
+  ];
+
   return (
     <div className="main-card">
       <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
@@ -79,6 +85,43 @@ export default function Dashboard() {
               : 'Needs attention'}
           </p>
         </div>
+      </div>
+
+      <div className="bg-white p-4 rounded-xl shadow mt-6">
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="text-lg font-semibold">Periods</h2>
+          <span className="text-xs text-gray-500">Ledger proofs & evidence bundles</span>
+        </div>
+        <table className="period-table">
+          <thead>
+            <tr>
+              <th>Period</th>
+              <th>Tax Type</th>
+              <th>Status</th>
+              <th>Merkle Root</th>
+              <th>Evidence</th>
+            </tr>
+          </thead>
+          <tbody>
+            {periods.map((period) => (
+              <tr key={`${period.id}-${period.taxType}`}>
+                <td>{period.id}</td>
+                <td>{period.taxType}</td>
+                <td>
+                  <span className={`status-pill ${period.state.toLowerCase()}`}>
+                    {period.state}
+                  </span>
+                </td>
+                <td><code>{period.merkleRoot}</code></td>
+                <td className="actions">
+                  <Link to={`/periods/${period.id}?abn=${abn}&taxType=${period.taxType}`} className="text-blue-600 underline">
+                    View evidence
+                  </Link>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
       </div>
 
       <div className="mt-6 text-sm text-gray-700">

--- a/src/pages/PeriodDetail.tsx
+++ b/src/pages/PeriodDetail.tsx
@@ -1,0 +1,248 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
+import { EvidenceBundle, LedgerEntry } from "../types/evidence";
+
+const DEFAULT_ABN = "12345678901";
+const DEFAULT_TAX_TYPE = "GST";
+
+type DownloadFormat = "json" | "zip";
+
+export default function PeriodDetail() {
+  const { periodId = "" } = useParams();
+  const [searchParams] = useSearchParams();
+  const abn = searchParams.get("abn")?.trim() || DEFAULT_ABN;
+  const taxType = (searchParams.get("taxType") || searchParams.get("tax_type") || DEFAULT_TAX_TYPE).toUpperCase();
+
+  const [bundle, setBundle] = useState<EvidenceBundle | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
+  const [downloading, setDownloading] = useState<DownloadFormat | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadEvidence() {
+      if (!periodId) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const resp = await fetch(
+          `/evidence/${encodeURIComponent(periodId)}.json?abn=${encodeURIComponent(abn)}&taxType=${encodeURIComponent(taxType)}`
+        );
+        if (!resp.ok) {
+          throw new Error(`Unable to load evidence (${resp.status})`);
+        }
+        const data: EvidenceBundle = await resp.json();
+        if (!cancelled) {
+          setBundle(data);
+        }
+      } catch (err: unknown) {
+        if (!cancelled) {
+          const message = err instanceof Error ? err.message : "Failed to load evidence";
+          setError(message);
+          setBundle(null);
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    loadEvidence();
+    return () => {
+      cancelled = true;
+    };
+  }, [abn, periodId, taxType]);
+
+  const prettyBundle = useMemo(() => (bundle ? JSON.stringify(bundle, null, 2) : ""), [bundle]);
+
+  const latestEntry = useMemo<LedgerEntry | null>(() => {
+    if (!bundle?.ledger_proof.entries.length) return null;
+    return bundle.ledger_proof.entries[bundle.ledger_proof.entries.length - 1];
+  }, [bundle]);
+
+  async function handleDownload(format: DownloadFormat) {
+    if (!periodId) return;
+    setDownloadError(null);
+    setDownloading(format);
+    try {
+      const url = `/evidence/${encodeURIComponent(periodId)}.${format}?abn=${encodeURIComponent(abn)}&taxType=${encodeURIComponent(taxType)}`;
+      const resp = await fetch(url);
+      if (!resp.ok) {
+        throw new Error(`Download failed (${resp.status})`);
+      }
+      const blob = await resp.blob();
+      const anchor = document.createElement("a");
+      anchor.href = URL.createObjectURL(blob);
+      anchor.download = `evidence_${abn}_${periodId}_${taxType}.${format}`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      URL.revokeObjectURL(anchor.href);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Download failed";
+      setDownloadError(message);
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  const statusPillClass = bundle ? `status-pill ${bundle.period_summary.state.toLowerCase()}` : "status-pill";
+
+  return (
+    <div className="main-card">
+      <Link to="/bas" className="text-blue-600 text-sm underline">
+        ← Back to BAS overview
+      </Link>
+
+      <h1 className="text-2xl font-bold mt-2">Period {periodId || ""}</h1>
+      <p className="text-sm text-gray-600">Evidence bundle and ledger proofs for ABN {abn} ({taxType}).</p>
+
+      {loading && <p className="mt-4 text-gray-600">Loading evidence bundle…</p>}
+      {error && !loading && <div className="error-banner">{error}</div>}
+
+      {bundle && !loading && (
+        <>
+          <div className="period-summary-grid">
+            <div className="card">
+              <h3>Status</h3>
+              <div className={statusPillClass}>{bundle.period_summary.state}</div>
+              <p className="text-xs text-gray-500 mt-2">Rates version {bundle.rates_version}</p>
+            </div>
+            <div className="card">
+              <h3>Merkle Root</h3>
+              <div className="hash-value">{bundle.ledger_proof.merkle_root ?? "n/a"}</div>
+              <p className="text-xs text-gray-500 mt-2">Running hash: {bundle.ledger_proof.running_balance_hash ?? "n/a"}</p>
+            </div>
+            <div className="card">
+              <h3>Final Liability</h3>
+              <div className="value">
+                ${
+                  (bundle.period_summary.totals.final_liability_cents / 100).toLocaleString(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  })
+                }
+              </div>
+              <p className="text-xs text-gray-500 mt-2">
+                Credited to OWA $
+                {(bundle.period_summary.totals.credited_to_owa_cents / 100).toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </p>
+            </div>
+            <div className="card">
+              <h3>Receipt</h3>
+              <p className="text-sm text-gray-600">Channel: {bundle.receipt.channel ?? "Pending"}</p>
+              <p className="text-xs text-gray-500">Reference: {bundle.receipt.provider_ref ?? "n/a"}</p>
+            </div>
+          </div>
+
+          <div className="download-buttons">
+            <button
+              className="download-button"
+              onClick={() => setIsDrawerOpen(true)}
+              type="button"
+            >
+              View Evidence
+            </button>
+            <button
+              className="download-button secondary"
+              type="button"
+              onClick={() => handleDownload("json")}
+              disabled={downloading === "json"}
+            >
+              {downloading === "json" ? "Downloading JSON…" : "Download JSON"}
+            </button>
+            <button
+              className="download-button secondary"
+              type="button"
+              onClick={() => handleDownload("zip")}
+              disabled={downloading === "zip"}
+            >
+              {downloading === "zip" ? "Downloading ZIP…" : "Download ZIP"}
+            </button>
+          </div>
+
+          {downloadError && <div className="error-banner mt-3">{downloadError}</div>}
+
+          <div className="mt-6 text-sm text-gray-700">
+            <p>
+              Ledger entries sampled: {bundle.ledger_proof.entry_count} total, showing {bundle.ledger_proof.entries.length}. Latest
+              hash <span className="hash-value">{latestEntry?.hash_after ?? "n/a"}</span>
+            </p>
+          </div>
+        </>
+      )}
+
+      {isDrawerOpen && bundle && (
+        <div className="evidence-overlay" onClick={() => setIsDrawerOpen(false)}>
+          <div className="evidence-drawer" onClick={(evt) => evt.stopPropagation()}>
+            <div className="drawer-header">
+              <div>
+                <h2>Evidence bundle</h2>
+                <p className="text-sm text-gray-500">Generated {new Date(bundle.generated_at).toLocaleString()}</p>
+              </div>
+              <button className="drawer-close" type="button" onClick={() => setIsDrawerOpen(false)}>
+                Close
+              </button>
+            </div>
+            <div className="drawer-body">
+              <section className="drawer-section">
+                <h3>Receipt</h3>
+                <div className="receipt-card">
+                  <div>
+                    <strong>Channel</strong>
+                    <div>{bundle.receipt.channel ?? "Pending"}</div>
+                  </div>
+                  <div>
+                    <strong>Provider Ref</strong>
+                    <div className="hash-value">{bundle.receipt.provider_ref ?? "n/a"}</div>
+                  </div>
+                  <div>
+                    <strong>Transfer UUID</strong>
+                    <div className="hash-value">{bundle.receipt.id ?? "n/a"}</div>
+                  </div>
+                  <div>
+                    <strong>Dry Run</strong>
+                    <div>{bundle.receipt.dry_run ? "Yes" : "No"}</div>
+                  </div>
+                </div>
+                <pre className="receipt-raw">{bundle.receipt.raw ?? "No bank receipt available yet."}</pre>
+              </section>
+
+              <section className="drawer-section">
+                <h3>Ledger proof</h3>
+                <p className="text-sm text-gray-600 mb-2">
+                  Merkle root <span className="hash-value">{bundle.ledger_proof.merkle_root ?? "n/a"}</span> · Running hash{' '}
+                  <span className="hash-value">{bundle.ledger_proof.running_balance_hash ?? "n/a"}</span>
+                </p>
+                <ul className="ledger-entries">
+                  {bundle.ledger_proof.entries.map((entry) => (
+                    <li key={entry.id} className="ledger-entry">
+                      <div>
+                        <strong>#{entry.id}</strong> · {new Date(entry.created_at).toLocaleString()}
+                      </div>
+                      <div>Amount: {(entry.amount_cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} AUD</div>
+                      <div>Balance: {(entry.balance_after_cents / 100).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} AUD</div>
+                      <div>Receipt: <span className="hash-value">{entry.bank_receipt_hash ?? "n/a"}</span></div>
+                      <div>Hash: <span className="hash-value">{entry.hash_after ?? "n/a"}</span></div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+
+              <section className="drawer-section">
+                <h3>Evidence JSON</h3>
+                <pre className="evidence-json">{prettyBundle}</pre>
+              </section>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes/evidence.ts
+++ b/src/routes/evidence.ts
@@ -1,0 +1,93 @@
+import { Request, Response } from "express";
+import { buildEvidenceBundle } from "../evidence/bundle";
+import { createZip } from "../utils/zip";
+import { EvidenceBundle } from "../types/evidence";
+
+interface EvidenceIdentifiers {
+  abn: string;
+  taxType: string;
+  periodId: string;
+}
+
+function parseIdentifiers(req: Request, res: Response): EvidenceIdentifiers | null {
+  const { periodId } = req.params as { periodId?: string };
+  const abn = String((req.query.abn ?? "").toString()).trim();
+  const taxParam = String((req.query.taxType ?? req.query.tax_type ?? "").toString()).trim();
+
+  if (!periodId) {
+    res.status(400).json({ error: "PERIOD_ID_REQUIRED" });
+    return null;
+  }
+  if (!abn) {
+    res.status(400).json({ error: "ABN_REQUIRED" });
+    return null;
+  }
+  if (!taxParam) {
+    res.status(400).json({ error: "TAX_TYPE_REQUIRED" });
+    return null;
+  }
+
+  return { abn, taxType: taxParam.toUpperCase(), periodId };
+}
+
+function evidenceFileBase({ abn, periodId, taxType }: EvidenceIdentifiers) {
+  return `evidence_${abn}_${periodId}_${taxType}`;
+}
+
+function receiptText(bundle: EvidenceBundle): string {
+  if (bundle.receipt?.raw) {
+    return bundle.receipt.raw;
+  }
+  const lines = [
+    "APGMS Bank Receipt",
+    `Period: ${bundle.period_id}`,
+    `Channel: ${bundle.receipt.channel ?? "UNKNOWN"}`,
+    `Provider Reference: ${bundle.receipt.provider_ref ?? "N/A"}`,
+    `Transfer UUID: ${bundle.receipt.id ?? "N/A"}`,
+    `Amount (AUD): ${(bundle.period_summary.totals.final_liability_cents / 100).toFixed(2)}`,
+    `Dry Run: ${bundle.receipt.dry_run}`,
+  ];
+  return lines.join("\n");
+}
+
+function handleError(res: Response, error: unknown) {
+  const message = error instanceof Error ? error.message : "UNKNOWN";
+  if (message === "PERIOD_NOT_FOUND" || message === "RPT_NOT_FOUND") {
+    return res.status(404).json({ error: message });
+  }
+  console.error("[evidence]", error);
+  return res.status(500).json({ error: "INTERNAL_ERROR" });
+}
+
+export async function getEvidenceJson(req: Request, res: Response) {
+  const identifiers = parseIdentifiers(req, res);
+  if (!identifiers) return;
+  try {
+    const bundle = await buildEvidenceBundle(identifiers.abn, identifiers.taxType, identifiers.periodId);
+    res.setHeader("Cache-Control", "no-store");
+    res.type("application/json");
+    res.send(JSON.stringify(bundle, null, 2));
+  } catch (error) {
+    handleError(res, error);
+  }
+}
+
+export async function getEvidenceZip(req: Request, res: Response) {
+  const identifiers = parseIdentifiers(req, res);
+  if (!identifiers) return;
+  try {
+    const bundle = await buildEvidenceBundle(identifiers.abn, identifiers.taxType, identifiers.periodId);
+    const base = evidenceFileBase(identifiers);
+    const files = [
+      { name: `${base}.json`, data: JSON.stringify(bundle, null, 2) },
+      { name: `receipt_${bundle.receipt.id ?? "pending"}.txt`, data: receiptText(bundle) },
+    ];
+    const zipBuffer = createZip(files);
+    res.setHeader("Cache-Control", "no-store");
+    res.setHeader("Content-Disposition", `attachment; filename=\"${base}.zip\"`);
+    res.type("application/zip");
+    res.send(zipBuffer);
+  } catch (error) {
+    handleError(res, error);
+  }
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,5 +1,4 @@
 ﻿import { issueRPT } from "../rpt/issuer";
-import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
@@ -46,7 +45,3 @@ export async function settlementWebhook(req:any, res:any) {
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
-}

--- a/src/types/evidence.ts
+++ b/src/types/evidence.ts
@@ -1,0 +1,54 @@
+export interface LedgerEntry {
+  id: number;
+  transfer_uuid: string | null;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string | null;
+  prev_hash: string | null;
+  hash_after: string | null;
+  created_at: string;
+}
+
+export interface PeriodTotals {
+  accrued_cents: number;
+  credited_to_owa_cents: number;
+  final_liability_cents: number;
+}
+
+export interface PeriodSummary {
+  state: string;
+  totals: PeriodTotals;
+  labels: Record<string, number | null>;
+  anomaly_vector: Record<string, unknown>;
+  thresholds: Record<string, unknown>;
+  rates_version: string;
+}
+
+export interface EvidenceReceipt {
+  id: string | null;
+  channel: string | null;
+  provider_ref: string | null;
+  dry_run: boolean;
+  raw?: string | null;
+}
+
+export interface EvidenceBundle {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  generated_at: string;
+  rates_version: string;
+  period_summary: PeriodSummary;
+  ledger_proof: {
+    merkle_root: string | null;
+    running_balance_hash: string | null;
+    entry_count: number;
+    entries: LedgerEntry[];
+  };
+  rpt: {
+    payload: Record<string, unknown>;
+    signature: string;
+    public_key_id: string;
+  } | null;
+  receipt: EvidenceReceipt;
+}

--- a/src/utils/zip.ts
+++ b/src/utils/zip.ts
@@ -1,0 +1,144 @@
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50;
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50;
+const END_OF_CENTRAL_DIRECTORY_SIGNATURE = 0x06054b50;
+const VERSION = 20; // ZIP version 2.0
+
+const crcTable = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = (c & 1) !== 0 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i++) {
+    const byte = buffer[i];
+    crc = crcTable[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function dateToDos(date: Date) {
+  const year = Math.max(date.getFullYear(), 1980);
+  const dosDate = ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate();
+  const dosTime = (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2);
+  return { dosDate, dosTime };
+}
+
+export interface ZipFileEntry {
+  name: string;
+  data: Buffer | string;
+}
+
+export function createZip(entries: ZipFileEntry[]): Buffer {
+  const localRecords: Buffer[] = [];
+  const centralRecords: Buffer[] = [];
+  let offset = 0;
+  const now = new Date();
+  const { dosDate, dosTime } = dateToDos(now);
+
+  entries.forEach((entry) => {
+    const dataBuffer = Buffer.isBuffer(entry.data) ? entry.data : Buffer.from(entry.data, "utf8");
+    const nameBuffer = Buffer.from(entry.name, "utf8");
+    const crc = crc32(dataBuffer);
+    const localHeader = Buffer.alloc(30);
+    let cursor = 0;
+    localHeader.writeUInt32LE(LOCAL_FILE_HEADER_SIGNATURE, cursor);
+    cursor += 4;
+    localHeader.writeUInt16LE(VERSION, cursor);
+    cursor += 2;
+    localHeader.writeUInt16LE(0, cursor); // general purpose bit flag
+    cursor += 2;
+    localHeader.writeUInt16LE(0, cursor); // compression method (store)
+    cursor += 2;
+    localHeader.writeUInt16LE(dosTime, cursor);
+    cursor += 2;
+    localHeader.writeUInt16LE(dosDate, cursor);
+    cursor += 2;
+    localHeader.writeUInt32LE(crc >>> 0, cursor);
+    cursor += 4;
+    localHeader.writeUInt32LE(dataBuffer.length, cursor);
+    cursor += 4;
+    localHeader.writeUInt32LE(dataBuffer.length, cursor);
+    cursor += 4;
+    localHeader.writeUInt16LE(nameBuffer.length, cursor);
+    cursor += 2;
+    localHeader.writeUInt16LE(0, cursor); // extra field length
+    cursor += 2;
+
+    const localRecord = Buffer.concat([localHeader, nameBuffer, dataBuffer]);
+    localRecords.push(localRecord);
+
+    const centralHeader = Buffer.alloc(46);
+    let centralCursor = 0;
+    centralHeader.writeUInt32LE(CENTRAL_DIRECTORY_SIGNATURE, centralCursor);
+    centralCursor += 4;
+    centralHeader.writeUInt16LE(VERSION, centralCursor); // version made by
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(VERSION, centralCursor); // version needed to extract
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(0, centralCursor); // general purpose bit flag
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(0, centralCursor); // compression method
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(dosTime, centralCursor);
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(dosDate, centralCursor);
+    centralCursor += 2;
+    centralHeader.writeUInt32LE(crc >>> 0, centralCursor);
+    centralCursor += 4;
+    centralHeader.writeUInt32LE(dataBuffer.length, centralCursor);
+    centralCursor += 4;
+    centralHeader.writeUInt32LE(dataBuffer.length, centralCursor);
+    centralCursor += 4;
+    centralHeader.writeUInt16LE(nameBuffer.length, centralCursor);
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(0, centralCursor); // extra field length
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(0, centralCursor); // file comment length
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(0, centralCursor); // disk number start
+    centralCursor += 2;
+    centralHeader.writeUInt16LE(0, centralCursor); // internal file attributes
+    centralCursor += 2;
+    centralHeader.writeUInt32LE(0, centralCursor); // external file attributes
+    centralCursor += 4;
+    centralHeader.writeUInt32LE(offset, centralCursor); // relative offset of local header
+    centralCursor += 4;
+
+    const centralRecord = Buffer.concat([centralHeader, nameBuffer]);
+    centralRecords.push(centralRecord);
+
+    offset += localRecord.length;
+  });
+
+  const centralDirectory = Buffer.concat(centralRecords);
+  const centralSize = centralDirectory.length;
+  const centralOffset = offset;
+
+  const endRecord = Buffer.alloc(22);
+  let endCursor = 0;
+  endRecord.writeUInt32LE(END_OF_CENTRAL_DIRECTORY_SIGNATURE, endCursor);
+  endCursor += 4;
+  endRecord.writeUInt16LE(0, endCursor); // number of this disk
+  endCursor += 2;
+  endRecord.writeUInt16LE(0, endCursor); // number of the disk with the start of central directory
+  endCursor += 2;
+  endRecord.writeUInt16LE(entries.length, endCursor); // total entries on this disk
+  endCursor += 2;
+  endRecord.writeUInt16LE(entries.length, endCursor); // total entries overall
+  endCursor += 2;
+  endRecord.writeUInt32LE(centralSize, endCursor);
+  endCursor += 4;
+  endRecord.writeUInt32LE(centralOffset, endCursor);
+  endCursor += 4;
+  endRecord.writeUInt16LE(0, endCursor); // comment length
+
+  return Buffer.concat([...localRecords, centralDirectory, endRecord]);
+}


### PR DESCRIPTION
## Summary
- build auditor evidence bundles with ledger proof, receipt details, persisted JSON, and shared typings
- expose `/evidence/:periodId.json` and `/evidence/:periodId.zip` endpoints plus lightweight zip helper and migration
- add period detail page with evidence drawer, download actions, and refreshed dashboard styling

## Testing
- ❌ `npm run dev` *(fails: Cannot find module './api' in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e37b773d0483279505578c6db7bfae