### PR TITLE
Add observability stack and CI smoke coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_USER: apgms
+          POSTGRES_PASSWORD: apgms_pw
+          POSTGRES_DB: apgms
+        options: >-
+          --health-cmd "pg_isready -U apgms"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Generate Ed25519 secret
+        id: ed25519
+        run: |
+          echo "secret=$(openssl rand -base64 64)" >> "$GITHUB_OUTPUT"
+
+      - name: Run migrations
+        env:
+          DATABASE_URL: postgres://apgms:apgms_pw@127.0.0.1:5432/apgms
+        run: pnpm run migrate
+
+      - name: Seed smoke data
+        env:
+          DATABASE_URL: postgres://apgms:apgms_pw@127.0.0.1:5432/apgms
+        run: pnpm run seed:smoke
+
+      - name: Unit tests (payments)
+        env:
+          DATABASE_URL: postgres://apgms:apgms_pw@127.0.0.1:5432/apgms
+        run: pnpm --filter payments test -- --runInBand
+
+      - name: Smoke test
+        env:
+          DATABASE_URL: postgres://apgms:apgms_pw@127.0.0.1:5432/apgms
+          RPT_ED25519_SECRET_BASE64: ${{ steps.ed25519.outputs.secret }}
+        run: pnpm run smoke

--- a/apps/services/payments/package.json
+++ b/apps/services/payments/package.json
@@ -15,7 +15,14 @@
     "axios": "1.7.7",
     "body-parser": "1.20.2",
     "express": "4.19.2",
-    "pg": "8.12.0"
+    "pg": "8.12.0",
+    "prom-client": "^15.1.1",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
+    "@opentelemetry/resources": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.21.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.52.1"
   },
   "devDependencies": {
     "@types/express": "4.17.21",

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { merkleRootHex, sha256Hex } from "../../../../src/crypto/merkle.js";
 
 export async function deposit(req: Request, res: Response) {
   try {
@@ -14,24 +15,60 @@ export async function deposit(req: Request, res: Response) {
       await client.query("BEGIN");
 
       const { rows: last } = await client.query(
-        `SELECT balance_after_cents FROM owa_ledger
-         WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-         ORDER BY id DESC LIMIT 1`,
+        `SELECT balance_after_cents, hash_after
+           FROM owa_ledger
+          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+          ORDER BY id DESC LIMIT 1`,
         [abn, taxType, periodId]
       );
       const prevBal = last[0]?.balance_after_cents ?? 0;
+      const prevHash = last[0]?.hash_after ?? "";
       const newBal = prevBal + amt;
+
+      const transferUuid = randomUUID();
+      const bankReceiptHash = `rcpt:${transferUuid.replace(/-/g, "").slice(0, 24)}`;
+      const hashAfter = sha256Hex(prevHash + bankReceiptHash + String(newBal));
 
       const { rows: ins } = await client.query(
         `INSERT INTO owa_ledger
-           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,now())
-         RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
+           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())
+         RETURNING id,transfer_uuid,balance_after_cents,hash_after`,
+        [abn, taxType, periodId, transferUuid, amt, newBal, bankReceiptHash, prevHash, hashAfter]
+      );
+
+      const { rows: ledgerRows } = await client.query(
+        `SELECT transfer_uuid, amount_cents, balance_after_cents
+           FROM owa_ledger
+          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+          ORDER BY id`,
+        [abn, taxType, periodId]
+      );
+      const merkle = merkleRootHex(
+        ledgerRows.map((row) => `${row.transfer_uuid}:${row.amount_cents}:${row.balance_after_cents}`)
+      );
+
+      await client.query(
+        `INSERT INTO periods(
+           abn,tax_type,period_id,state,basis,accrued_cents,credited_to_owa_cents,final_liability_cents,
+           merkle_root,running_balance_hash,anomaly_vector,thresholds)
+         VALUES ($1,$2,$3,'OPEN','ACCRUAL',0,$4,$4,$5,$6,'{}','{}')
+         ON CONFLICT (abn,tax_type,period_id)
+         DO UPDATE SET
+           credited_to_owa_cents = EXCLUDED.credited_to_owa_cents,
+           final_liability_cents = EXCLUDED.final_liability_cents,
+           merkle_root = EXCLUDED.merkle_root,
+           running_balance_hash = EXCLUDED.running_balance_hash`,
+        [abn, taxType, periodId, newBal, merkle, hashAfter]
       );
 
       await client.query("COMMIT");
-      return res.json({ ok: true, ledger_id: ins[0].id, balance_after_cents: ins[0].balance_after_cents });
+      return res.json({
+        ok: true,
+        ledger_id: ins[0].id,
+        transfer_uuid: ins[0].transfer_uuid,
+        balance_after_cents: ins[0].balance_after_cents,
+      });
 
     } catch (e:any) {
       await client.query("ROLLBACK");

--- a/apps/services/payments/src/types/express.d.ts
+++ b/apps/services/payments/src/types/express.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+    }
+    interface Locals {
+      requestId?: string;
+    }
+  }
+}
+
+export {};

--- a/apps/services/payments/tsconfig.json
+++ b/apps/services/payments/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "sourceMap": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.d.ts"]
 }

--- a/libs/observability/index.ts
+++ b/libs/observability/index.ts
@@ -1,0 +1,178 @@
+import { randomUUID } from 'node:crypto';
+import { AsyncLocalStorage } from 'node:async_hooks';
+import type { Request, Response, NextFunction } from 'express';
+import client from 'prom-client';
+import { diag, DiagConsoleLogger, DiagLogLevel } from '@opentelemetry/api';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
+import { Resource } from '@opentelemetry/resources';
+import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
+
+interface ObservabilityOptions {
+  serviceName: string;
+}
+
+interface RequestContext {
+  requestId: string;
+}
+
+const asyncStorage = new AsyncLocalStorage<RequestContext>();
+
+export function getCurrentRequestId(): string | undefined {
+  return asyncStorage.getStore()?.requestId;
+}
+
+function resolveEndpointUrl(): string | undefined {
+  const explicit = process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT;
+  if (explicit) {
+    return explicit;
+  }
+  const generic = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  if (generic) {
+    const trimmed = generic.endsWith('/') ? generic.slice(0, -1) : generic;
+    return `${trimmed}/v1/traces`;
+  }
+  return undefined;
+}
+
+function parseHeaders(): Record<string, string> | undefined {
+  const raw = process.env.OTEL_EXPORTER_OTLP_HEADERS;
+  if (!raw) {
+    return undefined;
+  }
+  const headers: Record<string, string> = {};
+  for (const part of raw.split(',')) {
+    const [key, ...rest] = part.split('=');
+    if (!key || rest.length === 0) continue;
+    headers[key.trim()] = rest.join('=').trim();
+  }
+  return headers;
+}
+
+let startedSdk: NodeSDK | null = null;
+let shuttingDown = false;
+
+export function initializeTelemetry(options: ObservabilityOptions): void {
+  if (startedSdk) {
+    return;
+  }
+
+  diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.ERROR);
+
+  const exporter = new OTLPTraceExporter({
+    url: resolveEndpointUrl(),
+    headers: parseHeaders(),
+  });
+
+  const sdk = new NodeSDK({
+    resource: new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: options.serviceName,
+    }),
+    traceExporter: exporter,
+    instrumentations: [getNodeAutoInstrumentations()],
+  });
+
+  sdk
+    .start()
+    .then(() => {
+      console.log(`[telemetry] OpenTelemetry started for ${options.serviceName}`);
+    })
+    .catch((err) => {
+      console.error('[telemetry] failed to start', err);
+    });
+
+  const shutdown = async () => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    try {
+      await sdk.shutdown();
+      console.log('[telemetry] gracefully shut down');
+    } catch (err) {
+      console.error('[telemetry] shutdown error', err);
+    }
+  };
+
+  process.once('SIGTERM', shutdown);
+  process.once('SIGINT', shutdown);
+  process.once('beforeExit', shutdown);
+
+  startedSdk = sdk;
+}
+
+function resolveRoute(req: Request): string {
+  if (req.route?.path) {
+    return req.baseUrl ? `${req.baseUrl}${req.route.path}` : req.route.path;
+  }
+  if (req.originalUrl) {
+    return req.originalUrl.split('?')[0];
+  }
+  return req.url || 'unknown';
+}
+
+export function createExpressObservability(options: ObservabilityOptions) {
+  const register = new client.Registry();
+  register.setDefaultLabels({ service: options.serviceName });
+  client.collectDefaultMetrics({ register });
+
+  const requestCounter = new client.Counter({
+    name: 'http_server_requests_total',
+    help: 'Total number of HTTP requests received',
+    labelNames: ['method', 'route', 'status_code'],
+    registers: [register],
+  });
+
+  const requestDuration = new client.Histogram({
+    name: 'http_server_request_duration_seconds',
+    help: 'Duration of HTTP requests in seconds',
+    labelNames: ['method', 'route', 'status_code'],
+    buckets: [
+      0.005, 0.01, 0.025, 0.05,
+      0.1, 0.25, 0.5, 1, 2.5, 5, 10,
+    ],
+    registers: [register],
+  });
+
+  return {
+    metricsHandler: async (_req: Request, res: Response) => {
+      res.setHeader('Content-Type', register.contentType);
+      res.end(await register.metrics());
+    },
+    requestMiddleware: (req: Request, res: Response, next: NextFunction) => {
+      const incoming = req.header('x-request-id');
+      const requestId = incoming && incoming.trim().length > 0 ? incoming.trim() : randomUUID();
+      (req as any).requestId = requestId;
+      res.locals.requestId = requestId;
+      res.setHeader('x-request-id', requestId);
+
+      const originalJson = res.json.bind(res);
+      res.json = ((body: any) => {
+        if (body && typeof body === 'object' && !Buffer.isBuffer(body)) {
+          if (body.requestId === undefined) {
+            body.requestId = requestId;
+          }
+        }
+        return originalJson(body);
+      }) as typeof res.json;
+
+      const start = process.hrtime.bigint();
+
+      asyncStorage.run({ requestId }, () => {
+        res.on('finish', () => {
+          const durationNs = Number(process.hrtime.bigint() - start);
+          const durationSeconds = durationNs / 1e9;
+          const route = resolveRoute(req);
+          const statusCode = res.statusCode.toString();
+          const labels = { method: req.method, route, status_code: statusCode } as const;
+          requestCounter.inc(labels);
+          requestDuration.observe(labels, durationSeconds);
+          const durationMs = (durationNs / 1e6).toFixed(2);
+          console.log(
+            `[${options.serviceName}] ${req.method} ${route} ${statusCode} ${durationMs}ms requestId=${requestId}`
+          );
+        });
+        next();
+      });
+    },
+  };
+}

--- a/libs/paymentsClient.ts
+++ b/libs/paymentsClient.ts
@@ -1,4 +1,6 @@
 // libs/paymentsClient.ts
+import { getCurrentRequestId } from "./observability/index.js";
+
 type Common = { abn: string; taxType: string; periodId: string };
 export type DepositArgs = Common & { amountCents: number };   // > 0
 export type ReleaseArgs = Common & { amountCents: number };   // < 0
@@ -8,6 +10,15 @@ const BASE =
   process.env.NEXT_PUBLIC_PAYMENTS_BASE_URL ||
   process.env.PAYMENTS_BASE_URL ||
   "http://localhost:3001";
+
+function withRequestHeaders(init: RequestInit = {}) {
+  const headers = new Headers(init.headers || {});
+  const requestId = getCurrentRequestId();
+  if (requestId) {
+    headers.set("x-request-id", requestId);
+  }
+  return { ...init, headers } satisfies RequestInit;
+}
 
 async function handle(res: Response) {
   const text = await res.text();
@@ -22,31 +33,37 @@ async function handle(res: Response) {
 
 export const Payments = {
   async deposit(args: DepositArgs) {
-    const res = await fetch(`${BASE}/deposit`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(args),
-    });
+    const res = await fetch(
+      `${BASE}/deposit`,
+      withRequestHeaders({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      })
+    );
     return handle(res);
   },
   async payAto(args: ReleaseArgs) {
-    const res = await fetch(`${BASE}/payAto`, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify(args),
-    });
+    const res = await fetch(
+      `${BASE}/payAto`,
+      withRequestHeaders({
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(args),
+      })
+    );
     return handle(res);
   },
   async balance(q: Common) {
     const u = new URL(`${BASE}/balance`);
     Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
-    const res = await fetch(u);
+    const res = await fetch(u, withRequestHeaders());
     return handle(res);
   },
   async ledger(q: Common) {
     const u = new URL(`${BASE}/ledger`);
     Object.entries(q).forEach(([k, v]) => u.searchParams.set(k, String(v)));
-    const res = await fetch(u);
+    const res = await fetch(u, withRequestHeaders());
     return handle(res);
   },
 };

--- a/package.json
+++ b/package.json
@@ -4,12 +4,15 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "migrate": "tsx scripts/run_migrations.ts",
+        "seed:smoke": "tsx scripts/seed_smoke.ts",
+        "smoke": "tsx scripts/smoke.ts"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.0.0",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",
@@ -19,10 +22,17 @@
     },
     "dependencies": {
         "csv-parse": "^6.1.0",
-        "dotenv": "^17.2.3",
-        "express": "^5.1.0",
-        "pg": "^8.16.3",
-        "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+    "dotenv": "^17.2.3",
+    "express": "^5.1.0",
+    "pg": "^8.16.3",
+    "prom-client": "^15.1.1",
+    "tweetnacl": "^1.0.3",
+    "uuid": "^13.0.0",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-node": "^0.52.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
+    "@opentelemetry/resources": "^1.9.0",
+    "@opentelemetry/semantic-conventions": "^1.21.0",
+    "@opentelemetry/auto-instrumentations-node": "^0.52.1"
     }
 }

--- a/scripts/run_migrations.ts
+++ b/scripts/run_migrations.ts
@@ -1,0 +1,82 @@
+import { Client } from "pg";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+const MIGRATIONS_DIR = path.resolve(process.cwd(), "migrations");
+
+async function listMigrationFiles(): Promise<string[]> {
+  const entries = await fs.readdir(MIGRATIONS_DIR);
+  return entries
+    .filter((file) => file.endsWith(".sql"))
+    .sort();
+}
+
+async function readMigration(file: string) {
+  const fullPath = path.join(MIGRATIONS_DIR, file);
+  const sql = await fs.readFile(fullPath, "utf8");
+  const checksum = crypto.createHash("sha256").update(sql).digest("hex");
+  return { sql, checksum };
+}
+
+async function ensureTable(client: Client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      filename TEXT PRIMARY KEY,
+      checksum TEXT NOT NULL,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL not set");
+  }
+
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    await ensureTable(client);
+    const files = await listMigrationFiles();
+    const appliedRes = await client.query(`SELECT filename, checksum FROM schema_migrations`);
+    const applied = new Map<string, string>(appliedRes.rows.map((row) => [row.filename, row.checksum]));
+
+    for (const file of files) {
+      const { sql, checksum } = await readMigration(file);
+      const existing = applied.get(file);
+      if (existing) {
+        if (existing !== checksum) {
+          throw new Error(`Migration drift detected for ${file}`);
+        }
+        continue;
+      }
+      console.log(`[migrate] applying ${file}`);
+      await client.query("BEGIN");
+      try {
+        await client.query(sql);
+        await client.query(`INSERT INTO schema_migrations(filename, checksum) VALUES ($1,$2)`, [file, checksum]);
+        await client.query("COMMIT");
+      } catch (err) {
+        await client.query("ROLLBACK");
+        throw err;
+      }
+    }
+
+    for (const [filename] of applied) {
+      if (!files.includes(filename)) {
+        throw new Error(`Migration ${filename} recorded in database but missing from repository`);
+      }
+    }
+    console.log("[migrate] complete");
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[migrate] failed", err);
+  process.exitCode = 1;
+});

--- a/scripts/seed_smoke.ts
+++ b/scripts/seed_smoke.ts
@@ -1,0 +1,91 @@
+import { Client } from "pg";
+import { randomUUID } from "node:crypto";
+import { sha256Hex } from "../src/crypto/merkle";
+
+const abn = process.env.SMOKE_ABN ?? "12345678901";
+const taxType = process.env.SMOKE_TAX_TYPE ?? "GST";
+const periodId = process.env.SMOKE_PERIOD_ID ?? "2025-10";
+const allowRail = process.env.SMOKE_RAIL ?? "EFT";
+const allowReference = process.env.SMOKE_REFERENCE ?? "SMOKE-PRN";
+
+const credits = (process.env.SMOKE_CREDITS ?? "60000,40000,23456")
+  .split(",")
+  .map((v) => Number(v.trim()))
+  .filter((n) => Number.isFinite(n) && n > 0);
+
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    throw new Error("DATABASE_URL not set");
+  }
+
+  const client = new Client({ connectionString: databaseUrl });
+  await client.connect();
+
+  try {
+    await client.query("BEGIN");
+    await client.query(`DELETE FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3`, [abn, taxType, periodId]);
+    await client.query(`DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3`, [abn, taxType, periodId]);
+    await client.query(`DELETE FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`, [abn, taxType, periodId]);
+
+    let prevHash = "";
+    let balance = 0;
+    for (const amount of credits) {
+      balance += amount;
+      const transferUuid = randomUUID();
+      const bankHash = `seed:${transferUuid.slice(0, 12)}`;
+      const hashAfter = sha256Hex(prevHash + bankHash + String(balance));
+      await client.query(
+        `INSERT INTO owa_ledger(
+           abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())`,
+        [abn, taxType, periodId, transferUuid, amount, balance, bankHash, prevHash, hashAfter]
+      );
+      prevHash = hashAfter;
+    }
+
+    await client.query(
+      `INSERT INTO periods(
+         abn,tax_type,period_id,state,basis,accrued_cents,credited_to_owa_cents,final_liability_cents,
+         merkle_root,running_balance_hash,anomaly_vector,thresholds)
+       VALUES ($1,$2,$3,'OPEN','ACCRUAL',0,$4,$4,NULL,$5,'{}',$6::jsonb)
+       ON CONFLICT (abn,tax_type,period_id)
+       DO UPDATE SET
+         state='OPEN',
+         credited_to_owa_cents=$4,
+         final_liability_cents=$4,
+         running_balance_hash=$5,
+         thresholds=$6::jsonb`,
+      [abn, taxType, periodId, balance, prevHash, JSON.stringify(DEFAULT_THRESHOLDS)]
+    );
+
+    await client.query(
+      `INSERT INTO remittance_destinations(abn,label,rail,reference,account_bsb,account_number)
+       VALUES ($1,$2,$3,$4,$5,$6)
+       ON CONFLICT (abn, rail, reference)
+       DO UPDATE SET label=EXCLUDED.label, account_bsb=EXCLUDED.account_bsb, account_number=EXCLUDED.account_number`,
+      [abn, `${allowRail} primary`, allowRail, allowReference, "123-456", "987654321"]
+    );
+
+    await client.query("COMMIT");
+    console.log(`[seed] period ${abn}/${taxType}/${periodId} ready`);
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("[seed] failed", err);
+  process.exitCode = 1;
+});

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,175 @@
+import { spawn } from "node:child_process";
+import { setTimeout as delay } from "node:timers/promises";
+import crypto from "node:crypto";
+import nacl from "tweetnacl";
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL not set");
+}
+
+const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const secret =
+  process.env.RPT_ED25519_SECRET_BASE64 ??
+  Buffer.from(nacl.sign.keyPair().secretKey).toString("base64");
+
+const abn = process.env.SMOKE_ABN ?? "12345678901";
+const taxType = process.env.SMOKE_TAX_TYPE ?? "GST";
+const periodId = process.env.SMOKE_PERIOD_ID ?? "2025-10";
+
+async function waitForHealth(url: string, timeoutMs = 30000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const res = await fetch(url, { headers: { "x-request-id": crypto.randomUUID() } });
+      if (res.ok) return;
+    } catch {
+      /* retry */
+    }
+    await delay(500);
+  }
+  throw new Error(`Timeout waiting for ${url}`);
+}
+
+function startService(
+  name: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  healthUrl: string
+) {
+  const proc = spawn(pnpmCmd, args, {
+    cwd: process.cwd(),
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  proc.stdout.on("data", (chunk) => process.stdout.write(`[${name}] ${chunk}`));
+  proc.stderr.on("data", (chunk) => process.stderr.write(`[${name}] ${chunk}`));
+
+  let readyResolved = false;
+  const ready = waitForHealth(healthUrl)
+    .then(() => {
+      readyResolved = true;
+    })
+    .catch((err) => {
+      proc.kill("SIGTERM");
+      throw err;
+    });
+
+  const exitPromise = new Promise<void>((resolve, reject) => {
+    proc.on("exit", (code) => {
+      if (!readyResolved) {
+        reject(new Error(`${name} exited before becoming healthy (code ${code})`));
+        return;
+      }
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${name} exited with code ${code}`));
+      }
+    });
+  });
+
+  return {
+    ready,
+    async stop() {
+      proc.kill("SIGTERM");
+      const timeout = delay(5000).then(() => {
+        if (!proc.killed) proc.kill("SIGKILL");
+      });
+      await Promise.race([exitPromise, timeout]);
+    },
+  };
+}
+
+async function postJson(url: string, body: unknown) {
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-request-id": crypto.randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`${url} -> ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function getJson(url: string) {
+  const res = await fetch(url, {
+    headers: { "x-request-id": crypto.randomUUID() },
+  });
+  if (!res.ok) {
+    throw new Error(`${url} -> ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+async function main() {
+  const baseEnv = {
+    ...process.env,
+    DATABASE_URL: databaseUrl,
+    RPT_ED25519_SECRET_BASE64: secret,
+  };
+
+  const paymentsEnv = {
+    ...baseEnv,
+    PORT: process.env.PAYMENTS_PORT ?? "3001",
+  };
+
+  const appEnv = {
+    ...baseEnv,
+    PORT: process.env.APP_PORT ?? "3000",
+    PAYMENTS_BASE_URL: `http://127.0.0.1:${paymentsEnv.PORT}`,
+  };
+
+  const payments = startService(
+    "payments",
+    ["--filter", "payments", "dev"],
+    paymentsEnv,
+    `http://127.0.0.1:${paymentsEnv.PORT}/healthz`
+  );
+  await payments.ready;
+
+  const app = startService(
+    "app",
+    ["dev"],
+    appEnv,
+    `http://127.0.0.1:${appEnv.PORT}/healthz`
+  );
+  await app.ready;
+
+  try {
+    const deposit = await postJson(`http://127.0.0.1:${appEnv.PORT}/api/payments/deposit`, {
+      abn,
+      taxType,
+      periodId,
+      amountCents: 15000,
+    });
+    console.log("[smoke] deposit", deposit);
+
+    const close = await postJson(`http://127.0.0.1:${appEnv.PORT}/api/close-issue`, {
+      abn,
+      taxType,
+      periodId,
+    });
+    console.log("[smoke] close-and-issue", close);
+
+    const evidence = await getJson(
+      `http://127.0.0.1:${appEnv.PORT}/api/evidence?abn=${encodeURIComponent(abn)}&taxType=${encodeURIComponent(
+        taxType
+      )}&periodId=${encodeURIComponent(periodId)}`
+    );
+    console.log("[smoke] evidence keys", Object.keys(evidence));
+  } finally {
+    await app.stop().catch((err) => console.error("[smoke] app stop", err));
+    await payments.stop().catch((err) => console.error("[smoke] payments stop", err));
+  }
+}
+
+main().catch((err) => {
+  console.error("[smoke] failed", err);
+  process.exitCode = 1;
+});

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,5 +1,6 @@
-﻿import { sha256Hex } from "../crypto/merkle";
+import { sha256Hex } from "../crypto/merkle";
 import { Pool } from "pg";
+
 const pool = new Pool();
 
 export async function appendAudit(actor: string, action: string, payload: any) {
@@ -8,7 +9,8 @@ export async function appendAudit(actor: string, action: string, payload: any) {
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
+    `INSERT INTO audit_log(actor,action,payload_hash,prev_hash,terminal_hash)
+     VALUES ($1,$2,$3,$4,$5)`,
     [actor, action, payloadHash, prevHash, terminalHash]
   );
   return terminalHash;

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,40 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
+  const periodRes = await pool.query(
+    `SELECT anomaly_vector, thresholds FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+    [abn, taxType, periodId]
+  );
+  const period = periodRes.rows[0] ?? null;
+
+  const rptRes = await pool.query(
+    `SELECT payload, signature
+       FROM rpt_tokens
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC LIMIT 1`,
+    [abn, taxType, periodId]
+  );
+  const rpt = rptRes.rows[0] ?? null;
+
+  const ledgerRes = await pool.query(
+    `SELECT created_at AS ts, amount_cents, hash_after, bank_receipt_hash, transfer_uuid, balance_after_cents
+       FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id`,
+    [abn, taxType, periodId]
+  );
+  const deltas = ledgerRes.rows;
+  const last = deltas.length ? deltas[deltas.length - 1] : null;
+
+  return {
+    bas_labels: { W1: null, W2: null, "1A": null, "1B": null },
     rpt_payload: rpt?.payload ?? null,
     rpt_signature: rpt?.signature ?? null,
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    anomaly_thresholds: period?.thresholds ?? {},
+    discrepancy_log: [],
   };
-  return bundle;
 }

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,13 +1,14 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    `SELECT * FROM remittance_destinations WHERE abn=$1 AND rail=$2 AND reference=$3`,
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -15,28 +16,50 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 }
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY",
+  reference: string
+) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query(`INSERT INTO idempotency_keys(key,last_status) VALUES($1,$2)`, [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
+  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0, 12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    `SELECT balance_after_cents, hash_after
+       FROM owa_ledger
+      WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+      ORDER BY id DESC LIMIT 1`,
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    `INSERT INTO owa_ledger(
+       abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after,created_at)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())`,
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await appendAudit("rails", "release", {
+    abn,
+    taxType,
+    periodId,
+    amountCents,
+    rail,
+    reference,
+    bank_receipt_hash,
+    transfer_uuid,
+  });
+  await pool.query(`UPDATE idempotency_keys SET last_status=$2 WHERE key=$1`, [transfer_uuid, "DONE"]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -1,52 +1,94 @@
-﻿import { issueRPT } from "../rpt/issuer";
+import type { Request, Response } from "express";
+import { issueRPT } from "../rpt/issuer";
 import { buildEvidenceBundle } from "../evidence/bundle";
 import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+
 const pool = new Pool();
 
-export async function closeAndIssue(req:any, res:any) {
-  const { abn, taxType, periodId, thresholds } = req.body;
-  // TODO: set state -> CLOSING, compute final_liability_cents, merkle_root, running_balance_hash beforehand
-  const thr = thresholds || { epsilon_cents: 50, variance_ratio: 0.25, dup_rate: 0.01, gap_minutes: 60, delta_vs_baseline: 0.2 };
+const DEFAULT_THRESHOLDS = {
+  epsilon_cents: 50,
+  variance_ratio: 0.25,
+  dup_rate: 0.01,
+  gap_minutes: 60,
+  delta_vs_baseline: 0.2,
+};
+
+export async function closeAndIssue(req: Request, res: Response) {
+  const { abn, taxType, periodId } = req.body || {};
+  const thresholds = { ...DEFAULT_THRESHOLDS, ...(req.body?.thresholds ?? {}) };
+  if (!abn || !taxType || !periodId) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+  }
   try {
-    const rpt = await issueRPT(abn, taxType, periodId, thr);
+    const totals = await pool.query(
+      `SELECT COALESCE(SUM(CASE WHEN amount_cents > 0 THEN amount_cents ELSE 0 END),0) AS credited
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    const credited = Number(totals.rows[0]?.credited ?? 0);
+
+    await pool.query(
+      `INSERT INTO periods(
+         abn,tax_type,period_id,state,basis,accrued_cents,credited_to_owa_cents,final_liability_cents,anomaly_vector,thresholds)
+       VALUES ($1,$2,$3,'CLOSING','ACCRUAL',0,$4,$4,'{}',$5::jsonb)
+       ON CONFLICT (abn,tax_type,period_id)
+       DO UPDATE SET
+         state='CLOSING',
+         credited_to_owa_cents=$4,
+         final_liability_cents=$4,
+         thresholds=$5::jsonb`,
+      [abn, taxType, periodId, credited, JSON.stringify(thresholds)]
+    );
+
+    const rpt = await issueRPT(abn, taxType as "PAYGW" | "GST", periodId, thresholds);
     return res.json(rpt);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message || String(e) });
   }
 }
 
-export async function payAto(req:any, res:any) {
-  const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+export async function payAto(req: Request, res: Response) {
+  const { abn, taxType, periodId, rail } = req.body || {};
+  if (!abn || !taxType || !periodId || !rail) {
+    return res.status(400).json({ error: "Missing abn/taxType/periodId/rail" });
+  }
+  const pr = await pool.query(
+    `SELECT payload FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1`,
+    [abn, taxType, periodId]
+  );
+  if (pr.rowCount === 0) return res.status(400).json({ error: "NO_RPT" });
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      `UPDATE periods SET state='RELEASED' WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
     return res.json(r);
-  } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+  } catch (e: any) {
+    return res.status(400).json({ error: e?.message || String(e) });
   }
 }
 
-export async function paytoSweep(req:any, res:any) {
-  const { abn, amount_cents, reference } = req.body;
-  const r = await paytoDebit(abn, amount_cents, reference);
-  return res.json(r);
+export async function paytoSweep(req: Request, res: Response) {
+  const { abn, amount_cents, reference } = req.body || {};
+  const result = await paytoDebit(abn, amount_cents, reference);
+  return res.json(result);
 }
 
-export async function settlementWebhook(req:any, res:any) {
+export async function settlementWebhook(req: Request, res: Response) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
   return res.json({ ingested: rows.length });
 }
 
-export async function evidence(req:any, res:any) {
+export async function evidence(req: Request, res: Response) {
   const { abn, taxType, periodId } = req.query as any;
   res.json(await buildEvidenceBundle(abn, taxType, periodId));
 }

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,37 +1,138 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
+import nacl from "tweetnacl";
 import { signRpt, RptPayload } from "../crypto/ed25519";
-import { exceeds } from "../anomaly/deterministic";
+import { isAnomalous } from "../anomaly/deterministic";
+import { merkleRootHex } from "../crypto/merkle";
+
 const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
-  if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
-  const row = p.rows[0];
-  if (row.state !== "CLOSING") throw new Error("BAD_STATE");
+let cachedSecretKey: Uint8Array | null = null;
 
-  const v = row.anomaly_vector || {};
-  if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
-    throw new Error("BLOCKED_ANOMALY");
+function getSecretKey(): Uint8Array {
+  if (cachedSecretKey) {
+    return cachedSecretKey;
   }
-  const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
-  if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
-    throw new Error("BLOCKED_DISCREPANCY");
+  const env = process.env.RPT_ED25519_SECRET_BASE64;
+  if (env) {
+    cachedSecretKey = new Uint8Array(Buffer.from(env, "base64"));
+    return cachedSecretKey;
   }
+  const generated = nacl.sign.keyPair();
+  cachedSecretKey = generated.secretKey;
+  console.warn("[issuer] RPT_ED25519_SECRET_BASE64 not set; using ephemeral key");
+  return cachedSecretKey;
+}
 
-  const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
-    amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
-  };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+export async function issueRPT(
+  abn: string,
+  taxType: "PAYGW" | "GST",
+  periodId: string,
+  thresholds: Record<string, number>
+) {
+  const client = await pool.connect();
+  let committed = false;
+  try {
+    await client.query("BEGIN");
+
+    const periodRes = await client.query(
+      `SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3 FOR UPDATE`,
+      [abn, taxType, periodId]
+    );
+    if (periodRes.rowCount === 0) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+    const period = periodRes.rows[0];
+    if (period.state !== "CLOSING") {
+      throw new Error("BAD_STATE");
+    }
+
+    const anomalyVector = period.anomaly_vector ?? {};
+    const storedThresholds = period.thresholds ?? {};
+    const effectiveThresholds = { ...storedThresholds, ...thresholds } as Record<string, number>;
+
+    if (isAnomalous(anomalyVector, effectiveThresholds)) {
+      await client.query(`UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1`, [period.id]);
+      await client.query("COMMIT");
+      committed = true;
+      throw new Error("BLOCKED_ANOMALY");
+    }
+
+    const credited = Number(period.credited_to_owa_cents ?? 0);
+    const liability = Number(period.final_liability_cents ?? credited);
+    const epsilonLimit = Number(effectiveThresholds["epsilon_cents"] ?? 0);
+    if (Math.abs(liability - credited) > epsilonLimit) {
+      await client.query(`UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1`, [period.id]);
+      await client.query("COMMIT");
+      committed = true;
+      throw new Error("BLOCKED_DISCREPANCY");
+    }
+
+    const ledgerRes = await client.query(
+      `SELECT transfer_uuid, amount_cents, balance_after_cents, hash_after
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id`,
+      [abn, taxType, periodId]
+    );
+    const ledgerRows = ledgerRes.rows;
+    const merkle = period.merkle_root ?? merkleRootHex(
+      ledgerRows.map((row) => `${row.transfer_uuid}:${row.amount_cents}:${row.balance_after_cents}`)
+    );
+    const runningHash =
+      period.running_balance_hash ??
+      (ledgerRows.length ? ledgerRows[ledgerRows.length - 1].hash_after ?? "" : "");
+
+    const payload: RptPayload = {
+      entity_id: period.abn,
+      period_id: period.period_id,
+      tax_type: period.tax_type,
+      amount_cents: liability,
+      merkle_root: merkle,
+      running_balance_hash: runningHash,
+      anomaly_vector: anomalyVector,
+      thresholds: effectiveThresholds,
+      rail_id: "EFT",
+      reference: process.env.ATO_PRN || "ATO-PRN-DEV",
+      expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+      nonce: crypto.randomUUID(),
+    };
+
+    const signature = signRpt(payload, getSecretKey());
+
+    await client.query(
+      `INSERT INTO rpt_tokens(abn,tax_type,period_id,payload,signature,status)
+       VALUES ($1,$2,$3,$4,$5,'ISSUED')
+       ON CONFLICT (abn,tax_type,period_id)
+       DO UPDATE SET
+         payload = EXCLUDED.payload,
+         signature = EXCLUDED.signature,
+         status = 'ISSUED',
+         created_at = now()`,
+      [abn, taxType, periodId, payload, signature]
+    );
+
+    await client.query(
+      `UPDATE periods
+          SET state='READY_RPT',
+              thresholds=$4::jsonb,
+              merkle_root=$5,
+              running_balance_hash=$6,
+              final_liability_cents=$7,
+              credited_to_owa_cents=$8
+        WHERE id=$1`,
+      [period.id, taxType, periodId, JSON.stringify(effectiveThresholds), merkle, runningHash, liability, credited]
+    );
+
+    await client.query("COMMIT");
+    committed = true;
+    return { payload, signature };
+  } catch (err) {
+    if (!committed) {
+      await client.query("ROLLBACK");
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,12 @@
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+    }
+    interface Locals {
+      requestId?: string;
+    }
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a shared observability helper that wires prom-client metrics, x-request-id propagation, and OpenTelemetry NodeSDK startup
- expose /healthz and /metrics on the app and payments services while hardening the deposit, issuance, and evidence flows
- add migration/seeding/smoke scripts and wire them into a CI workflow that provisions Postgres, runs tests, and exercises the smoke path

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e389875b048327b1b4662b377bff81