### PR TITLE
Add help center, docs coverage, and runtime banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 2025-10-05
+- Added in-app Help Center with searchable articles and keyboard shortcut.
+- Surfaced prototype/live rail banner plus What’s New updates panel.
+- Documented payments endpoints and automated docs coverage check.
+
+## 2025-09-30
+- Improved PAYGW ledger reconciliation tooling.
+- Hardened RPT verification middleware and audit logging.

--- a/docs/api/payments/balance.mdx
+++ b/docs/api/payments/balance.mdx
@@ -1,0 +1,35 @@
+---
+title: Balance endpoint
+---
+
+# GET /api/payments/balance
+
+Use this read-only endpoint to check the running balance for an One-Way Account period. It queries the ledger in descending order
+and totals deposits and releases for the requested ABN, tax type and period.
+
+## Request
+
+- **Query string:**
+  - `abn` – required 11 digit ABN.
+  - `taxType` – required tax stream (e.g. `PAYGW`, `GST`).
+  - `periodId` – required identifier such as `2025-Q4`.
+
+## Response
+
+```
+{
+  "abn": "12345678901",
+  "taxType": "PAYGW",
+  "periodId": "2025-Q4",
+  "balance_cents": 120000,
+  "has_release": true
+}
+```
+
+- `balance_cents` is the current balance after summing deposits and releases.
+- `has_release` becomes `true` as soon as a release has been recorded for the period.
+
+## Errors
+
+- `400` when any required query argument is missing.
+- `500` if the ledger query fails.

--- a/docs/api/payments/deposit.mdx
+++ b/docs/api/payments/deposit.mdx
@@ -1,0 +1,37 @@
+---
+title: Deposit endpoint
+---
+
+# POST /api/payments/deposit
+
+Record a positive inflow into the protected One-Way Account. Deposits are idempotent within the upstream service using a UUID p
+er row.
+
+## Request body
+
+```
+{
+  "abn": "12345678901",
+  "taxType": "PAYGW",
+  "periodId": "2025-Q4",
+  "amountCents": 120000
+}
+```
+
+- `amountCents` must be greater than zero.
+- The service automatically assigns a new ledger UUID and updates the running balance.
+
+## Response
+
+```
+{
+  "ok": true,
+  "ledger_id": 41,
+  "balance_after_cents": 120000
+}
+```
+
+## Errors
+
+- `400` for missing body parameters or a non-positive `amountCents`.
+- `500` for unexpected persistence errors.

--- a/docs/api/payments/ledger.mdx
+++ b/docs/api/payments/ledger.mdx
@@ -1,0 +1,47 @@
+---
+title: Ledger endpoint
+---
+
+# GET /api/payments/ledger
+
+Fetch a chronological list of One-Way Account entries for a period. The ledger includes deposits, releases and the running balanc
+e after each entry.
+
+## Request
+
+- `abn` (query) – ABN tied to the ledger.
+- `taxType` (query) – PAYGW, GST or other configured tax stream.
+- `periodId` (query) – Reference for the withholding period you want to inspect.
+
+## Response
+
+```
+{
+  "abn": "12345678901",
+  "taxType": "PAYGW",
+  "periodId": "2025-Q4",
+  "rows": [
+    {
+      "id": 42,
+      "amount_cents": 120000,
+      "balance_after_cents": 120000,
+      "created_at": "2025-05-01T02:30:00Z",
+      "rpt_verified": false
+    },
+    {
+      "id": 43,
+      "amount_cents": -119500,
+      "balance_after_cents": 500,
+      "release_uuid": "44d0...",
+      "rpt_verified": true
+    }
+  ]
+}
+```
+
+Rows are ordered oldest to newest so you can reconstruct the balance history.
+
+## Errors
+
+- `400` when the required query values are missing.
+- `500` if the ledger query throws an error.

--- a/docs/api/payments/release.mdx
+++ b/docs/api/payments/release.mdx
@@ -1,0 +1,44 @@
+---
+title: Release endpoint
+---
+
+# POST /api/payments/release
+
+Create a negative ledger entry when remitting funds to the ATO. The route requires a verified Remittance Payload Token (RPT) and
+doubles as a compliance checkpoint.
+
+## Request body
+
+```
+{
+  "abn": "12345678901",
+  "taxType": "PAYGW",
+  "periodId": "2025-Q4",
+  "amountCents": -119500
+}
+```
+
+- `amountCents` must be negative. The service default is `-100` if omitted.
+- RPT verification is handled by middleware before the handler executes.
+
+## Response
+
+```
+{
+  "ok": true,
+  "ledger_id": 43,
+  "transfer_uuid": "0dd3...",
+  "release_uuid": "44d0...",
+  "balance_after_cents": 500,
+  "rpt_ref": {
+    "rpt_id": "2025-05-ATO",
+    "kid": "ato-demo",
+    "payload_sha256": "..."
+  }
+}
+```
+
+## Errors
+
+- `400` if validation fails, the RPT is missing, or the ledger insert violates constraints.
+- `403` when the middleware could not validate the RPT payload.

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,206 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "APGMS Payments API",
+    "version": "1.0.0",
+    "description": "OpenAPI description for the APGMS payments endpoints exposed under /api/payments."
+  },
+  "servers": [
+    { "url": "https://api.example.com/api/payments", "description": "Production" },
+    { "url": "http://localhost:3001", "description": "Local development" }
+  ],
+  "paths": {
+    "/balance": {
+      "get": {
+        "summary": "Retrieve the current balance for a tax period",
+        "operationId": "getBalance",
+        "parameters": [
+          {
+            "name": "abn",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "Australian Business Number in 11 digit format."
+          },
+          {
+            "name": "taxType",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "example": "PAYGW" },
+            "description": "Tax type identifier (PAYGW, GST, etc)."
+          },
+          {
+            "name": "periodId",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string", "example": "2025-Q4" },
+            "description": "Internal identifier for the withholding period."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Balance response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "abn": { "type": "string" },
+                    "taxType": { "type": "string" },
+                    "periodId": { "type": "string" },
+                    "balance_cents": { "type": "integer", "format": "int64" },
+                    "has_release": { "type": "boolean" }
+                  },
+                  "required": ["abn", "taxType", "periodId", "balance_cents", "has_release"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Missing or invalid query parameters" },
+          "500": { "description": "Unexpected server error" }
+        }
+      }
+    },
+    "/ledger": {
+      "get": {
+        "summary": "List ledger entries for a tax period",
+        "operationId": "getLedger",
+        "parameters": [
+          { "name": "abn", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "taxType", "in": "query", "required": true, "schema": { "type": "string" } },
+          { "name": "periodId", "in": "query", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ledger rows",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "abn": { "type": "string" },
+                    "taxType": { "type": "string" },
+                    "periodId": { "type": "string" },
+                    "rows": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "id": { "type": "integer" },
+                          "amount_cents": { "type": "integer" },
+                          "balance_after_cents": { "type": "integer" },
+                          "rpt_verified": { "type": "boolean" },
+                          "release_uuid": { "type": "string", "nullable": true },
+                          "bank_receipt_id": { "type": "string", "nullable": true },
+                          "created_at": { "type": "string", "format": "date-time" }
+                        }
+                      }
+                    }
+                  },
+                  "required": ["abn", "taxType", "periodId", "rows"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Missing or invalid query parameters" },
+          "500": { "description": "Unexpected server error" }
+        }
+      }
+    },
+    "/deposit": {
+      "post": {
+        "summary": "Record a deposit into an One-Way Account",
+        "operationId": "postDeposit",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "abn": { "type": "string" },
+                  "taxType": { "type": "string" },
+                  "periodId": { "type": "string" },
+                  "amountCents": { "type": "integer", "minimum": 1 }
+                },
+                "required": ["abn", "taxType", "periodId", "amountCents"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Deposit accepted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "ledger_id": { "type": "integer" },
+                    "balance_after_cents": { "type": "integer" }
+                  },
+                  "required": ["ok", "ledger_id", "balance_after_cents"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Validation failed" },
+          "500": { "description": "Unexpected server error" }
+        }
+      }
+    },
+    "/release": {
+      "post": {
+        "summary": "Release funds to the ATO (negative ledger entry)",
+        "operationId": "postRelease",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "abn": { "type": "string" },
+                  "taxType": { "type": "string" },
+                  "periodId": { "type": "string" },
+                  "amountCents": { "type": "integer", "maximum": -1 }
+                },
+                "required": ["abn", "taxType", "periodId", "amountCents"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Release recorded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ok": { "type": "boolean" },
+                    "ledger_id": { "type": "integer" },
+                    "transfer_uuid": { "type": "string" },
+                    "release_uuid": { "type": "string" },
+                    "balance_after_cents": { "type": "integer" },
+                    "rpt_ref": {
+                      "type": "object",
+                      "properties": {
+                        "rpt_id": { "type": "string" },
+                        "kid": { "type": "string" },
+                        "payload_sha256": { "type": "string" }
+                      }
+                    }
+                  },
+                  "required": ["ok", "ledger_id", "transfer_uuid", "release_uuid", "balance_after_cents", "rpt_ref"]
+                }
+              }
+            }
+          },
+          "400": { "description": "Validation failed or RPT missing" }
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "docs:check": "tsx scripts/docs/checkCoverage.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/public/CHANGELOG.md
+++ b/public/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 2025-10-05
+- Added in-app Help Center with searchable articles and keyboard shortcut.
+- Surfaced prototype/live rail banner plus What’s New updates panel.
+- Documented payments endpoints and automated docs coverage check.
+
+## 2025-09-30
+- Improved PAYGW ledger reconciliation tooling.
+- Hardened RPT verification middleware and audit logging.

--- a/scripts/docs/checkCoverage.ts
+++ b/scripts/docs/checkCoverage.ts
@@ -1,0 +1,80 @@
+import fs from "node:fs";
+import path from "node:path";
+
+type HttpMethod = "get" | "post" | "put" | "patch" | "delete" | "options" | "head" | "trace";
+
+type OpenAPISpec = {
+  paths: Record<string, Partial<Record<HttpMethod, unknown>>>;
+};
+
+function loadOpenApi(filePath: string): OpenAPISpec {
+  const absolute = path.resolve(filePath);
+  if (!fs.existsSync(absolute)) {
+    throw new Error(`Cannot find OpenAPI file at ${absolute}`);
+  }
+  const data = fs.readFileSync(absolute, "utf8");
+  return JSON.parse(data) as OpenAPISpec;
+}
+
+function listMdxFiles(dir: string): string[] {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const resolved = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...listMdxFiles(resolved));
+    } else if (entry.isFile() && resolved.endsWith(".mdx")) {
+      files.push(resolved);
+    }
+  }
+  return files;
+}
+
+function normalise(content: string): string {
+  return content.replace(/\s+/g, " ").toLowerCase();
+}
+
+function main() {
+  const spec = loadOpenApi("openapi.json");
+  const docsDir = path.resolve("docs");
+  if (!fs.existsSync(docsDir)) {
+    throw new Error(`Docs directory not found at ${docsDir}`);
+  }
+
+  const mdxFiles = listMdxFiles(docsDir);
+  if (mdxFiles.length === 0) {
+    throw new Error("No MDX documentation files were found under docs/.");
+  }
+
+  const mdxContent = mdxFiles.map((file) => ({
+    file,
+    content: normalise(fs.readFileSync(file, "utf8")),
+  }));
+
+  const missing: string[] = [];
+  for (const [route, operations] of Object.entries(spec.paths || {})) {
+    for (const [method, operation] of Object.entries(operations)) {
+      const typedMethod = method.toLowerCase() as HttpMethod;
+      if (!operation || !["get", "post", "put", "patch", "delete"].includes(typedMethod)) {
+        continue;
+      }
+      const token = `${typedMethod.toUpperCase()} ${route}`.toLowerCase();
+      const pathToken = route.toLowerCase();
+      const documented = mdxContent.some(({ content }) =>
+        content.includes(token) || content.includes(pathToken)
+      );
+      if (!documented) {
+        missing.push(`${typedMethod.toUpperCase()} ${route}`);
+      }
+    }
+  }
+
+  if (missing.length > 0) {
+    console.error("Documentation coverage check failed. Missing endpoints:\n" + missing.join("\n"));
+    process.exit(1);
+  }
+
+  console.log("Documentation coverage check passed for", mdxFiles.length, "MDX file(s).");
+}
+
+main();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import AppLayout from "./components/AppLayout";
+import { SupportProvider } from "./context/SupportContext";
 
 import Dashboard from "./pages/Dashboard";
 import BAS from "./pages/BAS";
@@ -14,19 +15,21 @@ import Help from "./pages/Help";
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <SupportProvider>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </SupportProvider>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import HelpCenter from "./HelpCenter";
+import WhatsNewPanel from "./WhatsNewPanel";
+import { useSupport } from "../context/SupportContext";
+import { getRuntimeBanner } from "../utils/runtime";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -14,13 +18,30 @@ const navLinks = [
 ];
 
 export default function AppLayout() {
+  const { openHelpCenter, openWhatsNew } = useSupport();
+  const banner = getRuntimeBanner();
+
   return (
     <div>
       <header className="app-header">
-        <img src={atoLogo} alt="ATO Logo" />
-        <h1>APGMS - Automated PAYGW & GST Management</h1>
-        <p>ATO-Compliant Tax Management System</p>
-        <nav style={{ marginTop: 16 }}>
+        <div className="app-header-inner">
+          <div className="app-branding">
+            <img src={atoLogo} alt="ATO Logo" />
+            <div>
+              <h1>APGMS - Automated PAYGW & GST Management</h1>
+              <p>ATO-Compliant Tax Management System</p>
+            </div>
+          </div>
+          <div className="app-header-actions">
+            <button type="button" className="header-button" onClick={openWhatsNew}>
+              What&apos;s New
+            </button>
+            <button type="button" className="header-button" onClick={() => openHelpCenter()}>
+              Help Center · Shift + /
+            </button>
+          </div>
+        </div>
+        <nav className="app-nav">
           {navLinks.map((link) => (
             <NavLink
               key={link.to}
@@ -44,6 +65,12 @@ export default function AppLayout() {
         </nav>
       </header>
 
+      <div className="mode-banner" role="status" aria-live="polite">
+        <span className="mode-pill">{banner.modeLabel}</span>
+        <span className="mode-separator">•</span>
+        <span className="mode-rails">Rails: {banner.railsLabel}</span>
+      </div>
+
       {/* 👇 This tells React Router where to render the child pages */}
       <main style={{ padding: 20 }}>
         <Outlet />
@@ -52,6 +79,9 @@ export default function AppLayout() {
       <footer className="app-footer">
         <p>© 2025 APGMS | Compliant with Income Tax Assessment Act 1997 & GST Act 1999</p>
       </footer>
+
+      <HelpCenter />
+      <WhatsNewPanel />
     </div>
   );
 }

--- a/src/components/HelpCenter.tsx
+++ b/src/components/HelpCenter.tsx
@@ -1,0 +1,145 @@
+import React, { useEffect, useMemo, useRef } from "react";
+import { useSupport } from "../context/SupportContext";
+import { HelpArticle, helpArticles, getHelpArticleById } from "../support/helpContent";
+
+function buildSearchIndex(article: HelpArticle) {
+  const haystack = [
+    article.title,
+    article.summary,
+    article.body.join(" "),
+    article.keywords.join(" "),
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack;
+}
+
+const indexedArticles = helpArticles.map((article) => ({
+  article,
+  haystack: buildSearchIndex(article),
+}));
+
+export default function HelpCenter() {
+  const { help, closeHelpCenter, setHelpQuery, setActiveHelpArticle } = useSupport();
+  const searchRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (help.isOpen) {
+      const id = window.requestAnimationFrame(() => searchRef.current?.focus());
+      return () => window.cancelAnimationFrame(id);
+    }
+    return undefined;
+  }, [help.isOpen]);
+
+  const trimmedQuery = help.query.trim().toLowerCase();
+
+  const filtered = useMemo(() => {
+    if (!trimmedQuery) {
+      return indexedArticles;
+    }
+    const parts = trimmedQuery.split(/\s+/).filter(Boolean);
+    return indexedArticles.filter(({ haystack }) =>
+      parts.every((token) => haystack.includes(token))
+    );
+  }, [trimmedQuery]);
+
+  const activeArticle = useMemo(() => {
+    const candidate = help.activeArticleId ? getHelpArticleById(help.activeArticleId) : null;
+    if (candidate) {
+      return candidate;
+    }
+    return filtered[0]?.article ?? helpArticles[0] ?? null;
+  }, [help.activeArticleId, filtered]);
+
+  const visibleArticles = useMemo(() => {
+    if (!activeArticle) {
+      return filtered.map(({ article }) => article);
+    }
+    const inFiltered = filtered.some(({ article }) => article.id === activeArticle.id);
+    const list = filtered.map(({ article }) => article);
+    if (!inFiltered) {
+      return [activeArticle, ...list];
+    }
+    return list;
+  }, [filtered, activeArticle]);
+
+  if (!help.isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="support-overlay" onClick={closeHelpCenter} role="dialog" aria-modal="true">
+      <div className="support-panel" onClick={(event) => event.stopPropagation()}>
+        <header className="support-header">
+          <div>
+            <h2 className="support-title">Help Center</h2>
+            <p className="support-subtitle">
+              {help.articleCount} guide{help.articleCount === 1 ? "" : "s"} · Shift + / to open · Esc to close
+            </p>
+          </div>
+          <button className="support-close" onClick={closeHelpCenter} type="button">
+            Close
+          </button>
+        </header>
+        <div className="support-body">
+          <aside className="help-sidebar">
+            <input
+              ref={searchRef}
+              value={help.query}
+              onChange={(event) => setHelpQuery(event.target.value)}
+              placeholder="Search help articles"
+              className="help-search"
+              aria-label="Search help articles"
+            />
+            <div className="help-results" role="list">
+              {visibleArticles.length === 0 && (
+                <div className="help-empty" role="status">
+                  No help topics match "{help.query}".
+                </div>
+              )}
+              {visibleArticles.map((article) => {
+                const isActive = activeArticle?.id === article.id;
+                return (
+                  <button
+                    key={article.id}
+                    type="button"
+                    className={isActive ? "help-result active" : "help-result"}
+                    onClick={() => setActiveHelpArticle(article.id)}
+                  >
+                    <span className="help-result-title">{article.title}</span>
+                    <span className="help-result-summary">{article.summary}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </aside>
+          <section className="help-article" aria-live="polite">
+            {activeArticle ? (
+              <div>
+                <h3>{activeArticle.title}</h3>
+                <p className="help-article-summary">{activeArticle.summary}</p>
+                {activeArticle.body.map((paragraph, index) => (
+                  <p key={index}>{paragraph}</p>
+                ))}
+                {activeArticle.links && activeArticle.links.length > 0 && (
+                  <div className="help-links">
+                    <h4>Related documentation</h4>
+                    <ul>
+                      {activeArticle.links.map((link) => (
+                        <li key={link.href}>
+                          <a href={link.href}>{link.label}</a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
+              </div>
+            ) : (
+              <p>Select a help topic to get started.</p>
+            )}
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/HelpTip.tsx
+++ b/src/components/HelpTip.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useSupport } from "../context/SupportContext";
+import { getHelpArticleById } from "../support/helpContent";
+
+type HelpTipProps = {
+  articleId: string;
+  label?: string;
+};
+
+export default function HelpTip({ articleId, label }: HelpTipProps) {
+  const { openHelpCenter } = useSupport();
+  const article = getHelpArticleById(articleId);
+  const accessibleLabel = label ?? article?.title ?? "Open help";
+  const searchQuery = article ? article.keywords.join(" ") || article.title : undefined;
+
+  return (
+    <button
+      type="button"
+      className="help-tip"
+      onClick={() => openHelpCenter({ articleId, query: searchQuery })}
+      aria-label={accessibleLabel}
+      title={article?.title ?? accessibleLabel}
+    >
+      ?
+    </button>
+  );
+}

--- a/src/components/WhatsNewPanel.tsx
+++ b/src/components/WhatsNewPanel.tsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useSupport } from "../context/SupportContext";
+
+type Section = {
+  title: string;
+  bullets: string[];
+  paragraphs: string[];
+};
+
+function getPublicPath(): string {
+  const fromMeta = typeof import.meta !== "undefined" && (import.meta as any)?.env?.BASE_URL;
+  const fromEnv = (process.env.PUBLIC_URL as string | undefined) ?? "";
+  const base = (fromMeta || fromEnv || "").replace(/\/$/, "");
+  return `${base}/CHANGELOG.md`.replace(/\/\//g, "/");
+}
+
+function parseChangelog(markdown: string): Section[] {
+  const lines = markdown.split(/\r?\n/);
+  const sections: Section[] = [];
+  let current: Section | null = null;
+  for (const line of lines) {
+    if (line.startsWith("## ")) {
+      if (current) {
+        sections.push(current);
+      }
+      current = { title: line.slice(3).trim(), bullets: [], paragraphs: [] };
+      continue;
+    }
+    if (line.startsWith("# ")) {
+      // Skip the main heading but make sure we have a section to attach content to.
+      if (!current) {
+        current = { title: line.slice(2).trim(), bullets: [], paragraphs: [] };
+      }
+      continue;
+    }
+    if (!current) {
+      current = { title: "Latest updates", bullets: [], paragraphs: [] };
+    }
+    const trimmed = line.trim();
+    if (!trimmed) {
+      continue;
+    }
+    if (trimmed.startsWith("- ")) {
+      current.bullets.push(trimmed.slice(2).trim());
+    } else {
+      current.paragraphs.push(trimmed);
+    }
+  }
+  if (current) {
+    sections.push(current);
+  }
+  return sections;
+}
+
+export default function WhatsNewPanel() {
+  const { whatsNewOpen, closeWhatsNew } = useSupport();
+  const [content, setContent] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!whatsNewOpen || content || loading) {
+      return;
+    }
+    let cancelled = false;
+    const controller = new AbortController();
+    async function fetchChangelog() {
+      try {
+        setLoading(true);
+        const response = await fetch(getPublicPath(), { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`Failed to load changelog: HTTP ${response.status}`);
+        }
+        const text = await response.text();
+        if (!cancelled) {
+          setContent(text);
+          setError(null);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message ?? "Unable to load changelog");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+    fetchChangelog();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [whatsNewOpen, content, loading]);
+
+  const sections = useMemo(() => (content ? parseChangelog(content) : []), [content]);
+
+  if (!whatsNewOpen) {
+    return null;
+  }
+
+  return (
+    <div className="support-overlay" onClick={closeWhatsNew} role="dialog" aria-modal="true">
+      <div className="whats-new-panel" onClick={(event) => event.stopPropagation()}>
+        <header className="support-header">
+          <div>
+            <h2 className="support-title">What&apos;s New</h2>
+            <p className="support-subtitle">Latest updates pulled from CHANGELOG.md</p>
+          </div>
+          <button className="support-close" onClick={closeWhatsNew} type="button">
+            Close
+          </button>
+        </header>
+        <div className="whats-new-body">
+          {loading && <p>Loading updates…</p>}
+          {error && !loading && <p className="whats-new-error">{error}</p>}
+          {!loading && !error && sections.length === 0 && <p>No updates yet.</p>}
+          {!loading && !error && sections.length > 0 && (
+            <div className="whats-new-sections">
+              {sections.map((section) => (
+                <section key={section.title} className="whats-new-section">
+                  <h3>{section.title}</h3>
+                  {section.paragraphs.map((paragraph, index) => (
+                    <p key={index}>{paragraph}</p>
+                  ))}
+                  {section.bullets.length > 0 && (
+                    <ul>
+                      {section.bullets.map((bullet, index) => (
+                        <li key={index}>{bullet}</li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/context/SupportContext.tsx
+++ b/src/context/SupportContext.tsx
@@ -1,0 +1,115 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import { getHelpArticleById, helpArticles } from "../support/helpContent";
+
+type HelpState = {
+  isOpen: boolean;
+  query: string;
+  activeArticleId: string | null;
+};
+
+type OpenHelpOptions = {
+  query?: string;
+  articleId?: string;
+};
+
+type SupportContextValue = {
+  help: HelpState & { articleCount: number };
+  openHelpCenter: (options?: OpenHelpOptions) => void;
+  closeHelpCenter: () => void;
+  setHelpQuery: (query: string) => void;
+  setActiveHelpArticle: (id: string | null) => void;
+  whatsNewOpen: boolean;
+  openWhatsNew: () => void;
+  closeWhatsNew: () => void;
+};
+
+const SupportContext = createContext<SupportContextValue | undefined>(undefined);
+
+export function SupportProvider({ children }: { children: React.ReactNode }) {
+  const [helpState, setHelpState] = useState<HelpState>({
+    isOpen: false,
+    query: "",
+    activeArticleId: null,
+  });
+  const [whatsNewOpen, setWhatsNewOpen] = useState(false);
+
+  const openHelpCenter = useCallback((options?: OpenHelpOptions) => {
+    setHelpState((prev) => {
+      const article = options?.articleId ? getHelpArticleById(options.articleId) : null;
+      const derivedQuery = article ? article.keywords.join(" ") || article.title : prev.query;
+      return {
+        isOpen: true,
+        query: options?.query ?? derivedQuery ?? "",
+        activeArticleId: options?.articleId ?? article?.id ?? prev.activeArticleId ?? null,
+      };
+    });
+  }, []);
+
+  const closeHelpCenter = useCallback(() => {
+    setHelpState((prev) => ({ ...prev, isOpen: false }));
+  }, []);
+
+  const setHelpQuery = useCallback((query: string) => {
+    setHelpState((prev) => ({ ...prev, query }));
+  }, []);
+
+  const setActiveHelpArticle = useCallback((id: string | null) => {
+    setHelpState((prev) => ({ ...prev, activeArticleId: id }));
+  }, []);
+
+  const openWhatsNew = useCallback(() => {
+    setWhatsNewOpen(true);
+  }, []);
+
+  const closeWhatsNew = useCallback(() => {
+    setWhatsNewOpen(false);
+  }, []);
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.shiftKey && (event.key === "?" || event.key === "/")) {
+        event.preventDefault();
+        openHelpCenter();
+      }
+      if (event.key === "Escape") {
+        if (helpState.isOpen) {
+          event.preventDefault();
+          closeHelpCenter();
+        } else if (whatsNewOpen) {
+          event.preventDefault();
+          closeWhatsNew();
+        }
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [helpState.isOpen, whatsNewOpen, openHelpCenter, closeHelpCenter, closeWhatsNew]);
+
+  const value = useMemo<SupportContextValue>(() => ({
+    help: { ...helpState, articleCount: helpArticles.length },
+    openHelpCenter,
+    closeHelpCenter,
+    setHelpQuery,
+    setActiveHelpArticle,
+    whatsNewOpen,
+    openWhatsNew,
+    closeWhatsNew,
+  }), [helpState, openHelpCenter, closeHelpCenter, setHelpQuery, setActiveHelpArticle, whatsNewOpen, openWhatsNew, closeWhatsNew]);
+
+  return <SupportContext.Provider value={value}>{children}</SupportContext.Provider>;
+}
+
+export function useSupport() {
+  const ctx = useContext(SupportContext);
+  if (!ctx) {
+    throw new Error("useSupport must be used within a SupportProvider");
+  }
+  return ctx;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -10,14 +10,29 @@ body {
   background: #00205b;
   color: #fff;
   padding: 28px 0 18px 0;
-  text-align: center;
-  border-radius: 0 0 8px 8px;
-  margin-bottom: 30px;
+  border-radius: 0 0 12px 12px;
+  margin-bottom: 22px;
+}
+
+.app-header-inner {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 20px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+}
+
+.app-branding {
+  display: flex;
+  align-items: center;
+  gap: 16px;
 }
 
 .app-header img {
   max-height: 60px;
-  margin-bottom: 10px;
 }
 
 .app-header h1 {
@@ -33,11 +48,71 @@ body {
   font-weight: 400;
 }
 
+.app-header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-button {
+  background: rgba(255, 255, 255, 0.18);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.32);
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.header-button:hover {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.app-nav {
+  margin-top: 16px;
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
 .app-footer {
   color: #888;
   text-align: center;
   margin: 44px 0 10px 0;
   font-size: 14px;
+}
+
+.mode-banner {
+  max-width: 1100px;
+  margin: 0 auto 24px auto;
+  padding: 12px 20px;
+  border-radius: 12px;
+  background: #e8edf9;
+  color: #052d6d;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.mode-pill {
+  background: #052d6d;
+  color: #fff;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.95rem;
+}
+
+.mode-separator {
+  opacity: 0.6;
+}
+
+.mode-rails {
+  font-size: 0.95rem;
 }
 
 /* Card & Container Styles */
@@ -196,4 +271,214 @@ th {
   background: #f1f6fa;
   font-weight: 600;
   color: #00205b;
+}
+
+/* Support overlays */
+.support-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 31, 71, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 1000;
+}
+
+.support-panel,
+.whats-new-panel {
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.18);
+  width: min(900px, 95vw);
+  max-height: 92vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.whats-new-panel {
+  width: min(640px, 92vw);
+}
+
+.support-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 24px 24px 0 24px;
+}
+
+.support-title {
+  margin: 0;
+  font-size: 1.6rem;
+}
+
+.support-subtitle {
+  margin: 4px 0 0 0;
+  font-size: 0.95rem;
+  color: #4a5a7a;
+}
+
+.support-close {
+  background: none;
+  border: none;
+  color: #052d6d;
+  font-weight: 600;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.support-body {
+  display: flex;
+  flex: 1;
+  padding: 16px 24px 24px 24px;
+  gap: 20px;
+  min-height: 0;
+}
+
+.help-sidebar {
+  width: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border-right: 1px solid #e6eaf5;
+  padding-right: 16px;
+  min-height: 0;
+}
+
+.help-search {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #c7d2eb;
+  font-size: 0.95rem;
+}
+
+.help-results {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-right: 6px;
+}
+
+.help-empty {
+  color: #7181a6;
+  font-size: 0.9rem;
+}
+
+.help-result {
+  border: 1px solid #d9e2f2;
+  border-radius: 12px;
+  padding: 10px 12px;
+  text-align: left;
+  background: #f7f9ff;
+  cursor: pointer;
+  transition: border 0.15s ease, background 0.15s ease;
+}
+
+.help-result.active {
+  border-color: #052d6d;
+  background: #e4ebff;
+}
+
+.help-result-title {
+  display: block;
+  font-weight: 600;
+  color: #052d6d;
+}
+
+.help-result-summary {
+  display: block;
+  font-size: 0.85rem;
+  color: #4a5a7a;
+  margin-top: 4px;
+}
+
+.help-article {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+.help-article-summary {
+  font-size: 1rem;
+  color: #334465;
+  font-weight: 500;
+}
+
+.help-links ul {
+  padding-left: 20px;
+}
+
+.help-links a {
+  color: #0d47a1;
+}
+
+.whats-new-body {
+  padding: 16px 24px 24px 24px;
+  overflow-y: auto;
+}
+
+.whats-new-error {
+  color: #c62828;
+  font-weight: 600;
+}
+
+.whats-new-section + .whats-new-section {
+  border-top: 1px solid #e6eaf5;
+  margin-top: 16px;
+  padding-top: 16px;
+}
+
+.help-tip {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  margin-left: 6px;
+  border-radius: 50%;
+  border: none;
+  background: #052d6d;
+  color: #fff;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.help-tip:hover {
+  background: #073b91;
+}
+
+@media (max-width: 900px) {
+  .support-panel,
+  .whats-new-panel {
+    width: 100%;
+    max-width: 100%;
+  }
+  .support-body {
+    flex-direction: column;
+  }
+  .help-sidebar {
+    width: 100%;
+    border-right: none;
+    border-bottom: 1px solid #e6eaf5;
+    padding-bottom: 16px;
+  }
+  .help-results {
+    max-height: 160px;
+  }
+}
+
+@media (max-width: 700px) {
+  .app-header-inner {
+    justify-content: center;
+  }
+  .app-branding {
+    flex-direction: column;
+    text-align: center;
+  }
+  .app-header-actions {
+    justify-content: center;
+  }
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import HelpTip from "../components/HelpTip";
 
 const tabs = [
   "Business Profile",
@@ -48,7 +49,10 @@ export default function Settings() {
             }}
           >
             <div style={{ marginBottom: 16 }}>
-              <label>ABN:</label>
+              <label>
+                ABN
+                <HelpTip articleId="abn-format" />
+              </label>
               <input
                 className="settings-input"
                 style={{ width: "100%" }}
@@ -122,7 +126,10 @@ export default function Settings() {
         )}
         {activeTab === "Payroll & Sales" && (
           <div style={{ maxWidth: 600, margin: "0 auto" }}>
-            <h3>Payroll Providers</h3>
+            <h3>
+              Payroll Providers
+              <HelpTip articleId="owa-balance" label="How payroll affects balances" />
+            </h3>
             <ul>
               <li>MYOB</li>
               <li>QuickBooks</li>
@@ -138,7 +145,10 @@ export default function Settings() {
         )}
         {activeTab === "Automated Transfers" && (
           <div style={{ maxWidth: 600, margin: "0 auto" }}>
-            <h3>Scheduled Transfers</h3>
+            <h3>
+              Scheduled Transfers
+              <HelpTip articleId="deposits-buffer" />
+            </h3>
             <table>
               <thead>
                 <tr>

--- a/src/pages/Wizard.tsx
+++ b/src/pages/Wizard.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import HelpTip from "../components/HelpTip";
 
 const steps = [
   "Business Details",
@@ -20,25 +21,40 @@ export default function Wizard() {
       <div style={{ background: "#f9f9f9", borderRadius: 10, padding: 24, minHeight: 120 }}>
         {step === 0 && (
           <div>
-            <label>Business ABN:</label>
+            <label>
+              Business ABN
+              <HelpTip articleId="abn-format" />
+            </label>
             <input className="settings-input" style={{ width: 220 }} defaultValue="12 345 678 901" />
             <br />
-            <label>Legal Name:</label>
+            <label>
+              Legal Name
+              <HelpTip articleId="ledger-audit" label="Why legal names matter" />
+            </label>
             <input className="settings-input" style={{ width: 220 }} defaultValue="Example Pty Ltd" />
           </div>
         )}
         {step === 1 && (
           <div>
-            <label>BSB:</label>
+            <label>
+              BSB
+              <HelpTip articleId="deposits-buffer" label="Use dedicated buffer accounts" />
+            </label>
             <input className="settings-input" style={{ width: 140 }} defaultValue="123-456" />
             <br />
-            <label>Account #:</label>
+            <label>
+              Account #
+              <HelpTip articleId="release-ato" label="Account matching for releases" />
+            </label>
             <input className="settings-input" style={{ width: 140 }} defaultValue="11111111" />
           </div>
         )}
         {step === 2 && (
           <div>
-            <label>Payroll Provider:</label>
+            <label>
+              Payroll Provider
+              <HelpTip articleId="owa-balance" label="Connect payroll to balances" />
+            </label>
             <select className="settings-input" style={{ width: 220 }}>
               <option>MYOB</option>
               <option>QuickBooks</option>
@@ -47,7 +63,10 @@ export default function Wizard() {
         )}
         {step === 3 && (
           <div>
-            <label>Automated PAYGW transfer?</label>
+            <label>
+              Automated PAYGW transfer?
+              <HelpTip articleId="release-ato" label="How releases post to the ledger" />
+            </label>
             <input type="checkbox" defaultChecked /> Yes
           </div>
         )}

--- a/src/support/helpContent.ts
+++ b/src/support/helpContent.ts
@@ -1,0 +1,89 @@
+export interface HelpLink {
+  label: string;
+  href: string;
+}
+
+export interface HelpArticle {
+  id: string;
+  title: string;
+  summary: string;
+  body: string[];
+  keywords: string[];
+  links?: HelpLink[];
+}
+
+export const helpArticles: HelpArticle[] = [
+  {
+    id: "owa-balance",
+    title: "Understand period balances",
+    summary: "How the balance API reports PAYGW/GST obligations in cents.",
+    body: [
+      "The balance endpoint tallies every ledger entry for a period and returns the post-sum balance in cents.",
+      "If a release has been lodged the response sets has_release=true so you can confirm the ATO has been paid.",
+      "Use this call inside dashboards or scheduled jobs to double check that withheld funds stay in reserve."
+    ],
+    keywords: ["balance", "api", "period", "owa", "paygw", "gst"],
+    links: [
+      { label: "GET /api/payments/balance", href: "/docs/api/payments/balance" }
+    ]
+  },
+  {
+    id: "ledger-audit",
+    title: "Ledger drill-down",
+    summary: "Inspect each movement in the One-Way Account for audit evidence.",
+    body: [
+      "Ledger results are ordered oldest-first so balances are easy to follow.",
+      "When rpt_verified is true the record has been authorised via Remittance Payload Token checks.",
+      "Use release_uuid to reconcile against ATO receipts or your bank reference." 
+    ],
+    keywords: ["ledger", "audit", "history", "rpt"],
+    links: [
+      { label: "GET /api/payments/ledger", href: "/docs/api/payments/ledger" }
+    ]
+  },
+  {
+    id: "deposits-buffer",
+    title: "Deposits into the buffer",
+    summary: "Record withheld cash before it leaves operational accounts.",
+    body: [
+      "Deposits must be positive integers representing cents. The service rejects zero or negative values.",
+      "The upstream service stores a unique transfer_uuid per insert so your own retries stay idempotent.",
+      "Schedule deposits alongside payroll and POS settlements to avoid mixing PAYGW and GST with trading cash."
+    ],
+    keywords: ["deposit", "buffer", "automated", "transfer"],
+    links: [
+      { label: "POST /api/payments/deposit", href: "/docs/api/payments/deposit" }
+    ]
+  },
+  {
+    id: "release-ato",
+    title: "ATO releases with RPT",
+    summary: "Explain negative ledger entries and RPT requirements.",
+    body: [
+      "Release calls require amountCents to be negative; the service defaults to -100 when a testing amount is missing.",
+      "rptGate middleware attaches the verified payload details to req.rpt so downstream handlers can trust the caller.",
+      "Responses include both transfer_uuid and release_uuid for matching against your banking rails." 
+    ],
+    keywords: ["release", "ato", "rpt", "shadow"],
+    links: [
+      { label: "POST /api/payments/release", href: "/docs/api/payments/release" }
+    ]
+  },
+  {
+    id: "abn-format",
+    title: "Correct ABN format",
+    summary: "Ensure the Australian Business Number matches ATO rules.",
+    body: [
+      "ABNs must be 11 digits without spaces when calling the API. UIs may display with spaces for readability.",
+      "When capturing ABNs we recommend validating the checksum before persisting the value.",
+      "Storing a canonical ABN avoids downstream reconciliation mismatches with the ATO."
+    ],
+    keywords: ["abn", "business", "profile", "validation"]
+  }
+];
+
+const articleIndex = new Map(helpArticles.map((article) => [article.id, article]));
+
+export function getHelpArticleById(id: string) {
+  return articleIndex.get(id) ?? null;
+}

--- a/src/utils/runtime.ts
+++ b/src/utils/runtime.ts
@@ -1,0 +1,64 @@
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function firstEnv(keys: string[], fallback?: string) {
+  for (const key of keys) {
+    const value = (process.env as Record<string, string | undefined>)[key];
+    if (value !== undefined) {
+      return value;
+    }
+  }
+  if (typeof import.meta !== "undefined") {
+    const metaEnv = (import.meta as any)?.env ?? {};
+    for (const key of keys) {
+      const value = metaEnv[key];
+      if (value !== undefined) {
+        return value;
+      }
+    }
+  }
+  return fallback;
+}
+
+function flagEnabled(keys: string[]) {
+  const value = firstEnv(keys);
+  if (value === undefined) {
+    return false;
+  }
+  return TRUE_VALUES.has(String(value).toLowerCase());
+}
+
+export function getRuntimeBanner() {
+  const rawMode = (firstEnv([
+    "REACT_APP_RUNTIME_MODE",
+    "VITE_RUNTIME_MODE",
+    "RUNTIME_MODE",
+  ]) ?? "").toString().toUpperCase();
+
+  const isPrototype = rawMode
+    ? rawMode !== "REAL" && rawMode !== "PRODUCTION"
+    : (process.env.NODE_ENV ?? "development") !== "production";
+
+  const modeLabel = isPrototype ? "Prototype Mode" : "Real Mode";
+
+  const dryRun = flagEnabled(["REACT_APP_DRY_RUN", "VITE_DRY_RUN", "DRY_RUN"]);
+  const shadow = flagEnabled([
+    "REACT_APP_SHADOW_ONLY",
+    "VITE_SHADOW_ONLY",
+    "SHADOW_ONLY",
+  ]);
+
+  const railsLabel = [
+    dryRun ? "DRY_RUN" : null,
+    shadow ? "SHADOW_ONLY" : null,
+  ]
+    .filter(Boolean)
+    .join(" + ") || "LIVE";
+
+  return {
+    modeLabel,
+    railsLabel,
+    isPrototype,
+    dryRun,
+    shadow,
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "scripts"]
 }


### PR DESCRIPTION
## Summary
- add an OpenAPI contract for the payments service along with MDX guides for every public endpoint and a coverage script that verifies docs stay in sync
- introduce a global support context that powers a searchable in-app Help Center, inline HelpTip triggers, and a What’s New panel sourced from CHANGELOG.md
- surface runtime status with a prototype/real mode banner and rails indicator while refreshing header controls for quick access to help resources

## Testing
- npm run docs:check

------
https://chatgpt.com/codex/tasks/task_e_68e389ddad208327a58ff4ac51efe8cf