### PR TITLE
Document ML usage constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ End-to-end encryption (e.g., AES-256)
 
 Robust audit logs
 
+Machine Learning Usage Constraints
+To remain compliant with regulatory and security requirements, do **not**:
+
+- Use ML to compute PAYGW, GST, penalties, or PAYGI obligations; these calculations must stay deterministic and rule-based.
+- Auto-post ML-generated outputs to the ledger, gates, or evidence repositories without a human confirming the action.
+- Store raw documents or personally identifiable information in ML systems beyond what is essential for feature engineering.
+
 License
 Open source under the MIT License.
 


### PR DESCRIPTION
## Summary
- add guidance on ML usage constraints covering deterministic tax calculations, human confirmation, and data handling limits

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e395c945ac83279dd9935cc6a8419c