### PR TITLE
feat: add cdk staging infra and pipeline automation

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,123 @@
+name: Deploy Staging
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+      - staging
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: staging
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_STAGING_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install CDK dependencies
+        working-directory: infra/cdk
+        run: |
+          npm install -g aws-cdk
+          npm ci
+
+      - name: Synthesize infrastructure
+        working-directory: infra/cdk
+        run: |
+          npm run build
+          npx cdk synth
+
+      - name: Build container image
+        env:
+          AWS_REGION: ${{ vars.AWS_REGION }}
+        run: |
+          ECR_URI=$(aws ecr describe-repositories --repository-names apgms-staging --query 'repositories[0].repositoryUri' --output text)
+          if [ -z "$ECR_URI" ] || [ "$ECR_URI" = "None" ]; then
+            echo "::error::Missing staging ECR repository. Run CDK deploy first."
+            exit 1
+          fi
+          echo "ECR_URI=$ECR_URI" >> $GITHUB_ENV
+          IMAGE_TAG=$(git rev-parse --short=12 $GITHUB_SHA)
+          echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_ENV
+          aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_URI"
+          docker build -t "$ECR_URI:$IMAGE_TAG" -t "$ECR_URI:staging" .
+
+      - name: Install application dependencies
+        run: npm ci
+
+      - name: Security scan container
+        env:
+          ECR_URI: ${{ env.ECR_URI }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        run: |
+          npm install -g trivy
+          trivy image --no-progress "$ECR_URI:$IMAGE_TAG"
+
+      - name: IaC policy scan
+        run: |
+          npm install -g checkov
+          checkov -d infra
+
+      - name: Run tests
+        run: npm test
+
+      - name: Push container image
+        env:
+          ECR_URI: ${{ env.ECR_URI }}
+          IMAGE_TAG: ${{ env.IMAGE_TAG }}
+        run: |
+          docker push "$ECR_URI:$IMAGE_TAG"
+          docker push "$ECR_URI:staging"
+
+      - name: Deploy infrastructure
+        working-directory: infra/cdk
+        env:
+          CDK_CONTEXT_JSON: >-
+            {"account":"${{ secrets.AWS_ACCOUNT_ID }}","region":"${{ vars.AWS_REGION }}","repository":"${{ github.repository }}","branch":"${{ github.ref_name }}","connectionArn":"${{ secrets.AWS_CODESTAR_CONNECTION_ARN }}"}
+        run: |
+          npm run build
+          npx cdk deploy ApGmsStagingPipeline --require-approval never --context account=${{ secrets.AWS_ACCOUNT_ID }} --context region=${{ vars.AWS_REGION }} --context repository=${{ github.repository }} --context branch=${{ github.ref_name }} --context connectionArn=${{ secrets.AWS_CODESTAR_CONNECTION_ARN }}
+
+      - name: Force ECS rollout
+        run: |
+          CLUSTER=$(aws cloudformation describe-stacks --stack-name ApGmsStaging-StagingEnvironmentStack --query 'Stacks[0].Outputs[?OutputKey==`ClusterName`].OutputValue' --output text)
+          SERVICE=$(aws cloudformation describe-stacks --stack-name ApGmsStaging-StagingEnvironmentStack --query 'Stacks[0].Outputs[?OutputKey==`ServiceName`].OutputValue' --output text)
+          aws ecs update-service --cluster "$CLUSTER" --service "$SERVICE" --force-new-deployment
+
+      - name: Verify health
+        run: |
+          DISTRIBUTION=$(aws cloudformation describe-stacks --stack-name ApGmsStaging-StagingEnvironmentStack --query 'Stacks[0].Outputs[?OutputKey==`DistributionDomain`].OutputValue' --output text)
+          for i in $(seq 1 15); do
+            STATUS=$(curl -s -o /tmp/body -w '%{http_code}' "https://$DISTRIBUTION/healthz")
+            cat /tmp/body
+            if [ "$STATUS" = "200" ]; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "::error::Health check failed"
+          exit 1
+
+      - name: Emit deployment metric
+        run: |
+          aws cloudwatch put-metric-data --namespace "ApGms/Staging" --metric-name "PipelineDeployment" --value 1 --unit Count --dimensions ImageTag=$IMAGE_TAG
+
+      - name: Publish traces note
+        run: |
+          echo "X-Ray tracing enabled via task role policy. Ensure application emits segments."

--- a/infra/cdk/README.md
+++ b/infra/cdk/README.md
@@ -1,0 +1,34 @@
+# APGMS Staging Environment CDK App
+
+This package defines the hardened staging environment for APGMS using the AWS Cloud Development Kit (CDK).
+
+## Architecture highlights
+
+- **Network** – Multi-AZ VPC with isolated data subnets, private application subnets, a single NAT gateway, and locked-down security groups.
+- **Compute** – ECS Fargate service (two tasks minimum) fronted by an internal Application Load Balancer, exposed publicly via Amazon API Gateway (HTTP API) and Amazon CloudFront protected with AWS WAF. Request IDs provided by clients are forwarded end-to-end via CloudFront origin request policies and API Gateway integration.
+- **Data** – Amazon RDS for PostgreSQL instance encrypted with a dedicated KMS key. Credentials are generated and rotated automatically in AWS Secrets Manager.
+- **Secrets & Encryption** – Dedicated KMS CMK encrypts RDS, Secrets Manager, CloudWatch Logs, and S3 access logs. Secrets are injected into the workload as task secrets.
+- **Observability** – CloudWatch log groups, ECS Container Insights, X-Ray permissions, and a parameterized namespace for custom metrics ensure metrics and traces are ingested automatically. The service publishes a `/healthz` endpoint consumed by load balancer and pipeline smoke checks.
+- **Pipeline** – A CDK Pipelines based CodePipeline provides build → scan (Trivy + Checkov) → test → deploy automation. Artifacts land in Amazon ECR before deployment, and ECS is forced to pull the freshly scanned `staging` tag on each rollout.
+
+## Usage
+
+```bash
+npm install -g aws-cdk
+cd infra/cdk
+npm install
+npm run build
+cdk synth
+cdk deploy ApGmsStagingPipeline \
+  --context account=123456789012 \
+  --context region=us-east-1 \
+  --context repository=apgms/apgms \
+  --context branch=main \
+  --context connectionArn=arn:aws:codestar-connections:us-east-1:123456789012:connection/abc123
+```
+
+The pipeline deploys a `Staging` stage that provisions infrastructure and then continuously delivers container revisions. Provide optional `hostedZoneId` and `domainName` contexts to create a `staging.<domain>` alias for the CloudFront distribution.
+
+## Health verification
+
+The service publishes `https://<distribution-domain>/healthz`. The pipeline deploy step runs ECS force-new-deployment and emits a custom metric (`ApGms/Staging`, `LastDeployedImage`) that can be tracked for deployment validation. X-Ray permissions enable distributed tracing when the application runs the X-Ray SDK.

--- a/infra/cdk/bin/apgms-staging.ts
+++ b/infra/cdk/bin/apgms-staging.ts
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+import 'source-map-support/register';
+import * as cdk from 'aws-cdk-lib';
+import { StagingPipelineStack } from '../lib/pipeline-stack';
+
+const app = new cdk.App();
+
+const env = {
+  account: app.node.tryGetContext('account') || process.env.CDK_DEFAULT_ACCOUNT,
+  region: app.node.tryGetContext('region') || process.env.CDK_DEFAULT_REGION,
+};
+
+new StagingPipelineStack(app, 'ApGmsStagingPipeline', {
+  env,
+});

--- a/infra/cdk/cdk.json
+++ b/infra/cdk/cdk.json
@@ -1,0 +1,3 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/apgms-staging.ts"
+}

--- a/infra/cdk/lib/pipeline-stack.ts
+++ b/infra/cdk/lib/pipeline-stack.ts
@@ -1,0 +1,160 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as pipelines from 'aws-cdk-lib/pipelines';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { StagingStage } from './staging-stage';
+
+export interface StagingPipelineStackProps extends cdk.StackProps {
+  readonly repoString?: string;
+  readonly branch?: string;
+  readonly connectionArn?: string;
+}
+
+export class StagingPipelineStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: StagingPipelineStackProps = {}) {
+    super(scope, id, props);
+
+    const repoString = props.repoString ?? this.node.tryGetContext('repository') ?? 'apgms/apgms';
+    const branch = props.branch ?? this.node.tryGetContext('branch') ?? 'main';
+    const connectionArn = props.connectionArn ?? this.node.tryGetContext('connectionArn') ?? 'arn:aws:codestar-connections:region:account-id:connection/placeholder';
+
+    const source = pipelines.CodePipelineSource.connection(repoString, branch, {
+      connectionArn,
+    });
+
+    const synthStep = new pipelines.ShellStep('Synth', {
+      input: source,
+      commands: [
+        'npm install -g aws-cdk',
+        'cd infra/cdk',
+        'npm ci',
+        'npm run build',
+        'npx cdk synth'
+      ],
+      primaryOutputDirectory: 'infra/cdk/cdk.out'
+    });
+
+    const pipeline = new pipelines.CodePipeline(this, 'Pipeline', {
+      pipelineName: 'ApGmsStagingPipeline',
+      synth: synthStep,
+      dockerEnabledForSelfMutation: true,
+      dockerEnabledForSynth: true,
+      crossAccountKeys: false
+    });
+
+    const stagingStage = new StagingStage(this, 'Staging', {
+      env: props.env,
+    });
+
+    const buildScanTest = new pipelines.CodeBuildStep('BuildScanTest', {
+      input: source,
+      partialBuildSpec: pipelines.CodeBuildStep.partialBuildSpec({
+        version: '0.2',
+        phases: {
+          install: {
+            commands: [
+              'npm install -g npm@latest',
+              'npm install -g trivy checkov'
+            ]
+          },
+          pre_build: {
+            commands: [
+              'aws --version',
+              'ECR_URI=$(aws ecr describe-repositories --repository-names apgms-staging --query "repositories[0].repositoryUri" --output text 2>/dev/null)',
+              'if [ -z "$ECR_URI" ] || [ "$ECR_URI" = "None" ]; then echo "ECR repository missing: ensure infra deployed" && exit 1; fi',
+              'echo "ECR_URI=$ECR_URI"'
+            ]
+          },
+          build: {
+            commands: [
+              'IMAGE_TAG=$(git rev-parse --short=12 HEAD)',
+              'export IMAGE_TAG',
+              'aws ecr get-login-password | docker login --username AWS --password-stdin "$ECR_URI"',
+              'docker build -t "$ECR_URI:$IMAGE_TAG" -t "$ECR_URI:staging" .',
+              'trivy image --no-progress "$ECR_URI:$IMAGE_TAG"',
+              'checkov -d .',
+              'npm ci',
+              'npm test',
+              'docker push "$ECR_URI:$IMAGE_TAG"',
+              'docker push "$ECR_URI:staging"',
+              'mkdir -p infra/artifacts',
+              'echo $IMAGE_TAG > infra/artifacts/image-tag.txt'
+            ]
+          }
+        },
+        artifacts: {
+          'base-directory': 'infra/artifacts',
+          files: ['image-tag.txt']
+        }
+      }),
+      buildEnvironment: {
+        privileged: true,
+        buildImage: codebuild.LinuxBuildImage.STANDARD_7_0
+      },
+      rolePolicyStatements: [
+        new iam.PolicyStatement({
+          actions: [
+            'ecr:GetAuthorizationToken',
+            'ecr:BatchCheckLayerAvailability',
+            'ecr:CompleteLayerUpload',
+            'ecr:UploadLayerPart',
+            'ecr:InitiateLayerUpload',
+            'ecr:PutImage',
+            'ecr:DescribeRepositories'
+          ],
+          resources: ['*']
+        }),
+        new iam.PolicyStatement({
+          actions: ['iam:PassRole'],
+          resources: ['*']
+        })
+      ],
+      primaryOutputDirectory: 'infra/artifacts'
+    });
+
+    const deployStep = new pipelines.CodeBuildStep('DeployToStaging', {
+      input: buildScanTest,
+      envFromCfnOutputs: {
+        CLUSTER_NAME: stagingStage.clusterName,
+        SERVICE_NAME: stagingStage.serviceName,
+        VPC_ID: stagingStage.vpcId,
+        DB_SECRET_ARN: stagingStage.dbSecretArn
+      },
+      commands: [
+        'IMAGE_TAG=$(cat image-tag.txt)',
+        'npm install -g aws-cdk',
+        'cd infra/cdk',
+        'npm ci',
+        'npm run build',
+        'npx cdk deploy ApGmsStaging/StagingEnvironmentStack --require-approval never',
+        'aws ecs update-service --cluster "$CLUSTER_NAME" --service "$SERVICE_NAME" --force-new-deployment',
+        'aws cloudwatch put-metric-data --namespace "ApGms/Staging" --metric-name "LastDeployedImage" --value 1 --dimensions ImageTag=$IMAGE_TAG',
+        'aws secretsmanager describe-secret --secret-id "$DB_SECRET_ARN"'
+      ],
+      buildEnvironment: {
+        privileged: true,
+        buildImage: codebuild.LinuxBuildImage.STANDARD_7_0
+      },
+      rolePolicyStatements: [
+        new iam.PolicyStatement({
+          actions: ['ecs:UpdateService', 'ecs:DescribeServices'],
+          resources: ['*']
+        }),
+        new iam.PolicyStatement({
+          actions: ['cloudwatch:PutMetricData'],
+          resources: ['*']
+        }),
+        new iam.PolicyStatement({
+          actions: ['secretsmanager:DescribeSecret'],
+          resources: ['*']
+        })
+      ]
+    });
+
+    pipeline.addStage(stagingStage, {
+      pre: [buildScanTest],
+      post: [deployStep]
+    });
+  }
+}

--- a/infra/cdk/lib/staging-stack.ts
+++ b/infra/cdk/lib/staging-stack.ts
@@ -1,0 +1,309 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as ecs from 'aws-cdk-lib/aws-ecs';
+import * as ecsPatterns from 'aws-cdk-lib/aws-ecs-patterns';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import * as rds from 'aws-cdk-lib/aws-rds';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import * as kms from 'aws-cdk-lib/aws-kms';
+import * as wafv2 from 'aws-cdk-lib/aws-wafv2';
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import * as origins from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import * as integrations from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as route53 from 'aws-cdk-lib/aws-route53';
+import * as route53_targets from 'aws-cdk-lib/aws-route53-targets';
+
+export interface StagingEnvironmentStackProps extends cdk.StackProps {}
+
+export class StagingEnvironmentStack extends cdk.Stack {
+  public readonly clusterName: cdk.CfnOutput;
+  public readonly serviceName: cdk.CfnOutput;
+  public readonly vpcId: cdk.CfnOutput;
+  public readonly dbSecretArn: cdk.CfnOutput;
+
+  constructor(scope: Construct, id: string, props: StagingEnvironmentStackProps = {}) {
+    super(scope, id, props);
+
+    const key = new kms.Key(this, 'DataKey', {
+      alias: 'alias/apgms/staging/data',
+      enableKeyRotation: true
+    });
+
+    const vpc = new ec2.Vpc(this, 'Vpc', {
+      maxAzs: 3,
+      natGateways: 1,
+      subnetConfiguration: [
+        { name: 'public', subnetType: ec2.SubnetType.PUBLIC, cidrMask: 24 },
+        { name: 'private-app', subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS, cidrMask: 24 },
+        { name: 'private-data', subnetType: ec2.SubnetType.PRIVATE_ISOLATED, cidrMask: 24 }
+      ]
+    });
+
+    const dbSecret = new secretsmanager.Secret(this, 'DbSecret', {
+      secretName: 'apgms/staging/database',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ username: 'appuser' }),
+        generateStringKey: 'password',
+        excludePunctuation: true
+      },
+      encryptionKey: key
+    });
+
+    const dbSecurityGroup = new ec2.SecurityGroup(this, 'DbSecurityGroup', {
+      vpc,
+      description: 'RDS access from ECS only'
+    });
+
+    const ecsSecurityGroup = new ec2.SecurityGroup(this, 'EcsSecurityGroup', {
+      vpc,
+      description: 'ECS tasks security group'
+    });
+
+    dbSecurityGroup.addIngressRule(ecsSecurityGroup, ec2.Port.tcp(5432), 'Allow ECS tasks to reach RDS');
+
+    const rdsInstance = new rds.DatabaseInstance(this, 'Database', {
+      vpc,
+      engine: rds.DatabaseInstanceEngine.postgres({ version: rds.PostgresEngineVersion.V15_3 }),
+      instanceType: ec2.InstanceType.of(ec2.InstanceClass.T4G, ec2.InstanceSize.MEDIUM),
+      vpcSubnets: { subnetGroupName: 'private-data' },
+      multiAz: true,
+      storageEncrypted: true,
+      credentials: rds.Credentials.fromSecret(dbSecret),
+      securityGroups: [dbSecurityGroup],
+      allocatedStorage: 100,
+      backupRetention: cdk.Duration.days(7),
+      cloudwatchLogsRetention: logs.RetentionDays.ONE_MONTH,
+      kmsKey: key,
+      removalPolicy: cdk.RemovalPolicy.DESTROY,
+      deletionProtection: false,
+      storageType: rds.StorageType.GP3,
+      autoMinorVersionUpgrade: true
+    });
+
+    rdsInstance.addRotationSingleUser({
+      automaticallyAfter: cdk.Duration.days(30),
+      excludeCharacters: '"@/'
+    });
+
+    const repository = new ecr.Repository(this, 'Repository', {
+      repositoryName: 'apgms-staging',
+      encryption: ecr.RepositoryEncryption.KMS,
+      encryptionKey: key,
+      imageScanOnPush: true,
+      lifecycleRules: [{ maxImageCount: 10 }]
+    });
+
+    const cluster = new ecs.Cluster(this, 'Cluster', {
+      vpc,
+      containerInsights: true
+    });
+
+    const taskRole = new iam.Role(this, 'TaskRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com')
+    });
+    taskRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonXRayDaemonWriteAccess'));
+    taskRole.addToPrincipalPolicy(new iam.PolicyStatement({
+      actions: ['secretsmanager:GetSecretValue'],
+      resources: [dbSecret.secretArn]
+    }));
+
+    const executionRole = new iam.Role(this, 'ExecutionRole', {
+      assumedBy: new iam.ServicePrincipal('ecs-tasks.amazonaws.com')
+    });
+    executionRole.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy'));
+
+    const logGroup = new logs.LogGroup(this, 'ServiceLogGroup', {
+      logGroupName: '/apgms/staging/service',
+      retention: logs.RetentionDays.ONE_MONTH,
+      encryptionKey: key
+    });
+
+    const albFargate = new ecsPatterns.ApplicationLoadBalancedFargateService(this, 'Service', {
+      cluster,
+      cpu: 512,
+      memoryLimitMiB: 1024,
+      taskImageOptions: {
+        image: ecs.ContainerImage.fromEcrRepository(repository, 'staging'),
+        containerName: 'apgms-api',
+        containerPort: 8080,
+        executionRole,
+        taskRole,
+        environment: {
+          NODE_ENV: 'staging',
+          REQUEST_ID_HEADER: 'X-Request-Id',
+          HEALTH_CHECK_PATH: '/healthz'
+        },
+        secrets: {
+          DATABASE_SECRET: ecs.Secret.fromSecretsManager(dbSecret)
+        },
+        logDriver: ecs.LogDrivers.awsLogs({ streamPrefix: 'apgms-api', logGroup })
+      },
+      desiredCount: 2,
+      publicLoadBalancer: false,
+      assignPublicIp: false,
+      taskSubnets: { subnetGroupName: 'private-app' },
+      securityGroups: [ecsSecurityGroup]
+    });
+
+    const loadBalancer = albFargate.loadBalancer;
+    const listener = albFargate.listener;
+
+    albFargate.targetGroup.configureHealthCheck({
+      path: '/healthz',
+      healthyThresholdCount: 2,
+      unhealthyThresholdCount: 2,
+      timeout: cdk.Duration.seconds(5),
+      interval: cdk.Duration.seconds(30)
+    });
+
+    repository.grantPull(taskRole);
+
+    const httpApi = new apigwv2.HttpApi(this, 'StagingHttpApi', {
+      apiName: 'apgms-staging-edge',
+      createDefaultStage: true,
+      corsPreflight: {
+        allowHeaders: ['Authorization', 'Content-Type', 'X-Request-Id'],
+        allowMethods: [apigwv2.CorsHttpMethod.ANY],
+        allowOrigins: ['*']
+      }
+    });
+
+    const vpcLink = new apigwv2.VpcLink(this, 'VpcLink', {
+      vpcLinkName: 'apgms-staging-link',
+      vpc,
+      subnets: { subnets: vpc.selectSubnets({ subnetGroupName: 'private-app' }).subnets },
+      securityGroups: loadBalancer.connections.securityGroups
+    });
+
+    httpApi.addRoutes({
+      path: '/{proxy+}',
+      methods: [apigwv2.HttpMethod.ANY],
+      integration: new integrations.HttpAlbIntegration('AlbIntegration', listener, {
+        vpcLink
+      })
+    });
+
+    const waf = new wafv2.CfnWebACL(this, 'Waf', {
+      defaultAction: { allow: {} },
+      scope: 'CLOUDFRONT',
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: 'apgms-staging-waf',
+        sampledRequestsEnabled: true
+      },
+      name: 'apgms-staging-waf',
+      rules: [
+        {
+          name: 'AWS-AWSManagedRulesCommonRuleSet',
+          priority: 0,
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: 'AWS',
+              name: 'AWSManagedRulesCommonRuleSet'
+            }
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'AWSCommon',
+            sampledRequestsEnabled: true
+          },
+          overrideAction: { none: {} }
+        }
+      ]
+    });
+
+    const apiDomain = cdk.Fn.select(2, cdk.Fn.split('/', httpApi.apiEndpoint));
+    const distribution = new cloudfront.Distribution(this, 'Distribution', {
+      defaultBehavior: {
+        origin: new origins.HttpOrigin(apiDomain, {
+          originSslProtocols: [cloudfront.OriginSslPolicy.TLS_V1_2],
+          protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY
+        }),
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+        originRequestPolicy: new cloudfront.OriginRequestPolicy(this, 'OriginRequestPolicy', {
+          originRequestPolicyName: 'apgms-staging-headers',
+          comment: 'Forward auth and request id headers',
+          headerBehavior: cloudfront.OriginRequestHeaderBehavior.allowList('Authorization', 'Content-Type', 'X-Request-Id'),
+          queryStringBehavior: cloudfront.OriginRequestQueryStringBehavior.all(),
+          cookieBehavior: cloudfront.OriginRequestCookieBehavior.all()
+        }),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS
+      },
+      webAclId: waf.attrArn,
+      enableLogging: true,
+      logBucket: new s3.Bucket(this, 'AccessLogs', {
+        encryption: s3.BucketEncryption.KMS,
+        encryptionKey: key,
+        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        enforceSSL: true,
+        versioned: true
+      })
+    });
+
+    const hostedZoneId = this.node.tryGetContext('hostedZoneId');
+    const domainName = this.node.tryGetContext('domainName');
+    if (hostedZoneId && domainName) {
+      const zone = route53.HostedZone.fromHostedZoneAttributes(this, 'HostedZone', {
+        hostedZoneId,
+        zoneName: domainName
+      });
+      new route53.ARecord(this, 'AliasRecord', {
+        zone,
+        recordName: `staging.${domainName}`,
+        target: route53.RecordTarget.fromAlias(new route53_targets.CloudFrontTarget(distribution))
+      });
+    }
+
+    new cdk.CfnOutput(this, 'RepositoryUri', {
+      value: repository.repositoryUri,
+      exportName: 'ApGmsStagingRepositoryUri'
+    });
+
+    this.clusterName = new cdk.CfnOutput(this, 'ClusterName', {
+      value: cluster.clusterName,
+      exportName: 'ApGmsStagingCluster'
+    });
+
+    this.serviceName = new cdk.CfnOutput(this, 'ServiceName', {
+      value: albFargate.service.serviceName,
+      exportName: 'ApGmsStagingService'
+    });
+
+    this.vpcId = new cdk.CfnOutput(this, 'VpcId', {
+      value: vpc.vpcId,
+      exportName: 'ApGmsStagingVpc'
+    });
+
+    this.dbSecretArn = new cdk.CfnOutput(this, 'DbSecretArn', {
+      value: dbSecret.secretArn,
+      exportName: 'ApGmsStagingDbSecret'
+    });
+
+    new cdk.CfnOutput(this, 'DistributionDomain', {
+      value: distribution.distributionDomainName
+    });
+
+    new cdk.CfnOutput(this, 'HealthEndpoint', {
+      value: `https://${distribution.distributionDomainName}/healthz`
+    });
+
+    new ssm.StringParameter(this, 'ObservabilityNamespace', {
+      parameterName: '/apgms/staging/observability/namespace',
+      stringValue: 'ApGms/Staging',
+      description: 'CloudWatch namespace for staging metrics'
+    });
+
+    new logs.LogGroup(this, 'AccessLogGroup', {
+      logGroupName: '/apgms/staging/edge',
+      retention: logs.RetentionDays.ONE_MONTH,
+      encryptionKey: key
+    });
+  }
+}

--- a/infra/cdk/lib/staging-stage.ts
+++ b/infra/cdk/lib/staging-stage.ts
@@ -1,0 +1,26 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { StagingEnvironmentStack } from './staging-stack';
+
+export interface StagingStageProps extends cdk.StageProps {}
+
+export class StagingStage extends cdk.Stage {
+  public readonly clusterName: cdk.CfnOutput;
+  public readonly serviceName: cdk.CfnOutput;
+  public readonly vpcId: cdk.CfnOutput;
+  public readonly dbSecretArn: cdk.CfnOutput;
+
+  constructor(scope: Construct, id: string, props: StagingStageProps) {
+    super(scope, id, props);
+
+    const stack = new StagingEnvironmentStack(this, 'StagingEnvironmentStack', {
+      env: props.env,
+      stackName: 'ApGmsStaging-StagingEnvironmentStack'
+    });
+
+    this.clusterName = stack.clusterName;
+    this.serviceName = stack.serviceName;
+    this.vpcId = stack.vpcId;
+    this.dbSecretArn = stack.dbSecretArn;
+  }
+}

--- a/infra/cdk/package.json
+++ b/infra/cdk/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "apgms-staging-infra",
+  "version": "0.1.0",
+  "bin": {
+    "apgms-staging": "bin/apgms-staging.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc -w",
+    "cdk": "cdk",
+    "synth": "cdk synth",
+    "deploy": "cdk deploy",
+    "diff": "cdk diff"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "aws-cdk": "^2.126.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.126.0",
+    "constructs": "^10.3.0",
+    "source-map-support": "^0.5.21"
+  }
+}

--- a/infra/cdk/tsconfig.json
+++ b/infra/cdk/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["es2020"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["cdk.out"]
+}


### PR DESCRIPTION
## Summary
- scaffold an AWS CDK app that provisions the hardened staging VPC, ECS Fargate service, encrypted PostgreSQL, and CloudFront+WAF edge
- wire a CDK Pipelines deployment that builds, scans, tests, and deploys the container image through ECR and ECS with observability outputs
- add a GitHub Actions workflow for one-click staging deploys mirroring the CDK pipeline steps

## Testing
- Not run (infrastructure as code only)


------
https://chatgpt.com/codex/tasks/task_e_68e38aa7b0088327a785e0cc8c4dea71