### PR TITLE
Add mode-aware tax rule guidance to GUI

### DIFF
--- a/apps/gui/app.js
+++ b/apps/gui/app.js
@@ -1,35 +1,219 @@
 (() => {
   const cfg = window.GUI_CONFIG || {};
   const base = (cfg.baseUrl || "/api").replace(/\/+$/, "");
-  const $ = (sel, root=document) => root.querySelector(sel);
+  const $ = (sel, root = document) => root.querySelector(sel);
 
-  const routes = ["home","connections","transactions","tax-bas","help","settings"];
-  function currentRoute(){ const h = location.hash.replace(/^#\/?/, "").toLowerCase(); return routes.includes(h) ? h : "home"; }
+  const fallbackBasContext = {
+    cashVsAccrual:
+      "Cash-basis reporters recognise GST when money is received or paid. Accrual-basis reporters recognise GST when the invoice is issued or received, even if payment happens later.",
+    dgst:
+      "Deferred GST (DGST) must be reported in the period that covers the Australian Border Force import declaration statement date, not the cargo arrival date.",
+    labels: [
+      {
+        code: "G1",
+        title: "Total sales",
+        description:
+          "Total taxable supplies including GST and exports (report GST-free amounts separately).",
+        link: "https://www.ato.gov.au/Business/Business-activity-statements-(BAS)/In-detail/BAS-Label-guides/G1-Total-sales/",
+        note: "Include cash or accrual timing in line with your accounting basis."
+      },
+      {
+        code: "W1",
+        title: "Total salary and wages",
+        description:
+          "Report gross payments subject to withholding (salary, wages, director fees).",
+        link: "https://www.ato.gov.au/Forms/How-to-complete-your-activity-statement/W1---total-salary-wages-and-other-payments/",
+        note: "Align PAYG withholding with the pay event period submitted to the ATO."
+      },
+      {
+        code: "1A",
+        title: "GST on sales",
+        description: "GST collected on taxable supplies for the period.",
+        link: "https://www.ato.gov.au/Business/Business-activity-statements-(BAS)/In-detail/BAS-Label-guides/1A-GST-on-sales/",
+        note: "Derive from G1 after excluding GST-free and input taxed amounts."
+      },
+      {
+        code: "DGST",
+        title: "Deferred GST",
+        description: "GST deferred at importation under the deferred GST scheme.",
+        link: "https://www.ato.gov.au/Business/Deferred-GST-scheme/",
+        note: "Report based on the Integrated Cargo System (ICS) deferred GST statement date."
+      }
+    ]
+  };
+
+  const fallbackRuleUpdates = [
+    {
+      code: "DGST",
+      title: "DGST timing aligns with ICS statement date",
+      summary:
+        "Deferred GST is payable when the import declaration statement is issued. The goods arrival date no longer drives the period selection.",
+      effectiveFrom: "2025-09-01",
+      link: "https://www.ato.gov.au/Business/Deferred-GST-scheme/"
+    },
+    {
+      code: "BAS-BASIS",
+      title: "Clarified cash vs accrual mapping",
+      summary:
+        "Cash reporters capture GST when payments clear; accrual reporters capture GST when invoices issue. This banner reminds preparers which mode is active.",
+      effectiveFrom: "2025-07-01",
+      link: "https://www.ato.gov.au/Business/GST/Accounting-for-GST/Cash-and-accrual-accounting/"
+    }
+  ];
+
+  const fallbackSegments = [
+    {
+      label: "July-August 2025",
+      start: "2025-07-01",
+      end: "2025-08-31",
+      ratesVersion: "2025.1",
+      note: "Carry-over fuel tax credit rates remain in effect until 31 Aug."
+    },
+    {
+      label: "September 2025",
+      start: "2025-09-01",
+      end: "2025-09-30",
+      ratesVersion: "2025.2",
+      note: "Updated DGST recognition applies from 1 Sep."
+    }
+  ];
+
+  const routes = ["home", "connections", "transactions", "tax-bas", "help", "settings"];
+
+  function currentRoute() {
+    const raw = location.hash.replace(/^#/, "");
+    const [path] = raw.split("?");
+    const parts = path.split("/").filter(Boolean);
+    const view = parts[0] || "home";
+    const detail = parts.slice(1).map((p) => p.toLowerCase());
+    return { view: routes.includes(view) ? view : "home", detail };
+  }
+
   window.addEventListener("hashchange", () => render());
 
-  async function api(path, init={}) {
-    const r = await fetch(base + path, { headers: { "Content-Type":"application/json" }, ...init });
+  async function api(path, init = {}) {
+    const r = await fetch(base + path, {
+      headers: { "Content-Type": "application/json" },
+      ...init
+    });
     if (!r.ok) throw new Error(String(r.status));
     const ct = r.headers.get("content-type") || "";
     return ct.includes("application/json") ? r.json() : r.text();
   }
 
+  function getModeInfo() {
+    const rules = cfg.rules || {};
+    const appMode = cfg.appMode || rules.appMode || rules.mode || "Sandbox";
+    const ratesVersion = cfg.ratesVersion || rules.ratesVersion || rules.version || "n/a";
+    const effectiveFrom = rules.effectiveFrom || cfg.ratesEffectiveFrom || "";
+    const effectiveTo = rules.effectiveTo || cfg.ratesEffectiveTo || "";
+    const periodLabel = cfg.periodLabel || rules.period || "Current period";
+    return { appMode, ratesVersion, effectiveFrom, effectiveTo, periodLabel };
+  }
+
+  function getRuleUpdates() {
+    const updates = Array.isArray(cfg.ruleUpdates) && cfg.ruleUpdates.length ? cfg.ruleUpdates : fallbackRuleUpdates;
+    return updates.map((u) => ({
+      code: u.code,
+      title: u.title,
+      summary: u.summary,
+      effectiveFrom: u.effectiveFrom,
+      link: u.link
+    }));
+  }
+
+  function getSegments() {
+    return Array.isArray(cfg.ruleSegments) && cfg.ruleSegments.length ? cfg.ruleSegments : fallbackSegments;
+  }
+
+  function getBasContext() {
+    const ctx = cfg.basContext || {};
+    const cashVsAccrual = ctx.cashVsAccrual || fallbackBasContext.cashVsAccrual;
+    const dgst = ctx.dgst || fallbackBasContext.dgst;
+    const labels = Array.isArray(ctx.labels) && ctx.labels.length ? ctx.labels : fallbackBasContext.labels;
+    return { cashVsAccrual, dgst, labels };
+  }
+
+  function renderSegmentsBlock(segments) {
+    if (!segments.length) return "";
+    return `
+      <div class="segment-list" aria-live="polite">
+        ${segments
+          .map(
+            (seg) => `
+              <div class="segment-item">
+                <div class="segment-dates">${seg.label || `${seg.start} - ${seg.end}`}</div>
+                <div class="segment-meta"><span class="badge">${seg.ratesVersion}</span>${seg.note ? `<span>${seg.note}</span>` : ""}</div>
+                <div class="segment-range">${seg.start} to ${seg.end}</div>
+              </div>
+            `
+          )
+          .join("")}
+      </div>`;
+  }
+
+  function renderUpdatesBlock(updates, heading = "What\u2019s New") {
+    if (!updates.length) return "";
+    return `
+      <div class="whats-new">
+        <h4>${heading}</h4>
+        <ul>
+          ${updates
+            .map(
+              (u) => `
+                <li class="whats-new-item">
+                  <span class="badge-new" aria-label="Updated rule">New</span>
+                  <div>
+                    <div class="whats-new-title">${u.title}</div>
+                    <div class="whats-new-date">Effective ${u.effectiveFrom || "TBA"}</div>
+                    <p>${u.summary}</p>
+                    ${u.link ? `<a class="external" href="${u.link}" target="_blank" rel="noopener">Read update</a>` : ""}
+                  </div>
+                </li>
+              `
+            )
+            .join("")}
+        </ul>
+      </div>`;
+  }
+
+  function modeBanner() {
+    const info = getModeInfo();
+    const href = cfg.links?.taxRules || "#/help/tax-rules";
+    const effective = info.effectiveFrom
+      ? `${info.effectiveFrom}${info.effectiveTo ? " to " + info.effectiveTo : ""}`
+      : "Active now";
+    return `
+      <div class="mode-banner" role="status" aria-live="polite">
+        <div class="mode-pill" aria-label="Operating mode">${info.appMode}</div>
+        <div class="mode-text">
+          <div class="mode-line"><strong>Rates:</strong> ${info.ratesVersion}</div>
+          <div class="mode-line"><strong>Effective:</strong> ${effective}</div>
+        </div>
+        <a class="mode-link" href="${href}">Tax rule reference</a>
+      </div>`;
+  }
+
+  function layout(viewHtml) {
+    return `${modeBanner()}${viewHtml}`;
+  }
+
   const View = {
-    nav(active){
+    nav(active) {
       return `
         <nav aria-label="Primary">
-          <a href="#/home"        class="${active==='home'?'active':''}">Home</a>
-          <a href="#/connections" class="${active==='connections'?'active':''}">Connections</a>
-          <a href="#/transactions"class="${active==='transactions'?'active':''}">Transactions</a>
-          <a href="#/tax-bas"     class="${active==='tax-bas'?'active':''}">Tax & BAS</a>
-          <a href="#/help"        class="${active==='help'?'active':''}">Help</a>
-          <a href="#/settings"    class="${active==='settings'?'active':''}">Settings</a>
+          <a href="#/home"        class="${active === "home" ? "active" : ""}">Home</a>
+          <a href="#/connections" class="${active === "connections" ? "active" : ""}">Connections</a>
+          <a href="#/transactions"class="${active === "transactions" ? "active" : ""}">Transactions</a>
+          <a href="#/tax-bas"     class="${active === "tax-bas" ? "active" : ""}">Tax & BAS</a>
+          <a href="#/help"        class="${active === "help" ? "active" : ""}">Help</a>
+          <a href="#/settings"    class="${active === "settings" ? "active" : ""}">Settings</a>
         </nav>`;
     },
 
-    home(){
+    home() {
       return `
-        ${this.nav('home')}
+        ${this.nav("home")}
         <header>
           <h1>${cfg.brand || "APGMS Normalizer"}</h1>
           <p>${cfg.title || "Customer Portal"}</p>
@@ -52,13 +236,13 @@
             <pre id="normOut" style="margin-top:8px;max-height:220px;overflow:auto"></pre>
           </div>
         </div>
-        <div class="footer">OpenAPI: <a target="_blank" href="${cfg.swaggerPath || '/api/openapi.json'}">${cfg.swaggerPath || '/api/openapi.json'}</a></div>
+        <div class="footer">OpenAPI: <a target="_blank" rel="noopener" href="${cfg.swaggerPath || "/api/openapi.json"}">${cfg.swaggerPath || "/api/openapi.json"}</a></div>
       `;
     },
 
-    connections(){
+    connections() {
       return `
-        ${this.nav('connections')}
+        ${this.nav("connections")}
         <div class="grid" style="grid-template-columns:2fr 1fr; margin-top:12px">
           <div class="card">
             <h3>Connected sources</h3>
@@ -91,9 +275,9 @@
       `;
     },
 
-    transactions(){
+    transactions() {
       return `
-        ${this.nav('transactions')}
+        ${this.nav("transactions")}
         <div class="card">
           <h3>Transactions</h3>
           <div style="display:flex; gap:8px; margin-bottom:8px">
@@ -106,12 +290,17 @@
       `;
     },
 
-    "tax-bas"(){
+    "tax-bas"() {
+      const info = getModeInfo();
+      const updates = getRuleUpdates();
+      const segments = getSegments();
+      const basCtx = getBasContext();
       return `
-        ${this.nav('tax-bas')}
+        ${this.nav("tax-bas")}
         <div class="grid" style="grid-template-columns:1fr 1fr; margin-top:12px">
           <div class="card">
             <h3>BAS Preparation</h3>
+            <p class="muted">${info.periodLabel}</p>
             <button class="btn" id="btnPreviewBas">Preview BAS (draft)</button>
             <pre id="basOut" style="margin-top:8px;max-height:260px;overflow:auto"></pre>
           </div>
@@ -123,27 +312,128 @@
             <div id="lodgeMsg" style="margin-top:8px"></div>
           </div>
         </div>
-      `;
-    },
-
-    help(){
-      return `
-        ${this.nav('help')}
-        <div class="card">
-          <h3>Help & Guidance</h3>
-          <ol>
-            <li>Use <b>Connections</b> to link Bank (CDR), Payroll/POS, and ATO (SBR).</li>
-            <li>Import or auto-ingest data; view in <b>Transactions</b>.</li>
-            <li>Prepare and validate <b>Tax & BAS</b>; lodge via SBR when ready.</li>
-            <li>See <span class="kbd">/api/openapi.json</span> for API details.</li>
-          </ol>
+        <div class="grid" style="grid-template-columns:1fr 1fr; margin-top:12px">
+          <div class="card">
+            <h3>GST rule context</h3>
+            <p>The current period uses <strong>${info.ratesVersion}</strong> rates for the <strong>${info.appMode}</strong> mode.</p>
+            ${renderSegmentsBlock(segments)}
+            ${renderUpdatesBlock(updates)}
+          </div>
+          <div class="card">
+            <h3>BAS labels & statutory timing</h3>
+            <p class="muted">Each label links to the ATO explanation for that obligation.</p>
+            <dl class="bas-labels">
+              ${basCtx.labels
+                .map(
+                  (label) => `
+                    <div class="bas-label" data-label="${label.code}">
+                      <dt><span class="badge">${label.code}</span> ${label.title}</dt>
+                      <dd>
+                        <p>${label.description}</p>
+                        ${label.note ? `<p class="muted">${label.note}</p>` : ""}
+                        ${label.link ? `<a class="external" href="${label.link}" target="_blank" rel="noopener">Read guidance</a>` : ""}
+                      </dd>
+                    </div>
+                  `
+                )
+                .join("")}
+            </dl>
+            <div class="bas-hint"><strong>Cash vs accrual:</strong> ${basCtx.cashVsAccrual}</div>
+            <div class="bas-hint"><strong>Deferred GST (DGST):</strong> ${basCtx.dgst}</div>
+          </div>
         </div>
       `;
     },
 
-    settings(){
+    help(ctx = {}) {
+      const section = (ctx.detail && ctx.detail[0]) || "overview";
+      const info = getModeInfo();
+      const updates = getRuleUpdates();
+      const segments = getSegments();
+      const basCtx = getBasContext();
+      const sections = [
+        {
+          id: "overview",
+          title: "Portal overview",
+          body: `
+            <p>Use the navigation to connect data sources, review transactions, and prepare statutory filings.</p>
+            <ol>
+              <li>Connect bank, payroll, and commerce sources to keep ledgers synchronised.</li>
+              <li>Review transformed transactions for anomalies before creating the BAS.</li>
+              <li>Validate with the ATO and lodge once the statutory period closes.</li>
+            </ol>
+          `
+        },
+        {
+          id: "tax-rules",
+          title: "Tax rules & effective dates",
+          body: `
+            <p>The service is running in <strong>${info.appMode}</strong> mode with rates version <strong>${info.ratesVersion}</strong>.</p>
+            <p>Effective window: ${info.effectiveFrom || "current"}${info.effectiveTo ? ` to ${info.effectiveTo}` : ""}. Preview the BAS to confirm figures align with these statutory windows.</p>
+            ${renderSegmentsBlock(segments)}
+            ${renderUpdatesBlock(updates, "Recent rule updates")}
+          `
+        },
+        {
+          id: "bas-labels",
+          title: "BAS labels guidance",
+          body: `
+            <p>These BAS codes align with Australian Taxation Office (ATO) definitions. Select the label to open the related guidance.</p>
+            <ul class="help-bas-list">
+              ${basCtx.labels
+                .map(
+                  (label) => `
+                    <li>
+                      <span class="badge">${label.code}</span>
+                      <span class="help-bas-title">${label.title}</span>
+                      ${label.link ? `<a class="external" href="${label.link}" target="_blank" rel="noopener">ATO reference</a>` : ""}
+                      <div class="help-bas-desc">${label.description}</div>
+                      ${label.note ? `<div class="help-bas-note">${label.note}</div>` : ""}
+                    </li>
+                  `
+                )
+                .join("")}
+            </ul>
+            <p><strong>Cash vs accrual:</strong> ${basCtx.cashVsAccrual}</p>
+            <p><strong>Deferred GST (DGST):</strong> ${basCtx.dgst}</p>
+          `
+        }
+      ];
+
       return `
-        ${this.nav('settings')}
+        ${this.nav("help")}
+        <div class="help-wrapper">
+          <aside class="card help-sidebar">
+            <h3>Help & Guidance</h3>
+            <ul>
+              ${sections
+                .map(
+                  (s) => `
+                    <li><a class="${section === s.id ? "active" : ""}" href="#/help/${s.id}">${s.title}</a></li>
+                  `
+                )
+                .join("")}
+            </ul>
+          </aside>
+          <div class="card help-content">
+            ${sections
+              .map(
+                (s) => `
+                  <article id="help-${s.id}" data-help-section="${s.id}" class="help-section ${section === s.id ? "active" : ""}">
+                    <h4>${s.title}</h4>
+                    ${s.body}
+                  </article>
+                `
+              )
+              .join("")}
+          </div>
+        </div>
+      `;
+    },
+
+    settings() {
+      return `
+        ${this.nav("settings")}
         <div class="grid" style="grid-template-columns:1fr 1fr; margin-top:12px">
           <div class="card">
             <h3>Appearance</h3>
@@ -167,100 +457,190 @@
     }
   };
 
-  async function wire(view) {
-    if (view==='home') {
-      $('#btnReady')?.addEventListener('click', async () => {
-        const pre = $('#svcOut'); pre.textContent = 'Checking...';
-        try { const r = await fetch(base+'/readyz'); pre.textContent = 'HTTP ' + r.status; } catch { pre.textContent = 'Unreachable'; }
-      });
-      $('#btnMetrics')?.addEventListener('click', async () => {
-        const pre = $('#svcOut'); pre.textContent = 'Loading metrics...';
-        try { pre.textContent = await (await fetch(base+'/metrics')).text(); } catch { pre.textContent = 'Failed'; }
-      });
-      $('#btnUpload')?.addEventListener('click', async () => {
-        const f = $('#file').files[0], out = $('#normOut'); if(!f){ alert('Choose a file'); return; }
-        const text = await f.text();
-        const payload = text.trim().startsWith('{') || text.trim().startsWith('[') ? JSON.parse(text) : { csv: text };
-        out.textContent = 'Uploading...';
+  async function wire(view, ctx = {}) {
+    if (view === "home") {
+      $("#btnReady")?.addEventListener("click", async () => {
+        const pre = $("#svcOut");
+        pre.textContent = "Checking...";
         try {
-          const res = await api('/normalize', { method:'POST', body: JSON.stringify(payload) });
-          out.textContent = JSON.stringify(res, null, 2);
-        } catch(e){ out.textContent = 'Failed: ' + e.message; }
+          const r = await fetch(base + "/readyz");
+          pre.textContent = "HTTP " + r.status;
+        } catch {
+          pre.textContent = "Unreachable";
+        }
       });
-      try { const y = await api('/dashboard/yesterday'); $('#yesterday').textContent = JSON.stringify(y); } catch { $('#yesterday').textContent='N/A'; }
+      $("#btnMetrics")?.addEventListener("click", async () => {
+        const pre = $("#svcOut");
+        pre.textContent = "Loading metrics...";
+        try {
+          pre.textContent = await (await fetch(base + "/metrics")).text();
+        } catch {
+          pre.textContent = "Failed";
+        }
+      });
+      $("#btnUpload")?.addEventListener("click", async () => {
+        const f = $("#file").files[0];
+        const out = $("#normOut");
+        if (!f) {
+          alert("Choose a file");
+          return;
+        }
+        const text = await f.text();
+        const payload =
+          text.trim().startsWith("{") || text.trim().startsWith("[")
+            ? JSON.parse(text)
+            : { csv: text };
+        out.textContent = "Uploading...";
+        try {
+          const res = await api("/normalize", { method: "POST", body: JSON.stringify(payload) });
+          out.textContent = JSON.stringify(res, null, 2);
+        } catch (e) {
+          out.textContent = "Failed: " + e.message;
+        }
+      });
+      try {
+        const y = await api("/dashboard/yesterday");
+        $("#yesterday").textContent = JSON.stringify(y);
+      } catch {
+        $("#yesterday").textContent = "N/A";
+      }
     }
 
-    if (view==='connections') {
-      async function loadList(){
-        const rows = await api('/connections');
-        const tb = $('#connTable tbody'); tb.innerHTML = '';
-        rows.forEach(x=>{
-          const tr = document.createElement('tr');
+    if (view === "connections") {
+      async function loadList() {
+        const rows = await api("/connections");
+        const tb = $("#connTable tbody");
+        tb.innerHTML = "";
+        rows.forEach((x) => {
+          const tr = document.createElement("tr");
           tr.innerHTML = `<td>${x.type}</td><td>${x.provider}</td><td>${x.status}</td><td><button class="btn" data-id="${x.id}">Remove</button></td>`;
           tb.appendChild(tr);
         });
-        tb.querySelectorAll('button').forEach(btn=>{
-          btn.onclick = async () => { await api(`/connections/${btn.dataset.id}`, { method:'DELETE' }); loadList(); };
+        tb.querySelectorAll("button").forEach((btn) => {
+          btn.onclick = async () => {
+            await api(`/connections/${btn.dataset.id}`, { method: "DELETE" });
+            loadList();
+          };
         });
       }
-      $('#btnConnect').onclick = async () => {
-        $('#connMsg').textContent = 'Starting connection...';
-        const type = $('#connType').value, provider = $('#provider').value;
+      $("#btnConnect").onclick = async () => {
+        $("#connMsg").textContent = "Starting connection...";
+        const type = $("#connType").value;
+        const provider = $("#provider").value;
         try {
-          const { url } = await api('/connections/start', { method:'POST', body: JSON.stringify({ type, provider }) });
-          $('#connMsg').innerHTML = `Open auth window: <a target="_blank" href="${url}">${url}</a>`;
-        } catch(e){ $('#connMsg').textContent = 'Failed: ' + e.message; }
+          const { url } = await api("/connections/start", {
+            method: "POST",
+            body: JSON.stringify({ type, provider })
+          });
+          $("#connMsg").innerHTML = `Open auth window: <a target="_blank" rel="noopener" href="${url}">${url}</a>`;
+        } catch (e) {
+          $("#connMsg").textContent = "Failed: " + e.message;
+        }
       };
       loadList();
     }
 
-    if (view==='transactions') {
+    if (view === "transactions") {
       async function load() {
-        const q = $('#q').value, src = $('#filterSource').value;
-        const data = await api(`/transactions?q=${encodeURIComponent(q||'')}&source=${encodeURIComponent(src||'')}`);
-        const tb = $('#txTable tbody'); tb.innerHTML='';
-        data.items.forEach(t=>{
-          const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${t.date}</td><td>${t.source}</td><td>${t.description}</td><td style="text-align:right">${t.amount.toFixed(2)}</td><td>${t.category||''}</td>`;
+        const q = $("#q").value;
+        const src = $("#filterSource").value;
+        const data = await api(`/transactions?q=${encodeURIComponent(q || "")}&source=${encodeURIComponent(src || "")}`);
+        const tb = $("#txTable tbody");
+        tb.innerHTML = "";
+        data.items.forEach((t) => {
+          const tr = document.createElement("tr");
+          tr.innerHTML = `<td>${t.date}</td><td>${t.source}</td><td>${t.description}</td><td style="text-align:right">${t.amount.toFixed(2)}</td><td>${t.category || ""}</td>`;
           tb.appendChild(tr);
         });
-        const sel = $('#filterSource'); sel.innerHTML = '<option value="">All sources</option>';
-        data.sources.forEach(s=>{ const o = document.createElement('option'); o.value=s; o.textContent=s; sel.appendChild(o); });
+        const sel = $("#filterSource");
+        sel.innerHTML = '<option value="">All sources</option>';
+        data.sources.forEach((s) => {
+          const o = document.createElement("option");
+          o.value = s;
+          o.textContent = s;
+          sel.appendChild(o);
+        });
       }
-      $('#btnRefresh').onclick = load;
+      $("#btnRefresh").onclick = load;
       load();
     }
 
-    if (view==='tax-bas') {
-      $('#btnPreviewBas').onclick = async () => {
-        const out = $('#basOut'); out.textContent='Calculating...';
-        try { out.textContent = JSON.stringify(await api('/bas/preview'), null, 2); } catch(e){ out.textContent='Failed: '+e.message; }
+    if (view === "tax-bas") {
+      $("#btnPreviewBas").onclick = async () => {
+        const out = $("#basOut");
+        out.textContent = "Calculating...";
+        try {
+          out.textContent = JSON.stringify(await api("/bas/preview"), null, 2);
+        } catch (e) {
+          out.textContent = "Failed: " + e.message;
+        }
       };
-      $('#btnValidateBas').onclick = async () => { $('#lodgeMsg').textContent = 'Validating with ATO...'; try{ await api('/bas/validate', { method:'POST' }); $('#lodgeMsg').textContent='Validated'; } catch(e){ $('#lodgeMsg').textContent='Failed: '+e.message; } };
-      $('#btnLodgeBas').onclick = async () => { $('#lodgeMsg').textContent = 'Lodging with ATO...'; try{ await api('/bas/lodge', { method:'POST' }); $('#lodgeMsg').textContent='Lodged'; } catch(e){ $('#lodgeMsg').textContent='Failed: '+e.message; } };
-      try{ $('#atoStatus').textContent = (await api('/ato/status')).status; }catch{ $('#atoStatus').textContent='Unavailable'; }
+      $("#btnValidateBas").onclick = async () => {
+        $("#lodgeMsg").textContent = "Validating with ATO...";
+        try {
+          await api("/bas/validate", { method: "POST" });
+          $("#lodgeMsg").textContent = "Validated";
+        } catch (e) {
+          $("#lodgeMsg").textContent = "Failed: " + e.message;
+        }
+      };
+      $("#btnLodgeBas").onclick = async () => {
+        $("#lodgeMsg").textContent = "Lodging with ATO...";
+        try {
+          await api("/bas/lodge", { method: "POST" });
+          $("#lodgeMsg").textContent = "Lodged";
+        } catch (e) {
+          $("#lodgeMsg").textContent = "Failed: " + e.message;
+        }
+      };
+      try {
+        $("#atoStatus").textContent = (await api("/ato/status")).status;
+      } catch {
+        $("#atoStatus").textContent = "Unavailable";
+      }
     }
 
-    if (view==='settings') {
-      $('#theme').value = (localStorage.getItem('theme') || 'light');
-      document.documentElement.classList.toggle('theme-dark', $('#theme').value==='dark');
-      $('#theme').addEventListener('change', e=>{
-        localStorage.setItem('theme', e.target.value);
-        document.documentElement.classList.toggle('theme-dark', e.target.value==='dark');
+    if (view === "help") {
+      const target = ctx.detail && ctx.detail[0];
+      if (target) {
+        const el = document.querySelector(`[data-help-section="${target}"]`);
+        if (el) {
+          el.classList.add("help-highlight");
+          setTimeout(() => el.classList.remove("help-highlight"), 1800);
+          el.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      }
+    }
+
+    if (view === "settings") {
+      $("#theme").value = localStorage.getItem("theme") || "light";
+      document.documentElement.classList.toggle("theme-dark", $("#theme").value === "dark");
+      $("#theme").addEventListener("change", (e) => {
+        localStorage.setItem("theme", e.target.value);
+        document.documentElement.classList.toggle("theme-dark", e.target.value === "dark");
       });
-      $('#btnSaveSettings').onclick = async ()=>{
-        const payload = { retentionMonths: parseInt($('#retention').value,10), piiMask: $('#pii').value==='on' };
-        $('#saveMsg').textContent='Saving...';
-        try{ await api('/settings', { method:'POST', body: JSON.stringify(payload) }); $('#saveMsg').textContent='Saved.'; }catch(e){ $('#saveMsg').textContent='Failed: '+e.message; }
+      $("#btnSaveSettings").onclick = async () => {
+        const payload = {
+          retentionMonths: parseInt($("#retention").value, 10),
+          piiMask: $("#pii").value === "on"
+        };
+        $("#saveMsg").textContent = "Saving...";
+        try {
+          await api("/settings", { method: "POST", body: JSON.stringify(payload) });
+          $("#saveMsg").textContent = "Saved.";
+        } catch (e) {
+          $("#saveMsg").textContent = "Failed: " + e.message;
+        }
       };
     }
   }
 
-  function render(){
-    const view = currentRoute();
-    const root = document.getElementById('app');
-    root.innerHTML = View[view] ? View[view]() : View.home();
-    wire(view);
+  function render() {
+    const { view, detail } = currentRoute();
+    const root = document.getElementById("app");
+    const html = View[view] ? View[view].call(View, { detail }) : View.home.call(View, { detail });
+    root.innerHTML = layout(html);
+    wire(view, { detail });
   }
 
   render();

--- a/apps/gui/config.js
+++ b/apps/gui/config.js
@@ -2,5 +2,90 @@ window.GUI_CONFIG = {
   brand: "APGMS Normalizer",
   title: "Customer Portal",
   baseUrl: "/api",
-  swaggerPath: "/api/openapi.json"
+  swaggerPath: "/api/openapi.json",
+  appMode: "Sandbox",
+  ratesVersion: "2025.2",
+  periodLabel: "July – September 2025",
+  rules: {
+    effectiveFrom: "2025-07-01",
+    effectiveTo: "2025-09-30",
+    period: "July – September 2025",
+    ratesVersion: "2025.2"
+  },
+  ruleSegments: [
+    {
+      label: "July-August 2025",
+      start: "2025-07-01",
+      end: "2025-08-31",
+      ratesVersion: "2025.1",
+      note: "Carry-over fuel tax credit rates remain in effect until 31 Aug."
+    },
+    {
+      label: "September 2025",
+      start: "2025-09-01",
+      end: "2025-09-30",
+      ratesVersion: "2025.2",
+      note: "Updated DGST recognition applies from 1 Sep."
+    }
+  ],
+  ruleUpdates: [
+    {
+      code: "DGST",
+      title: "DGST timing aligns with ICS statement date",
+      summary:
+        "Deferred GST is payable when the import declaration statement is issued. The goods arrival date no longer drives the period selection.",
+      effectiveFrom: "2025-09-01",
+      link: "https://www.ato.gov.au/Business/Deferred-GST-scheme/"
+    },
+    {
+      code: "BAS-BASIS",
+      title: "Clarified cash vs accrual mapping",
+      summary:
+        "Cash reporters capture GST when payments clear; accrual reporters capture GST when invoices issue. This banner reminds preparers which mode is active.",
+      effectiveFrom: "2025-07-01",
+      link: "https://www.ato.gov.au/Business/GST/Accounting-for-GST/Cash-and-accrual-accounting/"
+    }
+  ],
+  basContext: {
+    cashVsAccrual:
+      "Cash-basis reporters recognise GST when money is received or paid. Accrual-basis reporters recognise GST when the invoice is issued or received, even if payment happens later.",
+    dgst:
+      "Deferred GST (DGST) must be reported in the period that covers the Australian Border Force import declaration statement date, not the cargo arrival date.",
+    labels: [
+      {
+        code: "G1",
+        title: "Total sales",
+        description:
+          "Total taxable supplies including GST and exports (report GST-free amounts separately).",
+        link: "https://www.ato.gov.au/Business/Business-activity-statements-(BAS)/In-detail/BAS-Label-guides/G1-Total-sales/",
+        note: "Include cash or accrual timing in line with your accounting basis."
+      },
+      {
+        code: "W1",
+        title: "Total salary and wages",
+        description:
+          "Report gross payments subject to withholding (salary, wages, director fees).",
+        link: "https://www.ato.gov.au/Forms/How-to-complete-your-activity-statement/W1---total-salary-wages-and-other-payments/",
+        note: "Align PAYG withholding with the pay event period submitted to the ATO."
+      },
+      {
+        code: "1A",
+        title: "GST on sales",
+        description: "GST collected on taxable supplies for the period.",
+        link: "https://www.ato.gov.au/Business/Business-activity-statements-(BAS)/In-detail/BAS-Label-guides/1A-GST-on-sales/",
+        note: "Derive from G1 after excluding GST-free and input taxed amounts."
+      },
+      {
+        code: "DGST",
+        title: "Deferred GST",
+        description: "GST deferred at importation under the deferred GST scheme.",
+        link: "https://www.ato.gov.au/Business/Deferred-GST-scheme/",
+        note: "Report based on the Integrated Cargo System (ICS) deferred GST statement date."
+      }
+    ]
+  },
+  links: {
+    docs: "https://www.ato.gov.au/Business/",
+    taxRules: "#/help/tax-rules"
+  }
 };

--- a/apps/gui/start.sh
+++ b/apps/gui/start.sh
@@ -1,11 +1,30 @@
 #!/bin/sh
 set -eu
+RULE_SEGMENTS_JSON=${GUI_RULE_SEGMENTS_JSON:-'[{"label":"July-August 2025","start":"2025-07-01","end":"2025-08-31","ratesVersion":"2025.1","note":"Carry-over fuel tax credit rates remain in effect until 31 Aug."},{"label":"September 2025","start":"2025-09-01","end":"2025-09-30","ratesVersion":"2025.2","note":"Updated DGST recognition applies from 1 Sep."}]'}
+RULE_UPDATES_JSON=${GUI_RULE_UPDATES_JSON:-'[{"code":"DGST","title":"DGST timing aligns with ICS statement date","summary":"Deferred GST is payable when the import declaration statement is issued. The goods arrival date no longer drives the period selection.","effectiveFrom":"2025-09-01","link":"https://www.ato.gov.au/Business/Deferred-GST-scheme/"},{"code":"BAS-BASIS","title":"Clarified cash vs accrual mapping","summary":"Cash reporters capture GST when payments clear; accrual reporters capture GST when invoices issue. This banner reminds preparers which mode is active.","effectiveFrom":"2025-07-01","link":"https://www.ato.gov.au/Business/GST/Accounting-for-GST/Cash-and-accrual-accounting/"}]'}
+BAS_CONTEXT_JSON=${GUI_BAS_CONTEXT_JSON:-'{"cashVsAccrual":"Cash-basis reporters recognise GST when money is received or paid. Accrual-basis reporters recognise GST when the invoice is issued or received, even if payment happens later.","dgst":"Deferred GST (DGST) must be reported in the period that covers the Australian Border Force import declaration statement date, not the cargo arrival date.","labels":[{"code":"G1","title":"Total sales","description":"Total taxable supplies including GST and exports (report GST-free amounts separately).","link":"https://www.ato.gov.au/Business/Business-activity-statements-(BAS)/In-detail/BAS-Label-guides/G1-Total-sales/","note":"Include cash or accrual timing in line with your accounting basis."},{"code":"W1","title":"Total salary and wages","description":"Report gross payments subject to withholding (salary, wages, director fees).","link":"https://www.ato.gov.au/Forms/How-to-complete-your-activity-statement/W1---total-salary-wages-and-other-payments/","note":"Align PAYG withholding with the pay event period submitted to the ATO."},{"code":"1A","title":"GST on sales","description":"GST collected on taxable supplies for the period.","link":"https://www.ato.gov.au/Business/Business-activity-statements-(BAS)/In-detail/BAS-Label-guides/1A-GST-on-sales/","note":"Derive from G1 after excluding GST-free and input taxed amounts."},{"code":"DGST","title":"Deferred GST","description":"GST deferred at importation under the deferred GST scheme.","link":"https://www.ato.gov.au/Business/Deferred-GST-scheme/","note":"Report based on the Integrated Cargo System (ICS) deferred GST statement date."}]}'
 cat >/usr/share/nginx/html/config.js <<CFG
 window.GUI_CONFIG = {
   brand: "${GUI_BRAND:-APGMS Normalizer}",
   title: "${GUI_TITLE:-Customer Portal}",
   baseUrl: "${GUI_BASE_URL:-/api}",
-  swaggerPath: "${GUI_SWAGGER_PATH:-/api/openapi.json}"
+  swaggerPath: "${GUI_SWAGGER_PATH:-/api/openapi.json}",
+  appMode: "${APP_MODE:-Sandbox}",
+  ratesVersion: "${RATES_VERSION:-2025.2}",
+  periodLabel: "${PERIOD_LABEL:-July – September 2025}",
+  rules: {
+    effectiveFrom: "${RATES_EFFECTIVE_FROM:-2025-07-01}",
+    effectiveTo: "${RATES_EFFECTIVE_TO:-2025-09-30}",
+    period: "${PERIOD_LABEL:-July – September 2025}",
+    ratesVersion: "${RATES_VERSION:-2025.2}"
+  },
+  ruleSegments: JSON.parse('${RULE_SEGMENTS_JSON}'),
+  ruleUpdates: JSON.parse('${RULE_UPDATES_JSON}'),
+  basContext: JSON.parse('${BAS_CONTEXT_JSON}'),
+  links: {
+    docs: "${GUI_DOCS_LINK:-https://www.ato.gov.au/Business/}",
+    taxRules: "/help/tax-rules"
+  }
 };
 CFG
 exec nginx -g "daemon off;"

--- a/apps/gui/styles.css
+++ b/apps/gui/styles.css
@@ -16,3 +16,55 @@ table{ width:100%; border-collapse:collapse }
 th,td{ padding:8px; border-bottom:1px solid var(--border) }
 .kbd{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; background:var(--card); border:1px solid var(--border); border-radius:6px; padding:2px 6px }
 .footer{ margin-top:24px; color:var(--muted) }
+.mode-banner{display:flex;align-items:center;gap:12px;margin:12px 0;padding:10px 14px;border:1px solid var(--border);border-radius:12px;background:linear-gradient(135deg,rgba(16,185,129,0.12),rgba(16,185,129,0.05));flex-wrap:wrap}
+.mode-pill{display:inline-flex;align-items:center;justify-content:center;padding:6px 12px;border-radius:999px;background:var(--primary);color:#fff;font-weight:600;text-transform:uppercase;letter-spacing:0.05em}
+.mode-text{display:flex;flex-direction:column;gap:2px;min-width:180px}
+.mode-line{font-size:13px;color:var(--fg)}
+.mode-link{margin-left:auto;font-weight:600;color:var(--primary);text-decoration:none}
+.mode-link:hover,.mode-link:focus{ text-decoration:underline }
+
+.muted{color:var(--muted);font-size:13px;margin:4px 0}
+.badge{display:inline-flex;align-items:center;gap:4px;background:rgba(16,185,129,0.15);color:var(--primary);border-radius:999px;padding:2px 8px;font-size:12px;font-weight:600}
+.badge-new{display:inline-flex;align-items:center;justify-content:center;background:rgba(244,114,182,0.2);color:#be185d;border-radius:999px;padding:2px 8px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:0.04em;margin-right:6px}
+.external{color:var(--primary);text-decoration:none;font-weight:600}
+.external:hover,.external:focus{text-decoration:underline}
+
+.segment-list{display:flex;flex-direction:column;gap:10px;margin-top:12px}
+.segment-item{border:1px solid var(--border);border-radius:10px;padding:10px;background:rgba(15,118,110,0.05)}
+.segment-dates{font-weight:600;font-size:13px}
+.segment-meta{display:flex;gap:8px;flex-wrap:wrap;margin:4px 0;font-size:12px;color:var(--muted)}
+.segment-range{font-size:12px;color:var(--muted)}
+
+.whats-new{margin-top:16px;border-top:1px solid var(--border);padding-top:12px}
+.whats-new h4{margin:0 0 8px 0}
+.whats-new ul{list-style:none;padding:0;margin:0;display:flex;flex-direction:column;gap:12px}
+.whats-new-item{display:flex;gap:10px}
+.whats-new-title{font-weight:600}
+.whats-new-date{font-size:12px;color:var(--muted);margin-bottom:4px}
+
+.bas-labels{display:flex;flex-direction:column;gap:12px;margin:12px 0}
+.bas-label dt{display:flex;align-items:center;gap:8px;font-weight:600}
+.bas-label dd{margin:4px 0 0 0;padding:0 0 0 0}
+.bas-label dd p{margin:4px 0}
+.bas-hint{margin-top:10px;padding:10px;border:1px dashed var(--border);border-radius:10px;background:rgba(59,130,246,0.05);font-size:13px;color:var(--fg)}
+
+.help-wrapper{display:grid;grid-template-columns:220px minmax(0,1fr);gap:12px;margin-top:12px}
+.help-sidebar ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+.help-sidebar a{display:block;padding:8px 10px;border-radius:8px;text-decoration:none;color:var(--fg);font-weight:500}
+.help-sidebar a.active,.help-sidebar a:hover,.help-sidebar a:focus{background:var(--primary);color:#fff}
+.help-content{display:flex;flex-direction:column;gap:16px}
+.help-section{padding-bottom:12px;border-bottom:1px solid var(--border)}
+.help-section:last-of-type{border-bottom:none}
+.help-section.active h4{color:var(--primary)}
+.help-highlight{box-shadow:0 0 0 2px rgba(16,185,129,0.35);border-radius:12px}
+
+.help-bas-list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:10px}
+.help-bas-title{font-weight:600;margin-left:6px}
+.help-bas-desc{font-size:13px;color:var(--fg);margin-left:26px}
+.help-bas-note{font-size:12px;color:var(--muted);margin-left:26px}
+
+@media (max-width:900px){
+  .help-wrapper{grid-template-columns:1fr}
+  .mode-banner{flex-direction:column;align-items:flex-start}
+  .mode-link{margin-left:0}
+}


### PR DESCRIPTION
## Summary
- add a mode banner that surfaces the active filing mode, rates version, and deep-links to the tax rules help section
- extend the Tax & BAS view with contextual BAS label notes, GST timing tips, and a "What’s New" panel driven by configurable rule metadata
- refresh static and runtime GUI config to ship rule context defaults and allow container overrides, plus add styling for the new help layout

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e38c9921d88327934e0f99c26afc24