### PR TITLE
feat(payments): scaffold real rail integration

### DIFF
--- a/apps/services/payments/src/bank/mockAdapter.ts
+++ b/apps/services/payments/src/bank/mockAdapter.ts
@@ -1,0 +1,28 @@
+import { randomUUID } from 'crypto';
+import { BankingPort, BpayRequest, EftRequest, Receipt } from '../rails/ports.js';
+
+export class MockAdapter implements BankingPort {
+  async bpay(request: BpayRequest): Promise<Receipt> {
+    const providerRef = `MOCK-BPAY-${randomUUID()}`;
+    return {
+      providerRef,
+      amountCents: request.amountCents,
+      channel: 'BPAY',
+      meta: { request },
+      raw: { provider_ref: providerRef },
+      processedAt: new Date(),
+    };
+  }
+
+  async eft(request: EftRequest): Promise<Receipt> {
+    const providerRef = `MOCK-EFT-${randomUUID()}`;
+    return {
+      providerRef,
+      amountCents: request.amountCents,
+      channel: 'EFT',
+      meta: { request },
+      raw: { provider_ref: providerRef },
+      processedAt: new Date(),
+    };
+  }
+}

--- a/apps/services/payments/src/bank/realAdapter.ts
+++ b/apps/services/payments/src/bank/realAdapter.ts
@@ -1,0 +1,172 @@
+import axios, { AxiosInstance } from 'axios';
+import https from 'https';
+import { readFileSync } from 'fs';
+import { randomUUID } from 'crypto';
+import { setTimeout as delay } from 'timers/promises';
+import { RailsConfig } from '../config/rails.js';
+import { BankingPort, BpayRequest, EftRequest, Receipt } from '../rails/ports.js';
+import { HttpError } from '../utils/errors.js';
+import { incrementRailRetries, observeRailLatency, setBreakerOpen } from '../utils/metrics.js';
+
+interface CircuitOptions {
+  failureThreshold: number;
+  resetTimeoutMs: number;
+}
+
+class SimpleCircuitBreaker {
+  private failures = 0;
+  private nextAttempt = 0;
+
+  constructor(private readonly options: CircuitOptions) {}
+
+  async execute<T>(operation: () => Promise<T>): Promise<T> {
+    const now = Date.now();
+    if (now < this.nextAttempt) {
+      setBreakerOpen(true);
+      throw new HttpError(503, 'RAIL_CIRCUIT_OPEN', 'bank rail circuit breaker open');
+    }
+
+    try {
+      const result = await operation();
+      this.failures = 0;
+      setBreakerOpen(false);
+      return result;
+    } catch (err) {
+      this.failures += 1;
+      if (this.failures >= this.options.failureThreshold) {
+        this.nextAttempt = now + this.options.resetTimeoutMs;
+        setBreakerOpen(true);
+      }
+      throw err;
+    }
+  }
+}
+
+function readOptional(path: string): Buffer | undefined {
+  if (!path) return undefined;
+  return readFileSync(path);
+}
+
+export class RealAdapter implements BankingPort {
+  private readonly client: AxiosInstance;
+  private readonly breaker: SimpleCircuitBreaker;
+
+  constructor() {
+    if (!RailsConfig.RAIL_BASE_URL) {
+      throw new Error('RAIL_BASE_URL must be configured for RealAdapter');
+    }
+
+    const agent = new https.Agent({
+      ca: readOptional(RailsConfig.MTLS_CA_PATH),
+      cert: readOptional(RailsConfig.MTLS_CERT_PATH),
+      key: readOptional(RailsConfig.MTLS_KEY_PATH),
+      rejectUnauthorized: true,
+    });
+
+    this.client = axios.create({
+      baseURL: RailsConfig.RAIL_BASE_URL,
+      timeout: RailsConfig.RAIL_TIMEOUT_MS,
+      httpsAgent: agent,
+    });
+
+    this.breaker = new SimpleCircuitBreaker({ failureThreshold: 5, resetTimeoutMs: 30000 });
+  }
+
+  async bpay(request: BpayRequest): Promise<Receipt> {
+    const payload = {
+      amount_cents: request.amountCents,
+      biller_code: request.billerCode,
+      crn: request.crn,
+      metadata: request.meta ?? {},
+    };
+    return this.execute('bpay', payload, request);
+  }
+
+  async eft(request: EftRequest): Promise<Receipt> {
+    const payload = {
+      amount_cents: request.amountCents,
+      bsb: request.bsb,
+      account_number: request.accountNumber,
+      account_name: request.accountName,
+      metadata: request.meta ?? {},
+    };
+    return this.execute('eft', payload, request);
+  }
+
+  private async execute(path: 'bpay' | 'eft', payload: Record<string, unknown>, req: { channel: 'BPAY' | 'EFT'; amountCents: number; idempotencyKey: string; abn: string; periodId: string; taxType: string; }): Promise<Receipt> {
+    const headers = {
+      'Idempotency-Key': req.idempotencyKey,
+      'X-Request-Id': randomUUID(),
+    };
+
+    const start = Date.now();
+    const attemptPayload = async () => {
+      let attempt = 0;
+      const maxAttempts = 3;
+      let lastError: unknown;
+      while (attempt < maxAttempts) {
+        attempt += 1;
+        try {
+          const response = await this.client.post(`/payments/${path}`, payload, { headers });
+          const providerRef = String(response.data?.provider_ref ?? response.data?.receipt_id ?? '');
+          if (!providerRef) {
+            throw new HttpError(502, 'RAIL_PROVIDER_NO_REF', 'provider did not return reference');
+          }
+          const processedAt = new Date(response.data?.processed_at ?? new Date().toISOString());
+          return {
+            providerRef,
+            amountCents: req.amountCents,
+            channel: req.channel,
+            meta: {
+              request,
+              response: response.data,
+            },
+            raw: response.data,
+            processedAt,
+          } satisfies Receipt;
+        } catch (err: any) {
+          lastError = err;
+          if (attempt >= maxAttempts) {
+            throw err;
+          }
+          incrementRailRetries(req.channel);
+          const backoffMs = 2 ** attempt * 250;
+          await delay(backoffMs);
+        }
+      }
+      throw lastError ?? new Error('Unknown rail failure');
+    };
+
+    try {
+      const receipt = await this.breaker.execute(attemptPayload);
+      observeRailLatency(req.channel, Date.now() - start, {
+        abn: req.abn,
+        periodId: req.periodId,
+        taxType: req.taxType,
+      });
+      console.log(JSON.stringify({
+        level: 'info',
+        event: 'payments.rail.success',
+        request_id: headers['X-Request-Id'],
+        abn: req.abn,
+        period_id: req.periodId,
+        tax_type: req.taxType,
+        channel: req.channel,
+        provider_ref: receipt.providerRef,
+      }));
+      return receipt;
+    } catch (err) {
+      console.error(JSON.stringify({
+        level: 'error',
+        event: 'payments.rail.failure',
+        request_id: headers['X-Request-Id'],
+        abn: req.abn,
+        period_id: req.periodId,
+        tax_type: req.taxType,
+        channel: req.channel,
+        error: err instanceof Error ? err.message : err,
+      }));
+      throw err;
+    }
+  }
+}

--- a/apps/services/payments/src/config/rails.ts
+++ b/apps/services/payments/src/config/rails.ts
@@ -1,0 +1,42 @@
+import '../loadEnv.js';
+
+export type RailChannel = 'BPAY' | 'EFT';
+
+function parseBool(v: string | undefined): boolean {
+  return v === '1' || v === 'true' || v === 'TRUE';
+}
+
+function parseList(v: string | undefined): string[] {
+  if (!v) return [];
+  return v
+    .split(',')
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
+const FEATURE_RAILS_REAL = parseBool(process.env.FEATURE_RAILS_REAL);
+const RAIL_CHANNEL = (process.env.RAIL_CHANNEL?.toUpperCase() as RailChannel | undefined) ?? 'BPAY';
+const MTLS_CERT_PATH = process.env.MTLS_CERT_PATH ?? '';
+const MTLS_KEY_PATH = process.env.MTLS_KEY_PATH ?? '';
+const MTLS_CA_PATH = process.env.MTLS_CA_PATH ?? '';
+const RAIL_BASE_URL = process.env.RAIL_BASE_URL ?? '';
+const RAIL_TIMEOUT_MS = Number(process.env.RAIL_TIMEOUT_MS ?? '10000');
+
+const ALLOWLIST_ABNS = parseList(process.env.ALLOWLIST_ABNS);
+const ALLOWLIST_BSB_REGEX = process.env.ALLOWLIST_BSB_REGEX ?? '^\\d{3}-?\\d{3}$';
+const ALLOWLIST_CRN_REGEX = process.env.ALLOWLIST_CRN_REGEX ?? '^\\d{8,10}$';
+
+export const RailsConfig = {
+  FEATURE_RAILS_REAL,
+  RAIL_CHANNEL,
+  MTLS_CERT_PATH,
+  MTLS_KEY_PATH,
+  MTLS_CA_PATH,
+  RAIL_BASE_URL,
+  RAIL_TIMEOUT_MS,
+  ALLOWLIST_ABNS,
+  ALLOWLIST_BSB_REGEX,
+  ALLOWLIST_CRN_REGEX,
+} as const;
+
+export type RailsConfigType = typeof RailsConfig;

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -10,6 +10,7 @@ import { payAtoRelease } from './routes/payAto.js';
 import { deposit } from './routes/deposit';
 import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
+import { importBankReconciliation } from './recon/bankReconcile.js';
 
 // Port (defaults to 3000)
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -32,6 +33,7 @@ app.get('/health', (_req, res) => res.json({ ok: true }));
 // Endpoints
 app.post('/deposit', deposit);
 app.post('/payAto', rptGate, payAtoRelease);
+app.post('/recon/bank/import', importBankReconciliation);
 app.get('/balance', balance);
 app.get('/ledger', ledger);
 

--- a/apps/services/payments/src/rails/index.ts
+++ b/apps/services/payments/src/rails/index.ts
@@ -1,0 +1,13 @@
+import { RailsConfig } from '../config/rails.js';
+import { BankingPort } from './ports.js';
+import { RealAdapter } from '../bank/realAdapter.js';
+import { MockAdapter } from '../bank/mockAdapter.js';
+
+let singleton: BankingPort | null = null;
+
+export function resolveBankingPort(): BankingPort {
+  if (!singleton) {
+    singleton = RailsConfig.FEATURE_RAILS_REAL ? new RealAdapter() : new MockAdapter();
+  }
+  return singleton;
+}

--- a/apps/services/payments/src/rails/ports.ts
+++ b/apps/services/payments/src/rails/ports.ts
@@ -1,0 +1,37 @@
+export type MoneyCents = number;
+
+export interface BaseRailRequest {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: MoneyCents;
+  idempotencyKey: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface BpayRequest extends BaseRailRequest {
+  channel: 'BPAY';
+  billerCode: string;
+  crn: string;
+}
+
+export interface EftRequest extends BaseRailRequest {
+  channel: 'EFT';
+  bsb: string;
+  accountNumber: string;
+  accountName?: string;
+}
+
+export interface Receipt {
+  providerRef: string;
+  amountCents: MoneyCents;
+  channel: 'BPAY' | 'EFT';
+  meta: Record<string, unknown>;
+  raw: unknown;
+  processedAt: Date;
+}
+
+export interface BankingPort {
+  bpay(request: BpayRequest): Promise<Receipt>;
+  eft(request: EftRequest): Promise<Receipt>;
+}

--- a/apps/services/payments/src/rails/validators.ts
+++ b/apps/services/payments/src/rails/validators.ts
@@ -1,0 +1,31 @@
+import { RailsConfig } from '../config/rails.js';
+import { HttpError } from '../utils/errors.js';
+
+export function assertABNAllowed(abn: string): void {
+  if (!abn) {
+    throw new HttpError(400, 'RAIL_ABN_REQUIRED', 'abn is required');
+  }
+  if (RailsConfig.ALLOWLIST_ABNS.length && !RailsConfig.ALLOWLIST_ABNS.includes(abn)) {
+    throw new HttpError(422, 'RAIL_ABN_NOT_ALLOWLISTED', 'abn is not allowlisted', { abn });
+  }
+}
+
+export function assertBSB(bsb: string): void {
+  if (!bsb) {
+    throw new HttpError(400, 'RAIL_BSB_REQUIRED', 'bsb is required');
+  }
+  const regex = new RegExp(RailsConfig.ALLOWLIST_BSB_REGEX);
+  if (!regex.test(bsb)) {
+    throw new HttpError(422, 'RAIL_BSB_INVALID', 'bsb failed validation', { bsb, pattern: RailsConfig.ALLOWLIST_BSB_REGEX });
+  }
+}
+
+export function assertCRN(crn: string): void {
+  if (!crn) {
+    throw new HttpError(400, 'RAIL_CRN_REQUIRED', 'crn is required');
+  }
+  const regex = new RegExp(RailsConfig.ALLOWLIST_CRN_REGEX);
+  if (!regex.test(crn)) {
+    throw new HttpError(422, 'RAIL_CRN_INVALID', 'crn failed validation', { crn, pattern: RailsConfig.ALLOWLIST_CRN_REGEX });
+  }
+}

--- a/apps/services/payments/src/recon/bankReconcile.ts
+++ b/apps/services/payments/src/recon/bankReconcile.ts
@@ -1,0 +1,144 @@
+import { Request, Response } from 'express';
+import { randomUUID } from 'crypto';
+import { pool } from '../index.js';
+
+interface NormalizedLine {
+  providerRef?: string;
+  amountCents: number;
+  paidAt: string;
+  crn?: string;
+  raw: unknown;
+}
+
+function parseImport(payload: unknown): NormalizedLine[] {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('import payload must be an object');
+  }
+  const { data, format } = payload as { data?: unknown; format?: string };
+  if (!data) {
+    throw new Error('import payload missing data');
+  }
+  if (format === 'csv' && typeof data === 'string') {
+    const lines = data.trim().split(/\r?\n/);
+    const [headerLine, ...rows] = lines;
+    const headers = headerLine.split(',').map(h => h.trim());
+    return rows.filter(Boolean).map(row => {
+      const cols = row.split(',');
+      const record: Record<string, string> = {};
+      headers.forEach((h, idx) => { record[h] = cols[idx]?.trim() ?? ''; });
+      return normalizeRecord(record);
+    });
+  }
+  if (Array.isArray(data)) {
+    return data.map(entry => normalizeRecord(entry as Record<string, unknown>));
+  }
+  if (typeof data === 'string') {
+    const parsed = JSON.parse(data);
+    if (Array.isArray(parsed)) {
+      return parsed.map(entry => normalizeRecord(entry as Record<string, unknown>));
+    }
+    throw new Error('JSON payload must be an array');
+  }
+  throw new Error('Unsupported import format');
+}
+
+function normalizeRecord(entry: Record<string, unknown>): NormalizedLine {
+  const amount = Number(entry.amount_cents ?? entry.amount ?? entry.Amount);
+  if (!Number.isFinite(amount)) {
+    throw new Error('Record missing amount');
+  }
+  const paidAt = typeof entry.paid_at === 'string' ? entry.paid_at : typeof entry.date === 'string' ? entry.date : new Date().toISOString();
+  return {
+    providerRef: typeof entry.provider_ref === 'string' ? entry.provider_ref : typeof entry.reference === 'string' ? entry.reference : undefined,
+    amountCents: Math.trunc(amount),
+    paidAt,
+    crn: typeof entry.crn === 'string' ? entry.crn : typeof entry.customer_reference === 'string' ? entry.customer_reference : undefined,
+    raw: entry,
+  };
+}
+
+export async function importBankReconciliation(req: Request, res: Response) {
+  let lines: NormalizedLine[];
+  try {
+    lines = parseImport(req.body);
+  } catch (err) {
+    return res.status(400).json({ error: 'RECON_PARSE_FAILED', message: (err as Error).message });
+  }
+  if (!lines.length) {
+    return res.status(400).json({ error: 'RECON_EMPTY', message: 'No lines to process' });
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const importId = randomUUID();
+    await client.query(
+      `INSERT INTO bank_recon_imports (id, raw_payload, created_at) VALUES ($1,$2::jsonb,now())`,
+      [importId, JSON.stringify(req.body)]
+    );
+
+    const matches: Array<{ settlementId: string; providerRef: string | undefined }> = [];
+
+    for (const line of lines) {
+      const { rows: releaseRows } = await client.query(
+        `SELECT br.id as receipt_id, br.channel, br.provider_ref, br.amount_cents, br.meta, ol.abn, ol.tax_type, ol.period_id
+         FROM bank_receipts br
+         JOIN owa_ledger ol ON ol.release_receipt_id = br.id
+         WHERE (br.provider_ref = $1 OR br.meta->'request'->>'crn' = $2)
+         LIMIT 1`,
+        [line.providerRef ?? null, line.crn ?? null]
+      );
+
+      if (!releaseRows.length) {
+        continue;
+      }
+      const record = releaseRows[0];
+      const settlementId = randomUUID();
+      await client.query(
+        `INSERT INTO settlements (id, abn, period_id, channel, amount_cents, paid_at, provider_ref, raw_ref, bank_receipt_id, import_id)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9,$10)`,
+        [
+          settlementId,
+          record.abn,
+          record.period_id,
+          record.channel,
+          line.amountCents,
+          line.paidAt,
+          record.provider_ref,
+          JSON.stringify(line.raw),
+          record.receipt_id,
+          importId,
+        ]
+      );
+
+      await client.query(
+        `UPDATE evidence_bundles
+           SET settlement = $4::jsonb,
+               bank_receipt_id = $5
+         WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+        [
+          record.abn,
+          record.tax_type,
+          record.period_id,
+          JSON.stringify({
+            channel: record.channel,
+            provider_ref: record.provider_ref,
+            amount_cents: line.amountCents,
+            paidAt: line.paidAt,
+          }),
+          record.receipt_id,
+        ]
+      );
+
+      matches.push({ settlementId, providerRef: record.provider_ref });
+    }
+
+    await client.query('COMMIT');
+    return res.json({ ok: true, importId, matches });
+  } catch (err: any) {
+    await client.query('ROLLBACK');
+    return res.status(500).json({ error: 'RECON_FAILED', message: String(err?.message || err) });
+  } finally {
+    client.release();
+  }
+}

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -1,34 +1,35 @@
-﻿// apps/services/payments/src/routes/payAto.ts
 import { Request, Response } from 'express';
-import crypto from 'crypto';
-import pg from 'pg'; const { Pool } = pg;
+import { randomUUID, createHash } from 'crypto';
 import { pool } from '../index.js';
+import { RailsConfig } from '../config/rails.js';
+import { resolveBankingPort } from '../rails/index.js';
+import { assertABNAllowed, assertBSB, assertCRN } from '../rails/validators.js';
+import { isHttpError } from '../utils/errors.js';
+import { buildEvidenceBundle } from '../evidence/evidenceBundle.js';
 
-function genUUID() {
-  return crypto.randomUUID();
-}
+const banking = resolveBankingPort();
 
-/**
- * Minimal release path:
- * - Requires rptGate to have attached req.rpt
- * - Inserts a single negative ledger entry for the given period
- * - Sets rpt_verified=true and a unique release_uuid to satisfy constraints
- */
 export async function payAtoRelease(req: Request, res: Response) {
-  const { abn, taxType, periodId, amountCents } = req.body || {};
-  if (!abn || !taxType || !periodId) {
-    return res.status(400).json({ error: 'Missing abn/taxType/periodId' });
+  const requestId = req.header('x-request-id') ?? randomUUID();
+  const { abn, taxType, periodId, amountCents, destination = {} } = req.body || {};
+
+  try {
+    assertABNAllowed(abn);
+    if (!taxType || !periodId) {
+      throw new Error('taxType and periodId are required');
+    }
+  } catch (err) {
+    if (isHttpError(err)) {
+      return res.status(err.status).json({ error: err.code, message: err.message, details: err.details });
+    }
+    return res.status(400).json({ error: 'RAIL_REQUEST_INVALID', message: (err as Error).message });
   }
 
-  // default a tiny test debit if not provided
-  const amt = Number.isFinite(Number(amountCents)) ? Number(amountCents) : -100;
-
-  // must be negative for a release
-  if (amt >= 0) {
+  const amt = Number.isFinite(Number(amountCents)) ? Number(amountCents) : NaN;
+  if (!Number.isFinite(amt) || amt >= 0) {
     return res.status(400).json({ error: 'amountCents must be negative for a release' });
   }
 
-  // rptGate attaches req.rpt when verification succeeds
   const rpt = (req as any).rpt;
   if (!rpt) {
     return res.status(403).json({ error: 'RPT not verified' });
@@ -37,56 +38,139 @@ export async function payAtoRelease(req: Request, res: Response) {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-
-    // compute running balance AFTER this entry:
-    // fetch last balance in this period (by id order), default 0
-    const { rows: lastRows } = await client.query<{
-      balance_after_cents: string | number;
-    }>(
-      `SELECT balance_after_cents
-       FROM owa_ledger
-       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-       ORDER BY id DESC
-       LIMIT 1`,
+    const { rows: lastRows } = await client.query<{ balance_after_cents: string | number }>(
+      `SELECT balance_after_cents FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1`,
       [abn, taxType, periodId]
     );
     const lastBal = lastRows.length ? Number(lastRows[0].balance_after_cents) : 0;
     const newBal = lastBal + amt;
 
-    const release_uuid = genUUID();
+    const idempotencyKey = `release:${abn}:${taxType}:${periodId}:${Math.abs(amt)}`;
+    const baseMeta = { requestId, abn, taxType, periodId };
 
-    const insert = `
+    let receipt;
+    if (RailsConfig.RAIL_CHANNEL === 'BPAY') {
+      const billerCode = destination.billerCode ?? destination.bpay_biller;
+      const crn = destination.crn ?? destination.customerReference ?? destination.reference;
+      try {
+        assertCRN(crn);
+      } catch (err) {
+        if (isHttpError(err)) return res.status(err.status).json({ error: err.code, message: err.message, details: err.details });
+        throw err;
+      }
+      receipt = await banking.bpay({
+        channel: 'BPAY',
+        abn,
+        taxType,
+        periodId,
+        amountCents: Math.abs(amt),
+        billerCode,
+        crn,
+        idempotencyKey,
+        meta: baseMeta,
+      });
+    } else {
+      const bsb = destination.bsb ?? destination.bsbNumber;
+      const accountNumber = destination.accountNumber ?? destination.acct;
+      if (!accountNumber || typeof accountNumber !== 'string') {
+        return res.status(400).json({ error: 'RAIL_ACCOUNT_REQUIRED', message: 'accountNumber is required for EFT' });
+      }
+      try {
+        assertBSB(bsb);
+      } catch (err) {
+        if (isHttpError(err)) return res.status(err.status).json({ error: err.code, message: err.message, details: err.details });
+        throw err;
+      }
+      receipt = await banking.eft({
+        channel: 'EFT',
+        abn,
+        taxType,
+        periodId,
+        amountCents: Math.abs(amt),
+        bsb,
+        accountNumber,
+        accountName: destination.accountName,
+        idempotencyKey,
+        meta: baseMeta,
+      });
+    }
+
+    const receiptId = randomUUID();
+    const receiptInsert = `
+      INSERT INTO bank_receipts (id, channel, provider_ref, amount_cents, created_at, meta)
+      VALUES ($1,$2,$3,$4,now(),$5::jsonb)
+      RETURNING id
+    `;
+    await client.query(receiptInsert, [
+      receiptId,
+      receipt.channel,
+      receipt.providerRef,
+      receipt.amountCents,
+      JSON.stringify(receipt.meta ?? {}),
+    ]);
+
+    const releaseUuid = randomUUID();
+    const transferUuid = randomUUID();
+    const bankReceiptHash = createHash('sha256').update(receipt.providerRef).digest('hex');
+
+    const ledgerInsert = `
       INSERT INTO owa_ledger
         (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents,
-         rpt_verified, release_uuid, created_at)
-      VALUES ($1,$2,$3,$4,$5,$6, TRUE, $7, now())
-      RETURNING id, transfer_uuid, balance_after_cents
+         bank_receipt_hash, release_uuid, rpt_verified, release_receipt_id, created_at)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8,TRUE,$9,now())
+      RETURNING id, balance_after_cents
     `;
-    const transfer_uuid = genUUID();
-    const { rows: ins } = await client.query(insert, [
+    const { rows: ledgerRows } = await client.query(ledgerInsert, [
       abn,
       taxType,
       periodId,
-      transfer_uuid,
+      transferUuid,
       amt,
       newBal,
-      release_uuid,
+      bankReceiptHash,
+      releaseUuid,
+      receiptId,
     ]);
+
+    await buildEvidenceBundle(client, {
+      abn,
+      taxType,
+      periodId,
+      bankReceipts: [
+        {
+          provider: receipt.channel,
+          receipt_id: receipt.providerRef,
+          receipt_uuid: receiptId,
+        },
+      ],
+      atoReceipts: [],
+      operatorOverrides: [],
+      owaAfterHash: String(ledgerRows[0].balance_after_cents),
+      settlement: {
+        channel: receipt.channel,
+        provider_ref: receipt.providerRef,
+        amount_cents: receipt.amountCents,
+        paidAt: receipt.processedAt.toISOString(),
+      },
+      receipt_id: receiptId,
+    });
 
     await client.query('COMMIT');
 
     return res.json({
       ok: true,
-      ledger_id: ins[0].id,
-      transfer_uuid,
-      release_uuid,
-      balance_after_cents: ins[0].balance_after_cents,
-      rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
+      release_uuid: releaseUuid,
+      transfer_uuid: transferUuid,
+      receipt_id: receiptId,
+      provider_ref: receipt.providerRef,
+      balance_after_cents: ledgerRows[0].balance_after_cents,
     });
-  } catch (e: any) {
+  } catch (err: any) {
     await client.query('ROLLBACK');
-    // common failures: unique single-release-per-period, allow-list, etc.
-    return res.status(400).json({ error: 'Release failed', detail: String(e?.message || e) });
+    if (isHttpError(err)) {
+      return res.status(err.status).json({ error: err.code, message: err.message, details: err.details });
+    }
+    return res.status(500).json({ error: 'RELEASE_FAILED', message: String(err?.message || err) });
   } finally {
     client.release();
   }

--- a/apps/services/payments/src/utils/errors.ts
+++ b/apps/services/payments/src/utils/errors.ts
@@ -1,0 +1,16 @@
+export class HttpError extends Error {
+  public readonly status: number;
+  public readonly code: string;
+  public readonly details?: Record<string, unknown>;
+
+  constructor(status: number, code: string, message: string, details?: Record<string, unknown>) {
+    super(message);
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export function isHttpError(err: unknown): err is HttpError {
+  return err instanceof Error && typeof (err as Partial<HttpError>).status === 'number' && typeof (err as Partial<HttpError>).code === 'string';
+}

--- a/apps/services/payments/src/utils/metrics.ts
+++ b/apps/services/payments/src/utils/metrics.ts
@@ -1,0 +1,32 @@
+const retries: Record<'BPAY' | 'EFT', number> = { BPAY: 0, EFT: 0 };
+let breakerOpen = false;
+
+export function observeRailLatency(channel: 'BPAY' | 'EFT', latencyMs: number, tags: Record<string, string>): void {
+  console.log(JSON.stringify({
+    level: 'debug',
+    metric: 'payments_rail_latency_ms',
+    value: latencyMs,
+    channel,
+    ...tags,
+  }));
+}
+
+export function incrementRailRetries(channel: 'BPAY' | 'EFT'): void {
+  retries[channel] += 1;
+  console.log(JSON.stringify({
+    level: 'debug',
+    metric: 'payments_rail_retries',
+    channel,
+    value: retries[channel],
+  }));
+}
+
+export function setBreakerOpen(open: boolean): void {
+  if (breakerOpen === open) return;
+  breakerOpen = open;
+  console.log(JSON.stringify({
+    level: 'warn',
+    metric: 'payments_rail_breaker_open',
+    value: open ? 1 : 0,
+  }));
+}

--- a/apps/services/payments/test/rails.validators.test.ts
+++ b/apps/services/payments/test/rails.validators.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+
+function loadValidators() {
+  return import('../src/rails/validators.js');
+}
+
+describe('rail validators', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    process.env.ALLOWLIST_ABNS = '12345678901,98765432109';
+    process.env.ALLOWLIST_BSB_REGEX = '^\\d{3}-?\\d{3}$';
+    process.env.ALLOWLIST_CRN_REGEX = '^\\d{8,10}$';
+  });
+
+  afterEach(() => {
+    delete process.env.ALLOWLIST_ABNS;
+    delete process.env.ALLOWLIST_BSB_REGEX;
+    delete process.env.ALLOWLIST_CRN_REGEX;
+  });
+
+  test('rejects ABN not in allow-list', async () => {
+    const { assertABNAllowed } = await loadValidators();
+    expect(() => assertABNAllowed('11111111111')).toThrowErrorMatchingInlineSnapshot(`"abn is not allowlisted"`);
+  });
+
+  test('rejects invalid BSB format', async () => {
+    const { assertBSB } = await loadValidators();
+    expect(() => assertBSB('12345')).toThrowErrorMatchingInlineSnapshot(`"bsb failed validation"`);
+  });
+
+  test('rejects invalid CRN format', async () => {
+    const { assertCRN } = await loadValidators();
+    expect(() => assertCRN('abc123')).toThrowErrorMatchingInlineSnapshot(`"crn failed validation"`);
+  });
+});

--- a/migrations/003_real_rails.sql
+++ b/migrations/003_real_rails.sql
@@ -1,0 +1,46 @@
+-- 003_real_rails.sql
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS bank_receipts (
+  id UUID PRIMARY KEY,
+  channel TEXT NOT NULL,
+  provider_ref TEXT NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  meta JSONB NOT NULL DEFAULT '{}',
+  dry_run BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+ALTER TABLE owa_ledger
+  ADD COLUMN IF NOT EXISTS rpt_verified BOOLEAN NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS release_uuid UUID,
+  ADD COLUMN IF NOT EXISTS release_receipt_id UUID REFERENCES bank_receipts(id);
+
+CREATE INDEX IF NOT EXISTS ix_bank_receipts_provider_ref
+  ON bank_receipts (provider_ref);
+
+CREATE TABLE IF NOT EXISTS bank_recon_imports (
+  id UUID PRIMARY KEY,
+  raw_payload JSONB NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS settlements (
+  id UUID PRIMARY KEY,
+  abn TEXT NOT NULL,
+  period_id TEXT NOT NULL,
+  channel TEXT NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  paid_at TIMESTAMPTZ NOT NULL,
+  provider_ref TEXT NOT NULL,
+  raw_ref JSONB NOT NULL DEFAULT '{}',
+  bank_receipt_id UUID REFERENCES bank_receipts(id),
+  import_id UUID REFERENCES bank_recon_imports(id),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE evidence_bundles
+  ADD COLUMN IF NOT EXISTS settlement JSONB,
+  ADD COLUMN IF NOT EXISTS bank_receipt_id UUID;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- introduce rail configuration, validation utilities, and adapter ports to toggle between mock and real banking rails
- implement a real mTLS-enabled rail adapter with retries, circuit breaking, and structured logging plus persistence of receipts and evidence links
- add bank reconciliation import flow with supporting migrations, storage tables, and validator-focused Jest coverage

## Testing
- `npm test` *(fails: jest binary unavailable in environment)*
- `npm run build` *(fails: TypeScript config requires NodeNext module setting)*

------
https://chatgpt.com/codex/tasks/task_e_68e396e829ac8327807ba467dcc6992f