### PR TITLE
Add privacy-by-design ML assist service

### DIFF
--- a/apps/services/ml_assist/__init__.py
+++ b/apps/services/ml_assist/__init__.py
@@ -1,0 +1,1 @@
+"""Privacy-preserving ML assist service."""

--- a/apps/services/ml_assist/logging_utils.py
+++ b/apps/services/ml_assist/logging_utils.py
@@ -1,0 +1,42 @@
+"""Logging helpers that redact PII before writing to logs."""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Iterable, Optional
+
+PII_PATTERN = re.compile(r"([A-Za-z0-9_.+-]+@[A-Za-z0-9-]+\.[A-Za-z0-9.-]+)|\b\d{4,}\b")
+
+
+class RedactingFilter(logging.Filter):
+    """Replace obvious PII patterns with a redaction marker."""
+
+    def __init__(self, name: str = "") -> None:
+        super().__init__(name)
+        self._replacement = "[REDACTED]"
+
+    def _clean(self, value: object) -> object:
+        if isinstance(value, str):
+            return PII_PATTERN.sub(self._replacement, value)
+        return value
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - logging internals
+        record.msg = self._clean(record.msg)
+        if record.args:
+            record.args = tuple(self._clean(arg) for arg in record.args)
+        return True
+
+
+_configured = False
+
+
+def install_redacting_filter(target_loggers: Optional[Iterable[str]] = None) -> None:
+    """Ensure the redacting filter is installed on the specified loggers."""
+    global _configured
+    if _configured:
+        return
+    names = list(target_loggers or ["ml_assist"])
+    for name in names:
+        logger = logging.getLogger(name)
+        logger.addFilter(RedactingFilter())
+    _configured = True

--- a/apps/services/ml_assist/main.py
+++ b/apps/services/ml_assist/main.py
@@ -1,0 +1,167 @@
+"""FastAPI app implementing privacy-by-design ML dataflows."""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Dict, Iterable
+
+from fastapi import Depends, FastAPI, Header, HTTPException, Request, status
+
+from .logging_utils import install_redacting_filter
+from .models import ArtifactRecord, OCRIngestRequest
+from .security import SecurityConfigError, decode_token, ensure_scopes, hash_identifier
+from .store import EncryptedMLStore, get_store
+
+LOGGER_NAME = "ml_assist"
+logger = logging.getLogger(LOGGER_NAME)
+install_redacting_filter([LOGGER_NAME, "uvicorn.error", "uvicorn.access"])
+
+app = FastAPI(title="ml-assist", version="0.1.0")
+store: EncryptedMLStore = get_store()
+
+
+def _allowed_networks() -> Iterable[str]:
+    raw = os.getenv("ML_INTERNAL_NETWORKS", "127.,10.,172.16.,192.168.,::1,testclient")
+    return [segment.strip() for segment in raw.split(",") if segment.strip()]
+
+
+async def require_internal(request: Request) -> None:
+    client_host = request.client.host if request.client else None
+    if client_host in (None, "testclient"):
+        return
+    for segment in _allowed_networks():
+        if client_host.startswith(segment):
+            return
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="External access denied")
+
+
+def _bearer_token(authorization: str = Header(..., alias="Authorization")) -> str:
+    parts = authorization.split()
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authorization header")
+    return parts[1]
+
+
+def require_scopes(*required_scopes: str):
+    async def _inner(token: str = Depends(_bearer_token)) -> Dict[str, Any]:
+        try:
+            claims = decode_token(token)
+            ensure_scopes(claims, required_scopes)
+            return claims
+        except SecurityConfigError as exc:
+            message = str(exc)
+            if message.startswith("Invalid access token"):
+                raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail=message) from exc
+            if message.startswith("Missing scopes"):
+                raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=message) from exc
+            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=message) from exc
+
+    return _inner
+
+
+def _extract_structured_fields(ocr_text: str, provided: Dict[str, Any]) -> Dict[str, Any]:
+    fields: Dict[str, Any] = dict(provided)
+    for raw_line in ocr_text.splitlines():
+        line = raw_line.strip()
+        if not line or ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        key = key.strip().lower().replace(" ", "_")
+        value = value.strip()
+        if key and value and key not in fields:
+            fields[key] = value
+    return fields
+
+
+def _hash_structured_fields(fields: Dict[str, Any]) -> Dict[str, str]:
+    hashed: Dict[str, str] = {}
+    for key, value in fields.items():
+        if value is None:
+            continue
+        hashed[key] = hash_identifier(str(value))
+    return hashed
+
+
+def _numeric_fields(fields: Dict[str, Any]) -> Dict[str, Any]:
+    numeric: Dict[str, Any] = {}
+    for key, value in fields.items():
+        if isinstance(value, (int, float)):
+            numeric[key] = value
+    return numeric
+
+
+def _sanitize_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
+    clean: Dict[str, Any] = {}
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        if isinstance(value, (int, float, bool)):
+            clean[key] = value
+        else:
+            clean[key] = hash_identifier(str(value))
+    return clean
+
+
+def _features_from_ocr(text: str) -> Dict[str, Any]:
+    stripped = [line for line in text.splitlines() if line.strip()]
+    return {
+        "line_count": len(stripped),
+        "char_count": len(text),
+    }
+
+
+@app.get("/health")
+def healthcheck() -> Dict[str, Any]:
+    return {"ok": True}
+
+
+@app.post("/ml/ingest", dependencies=[Depends(require_internal)])
+def ingest(payload: OCRIngestRequest, claims: Dict[str, Any] = Depends(require_scopes("ml:ingest"))) -> Dict[str, Any]:
+    structured = _extract_structured_fields(payload.ocr_text, payload.structured_fields)
+    hashed_identifiers = {key: hash_identifier(value) for key, value in payload.identifiers.items() if value}
+    hashed_structured = _hash_structured_fields(structured)
+    numeric_structured = _numeric_fields(structured)
+    sanitized_metadata = _sanitize_metadata(payload.metadata)
+    derived_features = _features_from_ocr(payload.ocr_text)
+
+    record = ArtifactRecord(
+        document_id=payload.document_id,
+        ingested_at=time.time(),
+        identifiers_hashed=hashed_identifiers,
+        structured_hashed=hashed_structured,
+        structured_numeric=numeric_structured,
+        metadata=sanitized_metadata,
+        derived_features=derived_features,
+    ).model_dump()
+
+    store.append_or_replace(record)
+
+    logger.info(
+        "ingest complete for document %s with %d identifiers", payload.document_id, len(hashed_identifiers)
+    )
+
+    return {"ok": True, "document_id": payload.document_id, "hashed_fields": len(hashed_structured)}
+
+
+@app.get("/ml/artifacts", dependencies=[Depends(require_internal)])
+def list_artifacts(claims: Dict[str, Any] = Depends(require_scopes("ml:read"))) -> Dict[str, Any]:
+    records = store.list_all()
+    return {"items": records, "count": len(records)}
+
+
+@app.get("/ml/artifacts/{document_id}", dependencies=[Depends(require_internal)])
+def get_artifact(document_id: str, claims: Dict[str, Any] = Depends(require_scopes("ml:read"))) -> Dict[str, Any]:
+    record = store.get(document_id)
+    if not record:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
+    return record
+
+
+@app.delete("/ml/artifacts/{document_id}", dependencies=[Depends(require_internal)])
+def delete_artifact(document_id: str, claims: Dict[str, Any] = Depends(require_scopes("ml:ingest"))) -> Dict[str, Any]:
+    if not store.get(document_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Artifact not found")
+    store.delete(document_id)
+    logger.info("artifact %s deleted", document_id)
+    return {"ok": True}

--- a/apps/services/ml_assist/models.py
+++ b/apps/services/ml_assist/models.py
@@ -1,0 +1,24 @@
+"""Pydantic models for ML assist payloads."""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from pydantic import BaseModel, Field
+
+
+class OCRIngestRequest(BaseModel):
+    document_id: str = Field(..., min_length=1)
+    ocr_text: str = Field(..., min_length=1)
+    identifiers: Dict[str, str] = Field(default_factory=dict)
+    structured_fields: Dict[str, Any] = Field(default_factory=dict)
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ArtifactRecord(BaseModel):
+    document_id: str
+    ingested_at: float
+    identifiers_hashed: Dict[str, str]
+    structured_hashed: Dict[str, str]
+    structured_numeric: Dict[str, Any]
+    metadata: Dict[str, Any]
+    derived_features: Dict[str, Any]

--- a/apps/services/ml_assist/requirements.txt
+++ b/apps/services/ml_assist/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.115.0
+uvicorn==0.30.6
+pydantic==2.9.2
+cryptography==43.0.1

--- a/apps/services/ml_assist/security.py
+++ b/apps/services/ml_assist/security.py
@@ -1,0 +1,107 @@
+"""Security helpers for the ML assist service."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+from functools import lru_cache
+from typing import Any, Dict, Iterable, Set
+
+from cryptography.fernet import Fernet
+
+
+class SecurityConfigError(RuntimeError):
+    """Raised when required security configuration is missing."""
+
+
+def _b64url_decode(data: str) -> bytes:
+    padding = "=" * (-len(data) % 4)
+    return base64.urlsafe_b64decode(data + padding)
+
+
+@lru_cache(maxsize=1)
+def get_hash_salt() -> bytes:
+    """Return the configured salt for hashing personal identifiers."""
+    salt = os.getenv("ML_PII_HASH_SALT") or os.getenv("PII_HASH_SALT")
+    if not salt:
+        raise SecurityConfigError("Set ML_PII_HASH_SALT (or PII_HASH_SALT) for hashing identifiers")
+    return salt.encode("utf-8")
+
+
+def hash_identifier(value: str) -> str:
+    """Hash a personal identifier with the configured salt."""
+    data = value.strip()
+    if not data:
+        raise ValueError("Identifier must be non-empty")
+    digest = hashlib.sha256()
+    digest.update(get_hash_salt())
+    digest.update(data.encode("utf-8"))
+    return digest.hexdigest()
+
+
+@lru_cache(maxsize=1)
+def get_cipher() -> Fernet:
+    """Return a Fernet cipher derived from the app secrets KMS key."""
+    key_material = os.getenv("APP_SECRETS_KMS_KEY")
+    if not key_material:
+        raise SecurityConfigError("Set APP_SECRETS_KMS_KEY to encrypt ML artifacts")
+    digest = hashlib.sha256(key_material.encode("utf-8")).digest()
+    encoded = base64.urlsafe_b64encode(digest)
+    return Fernet(encoded)
+
+
+@lru_cache(maxsize=1)
+def get_jwt_secret() -> bytes:
+    secret = os.getenv("APP_JWT_SECRET")
+    if not secret:
+        raise SecurityConfigError("Set APP_JWT_SECRET to validate access tokens")
+    return secret.encode("utf-8")
+
+
+def decode_token(token: str) -> Dict[str, Any]:
+    """Decode a compact JWT supporting HS256 without external dependencies."""
+    try:
+        header_b64, payload_b64, signature_b64 = token.split(".")
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise SecurityConfigError("Invalid access token format") from exc
+
+    try:
+        header = json.loads(_b64url_decode(header_b64))
+        payload = json.loads(_b64url_decode(payload_b64))
+    except (json.JSONDecodeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise SecurityConfigError("Invalid access token payload") from exc
+
+    if header.get("alg") != "HS256":
+        raise SecurityConfigError("Invalid access token algorithm")
+
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    expected = hmac.new(get_jwt_secret(), signing_input, hashlib.sha256).digest()
+    try:
+        provided = _b64url_decode(signature_b64)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise SecurityConfigError("Invalid access token signature") from exc
+
+    if not hmac.compare_digest(expected, provided):
+        raise SecurityConfigError("Invalid access token signature")
+
+    return payload
+
+
+def scopes_from_claims(claims: Dict[str, Any]) -> Set[str]:
+    """Extract a normalized set of scopes from JWT claims."""
+    scope_claim = claims.get("scope")
+    if isinstance(scope_claim, str):
+        return {s for s in scope_claim.split() if s}
+    if isinstance(scope_claim, Iterable):
+        return {str(s) for s in scope_claim if s}
+    return set()
+
+
+def ensure_scopes(claims: Dict[str, Any], required: Iterable[str]) -> None:
+    """Validate that all required scopes are present on the claims."""
+    provided = scopes_from_claims(claims)
+    missing = [scope for scope in required if scope not in provided]
+    if missing:
+        raise SecurityConfigError(f"Missing scopes: {', '.join(missing)}")

--- a/apps/services/ml_assist/store.py
+++ b/apps/services/ml_assist/store.py
@@ -1,0 +1,97 @@
+"""Encrypted storage for ML artifacts."""
+from __future__ import annotations
+
+import json
+import os
+import threading
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from .security import get_cipher
+
+
+class StoreCorruptionError(RuntimeError):
+    """Raised when the encrypted ML store cannot be decrypted."""
+
+
+class EncryptedMLStore:
+    """Persist ML artifacts in an encrypted file."""
+
+    def __init__(self, path: Path, cipher: Optional[Fernet] = None) -> None:
+        self._path = path
+        self._cipher = cipher or get_cipher()
+        self._lock = threading.Lock()
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def _read_encrypted(self) -> Optional[bytes]:
+        if not self._path.exists():
+            return None
+        return self._path.read_bytes()
+
+    def _decrypt_payload(self, payload: bytes) -> List[Dict[str, Any]]:
+        if not payload:
+            return []
+        try:
+            decrypted = self._cipher.decrypt(payload)
+        except InvalidToken as exc:
+            raise StoreCorruptionError("Unable to decrypt ML artifact store") from exc
+        if not decrypted:
+            return []
+        return json.loads(decrypted.decode("utf-8"))
+
+    def _encrypt(self, records: List[Dict[str, Any]]) -> bytes:
+        serialized = json.dumps(records, separators=(",", ":"), sort_keys=True).encode("utf-8")
+        return self._cipher.encrypt(serialized)
+
+    def _write_atomic(self, payload: bytes) -> None:
+        tmp_path = self._path.with_suffix(self._path.suffix + ".tmp")
+        tmp_path.write_bytes(payload)
+        tmp_path.replace(self._path)
+
+    def _load(self) -> List[Dict[str, Any]]:
+        raw = self._read_encrypted()
+        if raw is None:
+            return []
+        return self._decrypt_payload(raw)
+
+    def append_or_replace(self, record: Dict[str, Any]) -> None:
+        """Insert or replace an artifact by document id."""
+        with self._lock:
+            records = self._load()
+            for idx, existing in enumerate(records):
+                if existing.get("document_id") == record.get("document_id"):
+                    records[idx] = record
+                    break
+            else:
+                records.append(record)
+            self._write_atomic(self._encrypt(records))
+
+    def list_all(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return [dict(item) for item in self._load()]
+
+    def get(self, document_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            for record in self._load():
+                if record.get("document_id") == document_id:
+                    return dict(record)
+        return None
+
+    def delete(self, document_id: str) -> None:
+        with self._lock:
+            records = [r for r in self._load() if r.get("document_id") != document_id]
+            self._write_atomic(self._encrypt(records))
+
+
+@lru_cache(maxsize=1)
+def get_store() -> EncryptedMLStore:
+    """Return the configured store instance (cached)."""
+    path_env = os.getenv("ML_STORE_PATH")
+    if path_env:
+        path = Path(path_env)
+    else:
+        path = Path("/tmp/ml_assist_store.enc")
+    return EncryptedMLStore(path)

--- a/tests/ml_assist/test_privacy.py
+++ b/tests/ml_assist/test_privacy.py
@@ -1,0 +1,120 @@
+import os
+import json
+import hmac
+import hashlib
+import sys
+from importlib import reload
+from pathlib import Path
+from typing import Tuple
+
+import pytest
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _b64url(data: bytes) -> str:
+    import base64
+
+    return base64.urlsafe_b64encode(data).rstrip(b"=").decode("ascii")
+
+
+def _make_token(secret: str, scopes) -> str:
+    header = {"alg": "HS256", "typ": "JWT"}
+    payload = {"scope": " ".join(scopes)}
+    header_b64 = _b64url(json.dumps(header, separators=(",", ":")).encode("utf-8"))
+    payload_b64 = _b64url(json.dumps(payload, separators=(",", ":")).encode("utf-8"))
+    signing_input = f"{header_b64}.{payload_b64}".encode("ascii")
+    signature = hmac.new(secret.encode("utf-8"), signing_input, hashlib.sha256).digest()
+    signature_b64 = _b64url(signature)
+    return f"{header_b64}.{payload_b64}.{signature_b64}"
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch) -> Tuple[TestClient, object]:
+    monkeypatch.setenv("ML_PII_HASH_SALT", "unit-test-salt")
+    monkeypatch.setenv("APP_SECRETS_KMS_KEY", "unit-test-master-key")
+    monkeypatch.setenv("APP_JWT_SECRET", "unit-test-jwt-secret")
+    monkeypatch.setenv("ML_STORE_PATH", str(tmp_path / "ml_store.enc"))
+
+    from apps.services.ml_assist import security as security_module
+    from apps.services.ml_assist import store as store_module
+
+    security_module.get_hash_salt.cache_clear()
+    security_module.get_cipher.cache_clear()
+    security_module.get_jwt_secret.cache_clear()
+    store_module.get_store.cache_clear()
+
+    from apps.services.ml_assist import main as main_module
+
+    reload(main_module)
+    return TestClient(main_module.app), main_module
+
+
+def test_ingest_hashes_pii_and_encrypts_store(client):
+    test_client, module = client
+    ingest_token = _make_token("unit-test-jwt-secret", ["ml:ingest"])
+
+    payload = {
+        "document_id": "doc-123",
+        "ocr_text": "Invoice: INV-001\nABN: 53004085616\nTotal: 1234.56",
+        "identifiers": {"abn": "53004085616", "contact": "alice@example.com"},
+        "structured_fields": {"invoice_number": "INV-001"},
+        "metadata": {"uploader": "alice@example.com", "batch": 7},
+    }
+
+    response = test_client.post(
+        "/ml/ingest",
+        json=payload,
+        headers={"Authorization": f"Bearer {ingest_token}"},
+    )
+
+    assert response.status_code == 200
+    record = module.store.get("doc-123")
+    assert record is not None
+    assert record["identifiers_hashed"]["abn"] != "53004085616"
+    assert record["identifiers_hashed"]["contact"] != "alice@example.com"
+    assert record["structured_hashed"]["invoice_number"] != "INV-001"
+    assert "ocr_text" not in record
+
+    store_path = Path(os.environ["ML_STORE_PATH"])
+    assert store_path.exists()
+    ciphertext = store_path.read_bytes()
+    assert b"53004085616" not in ciphertext
+    assert b"alice@example.com" not in ciphertext
+
+
+def test_ml_read_scope_required(client):
+    test_client, _module = client
+    ingest_token = _make_token("unit-test-jwt-secret", ["ml:ingest"])
+    read_token = _make_token("unit-test-jwt-secret", ["ml:read"])
+
+    payload = {
+        "document_id": "doc-401",
+        "ocr_text": "Name: Bob\nTotal: 88.20",
+        "identifiers": {"customer_id": "123-456"},
+    }
+
+    resp = test_client.post(
+        "/ml/ingest",
+        json=payload,
+        headers={"Authorization": f"Bearer {ingest_token}"},
+    )
+    assert resp.status_code == 200
+
+    resp_forbidden = test_client.get(
+        "/ml/artifacts",
+        headers={"Authorization": f"Bearer {ingest_token}"},
+    )
+    assert resp_forbidden.status_code == 403
+
+    resp_ok = test_client.get(
+        "/ml/artifacts",
+        headers={"Authorization": f"Bearer {read_token}"},
+    )
+    assert resp_ok.status_code == 200
+    data = resp_ok.json()
+    assert data["count"] >= 1
+    assert any(item["document_id"] == "doc-401" for item in data["items"])


### PR DESCRIPTION
## Summary
- add a dedicated `ml_assist` FastAPI service that hashes PII on ingest, redacts logs, restricts internal access, and enforces JWT scopes for ml:ingest and ml:read consumers
- secure ML artifacts by encrypting the on-disk store with the shared KMS key, hashing structured/metadata fields, and exposing safe list/get/delete APIs
- introduce targeted tests that generate HS256 tokens, validate hashed storage, encryption, and scope-gated access along with the service requirements file

## Testing
- pytest tests/ml_assist/test_privacy.py

------
https://chatgpt.com/codex/tasks/task_e_68e3959d60808327b5f1661ab1761c88