### PR TITLE
Add invoice ingestion ML pipeline with GST suggestions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Audit from "./pages/Audit";
 import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
+import InvoiceIngest from "./pages/InvoiceIngest";
 
 export default function App() {
   return (
@@ -24,6 +25,7 @@ export default function App() {
           <Route path="/audit" element={<Audit />} />
           <Route path="/fraud" element={<Fraud />} />
           <Route path="/integrations" element={<Integrations />} />
+          <Route path="/invoice-ingest" element={<InvoiceIngest />} />
           <Route path="/help" element={<Help />} />
         </Route>
       </Routes>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -10,6 +10,7 @@ const navLinks = [
   { to: "/audit", label: "Audit" },
   { to: "/fraud", label: "Fraud" },
   { to: "/integrations", label: "Integrations" },
+  { to: "/invoice-ingest", label: "Invoice OCR" },
   { to: "/help", label: "Help" },
 ];
 

--- a/src/index.css
+++ b/src/index.css
@@ -197,3 +197,25 @@ th {
   font-weight: 600;
   color: #00205b;
 }
+
+.suggestion-table tr.applied {
+  background: #ecfdf5;
+}
+
+.suggestion-table textarea,
+.suggestion-table input {
+  font-family: inherit;
+}
+
+.suggestion-table button {
+  background: #00205b;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.suggestion-table button:hover {
+  background: #01348f;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { mlRouter } from "./routes/ml";
 
 dotenv.config();
 
@@ -27,6 +28,9 @@ app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+
+// Machine learning ingestion endpoints
+app.use("/ml", mlRouter);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/ml/ner.ts
+++ b/src/ml/ner.ts
@@ -1,0 +1,89 @@
+import { InvoiceLineSuggestion, OcrLine } from "./types";
+
+interface CategoryRule {
+  label: "taxable" | "exempt";
+  rate: number;
+  keywords: string[];
+  confidence: number;
+  rationale: string;
+}
+
+const CATEGORY_RULES: CategoryRule[] = [
+  {
+    label: "exempt",
+    rate: 0,
+    keywords: ["water", "fresh fruit", "bread", "basic food", "medical", "rent"],
+    confidence: 0.9,
+    rationale: "Matches GST-exempt essentials keyword",
+  },
+  {
+    label: "taxable",
+    rate: 0.1,
+    keywords: ["service", "consulting", "labour", "maintenance", "subscription"],
+    confidence: 0.75,
+    rationale: "Professional services attract 10% GST",
+  },
+  {
+    label: "taxable",
+    rate: 0.1,
+    keywords: ["alcohol", "beer", "wine", "spirits"],
+    confidence: 0.85,
+    rationale: "Alcoholic beverages GST at standard rate",
+  },
+  {
+    label: "taxable",
+    rate: 0.1,
+    keywords: ["software", "saas", "licence", "license"],
+    confidence: 0.8,
+    rationale: "Digital products taxed at 10%",
+  },
+];
+
+const DEFAULT_RATE = 0.1;
+const DEFAULT_CONFIDENCE = 0.5;
+
+export function inferSuggestions(lines: OcrLine[]): InvoiceLineSuggestion[] {
+  return lines.map((line) => {
+    const { amount, normalized } = extractAmount(line.text);
+    const keywordMatch = matchRule(normalized);
+
+    if (keywordMatch) {
+      return {
+        desc: normalized,
+        amount,
+        gstRateSuggested: keywordMatch.rule.rate,
+        confidence: Math.min(1, (line.confidence + keywordMatch.rule.confidence) / 2),
+        rationale: keywordMatch.rule.rationale,
+      };
+    }
+
+    return {
+      desc: normalized,
+      amount,
+      gstRateSuggested: amount === null ? null : DEFAULT_RATE,
+      confidence: Math.min(1, (line.confidence + DEFAULT_CONFIDENCE) / 2),
+      rationale: amount === null ? "Insufficient transactional detail" : "Default GST rate applied",
+    };
+  });
+}
+
+function matchRule(text: string): { rule: CategoryRule } | null {
+  const lower = text.toLowerCase();
+  for (const rule of CATEGORY_RULES) {
+    if (rule.keywords.some((kw) => lower.includes(kw))) {
+      return { rule };
+    }
+  }
+  return null;
+}
+
+function extractAmount(text: string): { amount: number | null; normalized: string } {
+  const match = text.match(/(-?\d+[\d,]*(?:\.\d{1,2})?)/);
+  if (!match) {
+    return { amount: null, normalized: text.trim() };
+  }
+  const amountStr = match[0].replace(/,/g, "");
+  const amount = Number.parseFloat(amountStr);
+  const normalized = text.replace(match[0], "").replace(/\s+/g, " ").trim();
+  return { amount: Number.isFinite(amount) ? amount : null, normalized: normalized || text.trim() };
+}

--- a/src/ml/ocr.ts
+++ b/src/ml/ocr.ts
@@ -1,0 +1,139 @@
+import { spawn } from "child_process";
+import { tmpdir } from "os";
+import { promises as fs } from "fs";
+import { join } from "path";
+import { OcrLine } from "./types";
+
+interface OcrEngine {
+  extractLines(buffer: Buffer, mime: string): Promise<OcrLine[]>;
+}
+
+class TesseractEngine implements OcrEngine {
+  async extractLines(buffer: Buffer, mime: string): Promise<OcrLine[]> {
+    // Tesseract does not read PDFs from stdin; if we detect a PDF we create a temp file.
+    const isPdf = mime === "application/pdf";
+
+    if (isPdf) {
+      const tmpFile = join(tmpdir(), `invoice-${Date.now()}.pdf`);
+      await fs.writeFile(tmpFile, buffer);
+      try {
+        return await this.runProcess(tmpFile);
+      } finally {
+        await fs.unlink(tmpFile).catch(() => undefined);
+      }
+    }
+
+    return await this.runProcess(buffer);
+  }
+
+  private runProcess(input: Buffer | string): Promise<OcrLine[]> {
+    return new Promise((resolve, reject) => {
+      const proc = spawn("tesseract", ["stdin", "stdout", "-l", "eng", "--psm", "6"], {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+
+      const chunks: Buffer[] = [];
+      proc.stdout.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+
+      let stderr = "";
+      proc.stderr.on("data", (chunk) => {
+        stderr += chunk.toString();
+      });
+
+      let settled = false;
+      const finish = (fn: () => void) => {
+        if (!settled) {
+          settled = true;
+          fn();
+        }
+      };
+
+      proc.on("error", (err) => finish(() => reject(err)));
+
+      proc.on("close", (code) => {
+        finish(() => {
+          if (code !== 0) {
+            return reject(new Error(`tesseract exited with code ${code}: ${stderr}`));
+          }
+          const text = Buffer.concat(chunks).toString("utf8");
+          resolve(
+            text
+              .split(/\r?\n/)
+              .map((line) => line.trim())
+              .filter(Boolean)
+              .map((line) => ({ text: line, confidence: 0.7 }))
+          );
+        });
+      });
+
+      if (typeof input === "string") {
+        fs.readFile(input)
+          .then((data) => {
+            proc.stdin.write(data);
+            proc.stdin.end();
+          })
+          .catch((err) => {
+            finish(() => reject(err));
+            proc.kill();
+          });
+      } else {
+        proc.stdin.write(input);
+        proc.stdin.end();
+      }
+    });
+  }
+}
+
+class FallbackEngine implements OcrEngine {
+  async extractLines(buffer: Buffer, _mime: string): Promise<OcrLine[]> {
+    const text = buffer.toString("utf8");
+    const lines = text
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+
+    return lines.map((line) => ({ text: line, confidence: 0.4 }));
+  }
+}
+
+let cachedEngine: OcrEngine | null = null;
+
+export async function extractOcrLines(buffer: Buffer, mime: string): Promise<OcrLine[]> {
+  if (!cachedEngine) {
+    cachedEngine = await resolveEngine();
+  }
+  return cachedEngine.extractLines(buffer, mime);
+}
+
+async function resolveEngine(): Promise<OcrEngine> {
+  try {
+    await assertTesseract();
+    return new TesseractEngine();
+  } catch (err) {
+    console.warn("[ml] Falling back to text OCR engine:", err);
+    return new FallbackEngine();
+  }
+}
+
+async function assertTesseract(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const proc = spawn("tesseract", ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (!settled) {
+        settled = true;
+        fn();
+      }
+    };
+    proc.on("error", (err) => finish(() => reject(err)));
+    proc.on("close", (code) => {
+      finish(() => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error("tesseract not available"));
+        }
+      });
+    });
+  });
+}

--- a/src/ml/pipeline.ts
+++ b/src/ml/pipeline.ts
@@ -1,0 +1,27 @@
+import { extractOcrLines } from "./ocr";
+import { inferSuggestions } from "./ner";
+import { persistDerivedFeatures } from "./store";
+import { InvoiceIngestRequest, InvoiceIngestResponse } from "./types";
+
+export async function ingestInvoice(request: InvoiceIngestRequest): Promise<InvoiceIngestResponse> {
+  const buffer = Buffer.from(request.content, "base64");
+  const ocrLines = await extractOcrLines(buffer, request.mime);
+  const suggestions = inferSuggestions(ocrLines);
+  const sanitized = suggestions.map((suggestion) => ({
+    ...suggestion,
+    desc: stripPiiTokens(suggestion.desc),
+  }));
+  persistDerivedFeatures(request.doc_id, sanitized);
+  return {
+    lines: sanitized,
+    advisory: true,
+  };
+}
+
+function stripPiiTokens(text: string): string {
+  return text
+    .replace(/\b\d{3}[- ]?\d{3}[- ]?\d{3}\b/g, "[ABN]")
+    .replace(/\b\d{2,3}[- ]?\d{3}[- ]?\d{3}\b/g, "[PHONE]")
+    .replace(/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi, "[EMAIL]")
+    .trim();
+}

--- a/src/ml/store.ts
+++ b/src/ml/store.ts
@@ -1,0 +1,31 @@
+import crypto from "crypto";
+import { InvoiceLineSuggestion } from "./types";
+
+interface StoredFeature {
+  docHash: string;
+  lineHash: string;
+  gstRateSuggested: number | null;
+  hasAmount: boolean;
+}
+
+const featureStore: StoredFeature[] = [];
+
+export function persistDerivedFeatures(docId: string, suggestions: InvoiceLineSuggestion[]): void {
+  const docHash = hash(docId);
+  for (const suggestion of suggestions) {
+    featureStore.push({
+      docHash,
+      lineHash: hash(suggestion.desc),
+      gstRateSuggested: suggestion.gstRateSuggested,
+      hasAmount: suggestion.amount !== null,
+    });
+  }
+}
+
+export function getFeatureStoreSnapshot(): StoredFeature[] {
+  return [...featureStore];
+}
+
+function hash(value: string | null | undefined): string {
+  return crypto.createHash("sha256").update(String(value ?? ""), "utf8").digest("hex");
+}

--- a/src/ml/types.ts
+++ b/src/ml/types.ts
@@ -1,0 +1,23 @@
+export interface OcrLine {
+  text: string;
+  confidence: number;
+}
+
+export interface InvoiceLineSuggestion {
+  desc: string;
+  amount: number | null;
+  gstRateSuggested: number | null;
+  confidence: number;
+  rationale?: string;
+}
+
+export interface InvoiceIngestRequest {
+  doc_id: string;
+  mime: string;
+  content: string; // base64 encoded
+}
+
+export interface InvoiceIngestResponse {
+  lines: InvoiceLineSuggestion[];
+  advisory: true;
+}

--- a/src/pages/InvoiceIngest.tsx
+++ b/src/pages/InvoiceIngest.tsx
@@ -1,0 +1,228 @@
+import React, { useMemo, useState } from "react";
+
+interface LineSuggestion {
+  desc: string;
+  amount: number | null;
+  gstRateSuggested: number | null;
+  confidence: number;
+  rationale?: string;
+  applied?: boolean;
+}
+
+interface ApiResponse {
+  lines: LineSuggestion[];
+  advisory: boolean;
+}
+
+export default function InvoiceIngest() {
+  const [file, setFile] = useState<File | null>(null);
+  const [suggestions, setSuggestions] = useState<LineSuggestion[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [advisory, setAdvisory] = useState(false);
+
+  const docId = useMemo(() => {
+    if (!file) return `invoice-${Date.now()}`;
+    return `${file.name}-${Date.now()}`;
+  }, [file]);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!file) {
+      setError("Upload an invoice PDF or image first.");
+      return;
+    }
+
+    setLoading(true);
+    setError(null);
+    setSuggestions([]);
+
+    try {
+      const payload = await buildPayload(file, docId);
+      const response = await fetch("/ml/ingest/invoice", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Server responded with ${response.status}`);
+      }
+
+      const data = (await response.json()) as ApiResponse;
+      setSuggestions(data.lines.map((line) => ({ ...line, applied: false })));
+      setAdvisory(Boolean(data.advisory));
+    } catch (err) {
+      console.error(err);
+      setError(err instanceof Error ? err.message : "Failed to ingest invoice");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleApply(index: number) {
+    setSuggestions((prev) =>
+      prev.map((line, i) =>
+        i === index
+          ? {
+              ...line,
+              applied: true,
+            }
+          : line
+      )
+    );
+  }
+
+  function handleFieldChange<T extends keyof LineSuggestion>(
+    index: number,
+    field: T,
+    value: LineSuggestion[T]
+  ) {
+    setSuggestions((prev) =>
+      prev.map((line, i) =>
+        i === index
+          ? {
+              ...line,
+              [field]: value,
+              applied: field === "applied" ? value : false,
+            }
+          : line
+      )
+    );
+  }
+
+  return (
+    <section>
+      <h2>Invoice OCR &amp; GST Coding Assistant</h2>
+      <p style={{ maxWidth: 720 }}>
+        Upload supplier invoices to pre-fill GST treatment per line. OCR (Tesseract)
+        and lightweight NER heuristics identify taxable vs exempt items. Operator
+        confirmation is still required before posting to ledgers.
+      </p>
+
+      <form onSubmit={handleSubmit} style={{ marginTop: 20, marginBottom: 32 }}>
+        <label style={{ display: "block", marginBottom: 12 }}>
+          <strong>Invoice document</strong>
+          <input
+            type="file"
+            accept="application/pdf,image/png,image/jpeg,image/tiff"
+            onChange={(event) => {
+              const next = event.target.files?.[0] ?? null;
+              setFile(next);
+            }}
+            style={{ display: "block", marginTop: 8 }}
+          />
+        </label>
+        <button type="submit" disabled={loading || !file}>
+          {loading ? "Processing…" : "Ingest invoice"}
+        </button>
+      </form>
+
+      {error && (
+        <div style={{ color: "#b00020", marginBottom: 16 }}>
+          <strong>Unable to ingest:</strong> {error}
+        </div>
+      )}
+
+      {advisory && suggestions.length > 0 && (
+        <div style={{ marginBottom: 16, color: "#2563eb" }}>
+          Advisory only — operator confirmation required before any ledger action.
+        </div>
+      )}
+
+      {suggestions.length > 0 && (
+        <table className="suggestion-table">
+          <thead>
+            <tr>
+              <th>Description</th>
+              <th>Amount</th>
+              <th>GST Rate</th>
+              <th>Confidence</th>
+              <th>Rationale</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody>
+            {suggestions.map((line, index) => (
+              <tr key={`${line.desc}-${index}`} className={line.applied ? "applied" : undefined}>
+                <td style={{ minWidth: 220 }}>
+                  <textarea
+                    value={line.desc}
+                    onChange={(event) => handleFieldChange(index, "desc", event.target.value)}
+                    rows={2}
+                    style={{ width: "100%" }}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={line.amount ?? ""}
+                    onChange={(event) =>
+                      handleFieldChange(
+                        index,
+                        "amount",
+                        event.target.value === "" ? null : Number(event.target.value)
+                      )
+                    }
+                    step="0.01"
+                    min="0"
+                    style={{ width: 100 }}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="number"
+                    value={line.gstRateSuggested ?? ""}
+                    onChange={(event) =>
+                      handleFieldChange(
+                        index,
+                        "gstRateSuggested",
+                        event.target.value === "" ? null : Number(event.target.value)
+                      )
+                    }
+                    step="0.01"
+                    min="0"
+                    max="1"
+                    style={{ width: 80 }}
+                  />
+                </td>
+                <td>{(line.confidence * 100).toFixed(0)}%</td>
+                <td style={{ maxWidth: 200 }}>{line.rationale ?? "Default"}</td>
+                <td>
+                  {line.applied ? (
+                    <span style={{ color: "#16a34a" }}>Applied</span>
+                  ) : (
+                    <button type="button" onClick={() => handleApply(index)}>
+                      Apply suggestion
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  );
+}
+
+async function buildPayload(file: File, docId: string) {
+  const buffer = await file.arrayBuffer();
+  const base64 = arrayBufferToBase64(buffer);
+  return {
+    doc_id: docId,
+    mime: file.type || "application/octet-stream",
+    content: base64,
+  };
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}

--- a/src/routes/ml.ts
+++ b/src/routes/ml.ts
@@ -1,0 +1,19 @@
+import express from "express";
+import { ingestInvoice } from "../ml/pipeline";
+import { InvoiceIngestRequest } from "../ml/types";
+
+export const mlRouter = express.Router();
+
+mlRouter.post("/ingest/invoice", async (req, res) => {
+  try {
+    const body = req.body as Partial<InvoiceIngestRequest>;
+    if (!body?.doc_id || !body?.mime || !body?.content) {
+      return res.status(400).json({ error: "doc_id, mime and content are required" });
+    }
+    const response = await ingestInvoice(body as InvoiceIngestRequest);
+    res.json(response);
+  } catch (err) {
+    console.error("[ml] ingest invoice failed", err);
+    res.status(500).json({ error: "Failed to ingest invoice" });
+  }
+});


### PR DESCRIPTION
## Summary
- add an OCR/NER ingestion pipeline for invoices including privacy-conscious storage and a `/ml/ingest/invoice` endpoint
- surface invoice GST suggestions in the SPA with an operator review workflow and navigation entry
- update styling for the new invoice suggestion table

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e3953a650c83278e246f43d1ae08e3