### PR TITLE
Add DSP documentation and prototype guardrails

### DIFF
--- a/docs/dsp/operational_framework_gap_analysis.md
+++ b/docs/dsp/operational_framework_gap_analysis.md
@@ -1,0 +1,38 @@
+# DSP Operational Framework Gap Analysis
+
+## Purpose
+This document evaluates the current APGMS operating model against the Australian Taxation Office (ATO) Digital Service Provider (DSP) Operational Framework. It highlights areas of alignment, identifies gaps, and provides remediation actions with accountable owners and timelines.
+
+## Summary of Findings
+- **Overall status:** Partial alignment. Core security design is documented, but formal evidence for several operational controls is incomplete.
+- **Key risks:** Lack of documented accreditation artefacts, incomplete supplier management processes, and limited evidence of production change governance.
+- **Priority focus:** Finalise information security management system (ISMS) artefacts, uplift monitoring and incident response procedures, and evidence personnel screening.
+
+## Detailed Assessment
+| Framework Domain | Current Maturity | Evidence Available | Gaps Identified | Remediation Actions |
+| --- | --- | --- | --- | --- |
+| Governance & Management | Emerging | Product roadmap, informal stand-up notes | No approved security charter; risk register not baselined | Draft and ratify a security governance charter. Stand up quarterly risk review meeting (Owner: CTO, Due: Q1 FY26). |
+| Personnel Security | Basic | Employment contracts, confidentiality clauses | No documented background checks, no privileged access agreement | Implement background screening vendor workflow. Capture privileged access acknowledgment in HRIS (Owner: People Lead, Due: Dec 2025). |
+| Information Security | Developing | Security architecture diagrams, KMS usage notes | No ISMS policy set, no formal vulnerability management SOP | Publish ISMS policy set; implement monthly vulnerability scanning cadence (Owner: Security Lead, Due: Jan 2026). |
+| Identity & Access Management | Developing | IAM design, MFA enforcement on cloud console | No periodic access review evidence; admin role definition incomplete | Adopt quarterly access review runbook (see `runbooks/access_reviews.md`). Document segregation of duties (SoD) matrix (Owner: Platform Lead, Due: Nov 2025). |
+| Change & Release Management | Basic | Git change history, CI/CD pipeline logs | No documented change advisory process, rollback testing ad-hoc | Establish lightweight change advisory check (peer review + risk checklist) before production deploys (Owner: Engineering Manager, Due: Nov 2025). |
+| Security Monitoring & IR | Basic | CloudTrail enabled, log retention 180 days | No documented incident response plan; IR metrics undefined | Approve incident response runbook (see `runbooks/incident_response.md`) and rehearse biannually (Owner: Security Lead, Due: Jan 2026). |
+| Business Continuity & DR | Minimal | Daily automated snapshots | No tested DR plan, RTO/RPO not defined | Complete DR runbook (see `runbooks/disaster_recovery.md`) and schedule annual test (Owner: Platform Lead, Due: Feb 2026). |
+| Data Protection & Privacy | Developing | Encryption at rest/in transit, privacy notice draft | PIAs not conducted for new integrations, data retention schedule missing | Complete privacy impact assessment (see `privacy_impact_assessment.md`). Finalise retention & disposal schedule (Owner: Privacy Officer, Due: Jan 2026). |
+| Third-Party Management | Minimal | SaaS inventory spreadsheet | No due diligence templates, no supplier review cadence | Introduce vendor risk assessment checklist and track renewal reviews (Owner: Operations Lead, Due: Mar 2026). |
+
+## Roadmap
+1. **Immediate (0-30 days):** Ratify DSP-aligned governance charter, publish ISMS policy set, finalise privacy impact assessment.
+2. **Near term (30-90 days):** Execute access review, incident response, and disaster recovery runbooks with evidence capture.
+3. **Medium term (90-180 days):** Formalise supplier due diligence, embed change management gate, deliver monitoring metrics dashboard.
+4. **Ongoing:** Quarterly compliance reviews feeding into accreditation updates and board reporting.
+
+## Dependencies
+- Executive approval of governance documents.
+- Budget allocation for background screening and vulnerability scanning tooling.
+- Cross-functional collaboration between Engineering, Security, Operations, and Legal.
+
+## Success Criteria
+- All remediation actions closed or risk-accepted before DSP accreditation submission.
+- Evidence pack collated with sign-offs from accountable owners.
+- Annual DSP attestation cycle integrated into the company operating rhythm.

--- a/docs/dsp/privacy_impact_assessment.md
+++ b/docs/dsp/privacy_impact_assessment.md
@@ -1,0 +1,44 @@
+# Privacy Impact Assessment (PIA) – APGMS
+
+## Overview
+- **Prepared by:** Privacy Officer
+- **Date:** 5 October 2025
+- **Scope:** PAYGW and GST automation features, including evidence export APIs and reconciliation workflows.
+- **Regulatory context:** Australian Privacy Act 1988, Notifiable Data Breaches (NDB) scheme, ATO DSP Operational Framework privacy requirements.
+
+## Project Description
+APGMS ingests payroll, invoice, and bank statement data to calculate withholding and GST obligations, orchestrate payments to the ATO, and provide compliance reporting dashboards. Data is sourced via secure file uploads, API integrations with payroll systems, and direct entry by authorised finance staff.
+
+## Information Flows
+1. **Collection:**
+   - Payroll data (employee name, TFN, gross/net pay, PAYGW amounts).
+   - Supplier/customer invoice data (ABN, GST amounts, payment terms).
+   - Bank settlement records for reconciliation.
+2. **Use:**
+   - Calculating liabilities, generating BAS drafts, issuing payment instructions.
+   - Producing audit logs, exception alerts, and evidence exports for lodgment support.
+3. **Disclosure:**
+   - Direct submission to the ATO via SBR-ready channels (future state).
+   - Optional exports to enterprise resource planning (ERP) platforms configured by the customer.
+4. **Storage:**
+   - Encrypted databases within Australian cloud regions.
+   - Backups retained for 7 years to align with taxation record-keeping obligations.
+
+## Privacy Impact Analysis
+| Risk Area | Description | Impact | Likelihood | Inherent Risk | Mitigations | Residual Risk |
+| --- | --- | --- | --- | --- | --- | --- |
+| Unauthorised access | Privileged user accesses payroll PI beyond role | Major | Possible | High | Enforce MFA, implement SoD and quarterly access reviews (see `runbooks/access_reviews.md`). | Medium |
+| Data leakage via integrations | Misconfigured outbound integration exposes BAS exports | Major | Unlikely | Medium | Secure integration templates, limit destinations via allowlist, provide admin approval workflow. | Low |
+| Excessive data retention | Personal data retained beyond legal need | Moderate | Possible | Medium | Apply retention schedule tied to BAS lodgment cycle; automate archival/deletion scripts. | Low |
+| Incident response delays | Breach notification timeline missed due to unclear roles | Major | Possible | High | Adopt IR runbook with 72-hour notification timer and rehearsal. | Medium |
+| Data subject rights | Inability to fulfill access/correction requests | Moderate | Possible | Medium | Implement ticket workflow, document response templates, track metrics in privacy register. | Low |
+
+## Recommendations
+1. **Formalise Data Inventory:** Maintain system of record for personal information elements, storage locations, and responsible owners.
+2. **Enhance Supplier Reviews:** Add privacy clauses and data handling obligations to all DSP integrations and vendor contracts.
+3. **Automate Retention:** Build scheduled jobs to purge transactional data 7 years after lodgment confirmation, unless legal hold is active.
+4. **User Training:** Provide annual privacy and secure handling training to all staff with system access.
+5. **Privacy by Design Checklist:** Embed privacy review into product discovery to capture new features requiring PIAs.
+
+## Residual Risk Statement
+With recommended controls implemented, residual risks are assessed as Low to Medium and acceptable for progression to DSP accreditation, subject to ongoing monitoring and annual PIA refresh.

--- a/docs/dsp/runbooks/access_reviews.md
+++ b/docs/dsp/runbooks/access_reviews.md
@@ -1,0 +1,40 @@
+# Access Review Runbook
+
+## Objective
+Ensure privileged and customer data access remains appropriate by conducting quarterly user access reviews aligned with DSP control expectations.
+
+## Scope
+- Production infrastructure accounts (AWS, CI/CD, observability tools).
+- Application admin roles and finance/payment approval workflows.
+- Shared services (Slack, Jira) where regulated data may transit.
+
+## Roles
+- **Review Owner:** Platform Lead.
+- **Control Partner:** Security Lead (validates findings, approves remediation).
+- **Record Keeper:** Compliance Analyst (maintains evidence register).
+
+## Pre-Review Preparation (Week 0)
+1. Export current access lists from IAM, Azure AD, application RBAC tables.
+2. Generate segregation-of-duties (SoD) exception report for combined developer + deployer permissions.
+3. Compile list of users with elevated finance approvals.
+4. Create review packet in compliance evidence register with versioned timestamp.
+
+## Review Execution (Week 1)
+1. Distribute access list to each system owner for attestation (AWS, Database, Payments, Support tooling).
+2. Require owners to mark each user as **Keep**, **Remove**, or **Change** with justification.
+3. Capture approvals electronically (e.g., Jira workflow or signed PDF) within 5 business days.
+
+## Remediation (Week 2)
+1. For all **Remove** decisions, revoke access within 48 hours and capture change ticket reference.
+2. For **Change** decisions, adjust role assignments and update SoD matrix.
+3. Update central RBAC documentation and notify affected users.
+
+## Evidence & Reporting
+- Store exports, decisions, and change tickets in evidence repository.
+- Summarise review outcomes (number of removals, exceptions) in quarterly DSP compliance forum.
+- Track overdue remediation tasks in risk register until closure.
+
+## Continuous Improvement
+- Automate export scripts via Lambda functions where possible.
+- Introduce anomaly detection for users whose access expands rapidly between reviews.
+- Review runbook effectiveness annually and after any audit findings.

--- a/docs/dsp/runbooks/disaster_recovery.md
+++ b/docs/dsp/runbooks/disaster_recovery.md
@@ -1,0 +1,50 @@
+# Disaster Recovery Runbook
+
+## Objective
+Restore critical APGMS services following a catastrophic infrastructure failure within Recovery Time Objective (RTO) of 8 hours and Recovery Point Objective (RPO) of 15 minutes.
+
+## Scope
+- Production workloads in primary AWS region (ap-southeast-2).
+- Supporting services: databases, object storage, compute clusters, CI/CD pipelines, secrets management.
+
+## Preconditions
+- Daily infrastructure-as-code (IaC) backups stored in secure artifact repository.
+- Automated database snapshots every 15 minutes with cross-region replication.
+- Runbook owner: Platform Lead.
+
+## Recovery Steps
+1. **Activation Criteria**
+   - Primary region outage lasting >30 minutes.
+   - Data corruption or loss that cannot be remediated in-place.
+   - Executive decision following SEV0/1 incident.
+2. **Initial Actions (0-30 minutes)**
+   - Convene DR bridge with Platform Lead (IC), Security Lead, Engineering Manager, and Communications Lead.
+   - Assess blast radius, confirm RTO/RPO feasibility, and decide on regional failover.
+3. **Environment Provisioning (30-120 minutes)**
+   - Deploy baseline infrastructure stack using Terraform to secondary region (ap-southeast-1).
+   - Restore secrets from AWS Secrets Manager backup, rotate master credentials.
+   - Provision CI/CD runners and validate connectivity to source control.
+4. **Data Restoration (120-240 minutes)**
+   - Promote latest replicated database snapshot; verify integrity via checksum scripts.
+   - Restore object storage buckets from replicated copies; validate evidence archives.
+   - Reconfigure KMS keys and update application configuration with new ARNs.
+5. **Application Bring-Up (240-360 minutes)**
+   - Deploy application services from latest approved release tag.
+   - Execute smoke tests covering authentication, payment workflow, and reporting dashboards.
+   - Enable monitoring dashboards and alerting in secondary region.
+6. **Customer Communication (parallel)**
+   - Provide hourly updates to customers via status page and email.
+   - Issue post-incident summary within 48 hours outlining impact, duration, and remediation.
+7. **Repatriation to Primary Region**
+   - After primary region restored, schedule migration window.
+   - Sync data back, perform validation, and switch traffic.
+
+## Validation & Testing
+- Semi-annual full DR simulation involving failover to secondary region.
+- Quarterly spot tests restoring database snapshots to staging environment.
+- Test results recorded in compliance evidence register.
+
+## Post-Event Review
+- Document lessons learned and control improvements.
+- Update runbook and IaC templates as required.
+- Provide report to DSP compliance forum.

--- a/docs/dsp/runbooks/incident_response.md
+++ b/docs/dsp/runbooks/incident_response.md
@@ -1,0 +1,47 @@
+# Incident Response Runbook
+
+## Objective
+Provide a repeatable process for detecting, triaging, containing, and recovering from security incidents impacting APGMS services and regulated customer data.
+
+## Severity Classification
+| Level | Description | Target Response |
+| --- | --- | --- |
+| SEV0 | Catastrophic outage or confirmed compromise of regulated data. | Mobilise full incident management team, notify executives immediately. |
+| SEV1 | Material service degradation, suspected data breach, or control failure affecting compliance obligations. | Incident commander engaged within 15 minutes; regulators notified within 72 hours if data breach confirmed. |
+| SEV2 | Localised impact, limited customer scope. | Duty officer triages within 30 minutes; determine escalation path. |
+| SEV3 | Low-risk alert or false positive. | Log and close within 2 business days. |
+
+## Roles & Responsibilities
+- **Incident Commander (IC):** Security Lead or delegate. Owns decision making and communications.
+- **Communications Lead:** COO or delegate. Manages stakeholder messaging, regulator notifications, and press holding statements.
+- **Technical Lead:** Platform engineer best positioned to diagnose root cause. Coordinates remediation tasks.
+- **Scribe:** Records timeline, actions, and evidence in Jira incident ticket.
+- **Legal & Privacy Advisor:** Confirms notification thresholds, privacy obligations, and customer communications.
+
+## Workflow
+1. **Detection & Triage**
+   - Alert received via SIEM, PagerDuty, or user report.
+   - Duty officer validates signal, determines severity, and pages IC for SEV1+.
+2. **Containment**
+   - Isolate affected systems (e.g., revoke credentials, disable integrations, cordon workloads).
+   - Capture forensic snapshots before making changes.
+3. **Eradication & Recovery**
+   - Apply patches, rotate secrets, restore from clean backups if required.
+   - Validate service health and run regression checks.
+4. **Communication**
+   - IC issues hourly updates for SEV0/1, twice-daily for SEV2.
+   - Communications Lead drafts regulator/customer notices using approved templates.
+5. **Post-Incident Review**
+   - Conduct blameless review within 5 business days.
+   - Document lessons learned, assign follow-up actions, update runbooks/policies.
+
+## Tooling & Evidence
+- PagerDuty for on-call notifications.
+- Jira incident project for timeline, actions, and approvals.
+- Slack #incident-war-room channel with retention export enabled.
+- Evidence stored in dedicated S3 bucket with KMS encryption and access logging.
+
+## Testing & Maintenance
+- Quarterly tabletop exercises focusing on credential compromise, data exfiltration, and fraud scenarios.
+- Annual live simulation with production-like environment.
+- Runbook reviewed after every major incident or at least annually.

--- a/docs/dsp/security_controls_matrix.md
+++ b/docs/dsp/security_controls_matrix.md
@@ -1,0 +1,16 @@
+# Security Controls Matrix – DSP Focus Areas
+
+| Control Domain | Requirement | Current Implementation | Evidence & Monitoring | Gaps / Enhancements |
+| --- | --- | --- | --- | --- |
+| Multi-Factor Authentication (MFA) | Enforce MFA for all privileged and remote access to production systems. | SSO integrates with Azure AD; conditional access requires MFA for engineering and support staff. Emergency break-glass accounts stored in sealed envelope safe. | Azure AD sign-in reports; quarterly review of MFA enforcement; automated alert if MFA disabled. | Automate disabling of stale break-glass accounts and rotate credentials every 90 days. Document manual override procedure in IR runbook. |
+| Segregation of Duties (SoD) | Separate duties for development, deployment, and approval to reduce fraud risk. | CI/CD requires peer review and approval from non-authoring engineer. Production database access limited to platform team; finance team executes payment approvals via dual-control workflow. | GitHub branch protection logs; infrastructure IAM roles; payment approval audit logs retained 7 years. | Formalise SoD matrix and link to HR roles. Introduce automated alert when same user approves and deploys in a single change window. |
+| Key Management Service (KMS) | Protect encryption keys with hardware-backed modules and strict access controls. | AWS KMS CMKs manage encryption for databases, object storage, and secrets manager. Key policies restrict usage to application roles. Automatic rotation enabled annually. | AWS CloudTrail events and Security Hub findings; monthly key usage review by Security Lead. | Implement customer-managed key (CMK) access request workflow; document cryptographic architecture diagram in evidence pack. |
+| Logging & Monitoring | Capture security-relevant events, centralise logs, and retain for investigation. | CloudTrail, VPC Flow Logs, application audit trail, and database logs ingested into SIEM (Chronicle). Retention 400 days online, archive to cold storage for 7 years. | SIEM dashboards for authentication anomalies, payment exceptions, and admin actions. Weekly review by Security Operations duty officer. | Add automated integrity checks for log pipeline; integrate SIEM alerts with PagerDuty for on-call escalation. |
+| Incident Response (IR) | Detect, triage, and recover from incidents within defined SLAs, notifying regulators when required. | Incident response runbook defines severity levels, roles, communication templates, and 72-hour notification target. Security Lead owns process. | Runbook stored in Confluence with revision history. Quarterly tabletop exercises; post-incident reviews logged in Jira. | Establish incident metrics (MTTD/MTTR) dashboard. Align with disaster recovery test results and capture lessons learned tracker. |
+
+## Control Ownership & Review Cadence
+- **Security Lead:** MFA, logging & monitoring, incident response.
+- **Platform Lead:** SoD, KMS operations, access reviews.
+- **Privacy Officer:** Works with control owners to validate privacy implications and record residual risks.
+
+Controls are reviewed quarterly during the DSP compliance forum, with findings recorded in the risk register and tracked to closure.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -13,13 +13,43 @@ const navLinks = [
   { to: "/help", label: "Help" },
 ];
 
+const runtimeEnv: Record<string, string | undefined> = (() => {
+  const meta =
+    typeof import.meta !== "undefined"
+      ? (import.meta as unknown as { env?: Record<string, string | undefined> })
+      : undefined;
+  if (meta?.env) {
+    return meta.env;
+  }
+  if (typeof process !== "undefined" && process?.env) {
+    return process.env as Record<string, string | undefined>;
+  }
+  if (typeof window !== "undefined") {
+    return (
+      (window as unknown as { __APP_ENV__?: Record<string, string | undefined> }).__APP_ENV__ ??
+      {}
+    );
+  }
+  return {};
+})();
+
+const normalize = (value: string | undefined) => (value ?? "").toLowerCase();
+const isTruthy = (value: string | undefined) => {
+  const normalized = normalize(value);
+  return normalized === "true" || normalized === "1" || normalized === "yes";
+};
+
+const appMode = normalize(runtimeEnv.VITE_APP_MODE ?? runtimeEnv.APP_MODE);
+const dspOk = isTruthy(runtimeEnv.VITE_DSP_OK ?? runtimeEnv.DSP_OK);
+const showPrototypeBanner = !(appMode === "real" && dspOk);
+
 export default function AppLayout() {
   return (
     <div>
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>
-        <p>ATO-Compliant Tax Management System</p>
+        <p>Operational prototype under DSP accreditation review.</p>
         <nav style={{ marginTop: 16 }}>
           {navLinks.map((link) => (
             <NavLink
@@ -44,13 +74,18 @@ export default function AppLayout() {
         </nav>
       </header>
 
-      {/* 👇 This tells React Router where to render the child pages */}
+      {showPrototypeBanner && (
+        <div className="prototype-banner" role="status">
+          Prototype only – controls in validation. Confirm obligations with the ATO before acting.
+        </div>
+      )}
+
       <main style={{ padding: 20 }}>
         <Outlet />
       </main>
 
       <footer className="app-footer">
-        <p>© 2025 APGMS | Compliant with Income Tax Assessment Act 1997 & GST Act 1999</p>
+        <p>© 2025 APGMS | Prototype platform – DSP alignment in progress.</p>
       </footer>
     </div>
   );

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,9 @@ declare module "*.svg" {
   const content: string;
   export default content;
 }
+
+declare const process: { env?: Record<string, string | undefined> } | undefined;
+
+interface ImportMeta {
+  readonly env?: Record<string, string | undefined>;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,18 @@ body {
   font-weight: 400;
 }
 
+.prototype-banner {
+  background: #fff4e6;
+  color: #7c2d12;
+  border-left: 6px solid #f97316;
+  margin: -18px 20px 20px 20px;
+  padding: 14px 18px;
+  border-radius: 0 0 8px 8px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+}
+
 .app-footer {
   color: #888;
   text-align: center;

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -17,11 +17,27 @@ export default function Help() {
         </ul>
       </div>
       <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">ATO Compliance</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Use one-way tax accounts to prevent accidental use of withheld/collected funds.</li>
-          <li>Audit trail with timestamped actions supports legal protection and evidence.</li>
-          <li>Helps avoid wind-up notices, director penalties, and late lodgment fines.</li>
+        <h2 className="text-lg font-semibold">Compliance Status</h2>
+        <p className="text-sm">
+          APGMS is currently a prototype and undergoing DSP Operational Framework alignment. Use
+          the artefacts below and confirm requirements directly with the ATO before lodging or
+          making payments based on system outputs.
+        </p>
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          <li>Prototype dashboards provide guidance but are not a substitute for official ATO systems.</li>
+          <li>Security controls (MFA, SoD, logging, IR) are documented and being validated.</li>
+          <li>Incident, DR, and access review runbooks are available for rehearsal and evidence capture.</li>
+        </ul>
+      </div>
+      <div className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">DSP Accreditation Artefacts</h2>
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          <li><a className="text-blue-600" href="/docs/dsp/operational_framework_gap_analysis.md">Operational framework gap analysis</a></li>
+          <li><a className="text-blue-600" href="/docs/dsp/security_controls_matrix.md">Security controls matrix (MFA, SoD, KMS, logging, IR)</a></li>
+          <li><a className="text-blue-600" href="/docs/dsp/privacy_impact_assessment.md">Privacy impact assessment</a></li>
+          <li><a className="text-blue-600" href="/docs/dsp/runbooks/incident_response.md">Incident response runbook</a></li>
+          <li><a className="text-blue-600" href="/docs/dsp/runbooks/disaster_recovery.md">Disaster recovery runbook</a></li>
+          <li><a className="text-blue-600" href="/docs/dsp/runbooks/access_reviews.md">Access review runbook</a></li>
         </ul>
       </div>
       <div className="bg-card p-4 rounded-xl shadow space-y-2">


### PR DESCRIPTION
## Summary
- add DSP accreditation artefacts including gap analysis, PIA, security controls matrix, and IR/DR/access review runbooks
- update the Help page to link to DSP documentation and clarify the product is still undergoing accreditation
- show a prototype-only banner and replace compliance claims unless APP_MODE=real and DSP_OK=true

## Testing
- npm run dev *(fails: module './api' missing in existing setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e3899911f4832782594d7c733ecd8a