### PR TITLE
Fix audit service database handling

### DIFF
--- a/apps/services/audit/main.py
+++ b/apps/services/audit/main.py
@@ -1,24 +1,170 @@
-﻿# apps/services/audit/main.py
-from fastapi import FastAPI
-import os, psycopg2, json
+# apps/services/audit/main.py
+from __future__ import annotations
+
+import logging
+import os
+from contextlib import contextmanager
+from datetime import datetime
+from typing import Any, Dict, Generator, Optional
+
+import psycopg2
+from fastapi import FastAPI, HTTPException
+from psycopg2 import pool
+from psycopg2.extras import RealDictCursor
+
+LOGGER = logging.getLogger(__name__)
 
 app = FastAPI(title="audit")
 
-def db():
-    return psycopg2.connect(
-        host=os.getenv("PGHOST","127.0.0.1"),
-        user=os.getenv("PGUSER","postgres"),
-        password=os.getenv("PGPASSWORD","postgres"),
-        dbname=os.getenv("PGDATABASE","postgres"),
-        port=int(os.getenv("PGPORT","5432"))
-    )
+DB_MIN_CONN = int(os.getenv("PGPOOL_MIN", "1"))
+DB_MAX_CONN = int(os.getenv("PGPOOL_MAX", "5"))
+
+_POOL: Optional[pool.SimpleConnectionPool] = None
+
+
+def _get_connection_kwargs() -> Dict[str, Any]:
+    return {
+        "host": os.getenv("PGHOST", "127.0.0.1"),
+        "user": os.getenv("PGUSER", "postgres"),
+        "password": os.getenv("PGPASSWORD", "postgres"),
+        "dbname": os.getenv("PGDATABASE", "postgres"),
+        "port": int(os.getenv("PGPORT", "5432")),
+    }
+
+
+def init_pool(minconn: int = DB_MIN_CONN, maxconn: int = DB_MAX_CONN) -> None:
+    """Initialise the global connection pool."""
+
+    global _POOL
+    if _POOL is None:
+        LOGGER.info(
+            "Initialising audit-service connection pool (min=%s, max=%s)",
+            minconn,
+            maxconn,
+        )
+        _POOL = pool.SimpleConnectionPool(minconn, maxconn, **_get_connection_kwargs())
+
+
+def close_pool() -> None:
+    """Close all pooled connections."""
+
+    global _POOL
+    if _POOL is not None:
+        LOGGER.info("Closing audit-service connection pool")
+        _POOL.closeall()
+        _POOL = None
+
+
+def get_pool() -> pool.SimpleConnectionPool:
+    if _POOL is None:
+        raise RuntimeError("Database pool has not been initialised")
+    return _POOL
+
+
+@contextmanager
+def db_cursor() -> Generator[RealDictCursor, None, None]:
+    connection_pool = get_pool()
+    conn = connection_pool.getconn()
+    try:
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        try:
+            yield cursor
+        finally:
+            cursor.close()
+            conn.rollback()
+    finally:
+        connection_pool.putconn(conn)
+
+
+@app.on_event("startup")
+def _on_startup() -> None:
+    if os.getenv("AUDIT_SKIP_POOL_INIT") == "1":
+        LOGGER.info("Skipping connection pool initialisation per AUDIT_SKIP_POOL_INIT")
+        return
+    init_pool()
+
+
+@app.on_event("shutdown")
+def _on_shutdown() -> None:
+    close_pool()
+
+
+def _serialise_datetime(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
 
 @app.get("/audit/bundle/{period_id}")
-def bundle(period_id: str):
-    conn = db(); cur = conn.cursor()
-    cur.execute("SELECT rpt_json, rpt_sig, issued_at FROM rpt_store WHERE period_id=%s ORDER BY issued_at DESC LIMIT 1", (period_id,))
-    rpt = cur.fetchone()
-    cur.execute("SELECT event_time, category, message FROM audit_log WHERE message LIKE %s ORDER BY event_time", (f'%\"period_id\":\"{period_id}\"%',))
-    logs = [{"event_time": str(r[0]), "category": r[1], "message": r[2]}] if cur.rowcount else []
-    cur.close(); conn.close()
-    return {"period_id": period_id, "rpt": rpt[0] if rpt else None, "audit": logs}
+def bundle(period_id: str) -> Dict[str, Any]:
+    try:
+        with db_cursor() as cursor:
+            cursor.execute(
+                """
+                SELECT rpt_json, rpt_sig, issued_at
+                FROM rpt_store
+                WHERE period_id=%s
+                ORDER BY issued_at DESC
+                LIMIT 1
+                """,
+                (period_id,),
+            )
+            rpt_row = cursor.fetchone()
+
+            cursor.execute(
+                """
+                SELECT event_time, category, message
+                FROM audit_log
+                WHERE message LIKE %s
+                ORDER BY event_time
+                """,
+                (f'%"period_id":"{period_id}"%',),
+            )
+            audit_rows = cursor.fetchall()
+
+    except psycopg2.Error as exc:  # pragma: no cover - defensive catch
+        LOGGER.exception(
+            "Database error while fetching audit bundle for period %s", period_id
+        )
+        raise HTTPException(status_code=500, detail="Database error") from exc
+    except RuntimeError as exc:
+        LOGGER.exception("Database pool unavailable")
+        raise HTTPException(status_code=500, detail="Service not ready") from exc
+
+    report: Optional[Dict[str, Any]] = None
+    if rpt_row:
+        report = {
+            "rpt_json": rpt_row.get("rpt_json"),
+            "rpt_sig": rpt_row.get("rpt_sig"),
+            "issued_at": _serialise_datetime(rpt_row.get("issued_at")),
+        }
+
+    logs = (
+        [
+            {
+                "event_time": _serialise_datetime(row.get("event_time")),
+                "category": row.get("category"),
+                "message": row.get("message"),
+            }
+            for row in audit_rows
+        ]
+        if audit_rows
+        else []
+    )
+
+    return {"period_id": period_id, "rpt": report, "audit": logs}
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, str]:
+    try:
+        with db_cursor() as cursor:
+            cursor.execute("SELECT 1")
+            cursor.fetchone()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail="Service not ready") from exc
+    except psycopg2.Error as exc:  # pragma: no cover - defensive catch
+        LOGGER.exception("Database error during health check")
+        raise HTTPException(status_code=503, detail="Database error") from exc
+
+    return {"status": "ok"}

--- a/tests/apps/services/audit/test_main.py
+++ b/tests/apps/services/audit/test_main.py
@@ -1,0 +1,155 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import sys
+import types
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[4]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+fake_psycopg2 = types.ModuleType("psycopg2")
+fake_psycopg2.Error = Exception
+
+fake_psycopg2_pool = types.ModuleType("psycopg2.pool")
+fake_psycopg2_pool.SimpleConnectionPool = object  # type: ignore[attr-defined]
+
+fake_psycopg2_extras = types.ModuleType("psycopg2.extras")
+fake_psycopg2_extras.RealDictCursor = object  # type: ignore[attr-defined]
+
+fake_psycopg2.pool = fake_psycopg2_pool
+fake_psycopg2.extras = fake_psycopg2_extras
+
+sys.modules.setdefault("psycopg2", fake_psycopg2)
+sys.modules.setdefault("psycopg2.pool", fake_psycopg2_pool)
+sys.modules.setdefault("psycopg2.extras", fake_psycopg2_extras)
+
+from apps.services.audit import main
+
+
+class FakeCursor:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+        self._last_query: Optional[str] = None
+        self._results: List[Dict[str, Any]] = []
+
+    def execute(self, query: str, params: Optional[tuple] = None) -> None:
+        self._last_query = " ".join(query.split())
+        period_id_param = params[0] if params else None
+        if "FROM rpt_store" in self._last_query:
+            row = self._data["rpt_store"].get(period_id_param)
+            self._results = [row] if row else []
+        elif "FROM audit_log" in self._last_query:
+            matched: List[Dict[str, Any]] = []
+            if period_id_param:
+                for key, rows in self._data["audit_log"].items():
+                    if key in str(period_id_param):
+                        matched = rows
+                        break
+            self._results = matched
+        else:
+            self._results = [{"?column?": 1}]
+
+    def fetchone(self) -> Optional[Dict[str, Any]]:
+        return self._results[0] if self._results else None
+
+    def fetchall(self) -> List[Dict[str, Any]]:
+        return list(self._results)
+
+    def close(self) -> None:  # pragma: no cover - interface compliance
+        pass
+
+
+class FakeConnection:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+
+    def cursor(self, cursor_factory=None):  # pragma: no cover - signature parity
+        return FakeCursor(self._data)
+
+    def rollback(self) -> None:  # pragma: no cover - interface compliance
+        pass
+
+
+class FakePool:
+    def __init__(self, data: Dict[str, Any]) -> None:
+        self._data = data
+
+    def getconn(self) -> FakeConnection:
+        return FakeConnection(self._data)
+
+    def putconn(self, _conn: FakeConnection) -> None:  # pragma: no cover - compliance
+        pass
+
+    def closeall(self) -> None:  # pragma: no cover - compliance
+        pass
+
+
+@pytest.fixture(autouse=True)
+def patch_pool(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AUDIT_SKIP_POOL_INIT", "1")
+    fake_data = {
+        "rpt_store": {
+            "2024-01": {
+                "rpt_json": {"foo": "bar"},
+                "rpt_sig": "sig",
+                "issued_at": datetime(2024, 1, 1, 12, 0, 0),
+            }
+        },
+        "audit_log": {
+            "2024-01": [
+                {
+                    "event_time": datetime(2024, 1, 1, 12, 0, 0),
+                    "category": "info",
+                    "message": '{"period_id":"2024-01"}',
+                },
+                {
+                    "event_time": datetime(2024, 1, 1, 13, 30, 0),
+                    "category": "warning",
+                    "message": '{"period_id":"2024-01","status":"late"}',
+                },
+            ]
+        },
+    }
+
+    monkeypatch.setattr(main, "_POOL", FakePool(fake_data))
+    yield
+    main.close_pool()
+
+
+def test_bundle_returns_audit_rows() -> None:
+    with TestClient(main.app) as client:
+        response = client.get("/audit/bundle/2024-01")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["period_id"] == "2024-01"
+    assert body["rpt"] == {
+        "rpt_json": {"foo": "bar"},
+        "rpt_sig": "sig",
+        "issued_at": "2024-01-01T12:00:00",
+    }
+    assert body["audit"] == [
+        {
+            "event_time": "2024-01-01T12:00:00",
+            "category": "info",
+            "message": '{"period_id":"2024-01"}',
+        },
+        {
+            "event_time": "2024-01-01T13:30:00",
+            "category": "warning",
+            "message": '{"period_id":"2024-01","status":"late"}',
+        },
+    ]
+
+
+def test_healthz_uses_pool() -> None:
+    with TestClient(main.app) as client:
+        response = client.get("/healthz")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- replace direct psycopg2 connections with a shared connection pool and context-managed cursors in the audit service
- add structured response handling, error reporting, and a /healthz endpoint to keep the service healthy
- introduce unit tests exercising the bundle endpoint and health check using a stubbed pool

## Testing
- pytest tests/apps/services/audit/test_main.py

------
https://chatgpt.com/codex/tasks/task_e_68e389ab54788327abf2cf22e63dc60b