### PR TITLE
Enforce MFA and structured logging for OSF baseline compliance

### DIFF
--- a/docs/security/breach-response.md
+++ b/docs/security/breach-response.md
@@ -1,0 +1,31 @@
+# Security Incident and Breach Response
+
+This service enforces the ATO DSP Operational Security Framework (OSF) baseline controls for
+high-risk release actions. The following controls are in place:
+
+- **JWT authentication and role checks** are required before sensitive handlers execute. Roles are
+  expressed as scopes such as `release:execute`, `allowlist:write`, and `evidence:read`.
+- **TOTP-based MFA step-up** is enforced on release, allow-list management, and evidence export.
+  Clients must supply the current TOTP code in the `X-MFA-TOTP` header (or `mfaTotp` body field for
+  non-GET requests). Codes are verified against the `MFA_TOTP_SECRET` environment variable.
+- **Structured logging** attaches a generated `request_id`, hashed actor reference, and event type to
+  every request, audit action, and security event. Logs are retained for the number of days specified
+  by `LOG_RETENTION_DAYS` (defaults to 365) and the retention configuration is announced at startup.
+- **Security headers and rate limits** protect sensitive endpoints. Repeated failures emit
+  `security_event` log entries to surface suspicious patterns.
+
+## Breach notification path
+
+1. Security controls emit structured `security_event` log entries that include `request_id`, the
+   hashed actor reference, and the triggering reason. Centralised monitoring should alert on these
+   events in near real time.
+2. Upon detecting a suspected breach, on-call staff must escalate immediately to the DSP security
+   officer via the internal emergency channel (`#sec-incident`) and email (`security@apgms.local`).
+3. The security officer coordinates triage, preserves logs for the configured retention period, and
+   initiates the ATO breach notification workflow documented in the DSP OSF requirements. External
+   notification to the ATO must occur within the mandated timeframe once impact is confirmed.
+4. After containment, a post-incident review is recorded along with the correlated `request_id`
+   values so that forensic teams can cross-reference database audit hashes.
+
+Refer to the OSF overview and requirements artefacts in the ATO developer portal for the detailed
+reporting obligations and timelines.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "packageManager": "pnpm@9",
     "devDependencies": {
         "@types/express": "^5.0.3",
+        "@types/helmet": "^7.0.1",
+        "@types/jsonwebtoken": "^9.0.6",
         "@types/node": "^24.6.2",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
@@ -21,6 +23,10 @@
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.1.5",
+        "helmet": "^7.0.0",
+        "jsonwebtoken": "^9.0.2",
+        "otplib": "^12.0.1",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"

--- a/src/config/security.ts
+++ b/src/config/security.ts
@@ -1,0 +1,10 @@
+export const securityConfig = {
+  jwtSecret: process.env.JWT_SECRET ?? "",
+  jwtIssuer: process.env.JWT_ISSUER,
+  jwtAudience: process.env.JWT_AUDIENCE,
+  mfaSecret: process.env.MFA_TOTP_SECRET ?? "",
+  sensitiveRateLimit: Number(process.env.SENSITIVE_RATE_LIMIT ?? 8),
+  sensitiveRateWindowMs: Number(process.env.SENSITIVE_RATE_WINDOW_MS ?? 5 * 60 * 1000),
+  logRetentionDays: Number(process.env.LOG_RETENTION_DAYS ?? 365),
+  serviceName: process.env.SERVICE_NAME ?? "apgms-api",
+};

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,17 @@ declare module "*.svg" {
   const content: string;
   export default content;
 }
+
+declare global {
+  namespace Express {
+    interface Request {
+      requestId?: string;
+      user?: {
+        sub?: string;
+        roles?: string[];
+      };
+    }
+  }
+}
+
+export {};

--- a/src/middleware/requestContext.ts
+++ b/src/middleware/requestContext.ts
@@ -1,0 +1,16 @@
+import { randomUUID } from "crypto";
+import type { RequestHandler } from "express";
+import { logStructuredEvent } from "../security/logger";
+
+export const requestContext: RequestHandler = (req, res, next) => {
+  const incomingId = req.header("x-request-id") || randomUUID();
+  req.requestId = incomingId;
+  res.setHeader("x-request-id", incomingId);
+
+  logStructuredEvent("request_received", req);
+  res.on("finish", () => {
+    logStructuredEvent("request_completed", req, { status: res.statusCode });
+  });
+
+  next();
+};

--- a/src/middleware/security.ts
+++ b/src/middleware/security.ts
@@ -1,0 +1,94 @@
+import type { RequestHandler } from "express";
+import jwt, { JwtPayload } from "jsonwebtoken";
+import { authenticator } from "otplib";
+import { securityConfig } from "../config/security";
+import { logSecurityEvent } from "../security/logger";
+
+type RolesClaim = string[] | string | undefined;
+
+function parseRoles(claim: RolesClaim): string[] {
+  if (!claim) return [];
+  if (Array.isArray(claim)) {
+    return claim.map((role) => String(role)).filter(Boolean);
+  }
+  if (typeof claim === "string") {
+    return claim
+      .split(/[\s,]+/)
+      .map((r) => r.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+export const authenticateJwt: RequestHandler = (req, res, next) => {
+  if (!securityConfig.jwtSecret) {
+    logSecurityEvent(req, "jwt_not_configured");
+    return res.status(500).json({ error: "AUTH_NOT_CONFIGURED" });
+  }
+
+  const authHeader = req.header("authorization") || req.header("Authorization");
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    logSecurityEvent(req, "jwt_missing");
+    return res.status(401).json({ error: "UNAUTHORIZED" });
+  }
+
+  const token = authHeader.slice("Bearer ".length).trim();
+  try {
+    const payload = jwt.verify(token, securityConfig.jwtSecret, {
+      audience: securityConfig.jwtAudience,
+      issuer: securityConfig.jwtIssuer,
+    }) as JwtPayload & { roles?: RolesClaim; scope?: RolesClaim };
+
+    const roles = new Set<string>();
+    parseRoles(payload.roles).forEach((role) => roles.add(role));
+    parseRoles(payload.scope).forEach((role) => roles.add(role));
+
+    req.user = {
+      sub: typeof payload.sub === "string" ? payload.sub : undefined,
+      roles: Array.from(roles),
+    };
+    return next();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    logSecurityEvent(req, "jwt_invalid", { detail: message });
+    return res.status(401).json({ error: "UNAUTHORIZED" });
+  }
+};
+
+export function requireRole(role: string): RequestHandler {
+  return (req, res, next) => {
+    const roles = req.user?.roles ?? [];
+    if (!roles.includes(role)) {
+      logSecurityEvent(req, "role_denied", { role });
+      return res.status(403).json({ error: "FORBIDDEN" });
+    }
+    return next();
+  };
+}
+
+export function requireTotp(purpose: string): RequestHandler {
+  return (req, res, next) => {
+    const secret = securityConfig.mfaSecret;
+    if (!secret) {
+      logSecurityEvent(req, "mfa_not_configured", { purpose });
+      return res.status(500).json({ error: "MFA_NOT_CONFIGURED" });
+    }
+
+    const headerToken = req.header("x-mfa-totp") || req.header("x-totp");
+    const bodyToken = typeof req.body?.mfaTotp === "string" ? req.body.mfaTotp : undefined;
+    const token = headerToken || bodyToken;
+
+    if (!token) {
+      logSecurityEvent(req, "mfa_missing", { purpose });
+      return res.status(403).json({ error: "MFA_REQUIRED" });
+    }
+
+    const normalized = token.replace(/\s+/g, "");
+    if (!/^[0-9]{6,8}$/.test(normalized) || !authenticator.check(normalized, secret)) {
+      logSecurityEvent(req, "mfa_invalid", { purpose });
+      return res.status(403).json({ error: "MFA_INVALID" });
+    }
+
+    return next();
+  };
+}

--- a/src/routes/allowlist.ts
+++ b/src/routes/allowlist.ts
@@ -1,0 +1,63 @@
+import { Request, Response } from "express";
+import { Pool } from "pg";
+import { appendAudit } from "../audit/appendOnly";
+import { hashIdentifier, logAuditEvent, logSecurityEvent } from "../security/logger";
+
+const pool = new Pool();
+
+export async function upsertAllowlist(req: Request, res: Response) {
+  const { abn, label, rail, reference, accountBsb, accountNumber } = req.body ?? {};
+
+  if (!abn || !label || !rail || !reference) {
+    logSecurityEvent(req, "allowlist_invalid_payload", { reason: "missing_fields" });
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+
+  const normalizedRail = String(rail).toUpperCase();
+  if (!["EFT", "BPAY"].includes(normalizedRail)) {
+    logSecurityEvent(req, "allowlist_invalid_payload", { reason: "invalid_rail", rail: normalizedRail });
+    return res.status(400).json({ error: "INVALID_RAIL" });
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const upsert = `
+      INSERT INTO remittance_destinations (abn, label, rail, reference, account_bsb, account_number)
+      VALUES ($1,$2,$3,$4,$5,$6)
+      ON CONFLICT (abn, rail, reference)
+      DO UPDATE SET label = EXCLUDED.label,
+                    account_bsb = EXCLUDED.account_bsb,
+                    account_number = EXCLUDED.account_number
+      RETURNING id, abn, label, rail, reference, account_bsb, account_number
+    `;
+    const { rows } = await client.query(upsert, [
+      String(abn),
+      String(label),
+      normalizedRail,
+      String(reference),
+      accountBsb ? String(accountBsb) : null,
+      accountNumber ? String(accountNumber) : null,
+    ]);
+
+    await client.query("COMMIT");
+
+    const actor = req.user?.sub ? `user:${hashIdentifier(req.user.sub)}` : "user:anonymous";
+    await appendAudit(actor, "allowlist_upsert", {
+      abn: String(abn),
+      rail: normalizedRail,
+      reference: String(reference),
+      requestId: req.requestId,
+    });
+    logAuditEvent(req, "allowlist_upsert", { rail: normalizedRail, reference: String(reference) });
+
+    return res.json({ ok: true, destination: rows[0] });
+  } catch (error) {
+    await client.query("ROLLBACK");
+    const detail = error instanceof Error ? error.message : String(error);
+    logSecurityEvent(req, "allowlist_upsert_failed", { detail });
+    return res.status(500).json({ error: "ALLOWLIST_UPDATE_FAILED" });
+  } finally {
+    client.release();
+  }
+}

--- a/src/security/logger.ts
+++ b/src/security/logger.ts
@@ -1,0 +1,41 @@
+import { createHash } from "crypto";
+import type { Request } from "express";
+import { securityConfig } from "../config/security";
+
+type LogData = Record<string, unknown>;
+
+function pruneUndefined(data: LogData): LogData {
+  return Object.fromEntries(Object.entries(data).filter(([, value]) => value !== undefined));
+}
+
+export function hashIdentifier(value?: string | null): string | undefined {
+  if (!value) return undefined;
+  return createHash("sha256").update(value).digest("hex").slice(0, 16);
+}
+
+export function logStructuredEvent(eventType: string, req: Request | null, data: LogData = {}): void {
+  const base: LogData = {
+    ts: new Date().toISOString(),
+    service: securityConfig.serviceName,
+    event_type: eventType,
+    request_id: req?.requestId,
+    method: req?.method,
+    path: req?.path,
+    actor_ref: hashIdentifier(req?.user?.sub ?? null),
+  };
+  const record = pruneUndefined({ ...base, ...data });
+  // eslint-disable-next-line no-console
+  console.log(JSON.stringify(record));
+}
+
+export function logSecurityEvent(req: Request | null, reason: string, data: LogData = {}): void {
+  logStructuredEvent("security_event", req, { reason, ...data });
+}
+
+export function logAuditEvent(req: Request | null, action: string, data: LogData = {}): void {
+  logStructuredEvent("audit_event", req, { action, ...data });
+}
+
+export function announceRetention(): void {
+  logStructuredEvent("logging_config", null, { retention_days: securityConfig.logRetentionDays });
+}


### PR DESCRIPTION
## Summary
- add security configuration, structured logging, and request context middleware with request identifiers
- gate release, allowlist, and evidence endpoints behind JWT roles, rate limits, and TOTP MFA while adding an allowlist admin route
- document breach notification workflow and add security dependencies required for OSF-aligned controls

## Testing
- npm run typecheck
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e38c6b36348327958b0be5c98deacc