### PR TITLE
Add prototype compliance banner and DSP readiness docs

### DIFF
--- a/docs/dsp/access_review_checklist.md
+++ b/docs/dsp/access_review_checklist.md
@@ -1,0 +1,24 @@
+# Access Review Checklist (Prototype Environment)
+
+**Purpose:** Ensure that only authorized team members retain access to the APGMS sandbox while accreditation work is in progress.
+
+## Quarterly Review Steps
+1. Export current access lists from identity provider groups mapped to APGMS roles.
+2. Verify each user's business need with their manager and project sponsor.
+3. Confirm that offboarded staff have been removed from all groups and API credentials revoked.
+4. Document any exceptions with compensating controls and planned remediation dates.
+5. Capture reviewer signatures (digital acknowledgement is acceptable during prototype).
+
+## Roles in Scope
+- Platform Administrators
+- Compliance & Assurance Analysts
+- Support Engineers (Sandbox only)
+- Read-only Stakeholders participating in pilots
+
+## Evidence to Retain
+- Access export files (CSV or PDF)
+- Signed review checklist
+- Tickets created for remediation tasks
+- Updated roster of privileged users
+
+Status: **Prototype** – repeat the checklist monthly until DSP accreditation and production readiness are complete.

--- a/docs/dsp/incident_response_runbook.md
+++ b/docs/dsp/incident_response_runbook.md
@@ -1,0 +1,33 @@
+# Incident Response Runbook (Prototype)
+
+**Status:** Prototype – for readiness exercises only. Production activation is pending DSP accreditation and go-live approvals.
+
+## 1. Preparation
+- Maintain responder on-call roster covering engineering, security, and support roles.
+- Ensure contact details for ATO liaison officers and payroll partners are current.
+- Validate that sandbox logging and audit export pipelines are operational before exercises.
+
+## 2. Identification
+- Monitor security dashboards for anomaly alerts or manual reports from pilot participants.
+- Classify incidents using the DSP severity scale (Informational, Minor, Major, Critical).
+- Open an incident record in the operations tracker and assign an incident commander.
+
+## 3. Containment
+- For data integrity concerns, freeze affected workflows in the sandbox environment.
+- Rotate sandbox credentials and revoke API keys related to the affected integration.
+- Preserve forensic data (logs, evidence exports) in the read-only archive bucket.
+
+## 4. Eradication & Recovery
+- Patch or reconfigure affected services in the non-production environment first.
+- Validate fixes via regression tests, then re-enable suspended integrations.
+- Document actions taken, residual risks, and verification results in the incident record.
+
+## 5. Post-Incident Activities
+- Conduct a retrospective within 5 business days with engineering, compliance, and product leads.
+- Capture follow-up actions with owners and due dates; track them to completion.
+- Update control documentation and DSP accreditation evidence packs with lessons learned.
+
+## 6. Communication Plan
+- Notify pilot customers and internal executives according to severity thresholds.
+- Provide status updates to the ATO DSP program manager when incidents are classified as Major or higher.
+- Publish a sanitized summary in the readiness log once remediation actions are closed.

--- a/docs/dsp/privacy_impact_assessment.md
+++ b/docs/dsp/privacy_impact_assessment.md
@@ -1,0 +1,29 @@
+# Privacy Impact Assessment Summary
+
+**Solution status:** Prototype – personal information handling controls are in validation and subject to change before production release.
+
+## Overview
+APGMS processes payroll, PAYGW, and GST remittance data provided by participating employers. The system currently operates in a controlled sandbox with synthetic or consented pilot data while accreditation tasks are underway.
+
+## Data Inventory
+- Employee identifiers (name, TFN surrogate, payroll identifiers)
+- Employer contact information and banking details
+- Payroll amounts, PAYGW calculations, GST obligations, lodgment history
+
+## Collection & Use
+Data is collected from employer source systems through secure API uploads. It is used to simulate withholding calculations, remittance scheduling, and BAS preparation workflows for evaluation purposes.
+
+## Storage & Security
+Sandbox infrastructure uses encrypted storage and isolated network segments. Access is restricted to the delivery team under least-privilege roles. Production-grade key management and monitoring will be activated once DSP accreditation is achieved.
+
+## Privacy Risks & Mitigations
+| Risk | Current Mitigation | Planned Enhancement |
+| --- | --- | --- |
+| Unauthorized access to pilot data | Role-based access and environment segregation | Roll out centralized identity with conditional access policies |
+| Data retention beyond evaluation needs | Manual retention reviews prior to quarterly clean-up | Automate retention with policy enforcement jobs and evidence logging |
+| Inaccurate consent tracking | Pilot agreements stored with project governance records | Integrate consent registry API and automate participant notifications |
+
+## Next Steps
+- Finalize records of processing for DSP submission
+- Complete privacy training for support staff
+- Update assessment once the platform transitions into accredited production mode

--- a/docs/dsp/security_controls_matrix.md
+++ b/docs/dsp/security_controls_matrix.md
@@ -1,0 +1,13 @@
+# Security Controls Matrix
+
+The APGMS prototype implements baseline controls while the team prepares for DSP accreditation. This matrix documents the controls that exist today and the compensating actions planned for live operations.
+
+| Control Area | Implemented Safeguards | Planned Enhancements for DSP Sign-off |
+| --- | --- | --- |
+| Authentication & Access | Unique operator accounts with role-based views in the administrative portal. Credentials are managed through the platform's identity service with MFA enforced in integrated IdP environments. | Integrate the production IdP tenant, enable hardware token support, and complete penetration testing evidence. |
+| Data Protection | All payroll and remittance data is encrypted in transit via TLS 1.3 between clients and services. At rest, the prototype uses managed storage with disk-level encryption enabled. | Transition to dedicated KMS-backed envelope encryption for production data stores and document cryptographic key rotation schedule. |
+| Audit & Logging | The prototype captures user actions (approvals, data edits) in an immutable event stream stored in the audit service. Daily reviews are logged by operations. | Automate anomaly detection with alerting to the security operations queue and retain signed audit exports for 7 years. |
+| Infrastructure Hardening | Containers are built from hardened base images with vulnerability scanning. Runtime hosts receive weekly patch baselines. | Establish CIS benchmark automation for the production cluster and document evidence of quarterly review. |
+| Incident Response | A lightweight runbook is available to responders and tested during tabletop exercises. | Conduct a full failover test in the production environment and align roles with the finalized incident response runbook. |
+
+Status: **Prototype** – use only for internal evaluation until DSP accreditation is confirmed.

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import ModeBanner from "./ModeBanner";
+import { getComplianceCopy } from "../utils/compliance";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -14,12 +16,15 @@ const navLinks = [
 ];
 
 export default function AppLayout() {
+  const { subtitle, footer } = getComplianceCopy();
+
   return (
     <div>
+      <ModeBanner />
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>
-        <p>ATO-Compliant Tax Management System</p>
+        <p>{subtitle}</p>
         <nav style={{ marginTop: 16 }}>
           {navLinks.map((link) => (
             <NavLink
@@ -50,7 +55,7 @@ export default function AppLayout() {
       </main>
 
       <footer className="app-footer">
-        <p>© 2025 APGMS | Compliant with Income Tax Assessment Act 1997 & GST Act 1999</p>
+        <p>{footer}</p>
       </footer>
     </div>
   );

--- a/src/components/ModeBanner.tsx
+++ b/src/components/ModeBanner.tsx
@@ -1,0 +1,54 @@
+import React from "react";
+import { getComplianceState } from "../utils/compliance";
+
+const helpLinks = {
+  prototype: "/help#prototype-readiness",
+  rpt: "/help#realtime-payments-testing",
+  bas: "/help#bas-label-guidance",
+  release: "/help#release-controls",
+};
+
+export default function ModeBanner() {
+  const { showPrototypeBanner, dspOk } = getComplianceState();
+
+  if (!showPrototypeBanner) {
+    return null;
+  }
+
+  return (
+    <div
+      className="mode-banner"
+      style={{
+        backgroundColor: "#512da8",
+        color: "#fff",
+        padding: "8px 16px",
+        textAlign: "center",
+        fontSize: 14,
+      }}
+    >
+      <strong>Prototype:</strong>{" "}
+      Accreditation activities with the DSP program are in progress. Review the{" "}
+      <a href={helpLinks.prototype} style={{ color: "#ffe082", marginLeft: 4 }}>
+        readiness notes
+      </a>
+      ,{" "}
+      <a href={helpLinks.rpt} style={{ color: "#ffe082", marginLeft: 4 }}>
+        RPT guidance
+      </a>
+      ,{" "}
+      <a href={helpLinks.bas} style={{ color: "#ffe082", marginLeft: 4 }}>
+        BAS label mapping
+      </a>
+      , and{" "}
+      <a href={helpLinks.release} style={{ color: "#ffe082", marginLeft: 4 }}>
+        release controls
+      </a>{" "}
+      before relying on system outputs.
+      {!dspOk && (
+        <span style={{ display: "block", marginTop: 4 }}>
+          Use only with pilot data until DSP approval is confirmed.
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,39 +1,98 @@
 import React from 'react';
 
+const docLinks = {
+  securityMatrix: '/docs/dsp/security_controls_matrix.md',
+  privacyAssessment: '/docs/dsp/privacy_impact_assessment.md',
+  incidentRunbook: '/docs/dsp/incident_response_runbook.md',
+  accessChecklist: '/docs/dsp/access_review_checklist.md',
+};
+
 export default function Help() {
   return (
     <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Help & Guidance</h1>
+      <h1 className="text-2xl font-bold">Help &amp; Guidance</h1>
       <p className="text-sm text-muted-foreground">
-        Access support for PAYGW, GST, BAS and using this system.
+        Resources for operating the APGMS prototype while accreditation with the ATO DSP program is in progress.
       </p>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Getting Started</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Set up your buffer accounts and payment schedule in <strong>Settings</strong>.</li>
-          <li>Use the <strong>Wizard</strong> to define PAYGW and GST split rules.</li>
-          <li>Review <strong>Dashboard</strong> for current obligations and payment alerts.</li>
-          <li>Go to <strong>BAS</strong> to lodge your Business Activity Statement each quarter.</li>
+
+      <section id="prototype-readiness" className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">Prototype Readiness Checklist</h2>
+        <p className="text-sm">
+          Review the control documentation before onboarding additional pilot data sets.
+        </p>
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          <li>
+            <a className="text-blue-600" href={docLinks.securityMatrix}>
+              Security Controls Matrix
+            </a>{' '}
+            – current safeguards and remaining DSP actions.
+          </li>
+          <li>
+            <a className="text-blue-600" href={docLinks.privacyAssessment}>
+              Privacy Impact Assessment Summary
+            </a>{' '}
+            – data handling expectations for the sandbox.
+          </li>
+          <li>
+            <a className="text-blue-600" href={docLinks.incidentRunbook}>
+              Incident Response Runbook
+            </a>{' '}
+            – how to exercise the prototype response process.
+          </li>
+          <li>
+            <a className="text-blue-600" href={docLinks.accessChecklist}>
+              Access Review Checklist
+            </a>{' '}
+            – quarterly access validation steps.
+          </li>
         </ul>
-      </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">ATO Compliance</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Use one-way tax accounts to prevent accidental use of withheld/collected funds.</li>
-          <li>Audit trail with timestamped actions supports legal protection and evidence.</li>
-          <li>Helps avoid wind-up notices, director penalties, and late lodgment fines.</li>
+      </section>
+
+      <section id="realtime-payments-testing" className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">RPT Integration Guidance</h2>
+        <p className="text-sm">
+          Use the pilot RPT rail to validate payment messaging only. Do not route production funds until DSP clearance is confirmed.
+        </p>
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          <li>Generate synthetic payer data and approvals in the Wizard before running payment tests.</li>
+          <li>Limit pilot transfers to the sandbox clearing accounts documented in the onboarding pack.</li>
+          <li>Capture reconciliation outcomes and share anomalies with the compliance lead.</li>
         </ul>
-      </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Support Links</h2>
+      </section>
+
+      <section id="bas-label-guidance" className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">BAS Label Mapping</h2>
+        <p className="text-sm">
+          The BAS workspace provides draft totals for review. Operators must confirm each label before lodging externally.
+        </p>
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          <li>Label W1/W2 figures originate from payroll imports and manual adjustments logged in the audit trail.</li>
+          <li>Labels G1, G2, and G3 derive from sales entries; GST credits (labels G10/G11) require supporting documentation upload.</li>
+          <li>Use the variance view to compare current quarter drafts against historical BAS submissions.</li>
+        </ul>
+      </section>
+
+      <section id="release-controls" className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">Release Controls &amp; Change Management</h2>
+        <p className="text-sm">
+          Releases remain gated while accreditation tasks are underway. Follow these controls to avoid unintentionally promoting prototype code.
+        </p>
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          <li>Submit changes through the change management board with sandbox impact assessments.</li>
+          <li>Tag prototype builds clearly in the repository and deployment dashboard before sharing with stakeholders.</li>
+          <li>Run the incident response tabletop whenever a release alters payment or reporting workflows.</li>
+        </ul>
+      </section>
+
+      <section className="bg-card p-4 rounded-xl shadow space-y-2">
+        <h2 className="text-lg font-semibold">External References</h2>
         <ul className="list-disc pl-5 text-sm">
           <li><a className="text-blue-600" href="https://www.ato.gov.au/business/payg-withholding/">ATO PAYGW Guide</a></li>
           <li><a className="text-blue-600" href="https://www.ato.gov.au/business/gst/">ATO GST Information</a></li>
           <li><a className="text-blue-600" href="https://www.ato.gov.au/business/business-activity-statements-(bas)/">ATO BAS Portal</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/super-for-employers/">ATO Super Obligations</a></li>
           <li><a className="text-blue-600" href="https://www.ato.gov.au/General/Online-services/">ATO Online Services</a></li>
         </ul>
-      </div>
+      </section>
     </div>
   );
 }

--- a/src/utils/compliance.ts
+++ b/src/utils/compliance.ts
@@ -1,0 +1,108 @@
+export interface ComplianceState {
+  appMode: string;
+  dspOk: boolean;
+  showPrototypeBanner: boolean;
+}
+
+const truthyValues = new Set(["1", "true", "yes", "y", "on", "ok", "approved"]);
+const falsyValues = new Set(["0", "false", "no", "n", "off"]);
+
+function readGlobalKey(key: string): unknown {
+  if (typeof globalThis !== "undefined") {
+    const globalAny = globalThis as Record<string, unknown>;
+    if (globalAny[key] !== undefined) {
+      return globalAny[key];
+    }
+    if (globalAny.window && (globalAny.window as Record<string, unknown>)[key] !== undefined) {
+      return (globalAny.window as Record<string, unknown>)[key];
+    }
+    const processLike = (globalAny.process as { env?: Record<string, unknown> }) || undefined;
+    if (processLike?.env && processLike.env[key] !== undefined) {
+      return processLike.env[key];
+    }
+  }
+  return undefined;
+}
+
+function readEnvString(keys: string[], fallback?: string): string | undefined {
+  for (const key of keys) {
+    const value = readGlobalKey(key);
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      return String(value);
+    }
+  }
+  return fallback;
+}
+
+function readEnvBoolean(keys: string[], fallback = false): boolean {
+  for (const key of keys) {
+    const value = readGlobalKey(key);
+    if (value === undefined || value === null) {
+      continue;
+    }
+    if (typeof value === "boolean") {
+      return value;
+    }
+    const normalized = String(value).trim().toLowerCase();
+    if (truthyValues.has(normalized)) {
+      return true;
+    }
+    if (falsyValues.has(normalized)) {
+      return false;
+    }
+  }
+  return fallback;
+}
+
+export function getComplianceState(): ComplianceState {
+  const appMode = (readEnvString([
+    "APP_MODE",
+    "REACT_APP_APP_MODE",
+    "VITE_APP_MODE",
+    "NEXT_PUBLIC_APP_MODE",
+    "APP_STAGE",
+  ]) || "prototype").toLowerCase();
+
+  const dspOk = readEnvBoolean([
+    "DSP_OK",
+    "REACT_APP_DSP_OK",
+    "VITE_DSP_OK",
+    "NEXT_PUBLIC_DSP_OK",
+    "DSP_APPROVED",
+  ]);
+
+  const showPrototypeBanner = !(appMode === "real" && dspOk);
+
+  return {
+    appMode,
+    dspOk,
+    showPrototypeBanner,
+  };
+}
+
+export function getComplianceCopy(): {
+  subtitle: string;
+  footer: string;
+} {
+  const { dspOk, showPrototypeBanner } = getComplianceState();
+
+  if (dspOk && !showPrototypeBanner) {
+    return {
+      subtitle: "ATO-accredited deployment with DSP approvals in place.",
+      footer: "© 2025 APGMS | Accredited for Income Tax Assessment Act 1997 & GST Act 1999 obligations.",
+    };
+  }
+
+  return {
+    subtitle: "Prototype environment – workflows are for evaluation and accreditation preparation only.",
+    footer: "© 2025 APGMS | Prototype build pending DSP accreditation; do not rely on this system for statutory lodgments.",
+  };
+}


### PR DESCRIPTION
## Summary
- gate the app header/footer copy on DSP approval and surface a prototype-mode banner with help links
- extend the Help Center with prototype readiness, RPT, BAS label, and release control guidance
- add DSP accreditation preparation documents for security, privacy, incident response, and access reviews

## Testing
- not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e3933b0eec832788da4723d5520472