### PR TITLE
Add unsupervised payment anomaly detection endpoint and UI

### DIFF
--- a/src/anomaly/featureEngineering.ts
+++ b/src/anomaly/featureEngineering.ts
@@ -1,0 +1,181 @@
+import { NumericVector } from "./isolationForest";
+
+export interface ReconEventInput {
+  id: unknown;
+  amount: unknown;
+  hour_of_day: unknown;
+  day_of_week: unknown;
+  channel: unknown;
+  payer_hash: unknown;
+  CRN_valid: unknown;
+  period_state: unknown;
+}
+
+export interface PreparedReconEvent {
+  id: string;
+  vector: NumericVector;
+  features: {
+    amount: number;
+    hour_of_day: number;
+    day_of_week: number;
+    channel: string;
+    payer_hash: string;
+    CRN_valid: boolean;
+    period_state: string;
+  };
+  duplicateKey: string;
+}
+
+export function prepareReconEvents(events: ReconEventInput[]): PreparedReconEvent[] {
+  interface WorkingEvent {
+    id: string;
+    rawVector: NumericVector;
+    features: PreparedReconEvent["features"];
+    duplicateKey: string;
+  }
+
+  const cleaned: WorkingEvent[] = [];
+
+  for (const raw of events) {
+    if (!raw || typeof raw !== "object") {
+      continue;
+    }
+    const id = String((raw as { id?: unknown }).id ?? "").trim();
+    if (!id) {
+      continue;
+    }
+
+    const amount = toFiniteNumber((raw as { amount?: unknown }).amount);
+    const hour_of_day = clampInteger((raw as { hour_of_day?: unknown }).hour_of_day, 0, 23);
+    const day_of_week = clampInteger((raw as { day_of_week?: unknown }).day_of_week, 0, 6);
+    const channel = String((raw as { channel?: unknown }).channel ?? "unknown").trim() || "unknown";
+    const payer_hash = String((raw as { payer_hash?: unknown }).payer_hash ?? "unknown").trim() || "unknown";
+    const period_state = String((raw as { period_state?: unknown }).period_state ?? "unspecified").trim() || "unspecified";
+    const CRN_valid = toBoolean((raw as { CRN_valid?: unknown }).CRN_valid);
+
+    if (!Number.isFinite(amount) || hour_of_day === null || day_of_week === null) {
+      continue;
+    }
+
+    const rawVector: NumericVector = [
+      transformedAmount(amount),
+      hour_of_day,
+      day_of_week,
+      hashToUnit(channel),
+      hashToUnit(payer_hash),
+      CRN_valid ? 1 : 0,
+      hashToUnit(period_state),
+    ];
+
+    cleaned.push({
+      id,
+      rawVector,
+      features: { amount, hour_of_day, day_of_week, channel, payer_hash, CRN_valid, period_state },
+      duplicateKey: [
+        payer_hash,
+        channel,
+        period_state,
+        day_of_week,
+        hour_of_day,
+        roundKey(amount),
+        CRN_valid ? "1" : "0",
+      ].join("|"),
+    });
+  }
+
+  if (!cleaned.length) {
+    return [];
+  }
+
+  const scaled = scaleVectors(cleaned.map((row) => row.rawVector));
+  return cleaned.map((row, idx) => ({
+    id: row.id,
+    vector: scaled[idx],
+    features: row.features,
+    duplicateKey: row.duplicateKey,
+  }));
+}
+
+function scaleVectors(vectors: NumericVector[]): NumericVector[] {
+  if (!vectors.length) {
+    return [];
+  }
+  const dimension = vectors[0].length;
+  const minValues = new Array<number>(dimension).fill(Number.POSITIVE_INFINITY);
+  const maxValues = new Array<number>(dimension).fill(Number.NEGATIVE_INFINITY);
+
+  for (const row of vectors) {
+    for (let i = 0; i < dimension; i += 1) {
+      const value = row[i];
+      if (value < minValues[i]) minValues[i] = value;
+      if (value > maxValues[i]) maxValues[i] = value;
+    }
+  }
+
+  return vectors.map((row) =>
+    row.map((value, i) => {
+      const min = minValues[i];
+      const max = maxValues[i];
+      if (!Number.isFinite(min) || !Number.isFinite(max) || min === max) {
+        return 0.5;
+      }
+      return (value - min) / (max - min);
+    }),
+  );
+}
+
+function transformedAmount(amount: number): number {
+  const magnitude = Math.log10(Math.abs(amount) + 1);
+  return amount < 0 ? -magnitude : magnitude;
+}
+
+function toFiniteNumber(value: unknown): number | null {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return null;
+  }
+  return num;
+}
+
+function clampInteger(value: unknown, min: number, max: number): number | null {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    return null;
+  }
+  const rounded = Math.round(num);
+  if (rounded < min || rounded > max) {
+    return null;
+  }
+  return rounded;
+}
+
+function toBoolean(value: unknown): boolean {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    return value !== 0;
+  }
+  if (typeof value === "string") {
+    const lower = value.trim().toLowerCase();
+    return ["y", "yes", "1", "true", "valid"].includes(lower);
+  }
+  return false;
+}
+
+function hashToUnit(value: string): number {
+  let hash = 0;
+  for (let i = 0; i < value.length; i += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(i);
+    hash |= 0; // force 32-bit
+  }
+  const normalized = (hash >>> 0) % 10007;
+  return normalized / 10007;
+}
+
+function roundKey(amount: number): string {
+  return amount.toFixed(2);
+}

--- a/src/anomaly/isolationForest.ts
+++ b/src/anomaly/isolationForest.ts
@@ -1,0 +1,165 @@
+export type NumericVector = number[];
+
+interface IsolationForestOptions {
+  trees?: number;
+  sampleSize?: number;
+}
+
+interface TreeNode {
+  size?: number;
+  featureIndex?: number;
+  splitValue?: number;
+  left?: TreeNode;
+  right?: TreeNode;
+}
+
+export class IsolationForest {
+  private readonly trees: TreeNode[] = [];
+  private readonly treeCount: number;
+  private readonly requestedSampleSize: number;
+  private maxDepth = 0;
+  private normalizationFactor = 1;
+
+  constructor(options: IsolationForestOptions = {}) {
+    this.treeCount = Math.max(1, Math.floor(options.trees ?? 75));
+    this.requestedSampleSize = Math.max(2, Math.floor(options.sampleSize ?? 64));
+  }
+
+  fit(dataset: NumericVector[]): void {
+    if (!dataset.length) {
+      this.trees.length = 0;
+      this.normalizationFactor = 1;
+      return;
+    }
+
+    const sampleSize = Math.min(this.requestedSampleSize, dataset.length);
+    this.maxDepth = Math.ceil(Math.log2(sampleSize)) || 1;
+    this.normalizationFactor = this.c(sampleSize);
+
+    this.trees.length = 0;
+    for (let i = 0; i < this.treeCount; i += 1) {
+      const sample = this.randomSample(dataset, sampleSize);
+      this.trees.push(this.buildTree(sample, 0));
+    }
+  }
+
+  score(point: NumericVector): number {
+    if (!this.trees.length) {
+      return 0;
+    }
+    const totalPath = this.trees.reduce((sum, tree) => sum + this.pathLength(tree, point, 0), 0);
+    const avgPath = totalPath / this.trees.length;
+    const normalizer = this.normalizationFactor > 0 ? this.normalizationFactor : 1;
+    const rawScore = Math.pow(2, -avgPath / normalizer);
+    return Math.max(0, Math.min(1, rawScore));
+  }
+
+  private randomSample(dataset: NumericVector[], size: number): NumericVector[] {
+    const shuffled = dataset.slice();
+    for (let i = shuffled.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(this.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    return shuffled.slice(0, size);
+  }
+
+  private buildTree(points: NumericVector[], depth: number): TreeNode {
+    if (points.length <= 1 || depth >= this.maxDepth) {
+      return { size: points.length };
+    }
+
+    const dimension = points[0]?.length ?? 0;
+    if (dimension === 0) {
+      return { size: points.length };
+    }
+
+    const { featureIndex, min, max } = this.pickFeature(points, dimension);
+    if (featureIndex === -1 || min === undefined || max === undefined || min >= max) {
+      return { size: points.length };
+    }
+
+    const splitValue = min + this.random() * (max - min);
+    let left: NumericVector[] = [];
+    let right: NumericVector[] = [];
+    for (const row of points) {
+      if (row[featureIndex] <= splitValue) {
+        left.push(row);
+      } else {
+        right.push(row);
+      }
+    }
+
+    if (!left.length || !right.length) {
+      const sorted = points.slice().sort((a, b) => a[featureIndex] - b[featureIndex]);
+      const mid = Math.floor(sorted.length / 2);
+      left = sorted.slice(0, mid);
+      right = sorted.slice(mid);
+      if (!left.length || !right.length) {
+        return { size: points.length };
+      }
+    }
+
+    return {
+      featureIndex,
+      splitValue,
+      left: this.buildTree(left, depth + 1),
+      right: this.buildTree(right, depth + 1),
+    };
+  }
+
+  private pickFeature(points: NumericVector[], dimension: number): { featureIndex: number; min?: number; max?: number } {
+    const tried = new Set<number>();
+    while (tried.size < dimension) {
+      const idx = Math.floor(this.random() * dimension);
+      if (tried.has(idx)) {
+        continue;
+      }
+      tried.add(idx);
+      let min = Number.POSITIVE_INFINITY;
+      let max = Number.NEGATIVE_INFINITY;
+      for (const row of points) {
+        const value = row[idx];
+        if (value < min) min = value;
+        if (value > max) max = value;
+      }
+      if (min < max) {
+        return { featureIndex: idx, min, max };
+      }
+    }
+    return { featureIndex: -1 };
+  }
+
+  private pathLength(node: TreeNode | undefined, point: NumericVector, depth: number): number {
+    if (!node) {
+      return depth;
+    }
+    if (typeof node.size === "number") {
+      return depth + this.c(node.size);
+    }
+    if (node.featureIndex === undefined || node.splitValue === undefined) {
+      return depth;
+    }
+    if (point[node.featureIndex] <= node.splitValue) {
+      return this.pathLength(node.left, point, depth + 1);
+    }
+    return this.pathLength(node.right, point, depth + 1);
+  }
+
+  private c(n: number): number {
+    if (n <= 1) {
+      return 0;
+    }
+    return 2 * (this.harmonic(n - 1)) - (2 * (n - 1)) / n;
+  }
+
+  private harmonic(n: number): number {
+    if (n <= 0) {
+      return 0;
+    }
+    return Math.log(n) + 0.5772156649 + 1 / (2 * n) - 1 / (12 * n * n);
+  }
+
+  private random(): number {
+    return Math.random();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { mlReconRouter } from "./routes/mlRecon";
 
 dotenv.config();
 
@@ -27,6 +28,9 @@ app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+
+// Machine learning endpoints (unsupervised anomaly detection etc.)
+app.use("/ml", mlReconRouter);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/pages/Fraud.tsx
+++ b/src/pages/Fraud.tsx
@@ -1,24 +1,285 @@
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { reconSamples, type ReconEventSample } from "../utils/reconSamples";
+
+interface ReconUnsupervisedResponse {
+  id: string;
+  anomaly_score: number;
+  rank?: number;
+  isolation_score?: number;
+  duplicate_score?: number;
+}
+
+interface DerivedReconEvent extends ReconEventSample {
+  hour_of_day: number;
+  day_of_week: number;
+  formattedTime: string;
+}
+
+const UNUSUAL_THRESHOLD = 0.65;
 
 export default function Fraud() {
-  const [alerts] = useState([
-    { date: "02/06/2025", detail: "PAYGW payment skipped (flagged)" },
-    { date: "16/05/2025", detail: "GST transfer lower than usual" }
-  ]);
+  const events = useMemo<DerivedReconEvent[]>(
+    () =>
+      reconSamples.map((sample) => {
+        const date = new Date(sample.isoTimestamp);
+        const formatter = new Intl.DateTimeFormat(undefined, {
+          year: "numeric",
+          month: "short",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+          hour12: false,
+          timeZoneName: "short",
+        });
+        return {
+          ...sample,
+          hour_of_day: date.getUTCHours(),
+          day_of_week: date.getUTCDay(),
+          formattedTime: formatter.format(date),
+        };
+      }),
+    [],
+  );
+
+  const [scores, setScores] = useState<Record<string, ReconUnsupervisedResponse>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchScores() {
+      setLoading(true);
+      setError(null);
+      try {
+        const payload = {
+          events: events.map((event) => ({
+            id: event.id,
+            amount: event.amount,
+            hour_of_day: event.hour_of_day,
+            day_of_week: event.day_of_week,
+            channel: event.channel,
+            payer_hash: event.payer_hash,
+            CRN_valid: event.CRN_valid,
+            period_state: event.period_state,
+          })),
+        };
+
+        const response = await fetch("/ml/recon/unsupervised", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        });
+        if (!response.ok) {
+          throw new Error(`API returned ${response.status}`);
+        }
+        const data = (await response.json()) as ReconUnsupervisedResponse[];
+        if (!cancelled) {
+          const byId: Record<string, ReconUnsupervisedResponse> = {};
+          for (const row of data) {
+            byId[row.id] = row;
+          }
+          setScores(byId);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message ?? "Failed to load anomaly scores");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchScores();
+    return () => {
+      cancelled = true;
+    };
+  }, [events]);
+
+  const duplicates = useMemo(() => {
+    const map = new Map<string, DerivedReconEvent[]>();
+    for (const event of events) {
+      const key = makeDuplicateKey(event);
+      const list = map.get(key) ?? [];
+      list.push(event);
+      map.set(key, list);
+    }
+    return map;
+  }, [events]);
+
+  const selectedEvent = selectedId ? events.find((event) => event.id === selectedId) : undefined;
+  const selectedScore = selectedEvent ? scores[selectedEvent.id] : undefined;
+  const duplicatePeers = selectedEvent ? duplicates.get(makeDuplicateKey(selectedEvent)) : undefined;
+
   return (
     <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
-      <h3>Alerts</h3>
-      <ul>
-        {alerts.map((row, i) => (
-          <li key={i} style={{ color: "#e67c00", fontWeight: 500, marginBottom: 7 }}>
-            {row.date}: {row.detail}
-          </li>
-        ))}
-      </ul>
-      <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
-        (Machine learning analysis coming soon.)
+      <header className="mb-6">
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 6 }}>Duplicate & Outlier Monitor</h1>
+        <p style={{ maxWidth: 720, color: "#444" }}>
+          We run an unsupervised Isolation Forest across recent PAYGW and GST payments to spot suspicious duplicates
+          or abnormal deposits. Scores above {UNUSUAL_THRESHOLD.toFixed(2)} will surface as <strong>Unusual</strong>
+          alerts for manual follow-up.
+        </p>
+      </header>
+
+      {error && (
+        <div style={{ background: "#fee", border: "1px solid #f99", color: "#a33", padding: "12px 16px", borderRadius: 8, marginBottom: 16 }}>
+          Failed to score events: {error}
+        </div>
+      )}
+
+      <div style={{ overflowX: "auto" }}>
+        <table className="min-w-full text-sm border border-gray-200 rounded-lg">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-4 py-2 text-left">Payment</th>
+              <th className="px-4 py-2 text-left">When</th>
+              <th className="px-4 py-2 text-left">Channel</th>
+              <th className="px-4 py-2 text-left">Payer</th>
+              <th className="px-4 py-2 text-right">Amount</th>
+              <th className="px-4 py-2 text-left">Period</th>
+              <th className="px-4 py-2 text-left">Score</th>
+            </tr>
+          </thead>
+          <tbody>
+            {events.map((event) => {
+              const score = scores[event.id]?.anomaly_score;
+              const rank = scores[event.id]?.rank;
+              const isUnusual = typeof score === "number" && score >= UNUSUAL_THRESHOLD;
+              return (
+                <tr key={event.id} className="border-t hover:bg-gray-50">
+                  <td className="px-4 py-2 font-medium">{event.id}</td>
+                  <td className="px-4 py-2 text-gray-600">{event.formattedTime}</td>
+                  <td className="px-4 py-2 text-gray-700 uppercase">{event.channel}</td>
+                  <td className="px-4 py-2 text-gray-700">{event.payer_hash.replace("payer:", "")}</td>
+                  <td className="px-4 py-2 text-right">${event.amount.toLocaleString(undefined, { minimumFractionDigits: 2 })}</td>
+                  <td className="px-4 py-2">{event.period_state}</td>
+                  <td className="px-4 py-2">
+                    <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <span style={{ fontVariantNumeric: "tabular-nums", fontWeight: 600 }}>
+                        {typeof score === "number" ? score.toFixed(2) : loading ? "…" : "--"}
+                      </span>
+                      {typeof rank === "number" && (
+                        <span style={{ fontSize: "0.75rem", color: "#6b7280" }}>rank #{rank}</span>
+                      )}
+                      {isUnusual && (
+                        <button
+                          type="button"
+                          onClick={() => setSelectedId(event.id)}
+                          title="Isolation Forest marked this as unusual. Click to review the contributing features."
+                          style={{
+                            background: "#f59e0b",
+                            color: "#111827",
+                            padding: "2px 10px",
+                            borderRadius: 999,
+                            fontSize: "0.75rem",
+                            fontWeight: 700,
+                            border: "none",
+                            cursor: "pointer",
+                          }}
+                        >
+                          Unusual
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
+
+      {selectedEvent && (
+        <aside
+          style={{
+            marginTop: 24,
+            border: "1px solid #d1d5db",
+            borderRadius: 12,
+            padding: "18px 22px",
+            background: "#f8fafc",
+            maxWidth: 520,
+          }}
+        >
+          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+            <div>
+              <h2 style={{ fontSize: 20, fontWeight: 700, color: "#111827", marginBottom: 4 }}>Advisory detail</h2>
+              <p style={{ color: "#4b5563", margin: 0 }}>
+                Payment <strong>{selectedEvent.id}</strong> scored {selectedScore?.anomaly_score?.toFixed(2)}.
+                Isolation component: {selectedScore?.isolation_score?.toFixed(2)} · duplicate component: {selectedScore?.duplicate_score?.toFixed(2)}.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setSelectedId(null)}
+              style={{
+                background: "transparent",
+                border: "none",
+                color: "#6b7280",
+                cursor: "pointer",
+                fontSize: "0.9rem",
+              }}
+            >
+              Close
+            </button>
+          </div>
+
+          <dl style={{ display: "grid", gridTemplateColumns: "max-content 1fr", rowGap: 6, columnGap: 16, marginTop: 16, color: "#1f2937" }}>
+            <dt>Amount</dt>
+            <dd>${selectedEvent.amount.toLocaleString(undefined, { minimumFractionDigits: 2 })}</dd>
+            <dt>Channel</dt>
+            <dd className="uppercase">{selectedEvent.channel}</dd>
+            <dt>CRN Valid</dt>
+            <dd>{selectedEvent.CRN_valid ? "Yes" : "No"}</dd>
+            <dt>Payer hash</dt>
+            <dd>{selectedEvent.payer_hash}</dd>
+            <dt>Period state</dt>
+            <dd>{selectedEvent.period_state}</dd>
+            <dt>Captured</dt>
+            <dd>{selectedEvent.formattedTime}</dd>
+            <dt>Hour / weekday</dt>
+            <dd>
+              {selectedEvent.hour_of_day}:00 · {weekdayName(selectedEvent.day_of_week)}
+            </dd>
+          </dl>
+
+          {duplicatePeers && duplicatePeers.length > 1 && (
+            <div style={{ marginTop: 14, padding: "12px 14px", background: "#fff7ed", borderRadius: 8, border: "1px solid #f97316", color: "#9a3412" }}>
+              This payment shares identical payer, channel, timing and amount with {duplicatePeers.length - 1} other event(s):
+              <ul style={{ marginTop: 8, paddingLeft: 18 }}>
+                {duplicatePeers
+                  .filter((item) => item.id !== selectedEvent.id)
+                  .map((item) => (
+                    <li key={item.id}>{item.id} · {item.formattedTime}</li>
+                  ))}
+              </ul>
+            </div>
+          )}
+
+          <p style={{ marginTop: 16, fontSize: "0.85rem", color: "#6b7280" }}>
+            Advisory only – confirm with the payer or bank feed before taking action.
+          </p>
+        </aside>
+      )}
     </div>
   );
+}
+
+function makeDuplicateKey(event: DerivedReconEvent): string {
+  return [
+    event.payer_hash,
+    event.channel,
+    event.period_state,
+    event.day_of_week,
+    event.hour_of_day,
+    event.amount.toFixed(2),
+    event.CRN_valid ? "1" : "0",
+  ].join("|");
+}
+
+function weekdayName(dayIndex: number): string {
+  const lookup = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+  return lookup[dayIndex] ?? `Day ${dayIndex}`;
 }

--- a/src/routes/mlRecon.ts
+++ b/src/routes/mlRecon.ts
@@ -1,0 +1,64 @@
+import { Router } from "express";
+import { IsolationForest } from "../anomaly/isolationForest";
+import { prepareReconEvents, ReconEventInput } from "../anomaly/featureEngineering";
+
+const DEFAULT_DUPLICATE_WEIGHT = 0.75;
+
+export const mlReconRouter = Router();
+
+mlReconRouter.post("/recon/unsupervised", (req, res) => {
+  try {
+    const payload = (req.body?.events ?? []) as ReconEventInput[];
+    if (!Array.isArray(payload) || !payload.length) {
+      return res.status(400).json({ error: "events array required" });
+    }
+
+    const prepared = prepareReconEvents(payload);
+    if (!prepared.length) {
+      return res.status(400).json({ error: "no usable events" });
+    }
+
+    const forest = new IsolationForest({
+      trees: Math.min(150, Math.max(50, prepared.length * 2)),
+      sampleSize: Math.min(128, Math.max(16, Math.floor(prepared.length * 0.75))),
+    });
+
+    forest.fit(prepared.map((event) => event.vector));
+
+    const duplicates = new Map<string, number>();
+    for (const event of prepared) {
+      duplicates.set(event.duplicateKey, (duplicates.get(event.duplicateKey) ?? 0) + 1);
+    }
+
+    const results = prepared.map((event) => {
+      const isolationScore = forest.score(event.vector);
+      const dupCount = duplicates.get(event.duplicateKey) ?? 1;
+      const duplicateScore = dupCount > 1 ? 1 - Math.exp(-DEFAULT_DUPLICATE_WEIGHT * (dupCount - 1)) : 0;
+      const anomaly_score = Math.min(1, Math.max(isolationScore, duplicateScore));
+      return {
+        id: event.id,
+        anomaly_score: Number(anomaly_score.toFixed(4)),
+        isolation_score: Number(isolationScore.toFixed(4)),
+        duplicate_score: Number(duplicateScore.toFixed(4)),
+      };
+    });
+
+    const ranked = results
+      .slice()
+      .sort((a, b) => b.anomaly_score - a.anomaly_score)
+      .map((row, index) => ({ ...row, rank: index + 1 }));
+
+    const rankedById = new Map(ranked.map((row) => [row.id, row.rank] as const));
+    const decorated = results.map((row) => ({
+      id: row.id,
+      anomaly_score: row.anomaly_score,
+      rank: rankedById.get(row.id),
+      isolation_score: row.isolation_score,
+      duplicate_score: row.duplicate_score,
+    }));
+
+    return res.json(decorated);
+  } catch (error: any) {
+    return res.status(500).json({ error: "unsupervised detection failed", detail: String(error?.message ?? error) });
+  }
+});

--- a/src/utils/reconSamples.ts
+++ b/src/utils/reconSamples.ts
@@ -1,0 +1,84 @@
+export interface ReconEventSample {
+  id: string;
+  amount: number;
+  isoTimestamp: string;
+  channel: "portal" | "api" | "file" | "sftp";
+  payer_hash: string;
+  CRN_valid: boolean;
+  period_state: "OPEN" | "CLOSED" | "OVERDUE" | "AMENDED";
+}
+
+export const reconSamples: ReconEventSample[] = [
+  {
+    id: "pay-2025-0001",
+    amount: 4820.25,
+    isoTimestamp: "2025-05-28T00:15:00+10:00",
+    channel: "portal",
+    payer_hash: "payer:alpha",
+    CRN_valid: true,
+    period_state: "OPEN",
+  },
+  {
+    id: "pay-2025-0002",
+    amount: 4820.25,
+    isoTimestamp: "2025-05-28T00:19:00+10:00",
+    channel: "portal",
+    payer_hash: "payer:alpha",
+    CRN_valid: true,
+    period_state: "OPEN",
+  },
+  {
+    id: "dep-2025-0003",
+    amount: 1780.0,
+    isoTimestamp: "2025-05-28T10:04:00+10:00",
+    channel: "api",
+    payer_hash: "payer:bravo",
+    CRN_valid: true,
+    period_state: "OPEN",
+  },
+  {
+    id: "pay-2025-0004",
+    amount: 1875.5,
+    isoTimestamp: "2025-05-27T16:31:00+10:00",
+    channel: "api",
+    payer_hash: "payer:charlie",
+    CRN_valid: true,
+    period_state: "CLOSED",
+  },
+  {
+    id: "pay-2025-0005",
+    amount: 6225.0,
+    isoTimestamp: "2025-05-26T08:12:00+10:00",
+    channel: "file",
+    payer_hash: "payer:delta",
+    CRN_valid: false,
+    period_state: "OVERDUE",
+  },
+  {
+    id: "pay-2025-0006",
+    amount: 96000,
+    isoTimestamp: "2025-05-29T22:45:00+10:00",
+    channel: "sftp",
+    payer_hash: "payer:echo",
+    CRN_valid: false,
+    period_state: "AMENDED",
+  },
+  {
+    id: "pay-2025-0007",
+    amount: 1950.4,
+    isoTimestamp: "2025-05-25T11:20:00+10:00",
+    channel: "api",
+    payer_hash: "payer:foxtrot",
+    CRN_valid: true,
+    period_state: "OPEN",
+  },
+  {
+    id: "pay-2025-0008",
+    amount: 4820.25,
+    isoTimestamp: "2025-05-28T00:18:00+10:00",
+    channel: "portal",
+    payer_hash: "payer:alpha",
+    CRN_valid: true,
+    period_state: "OPEN",
+  },
+];


### PR DESCRIPTION
## Summary
- implement an isolation forest based recon scorer with duplicate weighting at `/ml/recon/unsupervised`
- add feature preparation utilities and seeded recon samples for the UI
- update the Fraud page to call the new endpoint and surface an “Unusual” badge with advisory details

## Testing
- `npx tsc --noEmit` *(fails: existing parse error in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e3954a5d788327af9353ecb86f6814