### PR TITLE
Automate recon gating and RPT issuance

### DIFF
--- a/apps/services/recon/main.py
+++ b/apps/services/recon/main.py
@@ -1,25 +1,191 @@
-﻿# apps/services/recon/main.py
-from fastapi import FastAPI
+# apps/services/recon/main.py
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
-import os, psycopg2, json, math
+import os
+import psycopg2
+import psycopg2.extras
+import math
+import statistics
+import json
+from datetime import datetime
+from hashlib import sha256
+from typing import Dict, Any, List
 
 app = FastAPI(title="recon")
 
+DEFAULT_THRESHOLDS = {
+    "epsilon_cents": 100,
+    "variance_ratio": 0.25,
+    "dup_rate": 0.05,
+    "gap_minutes": 60,
+    "delta_vs_baseline": 0.1,
+}
+
+
+def get_conn():
+    return psycopg2.connect(
+        host=os.getenv("PGHOST", "127.0.0.1"),
+        user=os.getenv("PGUSER", "apgms"),
+        password=os.getenv("PGPASSWORD", "apgms_pw"),
+        dbname=os.getenv("PGDATABASE", "apgms"),
+        port=int(os.getenv("PGPORT", "5432")),
+    )
+
+
 class ReconReq(BaseModel):
+    abn: str
+    tax_type: str
     period_id: str
-    paygw_total: float
-    gst_total: float
-    owa_paygw: float
-    owa_gst: float
-    anomaly_score: float
-    tolerance: float = 0.01
+    thresholds: Dict[str, float] | None = None
+
+
+def summarise_ledger(rows: List[Dict[str, Any]]):
+    credited = 0
+    debited = 0
+    for row in rows:
+        amount = int(row["amount_cents"])
+        if amount >= 0:
+            credited += amount
+        else:
+            debited += abs(amount)
+    net = credited - debited
+    last = rows[-1] if rows else None
+    merkle_seed = [
+        [
+            r["id"],
+            int(r["amount_cents"]),
+            int(r.get("balance_after_cents") or 0),
+            r.get("bank_receipt_hash") or "",
+            r.get("hash_after") or "",
+        ]
+        for r in rows
+    ]
+    merkle_root = sha256(str(merkle_seed).encode("utf-8")).hexdigest() if rows else None
+    return {
+        "credited_cents": credited,
+        "debited_cents": debited,
+        "net_cents": net,
+        "final_liability_cents": max(net, 0),
+        "running_balance_cents": int(last.get("balance_after_cents") or 0) if last else 0,
+        "running_balance_hash": last.get("hash_after") if last else None,
+        "merkle_root": merkle_root,
+    }
+
+
+def compute_anomaly_vector(rows: List[Dict[str, Any]], totals: Dict[str, int], baseline: int):
+    credit_amounts = [int(r["amount_cents"]) for r in rows if int(r["amount_cents"]) > 0]
+    if credit_amounts:
+        mean = statistics.fmean(credit_amounts)
+        variance = statistics.pvariance(credit_amounts, mu=mean)
+        stddev = math.sqrt(variance)
+        variance_ratio = 0 if mean == 0 else stddev / abs(mean)
+    else:
+        variance_ratio = 0.0
+
+    receipts = [r.get("bank_receipt_hash") for r in rows if r.get("bank_receipt_hash")]
+    unique_receipts = len(set(receipts))
+    dup_rate = 0.0 if not receipts else (len(receipts) - unique_receipts) / len(receipts)
+
+    timestamps = []
+    for r in rows:
+        ts = r.get("created_at")
+        if ts:
+            timestamps.append(datetime.fromisoformat(str(ts)))
+    if len(timestamps) > 1:
+        gap_seconds = abs((max(timestamps) - min(timestamps)).total_seconds())
+        gap_minutes = gap_seconds / 60.0
+    else:
+        gap_minutes = 0.0
+
+    if baseline == 0:
+        delta = 0.0 if totals["net_cents"] == 0 else 1.0
+    else:
+        delta = (totals["net_cents"] - baseline) / baseline
+
+    return {
+        "variance_ratio": round(variance_ratio, 6),
+        "dup_rate": round(dup_rate, 6),
+        "gap_minutes": round(gap_minutes, 3),
+        "delta_vs_baseline": round(delta, 6),
+    }
+
+
+def merge_thresholds(period_thresholds: Dict[str, Any] | None, overrides: Dict[str, Any] | None):
+    merged = dict(DEFAULT_THRESHOLDS)
+    if period_thresholds:
+        merged.update({k: float(v) for k, v in period_thresholds.items()})
+    if overrides:
+        merged.update({k: float(v) for k, v in overrides.items()})
+    return merged
+
 
 @app.post("/recon/run")
 def run(req: ReconReq):
-    pay_ok = math.isclose(req.paygw_total, req.owa_paygw, abs_tol=req.tolerance)
-    gst_ok = math.isclose(req.gst_total, req.owa_gst, abs_tol=req.tolerance)
-    anomaly_ok = req.anomaly_score < 0.8
-    if pay_ok and gst_ok and anomaly_ok:
-        return {"pass": True, "reason_code": None, "controls": ["BAS-GATE","RPT"], "next_state": "RPT-Issued"}
-    reason = "shortfall" if (not pay_ok or not gst_ok) else "anomaly_breach"
-    return {"pass": False, "reason_code": reason, "controls": ["BLOCK"], "next_state": "Blocked"}
+    conn = get_conn()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "select * from periods where abn=%s and tax_type=%s and period_id=%s",
+                (req.abn, req.tax_type, req.period_id),
+            )
+            period = cur.fetchone()
+            if not period:
+                raise HTTPException(status_code=404, detail="PERIOD_NOT_FOUND")
+
+            cur.execute(
+                """
+                select id, amount_cents, balance_after_cents, bank_receipt_hash, hash_after, created_at
+                  from owa_ledger
+                 where abn=%s and tax_type=%s and period_id=%s
+                 order by id
+                """,
+                (req.abn, req.tax_type, req.period_id),
+            )
+            ledger = cur.fetchall()
+
+        baseline = int(period.get("accrued_cents") or 0)
+        totals = summarise_ledger(ledger)
+        anomaly_vector = compute_anomaly_vector(ledger, totals, baseline)
+
+        period_thresholds = period.get("thresholds")
+        if isinstance(period_thresholds, str):
+            period_thresholds = json.loads(period_thresholds)
+        overrides = req.thresholds or {}
+        thresholds = merge_thresholds(period_thresholds, overrides)
+
+        epsilon = abs(totals["final_liability_cents"] - totals["running_balance_cents"])
+
+        pass_flag = True
+        reason = None
+        next_state = "READY_RPT"
+        if epsilon > thresholds["epsilon_cents"]:
+            pass_flag = False
+            reason = "DISCREPANCY_EPSILON"
+            next_state = "BLOCKED_DISCREPANCY"
+        else:
+            if anomaly_vector["variance_ratio"] > thresholds["variance_ratio"]:
+                pass_flag = False
+                reason = "ANOMALY_VARIANCE_RATIO"
+            elif anomaly_vector["dup_rate"] > thresholds["dup_rate"]:
+                pass_flag = False
+                reason = "ANOMALY_DUPLICATE_RATE"
+            elif anomaly_vector["gap_minutes"] > thresholds["gap_minutes"]:
+                pass_flag = False
+                reason = "ANOMALY_SETTLEMENT_GAP"
+            elif abs(anomaly_vector["delta_vs_baseline"]) > thresholds["delta_vs_baseline"]:
+                pass_flag = False
+                reason = "ANOMALY_DELTA_BASELINE"
+            if not pass_flag:
+                next_state = "BLOCKED_ANOMALY"
+
+        return {
+            "pass": pass_flag,
+            "reason_code": reason,
+            "epsilon_cents": epsilon,
+            "thresholds": thresholds,
+            "anomaly_vector": anomaly_vector,
+            "totals": totals,
+            "next_state": next_state,
+        }
+    finally:
+        conn.close()

--- a/src/anomaly/deterministic.ts
+++ b/src/anomaly/deterministic.ts
@@ -1,4 +1,4 @@
-﻿export interface AnomalyVector {
+export interface AnomalyVector {
   variance_ratio: number;
   dup_rate: number;
   gap_minutes: number;
@@ -10,13 +10,88 @@ export interface Thresholds {
   dup_rate?: number;
   gap_minutes?: number;
   delta_vs_baseline?: number;
+  epsilon_cents?: number;
+}
+
+export interface ReconLedgerEntry {
+  amount_cents: number;
+  bank_receipt_hash?: string | null;
+  created_at?: string | null;
+}
+
+export interface ReconTotals {
+  credited_cents: number;
+  net_cents: number;
+}
+
+export function computeAnomalyVector(
+  entries: ReconLedgerEntry[],
+  totals: ReconTotals,
+  baselineCents: number
+): AnomalyVector {
+  const creditAmounts = entries
+    .filter((e) => e.amount_cents > 0)
+    .map((e) => e.amount_cents);
+
+  const mean = creditAmounts.length
+    ? creditAmounts.reduce((acc, amt) => acc + amt, 0) / creditAmounts.length
+    : 0;
+  const variance = creditAmounts.length
+    ? creditAmounts.reduce((acc, amt) => acc + Math.pow(amt - mean, 2), 0) /
+      creditAmounts.length
+    : 0;
+  const stddev = Math.sqrt(variance);
+  const varianceRatio = mean === 0 ? 0 : stddev / Math.abs(mean);
+
+  const receiptHashes = entries
+    .filter((e) => e.amount_cents > 0 && e.bank_receipt_hash)
+    .map((e) => e.bank_receipt_hash as string);
+  const uniqueReceipts = new Set(receiptHashes);
+  const dupRate = receiptHashes.length === 0
+    ? 0
+    : (receiptHashes.length - uniqueReceipts.size) / receiptHashes.length;
+
+  const timestamps = entries
+    .map((e) => (e.created_at ? Date.parse(e.created_at) : NaN))
+    .filter((ts) => !Number.isNaN(ts));
+  const gapMinutes = timestamps.length > 1
+    ? Math.abs(Math.max(...timestamps) - Math.min(...timestamps)) / 60000
+    : 0;
+
+  const baseline = baselineCents === 0 ? 0 : baselineCents;
+  const deltaVsBaseline = baseline === 0
+    ? totals.net_cents === 0
+      ? 0
+      : 1
+    : (totals.net_cents - baseline) / baseline;
+
+  return {
+    variance_ratio: Number(varianceRatio.toFixed(6)),
+    dup_rate: Number(dupRate.toFixed(6)),
+    gap_minutes: Number(gapMinutes.toFixed(3)),
+    delta_vs_baseline: Number(deltaVsBaseline.toFixed(6)),
+  };
+}
+
+export function evaluateAnomaly(
+  vector: AnomalyVector,
+  thresholds: Thresholds = {}
+): { breach: boolean; code?: string } {
+  if (vector.variance_ratio > (thresholds.variance_ratio ?? 0.25)) {
+    return { breach: true, code: "VARIANCE_RATIO" };
+  }
+  if (vector.dup_rate > (thresholds.dup_rate ?? 0.05)) {
+    return { breach: true, code: "DUPLICATE_RATE" };
+  }
+  if (vector.gap_minutes > (thresholds.gap_minutes ?? 60)) {
+    return { breach: true, code: "SETTLEMENT_GAP" };
+  }
+  if (Math.abs(vector.delta_vs_baseline) > (thresholds.delta_vs_baseline ?? 0.1)) {
+    return { breach: true, code: "DELTA_BASELINE" };
+  }
+  return { breach: false };
 }
 
 export function isAnomalous(v: AnomalyVector, thr: Thresholds = {}): boolean {
-  return (
-    v.variance_ratio > (thr.variance_ratio ?? 0.25) ||
-    v.dup_rate > (thr.dup_rate ?? 0.05) ||
-    v.gap_minutes > (thr.gap_minutes ?? 60) ||
-    Math.abs(v.delta_vs_baseline) > (thr.delta_vs_baseline ?? 0.1)
-  );
+  return evaluateAnomaly(v, thr).breach;
 }

--- a/src/crypto/ed25519.ts
+++ b/src/crypto/ed25519.ts
@@ -1,10 +1,20 @@
-﻿import nacl from "tweetnacl";
+import nacl from "tweetnacl";
+
+export interface RptTotals {
+  credited_to_owa_cents: number;
+  net_cents: number;
+  final_liability_cents: number;
+  accrued_cents: number;
+}
 
 export interface RptPayload {
-  entity_id: string; period_id: string; tax_type: "PAYGW"|"GST";
-  amount_cents: number; merkle_root: string; running_balance_hash: string;
-  anomaly_vector: Record<string, number>; thresholds: Record<string, number>;
-  rail_id: "EFT"|"BPAY"|"PayTo"; reference: string; expiry_ts: string; nonce: string;
+  abn: string;
+  tax_type: "PAYGW" | "GST";
+  period_id: string;
+  totals: RptTotals;
+  rates_version: string;
+  nonce: string;
+  exp: string;
 }
 
 export function signRpt(payload: RptPayload, secretKey: Uint8Array): string {

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,52 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
+  const periodRes = await pool.query(
+    `select abn,tax_type,period_id,state,accrued_cents,credited_to_owa_cents,final_liability_cents,
+            merkle_root,running_balance_hash,anomaly_vector,thresholds
+       from periods
+      where abn=$1 and tax_type=$2 and period_id=$3`,
+    [abn, taxType, periodId]
+  );
+  const period = periodRes.rows[0] ?? null;
+
+  const rptRes = await pool.query(
+    `select payload, signature, payload_sha256, created_at
+       from rpt_tokens
+      where abn=$1 and tax_type=$2 and period_id=$3
+      order by id desc limit 1`,
+    [abn, taxType, periodId]
+  );
+  const rpt = rptRes.rows[0] ?? null;
+
+  const ledgerRes = await pool.query(
+    `select created_at as ts, amount_cents, balance_after_cents, hash_after, bank_receipt_hash
+       from owa_ledger
+      where abn=$1 and tax_type=$2 and period_id=$3
+      order by id`,
+    [abn, taxType, periodId]
+  );
+
+  const deltas = ledgerRes.rows.map((row) => ({
+    ts: row.ts,
+    amount_cents: Number(row.amount_cents ?? 0),
+    balance_after_cents: Number(row.balance_after_cents ?? 0),
+    hash_after: row.hash_after,
+    bank_receipt_hash: row.bank_receipt_hash,
+  }));
+  const last = deltas[deltas.length - 1] ?? null;
+
+  return {
+    bas_labels: { W1: null, W2: null, "1A": null, "1B": null },
     rpt_payload: rpt?.payload ?? null,
     rpt_signature: rpt?.signature ?? null,
+    rpt_sha256: rpt?.payload_sha256 ?? null,
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    anomaly_thresholds: period?.thresholds ?? {},
+    discrepancy_log: [],
+    period,
   };
-  return bundle;
 }

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -1,15 +1,28 @@
-﻿export type PeriodState = "OPEN"|"CLOSING"|"READY_RPT"|"BLOCKED_DISCREPANCY"|"BLOCKED_ANOMALY"|"RELEASED"|"FINALIZED";
-export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
+export type PeriodState =
+  | "OPEN"
+  | "CLOSING"
+  | "READY_RPT"
+  | "BLOCKED_DISCREPANCY"
+  | "BLOCKED_ANOMALY"
+  | "RELEASED"
+  | "FINALIZED";
+
+const transitions: Record<string, PeriodState> = {
+  "OPEN:CLOSE": "CLOSING",
+  "CLOSING:PASS": "READY_RPT",
+  "CLOSING:FAIL_DISCREPANCY": "BLOCKED_DISCREPANCY",
+  "CLOSING:FAIL_ANOMALY": "BLOCKED_ANOMALY",
+  "BLOCKED_DISCREPANCY:RETRY": "CLOSING",
+  "BLOCKED_ANOMALY:RETRY": "CLOSING",
+  "READY_RPT:RELEASE": "RELEASED",
+  "RELEASED:FINALIZE": "FINALIZED",
+};
 
 export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
+  const key = `${current}:${evt}`;
+  const next = transitions[key];
+  if (!next) {
+    throw new Error(`INVALID_TRANSITION:${key}`);
   }
+  return next;
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,330 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import crypto from "crypto";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
+import { computeAnomalyVector, evaluateAnomaly, ReconLedgerEntry } from "../anomaly/deterministic";
+import { nextState, PeriodState } from "../recon/stateMachine";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 100,
+  variance_ratio: 0.25,
+  dup_rate: 0.05,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.1,
+};
+
+const parsedTtl = Number(process.env.RPT_TTL_SECONDS);
+const RPT_TTL_SECONDS = Number.isFinite(parsedTtl) ? parsedTtl : 900;
+const RATES_VERSION = process.env.RPT_RATES_VERSION || "2025-10";
+const ATO_PRN = process.env.ATO_PRN || "ATO-PRN";
+
+type Thresholds = typeof DEFAULT_THRESHOLDS;
+
+interface LedgerRow {
+  id: number;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_hash: string | null;
+  hash_after: string | null;
+  created_at: string | null;
+}
+
+interface LedgerSummary {
+  credited_cents: number;
+  debited_cents: number;
+  net_cents: number;
+  final_liability_cents: number;
+  running_balance_cents: number;
+  running_balance_hash: string | null;
+  merkle_root: string | null;
+}
+
+function coerceNumber(value: any): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.trim() !== "") return Number(value);
+  if (typeof value === "bigint") return Number(value);
+  return 0;
+}
+
+function mapLedgerRow(row: any): LedgerRow {
+  return {
+    id: row.id,
+    amount_cents: coerceNumber(row.amount_cents),
+    balance_after_cents: coerceNumber(row.balance_after_cents),
+    bank_receipt_hash: row.bank_receipt_hash ?? null,
+    hash_after: row.hash_after ?? null,
+    created_at: row.created_at ?? null,
+  };
+}
+
+function computeMerkleRoot(rows: LedgerRow[]): string | null {
+  if (!rows.length) return null;
+  const leafData = rows.map((row) => [
+    row.id,
+    row.amount_cents,
+    row.balance_after_cents,
+    row.bank_receipt_hash ?? "",
+    row.hash_after ?? "",
+  ]);
+  return crypto.createHash("sha256").update(JSON.stringify(leafData)).digest("hex");
+}
+
+function summariseLedger(rows: LedgerRow[]): LedgerSummary {
+  let credited = 0;
+  let debited = 0;
+  rows.forEach((row) => {
+    if (row.amount_cents >= 0) {
+      credited += row.amount_cents;
+    } else {
+      debited += Math.abs(row.amount_cents);
+    }
+  });
+  const net = credited - debited;
+  const last = rows[rows.length - 1] ?? null;
+  return {
+    credited_cents: credited,
+    debited_cents: debited,
+    net_cents: net,
+    final_liability_cents: Math.max(net, 0),
+    running_balance_cents: last ? last.balance_after_cents : 0,
+    running_balance_hash: last ? last.hash_after : null,
+    merkle_root: computeMerkleRoot(rows),
+  };
+}
+
+function mergeThresholds(periodThresholds: any, overrides: any): Thresholds {
+  const merged = {
+    ...DEFAULT_THRESHOLDS,
+    ...(periodThresholds ?? {}),
+    ...(overrides ?? {}),
+  } as Record<string, number>;
+  return {
+    epsilon_cents: Number(merged.epsilon_cents ?? DEFAULT_THRESHOLDS.epsilon_cents),
+    variance_ratio: Number(merged.variance_ratio ?? DEFAULT_THRESHOLDS.variance_ratio),
+    dup_rate: Number(merged.dup_rate ?? DEFAULT_THRESHOLDS.dup_rate),
+    gap_minutes: Number(merged.gap_minutes ?? DEFAULT_THRESHOLDS.gap_minutes),
+    delta_vs_baseline: Number(merged.delta_vs_baseline ?? DEFAULT_THRESHOLDS.delta_vs_baseline),
+  };
+}
+
+async function withTransaction<T>(handler: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
   try {
-    const rpt = await issueRPT(abn, taxType, periodId, thr);
-    return res.json(rpt);
-  } catch (e:any) {
+    await client.query("BEGIN");
+    const result = await handler(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function closeAndIssue(req: any, res: any) {
+  const { abn, taxType, periodId, thresholds: overrides } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_PARAMS" });
+  }
+
+  try {
+    const result = await withTransaction(async (client) => {
+      const periodRes = await client.query(
+        `select * from periods where abn=$1 and tax_type=$2 and period_id=$3 for update`,
+        [abn, taxType, periodId]
+      );
+      if (periodRes.rowCount === 0) {
+        throw new Error("PERIOD_NOT_FOUND");
+      }
+      const period = periodRes.rows[0];
+      const currentState = period.state as PeriodState;
+      const closingState = nextState(currentState, "CLOSE");
+
+      const ledgerRes = await client.query(
+        `select id, amount_cents, balance_after_cents, bank_receipt_hash, hash_after, created_at
+           from owa_ledger
+          where abn=$1 and tax_type=$2 and period_id=$3
+          order by id`,
+        [abn, taxType, periodId]
+      );
+      const ledgerRows = ledgerRes.rows.map(mapLedgerRow);
+      const summary = summariseLedger(ledgerRows);
+
+      const baseline = coerceNumber(period.accrued_cents);
+      const reconEntries: ReconLedgerEntry[] = ledgerRows.map((row) => ({
+        amount_cents: row.amount_cents,
+        bank_receipt_hash: row.bank_receipt_hash,
+        created_at: row.created_at,
+      }));
+      const anomalyVector = computeAnomalyVector(
+        reconEntries,
+        { credited_cents: summary.credited_cents, net_cents: summary.net_cents },
+        baseline
+      );
+      const periodThresholds =
+        typeof period.thresholds === "string"
+          ? JSON.parse(period.thresholds)
+          : period.thresholds;
+      const thresholds = mergeThresholds(periodThresholds, overrides);
+
+      await client.query(
+        `update periods
+            set credited_to_owa_cents=$1,
+                final_liability_cents=$2,
+                running_balance_hash=$3,
+                merkle_root=$4,
+                anomaly_vector=$5::jsonb,
+                thresholds=$6::jsonb,
+                state=$7
+          where id=$8`,
+        [
+          summary.credited_cents,
+          summary.final_liability_cents,
+          summary.running_balance_hash,
+          summary.merkle_root,
+          JSON.stringify(anomalyVector),
+          JSON.stringify(thresholds),
+          closingState,
+          period.id,
+        ]
+      );
+
+      const epsilon = Math.abs(summary.final_liability_cents - summary.running_balance_cents);
+      if (epsilon > thresholds.epsilon_cents) {
+        const failState = nextState(closingState, "FAIL_DISCREPANCY");
+        await client.query(`update periods set state=$1 where id=$2`, [failState, period.id]);
+        return {
+          state: failState,
+          reason_code: "DISCREPANCY_EPSILON",
+          epsilon_cents: epsilon,
+          anomaly_vector: anomalyVector,
+          thresholds,
+          totals: summary,
+        };
+      }
+
+      const anomaly = evaluateAnomaly(anomalyVector, thresholds);
+      if (anomaly.breach) {
+        const failState = nextState(closingState, "FAIL_ANOMALY");
+        await client.query(`update periods set state=$1 where id=$2`, [failState, period.id]);
+        return {
+          state: failState,
+          reason_code: `ANOMALY_${anomaly.code}`,
+          epsilon_cents: epsilon,
+          anomaly_vector: anomalyVector,
+          thresholds,
+          totals: summary,
+        };
+      }
+
+      const readyState = nextState(closingState, "PASS");
+      const payload = {
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        totals: {
+          credited_to_owa_cents: summary.credited_cents,
+          net_cents: summary.net_cents,
+          final_liability_cents: summary.final_liability_cents,
+          accrued_cents: baseline,
+        },
+        rates_version: RATES_VERSION,
+        nonce: crypto.randomUUID(),
+        exp: new Date(Date.now() + RPT_TTL_SECONDS * 1000).toISOString(),
+      };
+
+      const rpt = await issueRPT(abn, taxType, periodId, payload, client);
+      await client.query(`update periods set state=$1 where id=$2`, [readyState, period.id]);
+
+      return {
+        state: readyState,
+        rpt,
+        epsilon_cents: epsilon,
+        anomaly_vector: anomalyVector,
+        thresholds,
+        totals: summary,
+      };
+    });
+
+    if (result.state === "BLOCKED_DISCREPANCY" || result.state === "BLOCKED_ANOMALY") {
+      return res.status(409).json(result);
+    }
+
+    return res.json(result);
+  } catch (err: any) {
+    console.error(err);
+    const message = err?.message || "INTERNAL_ERROR";
+    const status = message === "PERIOD_NOT_FOUND" ? 404 : 400;
+    return res.status(status).json({ error: message });
+  }
+}
+
+export async function payAto(req: any, res: any) {
+  const { abn, taxType, periodId, rail } = req.body;
+  if (!abn || !taxType || !periodId || !rail) {
+    return res.status(400).json({ error: "MISSING_PARAMS" });
+  }
+
+  const tokenRes = await pool.query(
+    `select payload, signature from rpt_tokens
+      where abn=$1 and tax_type=$2 and period_id=$3
+      order by id desc limit 1`,
+    [abn, taxType, periodId]
+  );
+  if (tokenRes.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
+  const rawPayload = tokenRes.rows[0].payload;
+  const payload = typeof rawPayload === "string" ? JSON.parse(rawPayload) : rawPayload || {};
+  const totals = payload?.totals || {};
+  const amount = Number(totals.final_liability_cents ?? 0);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return res.status(400).json({ error: "INVALID_RPT_TOTAL" });
+  }
+
+  const reference = ATO_PRN;
+  try {
+    await resolveDestination(abn, rail, reference);
+    const release = await releasePayment(abn, taxType, periodId, amount, rail, reference);
+    await pool.query(
+      `update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    return res.json(release);
+  } catch (e: any) {
     return res.status(400).json({ error: e.message });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
-  const payload = pr.rows[0].payload;
-  try {
-    await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-    return res.json(r);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
-  }
-}
-
-export async function paytoSweep(req:any, res:any) {
+export async function paytoSweep(req: any, res: any) {
   const { abn, amount_cents, reference } = req.body;
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: any, res: any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
-  // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: any, res: any) {
   const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "MISSING_PARAMS" });
+  }
+  try {
+    const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+    if (!bundle.period) {
+      return res.status(404).json({ error: "NOT_FOUND" });
+    }
+    res.json(bundle);
+  } catch (err: any) {
+    console.error(err);
+    res.status(500).json({ error: "INTERNAL_ERROR" });
+  }
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,47 @@
-﻿import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
+
 const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+const secretKeyBase64 = process.env.RPT_ED25519_SECRET_BASE64 || "";
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-  if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
-  const row = p.rows[0];
-  if (row.state !== "CLOSING") throw new Error("BAD_STATE");
+export interface IssueResult {
+  payload: RptPayload;
+  signature: string;
+  payload_sha256: string;
+}
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
-    throw new Error("BLOCKED_ANOMALY");
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  payload: RptPayload,
+  client?: PoolClient
+): Promise<IssueResult> {
+  if (!secretKeyBase64) {
+    throw new Error("RPT_SECRET_UNAVAILABLE");
   }
-  const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
-  if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
-    throw new Error("BLOCKED_DISCREPANCY");
-  }
 
-  const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
-    amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
-  };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+  const signer = client ?? (await pool.connect());
+  try {
+    const payloadStr = JSON.stringify(payload);
+    const secretKey = Buffer.from(secretKeyBase64, "base64");
+    const signature = signRpt(payload, new Uint8Array(secretKey));
+    const payloadSha256 = crypto
+      .createHash("sha256")
+      .update(payloadStr)
+      .digest("hex");
+
+    await signer.query(
+      `insert into rpt_tokens(abn,tax_type,period_id,payload,signature,payload_c14n,payload_sha256)
+       values ($1,$2,$3,$4::jsonb,$5,$6,$7)`,
+      [abn, taxType, periodId, payloadStr, signature, payloadStr, payloadSha256]
+    );
+
+    return { payload, signature, payload_sha256: payloadSha256 };
+  } finally {
+    if (!client) {
+      signer.release();
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- replace the recon microservice with deterministic ledger analysis, threshold evaluation, and structured failure reasons
- implement canonical RPT payload signing plus database writes and cover state transitions through a corrected period state machine
- orchestrate close-and-issue to sync ledger totals, run recon, gate on thresholds, and expose updated evidence payloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e389784be083278d67bc953f83a451