### PR TITLE
Add MFA, dual approvals, and audit security controls

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,60 @@
+# Security Controls
+
+This service enforces layered controls for sensitive operations. Key elements:
+
+## Authentication & Roles
+- Every API behind `/api` now requires a Bearer token signed with `AUTH_JWT_SECRET` (HS256).
+- Tokens must carry a `roles` claim containing one or more of: `viewer`, `operator`, `approver`, `admin`.
+- Optional `AUTH_JWT_AUDIENCE` and `AUTH_JWT_ISSUER` are enforced when set.
+- A successful TOTP challenge issues a short-lived step-up JWT with `mfa: true`.
+
+## Multi-factor Authentication (TOTP)
+1. `POST /auth/mfa/setup` (requires base auth) provisions a new secret, returns:
+   - The shared secret (Base32).
+   - An `otpauth://` URI.
+   - A QR link (`https://chart.googleapis.com/...`) that can be scanned by authenticator apps.
+2. `POST /auth/mfa/activate` verifies a code and marks the secret active.
+3. `POST /auth/mfa/challenge` validates a code and returns a step-up JWT (`mfa: true`).
+
+Secrets are encrypted before storage:
+- Local mode (`MFA_VAULT_BACKEND=local`, default) uses AES-256-GCM with a key supplied via `MFA_ENCRYPTION_KEY` (32 bytes, base64).
+- AWS KMS mode (`MFA_VAULT_BACKEND=aws`) dynamically loads `@aws-sdk/client-kms`; set `MFA_KMS_KEY_ID` and `MFA_KMS_REGION`/`AWS_REGION`.
+
+## MFA-protected routes
+The following endpoints require `mfa: true` and role checks:
+- `POST /api/pay` (ATO release attempts)
+- `POST /api/close-issue`
+- `POST /api/payto/sweep`
+- `GET /api/evidence`
+- `POST /api/rails/allow-list` & `DELETE /api/rails/allow-list`
+- `POST /api/receipts`
+- `POST /api/approvals/*`
+
+## Separation of Duties
+- Releases equal to or exceeding `RELEASE_DUAL_APPROVAL_CENTS` (default: 10,000,000 cents) require two distinct approvals from users other than the releaser.
+- Approvals are posted to `POST /api/approvals/releases` by `approver`/`admin` users after reviewing context.
+- The middleware fetches the latest RPT amount if the client omits `amountCents`, ensuring the approval hash matches the actual release payload.
+
+## Audit Trail
+All critical actions append immutable entries to `audit_log`:
+- deposit postings
+- close & RPT issuance (including failures)
+- release attempts, releases, and blocks/failures
+- MFA setup/activation/challenges
+- allow-list changes, receipt storage, evidence exports, approval submissions
+
+Each record stores `{prev_hash, hash}` derived from SHA-256 over the previous hash plus the new payload, forming a verifiable chain. The schema:
+```
+audit_log(id, ts, actor_id, action, target_type, target_id, payload, prev_hash, hash)
+```
+Validate by replaying the chain: recompute `hash = sha256(JSON.stringify(entry with prev_hash))` and compare sequentially.
+
+## Environment
+Set these variables in deployment:
+- `AUTH_JWT_SECRET` *(required)*
+- `AUTH_JWT_AUDIENCE`, `AUTH_JWT_ISSUER` *(optional but recommended)*
+- `MFA_ENCRYPTION_KEY` *(base64 32 bytes)*
+- `MFA_VAULT_BACKEND` (`local`|`aws`), `MFA_KMS_KEY_ID`, `MFA_KMS_REGION`
+- `RELEASE_DUAL_APPROVAL_CENTS`, `RELEASE_APPROVAL_TTL_MINUTES`
+
+For AWS mode install `@aws-sdk/client-kms` and allow outbound access to the KMS endpoint.

--- a/docs/sod.md
+++ b/docs/sod.md
@@ -1,0 +1,27 @@
+# Separation of Duties Workflow
+
+High-value releases (>= `RELEASE_DUAL_APPROVAL_CENTS`, default $100k) require two approvals before execution.
+
+## Roles
+- **Operator**: initiates release requests.
+- **Approver**: reviews and approves release payloads.
+- **Admin**: may perform either function and manage allow-list entries.
+
+## Workflow
+1. Operator requests a release via `POST /api/pay`.
+2. System computes the release hash from `{abn, taxType, periodId, amountCents}`.
+3. Approvers submit approvals:
+   ```json
+   POST /api/approvals/releases
+   {
+     "abn": "12345678901",
+     "taxType": "GST",
+     "periodId": "2025-Q1",
+     "amountCents": 25000000,
+     "reason": "Matched to BAS statement"
+   }
+   ```
+4. Middleware verifies at least two distinct approvers (excluding the release actor) have approved within `RELEASE_APPROVAL_TTL_MINUTES` (default 240).
+5. If requirements met, release proceeds; otherwise 403 is returned with the current approver list.
+
+Approvals are stored in `release_approvals` and are linked to audit entries for traceability.

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+import express from "express";
+
+export const api = express.Router();

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,15 +1,34 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
-const pool = new Pool();
+import type { Pool, PoolClient } from "pg";
+import { pool } from "../db/pool";
+import { sha256Hex } from "../crypto/merkle";
 
-export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
-  const prevHash = rows[0]?.terminal_hash || "";
-  const payloadHash = sha256Hex(JSON.stringify(payload));
-  const terminalHash = sha256Hex(prevHash + payloadHash);
-  await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
-    [actor, action, payloadHash, prevHash, terminalHash]
+export interface AuditEntry {
+  actorId?: string | null;
+  action: string;
+  targetType?: string | null;
+  targetId?: string | null;
+  payload: any;
+}
+
+export async function appendAudit(entry: AuditEntry, client?: Pool | PoolClient) {
+  const runner = client ?? pool;
+  const { rows } = await runner.query<{ hash: string }>(
+    "SELECT hash FROM audit_log ORDER BY id DESC LIMIT 1"
   );
-  return terminalHash;
+  const prevHash = rows[0]?.hash ?? "";
+  const record = {
+    prev_hash: prevHash,
+    actor_id: entry.actorId ?? null,
+    action: entry.action,
+    target_type: entry.targetType ?? null,
+    target_id: entry.targetId ?? null,
+    payload: entry.payload,
+  };
+  const hash = sha256Hex(JSON.stringify(record));
+  await runner.query(
+    `INSERT INTO audit_log (actor_id, action, target_type, target_id, payload, prev_hash, hash)
+     VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+    [record.actor_id, record.action, record.target_type, record.target_id, record.payload, prevHash, hash]
+  );
+  return hash;
 }

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,0 +1,144 @@
+import { createHmac, timingSafeEqual } from "crypto";
+import { AuthenticatedUser, UserRole } from "./types";
+
+const SUPPORTED_ALG = "HS256";
+const ROLE_SET: Set<UserRole> = new Set(["viewer", "operator", "approver", "admin"]);
+
+function base64UrlEncode(buffer: Buffer | string): string {
+  const b = typeof buffer === "string" ? Buffer.from(buffer, "utf8") : buffer;
+  return b
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function base64UrlDecode(input: string): Buffer {
+  const normalized = input.replace(/-/g, "+").replace(/_/g, "/");
+  const pad = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+  return Buffer.from(normalized + "=".repeat(pad), "base64");
+}
+
+function hmac(secret: string, data: string): Buffer {
+  return createHmac("sha256", secret).update(data).digest();
+}
+
+function getSecret(): string {
+  const secret = process.env.AUTH_JWT_SECRET;
+  if (!secret) {
+    throw new Error("AUTH_JWT_SECRET is required for JWT verification");
+  }
+  return secret;
+}
+
+function parseJson(buffer: Buffer): any {
+  try {
+    return JSON.parse(buffer.toString("utf8"));
+  } catch (err) {
+    throw new Error("Invalid JWT payload");
+  }
+}
+
+function normalizeRoles(input: unknown): UserRole[] {
+  const roles: string[] = Array.isArray(input)
+    ? input.map(String)
+    : typeof input === "string"
+    ? input.split(",").map((r) => r.trim())
+    : [];
+  const deduped = Array.from(new Set(roles.map((r) => r.toLowerCase())));
+  return deduped.filter((role): role is UserRole => ROLE_SET.has(role as UserRole));
+}
+
+function ensureAudience(payload: any) {
+  const audience = process.env.AUTH_JWT_AUDIENCE;
+  if (!audience) return true;
+  const aud = payload.aud;
+  if (Array.isArray(aud)) {
+    return aud.includes(audience);
+  }
+  return aud === audience;
+}
+
+export function verifyJwt(token: string): AuthenticatedUser {
+  const secret = getSecret();
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("Malformed token");
+  }
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const header = parseJson(base64UrlDecode(encodedHeader));
+  if (header.alg !== SUPPORTED_ALG) {
+    throw new Error(`Unsupported alg ${header.alg}`);
+  }
+  const payload = parseJson(base64UrlDecode(encodedPayload));
+
+  const expected = hmac(secret, `${encodedHeader}.${encodedPayload}`);
+  const actual = base64UrlDecode(encodedSignature);
+  if (expected.length !== actual.length || !timingSafeEqual(expected, actual)) {
+    throw new Error("Signature verification failed");
+  }
+
+  if (!ensureAudience(payload)) {
+    throw new Error("Audience mismatch");
+  }
+  if (process.env.AUTH_JWT_ISSUER && payload.iss !== process.env.AUTH_JWT_ISSUER) {
+    throw new Error("Issuer mismatch");
+  }
+  if (payload.exp && Date.now() / 1000 > Number(payload.exp)) {
+    throw new Error("Token expired");
+  }
+
+  const roles = normalizeRoles(payload.roles);
+  if (!payload.sub || !roles.length) {
+    throw new Error("Token missing subject or roles");
+  }
+
+  const user: AuthenticatedUser = {
+    sub: payload.sub,
+    roles,
+    name: typeof payload.name === "string" ? payload.name : undefined,
+    email: typeof payload.email === "string" ? payload.email : undefined,
+    mfa: payload.mfa === true,
+    tokenId: typeof payload.jti === "string" ? payload.jti : undefined,
+    issuedAt: typeof payload.iat === "number" ? payload.iat : undefined,
+    expiresAt: typeof payload.exp === "number" ? payload.exp : undefined,
+  };
+
+  return user;
+}
+
+export interface StepUpTokenOptions {
+  expiresInSeconds?: number;
+  overrides?: Partial<AuthenticatedUser>;
+}
+
+export function signStepUpToken(user: AuthenticatedUser, options: StepUpTokenOptions = {}) {
+  const secret = getSecret();
+  const header = { alg: SUPPORTED_ALG, typ: "JWT" };
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const expiresIn = options.expiresInSeconds ?? 5 * 60;
+  const exp = issuedAt + expiresIn;
+  const payload: Record<string, unknown> = {
+    sub: user.sub,
+    roles: user.roles,
+    name: user.name,
+    email: user.email,
+    mfa: true,
+    step_up: true,
+    iat: issuedAt,
+    exp,
+  };
+  if (process.env.AUTH_JWT_AUDIENCE) payload.aud = process.env.AUTH_JWT_AUDIENCE;
+  if (process.env.AUTH_JWT_ISSUER) payload.iss = process.env.AUTH_JWT_ISSUER;
+  if (options.overrides) {
+    for (const [key, value] of Object.entries(options.overrides)) {
+      payload[key] = value;
+    }
+  }
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const signature = base64UrlEncode(hmac(secret, `${encodedHeader}.${encodedPayload}`));
+  const token = `${encodedHeader}.${encodedPayload}.${signature}`;
+  return { token, expiresAt: exp };
+}

--- a/src/auth/secretVault.ts
+++ b/src/auth/secretVault.ts
@@ -1,0 +1,110 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+
+export type SecretBackend = "local" | "aws";
+
+export interface SecretEnvelope {
+  backend: SecretBackend;
+  ciphertext: string;
+  iv?: string;
+  tag?: string;
+  kmsKeyId?: string;
+}
+
+function getBackend(): SecretBackend {
+  const backend = (process.env.MFA_VAULT_BACKEND || "local").toLowerCase();
+  return backend === "aws" ? "aws" : "local";
+}
+
+function getLocalKey(): Buffer {
+  const secret = process.env.MFA_ENCRYPTION_KEY;
+  if (!secret) {
+    throw new Error("MFA_ENCRYPTION_KEY must be set for local MFA secret encryption");
+  }
+  const buf = Buffer.from(secret, "base64");
+  if (buf.length !== 32) {
+    throw new Error("MFA_ENCRYPTION_KEY must be 32 bytes base64 encoded");
+  }
+  return buf;
+}
+
+let kmsClient: any = null;
+let kmsModule: any = null;
+
+async function loadKms() {
+  if (!kmsModule) {
+    try {
+      kmsModule = await import("@aws-sdk/client-kms");
+    } catch (err) {
+      throw new Error(
+        "AWS KMS backend requested but @aws-sdk/client-kms is not installed. Add it to dependencies to enable this backend."
+      );
+    }
+  }
+  if (!kmsClient) {
+    kmsClient = new kmsModule.KMSClient({ region: process.env.MFA_KMS_REGION || process.env.AWS_REGION || "us-east-1" });
+  }
+  return {
+    client: kmsClient,
+    EncryptCommand: kmsModule.EncryptCommand,
+    DecryptCommand: kmsModule.DecryptCommand,
+  };
+}
+
+export async function encryptSecret(plaintext: string): Promise<SecretEnvelope> {
+  const backend = getBackend();
+  if (backend === "aws") {
+    const keyId = process.env.MFA_KMS_KEY_ID;
+    if (!keyId) {
+      throw new Error("MFA_KMS_KEY_ID is required when using aws vault backend");
+    }
+    const { client, EncryptCommand } = await loadKms();
+    const result = await client.send(new EncryptCommand({ KeyId: keyId, Plaintext: Buffer.from(plaintext, "utf8") }));
+    if (!result.CiphertextBlob) {
+      throw new Error("KMS encryption failed");
+    }
+    return {
+      backend,
+      ciphertext: Buffer.from(result.CiphertextBlob).toString("base64"),
+      kmsKeyId: keyId,
+    };
+  }
+
+  const key = getLocalKey();
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const encrypted = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    backend,
+    ciphertext: encrypted.toString("base64"),
+    iv: iv.toString("base64"),
+    tag: tag.toString("base64"),
+  };
+}
+
+export async function decryptSecret(envelope: SecretEnvelope): Promise<string> {
+  if (envelope.backend === "aws") {
+    const { client, DecryptCommand } = await loadKms();
+    const result = await client.send(
+      new DecryptCommand({ CiphertextBlob: Buffer.from(envelope.ciphertext, "base64"), KeyId: envelope.kmsKeyId })
+    );
+    if (!result.Plaintext) {
+      throw new Error("KMS decryption failed");
+    }
+    return Buffer.from(result.Plaintext).toString("utf8");
+  }
+
+  const key = getLocalKey();
+  const iv = envelope.iv ? Buffer.from(envelope.iv, "base64") : null;
+  const tag = envelope.tag ? Buffer.from(envelope.tag, "base64") : null;
+  if (!iv || !tag) {
+    throw new Error("Local envelope missing IV or tag");
+  }
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([
+    decipher.update(Buffer.from(envelope.ciphertext, "base64")),
+    decipher.final(),
+  ]);
+  return decrypted.toString("utf8");
+}

--- a/src/auth/totp.ts
+++ b/src/auth/totp.ts
@@ -1,0 +1,100 @@
+import { createHmac, randomBytes } from "crypto";
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+function base32Encode(buffer: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = "";
+
+  for (const byte of buffer) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      const index = (value >>> (bits - 5)) & 0x1f;
+      bits -= 5;
+      output += BASE32_ALPHABET[index];
+    }
+  }
+
+  if (bits > 0) {
+    const index = (value << (5 - bits)) & 0x1f;
+    output += BASE32_ALPHABET[index];
+  }
+
+  return output;
+}
+
+function base32Decode(input: string): Buffer {
+  let bits = 0;
+  let value = 0;
+  const bytes: number[] = [];
+  const normalized = input.replace(/=+$/g, "").toUpperCase();
+
+  for (const char of normalized) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index === -1) {
+      throw new Error("Invalid base32 character");
+    }
+    value = (value << 5) | index;
+    bits += 5;
+    if (bits >= 8) {
+      bytes.push((value >>> (bits - 8)) & 0xff);
+      bits -= 8;
+    }
+  }
+
+  return Buffer.from(bytes);
+}
+
+export function generateTotpSecret(length = 20): string {
+  const secret = randomBytes(length);
+  return base32Encode(secret);
+}
+
+function hmacSha1(key: Buffer, counter: number): Buffer {
+  const buffer = Buffer.alloc(8);
+  for (let i = 7; i >= 0; i -= 1) {
+    buffer[i] = counter & 0xff;
+    counter = Math.floor(counter / 256);
+  }
+  return createHmac("sha1", key).update(buffer).digest();
+}
+
+export function totp(secretBase32: string, timestamp = Date.now(), periodSeconds = 30, digits = 6): string {
+  const key = base32Decode(secretBase32);
+  const counter = Math.floor(timestamp / 1000 / periodSeconds);
+  const hmac = hmacSha1(key, counter);
+
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const binary =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  const otp = binary % 10 ** digits;
+  return otp.toString().padStart(digits, "0");
+}
+
+export function verifyTotp(secretBase32: string, token: string, window = 1, periodSeconds = 30, digits = 6): boolean {
+  const sanitized = token.replace(/\s+/g, "");
+  if (!/^\d{6}$/.test(sanitized)) {
+    return false;
+  }
+
+  const now = Date.now();
+  for (let offset = -window; offset <= window; offset += 1) {
+    const time = now + offset * periodSeconds * 1000;
+    if (totp(secretBase32, time, periodSeconds, digits) === sanitized) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function otpauthUrl(secret: string, label: string, issuer: string, periodSeconds = 30): string {
+  const encodedLabel = encodeURIComponent(label);
+  const encodedIssuer = encodeURIComponent(issuer);
+  return `otpauth://totp/${encodedLabel}?secret=${secret}&issuer=${encodedIssuer}&period=${periodSeconds}`;
+}

--- a/src/auth/types.ts
+++ b/src/auth/types.ts
@@ -1,0 +1,13 @@
+export type UserRole = "viewer" | "operator" | "approver" | "admin";
+
+export interface AuthenticatedUser {
+  sub: string;
+  roles: UserRole[];
+  name?: string;
+  email?: string;
+  mfa?: boolean;
+  tokenId?: string;
+  issuedAt?: number;
+  expiresAt?: number;
+  [key: string]: unknown;
+}

--- a/src/db/migrations/security.ts
+++ b/src/db/migrations/security.ts
@@ -1,0 +1,77 @@
+import type { Pool, PoolClient } from "pg";
+
+async function run(client: Pool | PoolClient, sql: string) {
+  await client.query(sql);
+}
+
+export async function ensureSecurityTables(client: Pool) {
+  await run(
+    client,
+    `CREATE TABLE IF NOT EXISTS audit_log (
+        id          BIGSERIAL PRIMARY KEY,
+        ts          TIMESTAMPTZ NOT NULL DEFAULT now(),
+        actor_id    TEXT,
+        action      TEXT NOT NULL,
+        target_type TEXT,
+        target_id   TEXT,
+        payload     JSONB NOT NULL,
+        prev_hash   TEXT,
+        hash        TEXT NOT NULL
+      );`
+  );
+  await run(
+    client,
+    `CREATE UNIQUE INDEX IF NOT EXISTS audit_log_hash_idx ON audit_log(hash);`
+  );
+
+  await run(
+    client,
+    `CREATE TABLE IF NOT EXISTS mfa_secrets (
+        user_id           TEXT PRIMARY KEY,
+        backend           TEXT NOT NULL,
+        secret_ciphertext TEXT NOT NULL,
+        secret_iv         TEXT,
+        secret_tag        TEXT,
+        kms_key_id        TEXT,
+        created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+        activated_at      TIMESTAMPTZ,
+        updated_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+      );`
+  );
+
+  await run(
+    client,
+    `CREATE TABLE IF NOT EXISTS release_approvals (
+        id           BIGSERIAL PRIMARY KEY,
+        release_hash TEXT NOT NULL,
+        payload      JSONB NOT NULL,
+        actor_id     TEXT NOT NULL,
+        actor_name   TEXT,
+        reason       TEXT,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+      );`
+  );
+  await run(
+    client,
+    `CREATE UNIQUE INDEX IF NOT EXISTS release_approvals_unique ON release_approvals(release_hash, actor_id);`
+  );
+
+  await run(
+    client,
+    `CREATE TABLE IF NOT EXISTS payment_receipts (
+        id           BIGSERIAL PRIMARY KEY,
+        abn          TEXT NOT NULL,
+        tax_type     TEXT NOT NULL,
+        period_id    TEXT NOT NULL,
+        source       TEXT NOT NULL,
+        receipt_id   TEXT NOT NULL,
+        payload      JSONB,
+        created_by   TEXT,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+      );`
+  );
+  await run(
+    client,
+    `CREATE INDEX IF NOT EXISTS payment_receipts_lookup ON payment_receipts(abn, tax_type, period_id, source);`
+  );
+}

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,10 @@
+import { Pool } from "pg";
+
+const connectionString =
+  process.env.DATABASE_URL ??
+  `postgres://${process.env.PGUSER || "apgms"}:${encodeURIComponent(process.env.PGPASSWORD || "")}` +
+    `@${process.env.PGHOST || "127.0.0.1"}:${process.env.PGPORT || "5432"}/${process.env.PGDATABASE || "apgms"}`;
+
+export const pool = new Pool({ connectionString });
+
+export type DbPool = typeof pool;

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,11 +1,23 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
+  const p = (
+    await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])
+  ).rows[0];
+  const rpt = (
+    await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [
+      abn,
+      taxType,
+      periodId,
+    ])
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
+  const last = deltas[deltas.length - 1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
     rpt_payload: rpt?.payload ?? null,
@@ -13,7 +25,7 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [], // TODO: populate from recon diffs
   };
   return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,17 @@
 import express from "express";
 import dotenv from "dotenv";
 
+import { pool } from "./db/pool";
+import { ensureSecurityTables } from "./db/migrations/security";
 import { idempotency } from "./middleware/idempotency";
+import { requireAuth, requireMfa, requireRoles } from "./middleware/auth";
+import { requireDualApproval } from "./middleware/approvals";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { addDestination, removeDestination } from "./routes/allowList";
+import { storeReceipt } from "./routes/receipts";
+import { deposit } from "./routes/deposit";
+import { authRouter } from "./routes/auth";
+import { approvalsRouter } from "./routes/approvals";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -18,21 +27,54 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
-// Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+// Auth & MFA
+app.use("/auth", requireAuth(), authRouter);
+
+// Approvals API
+app.use("/api/approvals", requireAuth(), requireRoles("approver", "admin"), requireMfa(), approvalsRouter);
+
+// Deposit endpoint (operator/admin)
+app.post("/api/deposit", requireAuth(), requireRoles("operator", "admin"), deposit);
+
+// Release endpoints requiring MFA and dual approval when threshold reached
+app.post(
+  "/api/pay",
+  requireAuth(),
+  requireRoles("operator", "admin"),
+  requireMfa(),
+  requireDualApproval(),
+  idempotency(),
+  payAto
+);
+
+app.post("/api/close-issue", requireAuth(), requireRoles("operator", "admin"), requireMfa(), closeAndIssue);
+app.post("/api/payto/sweep", requireAuth(), requireRoles("operator", "admin"), requireMfa(), paytoSweep);
+app.post("/api/settlement/webhook", requireAuth(), requireRoles("admin"), settlementWebhook);
+app.get("/api/evidence", requireAuth(), requireRoles("viewer", "operator", "approver", "admin"), requireMfa(), evidence);
+
+// Allow-list management
+app.post("/api/rails/allow-list", requireAuth(), requireRoles("operator", "admin"), requireMfa(), addDestination);
+app.delete("/api/rails/allow-list", requireAuth(), requireRoles("admin"), requireMfa(), removeDestination);
+
+// Receipt storage
+app.post("/api/receipts", requireAuth(), requireRoles("operator", "admin"), requireMfa(), storeReceipt);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
-app.use("/api", paymentsApi);
+app.use("/api", requireAuth(), paymentsApi);
 
 // Existing API router(s) after
-app.use("/api", api);
+app.use("/api", requireAuth(), api);
 
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));
 
-const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+async function start() {
+  await ensureSecurityTables(pool);
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => console.log("APGMS server listening on", port));
+}
+
+start().catch((err) => {
+  console.error("Failed to start server", err);
+  process.exit(1);
+});

--- a/src/middleware/approvals.ts
+++ b/src/middleware/approvals.ts
@@ -1,0 +1,55 @@
+import { Request, Response, NextFunction } from "express";
+import { getApprovalsForHash, computeReleaseHash } from "../services/approvals";
+import { AuthenticatedUser } from "../auth/types";
+import { pool } from "../db/pool";
+
+const DEFAULT_THRESHOLD = Number(process.env.RELEASE_DUAL_APPROVAL_CENTS || 100_000_00);
+const TTL_MINUTES = Number(process.env.RELEASE_APPROVAL_TTL_MINUTES || 240);
+
+export function requireDualApproval() {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { abn, taxType, periodId } = req.body || {};
+      if (!abn || !taxType || !periodId) {
+        return res.status(400).json({ error: "Missing release fields" });
+      }
+
+      let amount = Number(req.body?.amountCents);
+      if (!Number.isFinite(amount)) {
+        const rpt = await pool.query(
+          "select payload from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+          [abn, taxType, periodId]
+        );
+        amount = Number(rpt.rows[0]?.payload?.amount_cents);
+      }
+      if (!Number.isFinite(amount)) {
+        return res.status(400).json({ error: "Unable to determine release amount" });
+      }
+      amount = Math.abs(amount);
+
+      if (amount < DEFAULT_THRESHOLD) {
+        return next();
+      }
+
+      const hash = computeReleaseHash({ abn, taxType, periodId, amountCents: amount });
+      const approvals = await getApprovalsForHash(hash, TTL_MINUTES);
+      const user = req.user as AuthenticatedUser | undefined;
+      if (!user) return res.status(401).json({ error: "Unauthorized" });
+
+      const distinct = new Set<string>();
+      for (const approval of approvals) {
+        if (approval.actor_id !== user.sub) {
+          distinct.add(approval.actor_id);
+        }
+      }
+
+      if (distinct.size < 2) {
+        return res.status(403).json({ error: "Dual approval required", approvals: Array.from(distinct) });
+      }
+
+      return next();
+    } catch (err: any) {
+      return res.status(500).json({ error: "Approval check failed", detail: String(err?.message || err) });
+    }
+  };
+}

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction } from "express";
+import { verifyJwt } from "../auth/jwt";
+import { AuthenticatedUser, UserRole } from "../auth/types";
+
+function extractToken(req: Request): string | null {
+  const header = req.header("authorization") || req.header("Authorization");
+  if (!header) return null;
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+export function requireAuth() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const token = extractToken(req);
+      if (!token) {
+        return res.status(401).json({ error: "Missing bearer token" });
+      }
+      const user = verifyJwt(token);
+      req.user = user as AuthenticatedUser;
+      return next();
+    } catch (err: any) {
+      return res.status(401).json({ error: "Invalid token", detail: String(err?.message || err) });
+    }
+  };
+}
+
+export function requireRoles(...allowed: UserRole[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const user = req.user as AuthenticatedUser | undefined;
+    if (!user) return res.status(401).json({ error: "Unauthorized" });
+    const ok = user.roles.some((role) => allowed.includes(role));
+    if (!ok) {
+      return res.status(403).json({ error: "Insufficient role" });
+    }
+    return next();
+  };
+}
+
+export function requireMfa() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const user = req.user as AuthenticatedUser | undefined;
+    if (!user) return res.status(401).json({ error: "Unauthorized" });
+    if (user.mfa !== true) {
+      return res.status(403).json({ error: "MFA required" });
+    }
+    return next();
+  };
+}

--- a/src/middleware/idempotency.ts
+++ b/src/middleware/idempotency.ts
@@ -1,8 +1,8 @@
-﻿import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
+
 /** Express middleware for idempotency via Idempotency-Key header */
 export function idempotency() {
-  return async (req:any, res:any, next:any) => {
+  return async (req: any, res: any, next: any) => {
     const key = req.header("Idempotency-Key");
     if (!key) return next();
     try {
@@ -10,7 +10,7 @@ export function idempotency() {
       return next();
     } catch {
       const r = await pool.query("select last_status, response_hash from idempotency_keys where key=", [key]);
-      return res.status(200).json({ idempotent:true, status: r.rows[0]?.last_status || "DONE" });
+      return res.status(200).json({ idempotent: true, status: r.rows[0]?.last_status || "DONE" });
     }
   };
 }

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -25,6 +25,29 @@ export default function Help() {
         </ul>
       </div>
       <div className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">Security Workflows</h2>
+        <ul className="list-disc pl-5 text-sm">
+          <li>
+            Enable MFA under <strong>Profile &gt; Security</strong> – scan the QR code from
+            <code> POST /auth/mfa/setup</code>, confirm with <code>/activate</code>, then use
+            <code>/challenge</code> for a step-up token.
+          </li>
+          <li>
+            Releases &amp; allow-list changes require <strong>mfa=true</strong> tokens. Obtain them via
+            the challenge flow before calling protected endpoints.
+          </li>
+          <li>
+            For high-value releases, route the request to two approvers who submit
+            <code> POST /api/approvals/releases</code>. The release will unblock once two distinct
+            approvals are on file.
+          </li>
+          <li>
+            Evidence exports, deposit posts, and receipt uploads automatically append to the
+            tamper-evident audit chain.
+          </li>
+        </ul>
+      </div>
+      <div className="bg-card p-4 rounded-xl shadow space-y-2">
         <h2 className="text-lg font-semibold">Support Links</h2>
         <ul className="list-disc pl-5 text-sm">
           <li><a className="text-blue-600" href="https://www.ato.gov.au/business/payg-withholding/">ATO PAYGW Guide</a></li>

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,11 +1,10 @@
-﻿import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
-const pool = new Pool();
+import { pool } from "../db/pool";
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
   const { rows } = await pool.query(
     "select * from remittance_destinations where abn= and rail= and reference=",
     [abn, rail, reference]
@@ -15,18 +14,27 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 }
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY",
+  reference: string,
+  actorId?: string | null
+) {
   const transfer_uuid = uuidv4();
   try {
     await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
+  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0, 12);
 
   const { rows } = await pool.query(
     "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
@@ -36,7 +44,13 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
     "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
+  await appendAudit({
+    actorId: actorId ?? null,
+    action: "release",
+    targetType: "period",
+    targetId: `${abn}:${taxType}:${periodId}`,
+    payload: { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash },
+  });
   await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/allowList.ts
+++ b/src/routes/allowList.ts
@@ -1,0 +1,57 @@
+import { Request, Response } from "express";
+import { pool } from "../db/pool";
+import { appendAudit } from "../audit/appendOnly";
+import { AuthenticatedUser } from "../auth/types";
+
+export async function addDestination(req: Request, res: Response) {
+  try {
+    const { abn, rail, reference, account_name, account_bsb, account_number } = req.body || {};
+    if (!abn || !rail || !reference) {
+      return res.status(400).json({ error: "Missing fields" });
+    }
+    await pool.query(
+      `INSERT INTO remittance_destinations (abn, rail, reference, account_name, account_bsb, account_number)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (abn, rail, reference)
+       DO UPDATE SET account_name = EXCLUDED.account_name,
+                     account_bsb = EXCLUDED.account_bsb,
+                     account_number = EXCLUDED.account_number`,
+      [abn, rail, reference, account_name ?? null, account_bsb ?? null, account_number ?? null]
+    );
+    const user = req.user as AuthenticatedUser | undefined;
+    await appendAudit({
+      actorId: user?.sub,
+      action: "allow_list_upsert",
+      targetType: "remittance",
+      targetId: `${abn}:${rail}:${reference}`,
+      payload: { abn, rail, reference, account_name, account_bsb, account_number },
+    });
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: "Allow-list update failed", detail: String(err?.message || err) });
+  }
+}
+
+export async function removeDestination(req: Request, res: Response) {
+  try {
+    const { abn, rail, reference } = req.body || {};
+    if (!abn || !rail || !reference) {
+      return res.status(400).json({ error: "Missing fields" });
+    }
+    await pool.query(
+      `DELETE FROM remittance_destinations WHERE abn=$1 AND rail=$2 AND reference=$3`,
+      [abn, rail, reference]
+    );
+    const user = req.user as AuthenticatedUser | undefined;
+    await appendAudit({
+      actorId: user?.sub,
+      action: "allow_list_remove",
+      targetType: "remittance",
+      targetId: `${abn}:${rail}:${reference}`,
+      payload: { abn, rail, reference },
+    });
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: "Allow-list removal failed", detail: String(err?.message || err) });
+  }
+}

--- a/src/routes/approvals.ts
+++ b/src/routes/approvals.ts
@@ -1,0 +1,21 @@
+import { Request, Response, Router } from "express";
+import { AuthenticatedUser } from "../auth/types";
+import { recordApproval } from "../services/approvals";
+
+export const approvalsRouter = Router();
+
+approvalsRouter.post("/releases", async (req: Request, res: Response) => {
+  try {
+    const user = req.user as AuthenticatedUser | undefined;
+    if (!user) return res.status(401).json({ error: "Unauthorized" });
+    const { abn, taxType, periodId, amountCents, reason } = req.body || {};
+    if (!abn || !taxType || !periodId || !Number.isFinite(Number(amountCents))) {
+      return res.status(400).json({ error: "Missing fields" });
+    }
+    const release = { abn, taxType, periodId, amountCents: Number(amountCents) };
+    const hash = await recordApproval(release, user.sub, user.name, reason);
+    res.json({ ok: true, hash });
+  } catch (err: any) {
+    res.status(500).json({ error: "Approval failed", detail: String(err?.message || err) });
+  }
+});

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -1,0 +1,101 @@
+import { Request, Response, Router } from "express";
+import { AuthenticatedUser } from "../auth/types";
+import { generateTotpSecret, otpauthUrl, verifyTotp } from "../auth/totp";
+import { loadSecret, markActivated, upsertSecret } from "../services/mfa";
+import { signStepUpToken } from "../auth/jwt";
+import { appendAudit } from "../audit/appendOnly";
+
+const ISSUER = process.env.MFA_ISSUER || "APGMS";
+
+export const authRouter = Router();
+
+function requireUser(req: Request): AuthenticatedUser {
+  const user = req.user as AuthenticatedUser | undefined;
+  if (!user) {
+    throw new Error("User missing from request context");
+  }
+  return user;
+}
+
+authRouter.post("/mfa/setup", async (req: Request, res: Response) => {
+  try {
+    const user = requireUser(req);
+    const secret = generateTotpSecret();
+    await upsertSecret(user.sub, secret);
+
+    const label = `${user.email || user.sub}`;
+    const url = otpauthUrl(secret, `${ISSUER}:${label}`, ISSUER);
+    const qr = `https://chart.googleapis.com/chart?cht=qr&chs=200x200&chl=${encodeURIComponent(url)}`;
+
+    await appendAudit({
+      actorId: user.sub,
+      action: "mfa_setup",
+      targetType: "user",
+      targetId: user.sub,
+      payload: { label, issuer: ISSUER },
+    });
+
+    res.json({ secret, otpauth: url, qr });
+  } catch (err: any) {
+    res.status(500).json({ error: "MFA setup failed", detail: String(err?.message || err) });
+  }
+});
+
+authRouter.post("/mfa/activate", async (req: Request, res: Response) => {
+  try {
+    const user = requireUser(req);
+    const { code } = req.body || {};
+    const record = await loadSecret(user.sub);
+    if (!record) {
+      return res.status(400).json({ error: "MFA not initialized" });
+    }
+    if (!verifyTotp(record.secret, String(code ?? ""))) {
+      return res.status(400).json({ error: "Invalid code" });
+    }
+    await markActivated(user.sub);
+    await appendAudit({
+      actorId: user.sub,
+      action: "mfa_activate",
+      targetType: "user",
+      targetId: user.sub,
+      payload: { activated: true },
+    });
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: "MFA activation failed", detail: String(err?.message || err) });
+  }
+});
+
+authRouter.post("/mfa/challenge", async (req: Request, res: Response) => {
+  try {
+    const user = requireUser(req);
+    const { code } = req.body || {};
+    const record = await loadSecret(user.sub);
+    if (!record || !record.row.activated_at) {
+      return res.status(400).json({ error: "MFA not active" });
+    }
+    if (!verifyTotp(record.secret, String(code ?? ""))) {
+      await appendAudit({
+        actorId: user.sub,
+        action: "mfa_challenge_failed",
+        targetType: "user",
+        targetId: user.sub,
+        payload: { reason: "bad_code" },
+      });
+      return res.status(400).json({ error: "Invalid code" });
+    }
+
+    const { token, expiresAt } = signStepUpToken(user);
+    await appendAudit({
+      actorId: user.sub,
+      action: "mfa_challenge_passed",
+      targetType: "user",
+      targetId: user.sub,
+      payload: { expiresAt },
+    });
+
+    res.json({ token, expiresAt });
+  } catch (err: any) {
+    res.status(500).json({ error: "MFA challenge failed", detail: String(err?.message || err) });
+  }
+});

--- a/src/routes/receipts.ts
+++ b/src/routes/receipts.ts
@@ -1,0 +1,30 @@
+import { Request, Response } from "express";
+import { pool } from "../db/pool";
+import { appendAudit } from "../audit/appendOnly";
+import { AuthenticatedUser } from "../auth/types";
+
+export async function storeReceipt(req: Request, res: Response) {
+  try {
+    const user = req.user as AuthenticatedUser | undefined;
+    if (!user) return res.status(401).json({ error: "Unauthorized" });
+    const { abn, taxType, periodId, source, receiptId, payload } = req.body || {};
+    if (!abn || !taxType || !periodId || !source || !receiptId) {
+      return res.status(400).json({ error: "Missing fields" });
+    }
+    await pool.query(
+      `INSERT INTO payment_receipts (abn, tax_type, period_id, source, receipt_id, payload, created_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+      [abn, taxType, periodId, source, receiptId, payload ?? null, user.sub]
+    );
+    await appendAudit({
+      actorId: user.sub,
+      action: "receipt_store",
+      targetType: source,
+      targetId: receiptId,
+      payload: { abn, taxType, periodId, source, receiptId },
+    });
+    res.json({ ok: true });
+  } catch (err: any) {
+    res.status(500).json({ error: "Receipt store failed", detail: String(err?.message || err) });
+  }
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,136 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import { Request, Response } from "express";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
-import { Pool } from "pg";
-const pool = new Pool();
+import { pool } from "../db/pool";
+import { appendAudit } from "../audit/appendOnly";
+import { AuthenticatedUser } from "../auth/types";
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+export async function closeAndIssue(req: Request, res: Response) {
+  const { abn, taxType, periodId, thresholds } = req.body || {};
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+  }
+  const thr =
+    thresholds || {
+      epsilon_cents: 50,
+      variance_ratio: 0.25,
+      dup_rate: 0.01,
+      gap_minutes: 60,
+      delta_vs_baseline: 0.2,
+    };
+  const actor = req.user as AuthenticatedUser | undefined;
   try {
+    await appendAudit({
+      actorId: actor?.sub,
+      action: "close",
+      targetType: "period",
+      targetId: `${abn}:${taxType}:${periodId}`,
+      payload: { thresholds: thr },
+    });
     const rpt = await issueRPT(abn, taxType, periodId, thr);
+    await appendAudit({
+      actorId: actor?.sub,
+      action: "rpt_issue",
+      targetType: "period",
+      targetId: `${abn}:${taxType}:${periodId}`,
+      payload: { nonce: rpt.payload?.nonce, expiry: rpt.payload?.expiry_ts, rptId: rpt.rptId },
+    });
     return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    await appendAudit({
+      actorId: actor?.sub,
+      action: "rpt_issue_failed",
+      targetType: "period",
+      targetId: `${abn}:${taxType}:${periodId}`,
+      payload: { error: String(e?.message || e) },
+    });
+    return res.status(400).json({ error: e.message || String(e) });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: Request, res: Response) {
+  const { abn, taxType, periodId, rail } = req.body || {};
+  if (!abn || !taxType || !periodId || !rail) {
+    return res.status(400).json({ error: "Missing fields" });
+  }
+  const actor = req.user as AuthenticatedUser | undefined;
+  const targetId = `${abn}:${taxType}:${periodId}`;
+  await appendAudit({
+    actorId: actor?.sub,
+    action: "release_attempt",
+    targetType: "period",
+    targetId,
+    payload: { abn, taxType, periodId, rail },
+  });
+
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) {
+    await appendAudit({
+      actorId: actor?.sub,
+      action: "release_blocked",
+      targetType: "period",
+      targetId,
+      payload: { reason: "NO_RPT" },
+    });
+    return res.status(400).json({ error: "NO_RPT" });
+  }
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
+    const r = await releasePayment(
+      abn,
+      taxType,
+      periodId,
+      payload.amount_cents,
+      rail,
+      payload.reference,
+      actor?.sub
+    );
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    await appendAudit({
+      actorId: actor?.sub,
+      action: "release_failed",
+      targetType: "period",
+      targetId,
+      payload: { error: String(e?.message || e) },
+    });
+    return res.status(400).json({ error: e.message || String(e) });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
-  const { abn, amount_cents, reference } = req.body;
+export async function paytoSweep(req: Request, res: Response) {
+  const { abn, amount_cents, reference } = req.body || {};
   const r = await paytoDebit(abn, amount_cents, reference);
   return res.json(r);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: Request, res: Response) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
-  const { abn, taxType, periodId } = req.query as any;
-  res.json(await buildEvidenceBundle(abn, taxType, periodId));
+export async function evidence(req: Request, res: Response) {
+  const { abn, taxType, periodId } = req.query as Record<string, string>;
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+  }
+  const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+  await appendAudit({
+    actorId: (req.user as AuthenticatedUser | undefined)?.sub,
+    action: "evidence_export",
+    targetType: "period",
+    targetId: `${abn}:${taxType}:${periodId}`,
+    payload: { size: Array.isArray((bundle as any)?.owa_ledger_deltas) ? (bundle as any).owa_ledger_deltas.length : undefined },
+  });
+  res.json(bundle);
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,11 +1,16 @@
-﻿import { Pool } from "pg";
 import crypto from "crypto";
+import { pool } from "../db/pool";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
-const pool = new Pool();
+
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>
+) {
   const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
@@ -23,15 +28,24 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
+  const insert = await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,) returning id",
+    [abn, taxType, periodId, payload, signature]
+  );
   await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+  return { payload, signature, rptId: insert.rows[0]?.id };
 }

--- a/src/services/approvals.ts
+++ b/src/services/approvals.ts
@@ -1,0 +1,62 @@
+import type { Pool, PoolClient } from "pg";
+import { pool } from "../db/pool";
+import { sha256Hex } from "../crypto/merkle";
+import { appendAudit } from "../audit/appendOnly";
+
+export interface ReleaseRequest {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: number;
+}
+
+export function computeReleaseHash(input: ReleaseRequest): string {
+  return sha256Hex(JSON.stringify({
+    abn: input.abn,
+    taxType: input.taxType,
+    periodId: input.periodId,
+    amountCents: Math.abs(input.amountCents),
+  }));
+}
+
+export async function recordApproval(
+  release: ReleaseRequest,
+  actorId: string,
+  actorName: string | undefined,
+  reason: string | undefined,
+  client?: Pool | PoolClient
+) {
+  const normalized = { ...release, amountCents: Math.abs(release.amountCents) };
+  const hash = computeReleaseHash(normalized);
+  const payload = {
+    ...normalized,
+    hash,
+    reason,
+  };
+  const runner = client ?? pool;
+  await runner.query(
+    `INSERT INTO release_approvals (release_hash, payload, actor_id, actor_name, reason)
+     VALUES ($1,$2,$3,$4,$5)
+     ON CONFLICT (release_hash, actor_id)
+     DO UPDATE SET payload = EXCLUDED.payload, reason = EXCLUDED.reason, actor_name = EXCLUDED.actor_name, created_at = now()` ,
+    [hash, payload, actorId, actorName ?? null, reason ?? null]
+  );
+  await appendAudit({
+    actorId,
+    action: "release_approval",
+    targetType: "release",
+    targetId: hash,
+    payload,
+  }, runner);
+  return hash;
+}
+
+export async function getApprovalsForHash(hash: string, ttlMinutes: number) {
+  const { rows } = await pool.query(
+    `SELECT actor_id, actor_name, reason, created_at
+     FROM release_approvals
+     WHERE release_hash = $1 AND created_at >= now() - ($2::int || ' minutes')::interval`,
+    [hash, ttlMinutes]
+  );
+  return rows as Array<{ actor_id: string; actor_name: string | null; reason: string | null; created_at: Date }>;
+}

--- a/src/services/mfa.ts
+++ b/src/services/mfa.ts
@@ -1,0 +1,67 @@
+import type { Pool, PoolClient } from "pg";
+import { pool } from "../db/pool";
+import { encryptSecret, decryptSecret, SecretEnvelope } from "../auth/secretVault";
+
+export interface MfaSecretRow {
+  user_id: string;
+  backend: string;
+  secret_ciphertext: string;
+  secret_iv: string | null;
+  secret_tag: string | null;
+  kms_key_id: string | null;
+  created_at: Date;
+  activated_at: Date | null;
+  updated_at: Date;
+}
+
+export async function upsertSecret(userId: string, secret: string, client?: Pool | PoolClient) {
+  const envelope = await encryptSecret(secret);
+  const runner = client ?? pool;
+  await runner.query(
+    `INSERT INTO mfa_secrets (user_id, backend, secret_ciphertext, secret_iv, secret_tag, kms_key_id, activated_at)
+     VALUES ($1,$2,$3,$4,$5,$6,NULL)
+     ON CONFLICT (user_id)
+     DO UPDATE SET backend = EXCLUDED.backend,
+                   secret_ciphertext = EXCLUDED.secret_ciphertext,
+                   secret_iv = EXCLUDED.secret_iv,
+                   secret_tag = EXCLUDED.secret_tag,
+                   kms_key_id = EXCLUDED.kms_key_id,
+                   activated_at = NULL,
+                   updated_at = now()` ,
+    [
+      userId,
+      envelope.backend,
+      envelope.ciphertext,
+      envelope.iv ?? null,
+      envelope.tag ?? null,
+      envelope.kmsKeyId ?? null,
+    ]
+  );
+  return envelope;
+}
+
+export async function loadSecret(userId: string) {
+  const { rows } = await pool.query<MfaSecretRow>(
+    `SELECT * FROM mfa_secrets WHERE user_id = $1`,
+    [userId]
+  );
+  const row = rows[0];
+  if (!row) return null;
+  const envelope: SecretEnvelope = {
+    backend: row.backend === "aws" ? "aws" : "local",
+    ciphertext: row.secret_ciphertext,
+    iv: row.secret_iv ?? undefined,
+    tag: row.secret_tag ?? undefined,
+    kmsKeyId: row.kms_key_id ?? undefined,
+  };
+  const secret = await decryptSecret(envelope);
+  return { row, secret };
+}
+
+export async function markActivated(userId: string, client?: Pool | PoolClient) {
+  const runner = client ?? pool;
+  await runner.query(
+    `UPDATE mfa_secrets SET activated_at = now(), updated_at = now() WHERE user_id = $1`,
+    [userId]
+  );
+}

--- a/src/types/aws-sdk-client-kms.d.ts
+++ b/src/types/aws-sdk-client-kms.d.ts
@@ -1,0 +1,12 @@
+declare module "@aws-sdk/client-kms" {
+  export class KMSClient {
+    constructor(config?: any);
+    send(command: any): Promise<any>;
+  }
+  export class EncryptCommand {
+    constructor(input: any);
+  }
+  export class DecryptCommand {
+    constructor(input: any);
+  }
+}

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,11 @@
+import { AuthenticatedUser } from "../auth/types";
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: AuthenticatedUser;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- require authenticated requests with role checks and provide TOTP MFA setup/activation/challenge flows that issue short-lived step-up tokens
- add dual-approval enforcement and audit logging for high-value releases along with protected allow-list and receipt endpoints
- seed append-only audit, MFA secret, release approval, and receipt tables and document the security and separation-of-duties workflows

## Testing
- npm run dev -- --help *(fails without Postgres connectivity)*

------
https://chatgpt.com/codex/tasks/task_e_68e38957442c83279fb3254c44972fa3