### PR TITLE
Add feature flag controls to settings panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import AppLayout from "./components/AppLayout";
+import { AppProvider } from "./context/AppContext";
 
 import Dashboard from "./pages/Dashboard";
 import BAS from "./pages/BAS";
@@ -14,19 +15,21 @@ import Help from "./pages/Help";
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <AppProvider>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </AppProvider>
   );
 }

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -2,7 +2,47 @@ import React, { createContext, useState } from "react";
 import { mockPayroll, mockSales, mockBasHistory } from "../utils/mockData";
 import { BASHistory } from "../types/tax";
 
-export const AppContext = createContext<any>(null);
+export type AppMode = "dev" | "stage" | "prod";
+
+type FeatureFlags = Record<string, boolean>;
+
+type KeyMetadata = {
+  purpose: string;
+  kid: string;
+  rotationDue: string;
+};
+
+type RuleManifest = {
+  id: string;
+  revision: string;
+  publishedAt: string;
+  checksum: string;
+  notes?: string;
+};
+
+type AppContextShape = {
+  vaultBalance: number;
+  setVaultBalance: React.Dispatch<React.SetStateAction<number>>;
+  businessBalance: number;
+  setBusinessBalance: React.Dispatch<React.SetStateAction<number>>;
+  payroll: typeof mockPayroll;
+  setPayroll: React.Dispatch<React.SetStateAction<typeof mockPayroll>>;
+  sales: typeof mockSales;
+  setSales: React.Dispatch<React.SetStateAction<typeof mockSales>>;
+  basHistory: BASHistory[];
+  setBasHistory: React.Dispatch<React.SetStateAction<BASHistory[]>>;
+  auditLog: any[];
+  setAuditLog: React.Dispatch<React.SetStateAction<any[]>>;
+  appMode: AppMode;
+  setAppMode: React.Dispatch<React.SetStateAction<AppMode>>;
+  featureFlags: FeatureFlags;
+  setFeatureFlags: React.Dispatch<React.SetStateAction<FeatureFlags>>;
+  ratesVersion: string;
+  keyMetadata: KeyMetadata[];
+  ruleManifest: RuleManifest;
+};
+
+export const AppContext = createContext<AppContextShape>({} as AppContextShape);
 
 export function AppProvider({ children }: { children: React.ReactNode }) {
   const [vaultBalance, setVaultBalance] = useState(10000);
@@ -11,16 +51,61 @@ export function AppProvider({ children }: { children: React.ReactNode }) {
   const [sales, setSales] = useState(mockSales);
   const [basHistory, setBasHistory] = useState<BASHistory[]>(mockBasHistory);
   const [auditLog, setAuditLog] = useState<any[]>([]);
+  const [appMode, setAppMode] = useState<AppMode>("stage");
+  const [featureFlags, setFeatureFlags] = useState<FeatureFlags>({
+    FEATURE_SMART_ROUTING: true,
+    FEATURE_RISK_SCORING: true,
+    FEATURE_SETTLEMENT_BATCHING: false,
+    FEATURE_SHADOW_SETTLEMENT: false,
+    FEATURE_RULE_MANIFEST_SYNC: true,
+    DRY_RUN_PAYMENTS: false,
+    DRY_RUN_NOTIFICATIONS: true,
+  });
+  const [ratesVersion] = useState("2025.09-r1");
+  const [keyMetadata] = useState<KeyMetadata[]>([
+    {
+      purpose: "Primary signing key",
+      kid: "kid-live-2024-10",
+      rotationDue: "2025-12-31",
+    },
+    {
+      purpose: "Shadow settlement key",
+      kid: "kid-shadow-2025-01",
+      rotationDue: "2025-08-15",
+    },
+  ]);
+  const [ruleManifest] = useState<RuleManifest>({
+    id: "gst-lodgement",
+    revision: "2025.10.0",
+    publishedAt: "2025-10-01T02:45:00Z",
+    checksum: "8b6f2fa4",
+    notes: "Latest settlement risk filters synced from rules service.",
+  });
 
   return (
-    <AppContext.Provider value={{
-      vaultBalance, setVaultBalance,
-      businessBalance, setBusinessBalance,
-      payroll, setPayroll,
-      sales, setSales,
-      basHistory, setBasHistory,
-      auditLog, setAuditLog,
-    }}>
+    <AppContext.Provider
+      value={{
+        vaultBalance,
+        setVaultBalance,
+        businessBalance,
+        setBusinessBalance,
+        payroll,
+        setPayroll,
+        sales,
+        setSales,
+        basHistory,
+        setBasHistory,
+        auditLog,
+        setAuditLog,
+        appMode,
+        setAppMode,
+        featureFlags,
+        setFeatureFlags,
+        ratesVersion,
+        keyMetadata,
+        ruleManifest,
+      }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,24 @@
-import React, { useState } from "react";
+import React, { useContext, useMemo, useState } from "react";
+import { AppContext, AppMode } from "../context/AppContext";
+
+type FeatureDefinition = {
+  key: string;
+  label: string;
+  description: string;
+  category: string;
+  variant?: "preview" | "dryRun";
+};
+
+type FeatureAuditEntry = {
+  type: "feature" | "environment";
+  flag?: string;
+  value?: boolean;
+  mode?: AppMode;
+  previous?: AppMode;
+  next?: AppMode;
+  at: string;
+  actor: string;
+};
 
 const tabs = [
   "Business Profile",
@@ -9,11 +29,13 @@ const tabs = [
   "Compliance & Audit",
   "Customisation",
   "Notifications",
-  "Advanced"
+  "Advanced",
+  "Features"
 ];
 
 export default function Settings() {
   const [activeTab, setActiveTab] = useState(tabs[0]);
+  const appContext = useContext(AppContext);
   // Mock business profile state
   const [profile, setProfile] = useState({
     abn: "12 345 678 901",
@@ -21,6 +43,147 @@ export default function Settings() {
     trading: "Example Vending",
     contact: "info@example.com"
   });
+
+  const {
+    appMode,
+    setAppMode,
+    featureFlags,
+    setFeatureFlags,
+    auditLog,
+    setAuditLog,
+    ratesVersion,
+    keyMetadata,
+    ruleManifest,
+  } = appContext;
+
+  const featureDefinitions = useMemo<FeatureDefinition[]>(
+    () => [
+      {
+        key: "FEATURE_SMART_ROUTING",
+        label: "Smart routing",
+        description: "Optimise payouts across connected rails using the risk engine.",
+        category: "Core",
+      },
+      {
+        key: "FEATURE_RISK_SCORING",
+        label: "Risk scoring",
+        description: "Enable fraud heuristics and behavioural risk adjustments in flight.",
+        category: "Core",
+      },
+      {
+        key: "FEATURE_SETTLEMENT_BATCHING",
+        label: "Settlement batching",
+        description: "Batch settlements to reduce fees at the cost of slightly delayed disbursements.",
+        category: "Core",
+      },
+      {
+        key: "FEATURE_SHADOW_SETTLEMENT",
+        label: "Preview settlements (shadow)",
+        description: "Mirrors live settlement plans into the shadow environment for validation before promoting to prod.",
+        category: "Preview",
+        variant: "preview" as const,
+      },
+      {
+        key: "FEATURE_RULE_MANIFEST_SYNC",
+        label: "Rule manifest sync",
+        description: "Pull the latest manifest for GST and PAYGW orchestration rules.",
+        category: "Operations",
+      },
+      {
+        key: "DRY_RUN_PAYMENTS",
+        label: "Payments dry run",
+        description: "Execute orchestration without posting funds; emits audit-only events.",
+        category: "Safety",
+        variant: "dryRun" as const,
+      },
+      {
+        key: "DRY_RUN_NOTIFICATIONS",
+        label: "Notification dry run",
+        description: "Suppress outbound notifications while still logging template resolution.",
+        category: "Safety",
+        variant: "dryRun" as const,
+      },
+    ],
+    []
+  );
+
+  const modeMeta: Record<AppMode, { label: string; tone: string; description: string }> = {
+    dev: {
+      label: "Development",
+      tone: "#2563eb",
+      description: "Full control with hot reload and verbose logging.",
+    },
+    stage: {
+      label: "Staging",
+      tone: "#f59e0b",
+      description: "Safe for rehearsals; feature flips propagate to shadow workloads.",
+    },
+    prod: {
+      label: "Production",
+      tone: "#16a34a",
+      description: "Readonly. Changes require change window approval.",
+    },
+  };
+
+  const canEditFeatures = appMode !== "prod";
+
+  const featureAuditLog = useMemo(() => {
+    return auditLog.filter((entry): entry is FeatureAuditEntry =>
+      entry && (entry.type === "feature" || entry.type === "environment")
+    );
+  }, [auditLog]);
+
+  const handleModeChange = (nextMode: AppMode) => {
+    setAppMode(prevMode => {
+      if (prevMode === nextMode) {
+        return prevMode;
+      }
+
+      setAuditLog(prev => [
+        ...prev,
+        {
+          type: "environment",
+          previous: prevMode,
+          next: nextMode,
+          at: new Date().toISOString(),
+          actor: "ops-console",
+        },
+      ]);
+
+      return nextMode;
+    });
+  };
+
+  const handleToggle = (key: string) => {
+    if (!canEditFeatures) {
+      return;
+    }
+
+    setFeatureFlags(prevFlags => {
+      const updated = { ...prevFlags, [key]: !prevFlags[key] };
+      setAuditLog(prev => [
+        ...prev,
+        {
+          type: "feature",
+          flag: key,
+          value: updated[key],
+          mode: appMode,
+          at: new Date().toISOString(),
+          actor: "ops-console",
+        },
+      ]);
+      return updated;
+    });
+  };
+
+  const featuresByCategory = useMemo(() => {
+    return featureDefinitions.reduce<Record<string, FeatureDefinition[]>>((acc, feature) => {
+      const bucket = acc[feature.category] ?? [];
+      bucket.push(feature);
+      acc[feature.category] = bucket;
+      return acc;
+    }, {});
+  }, [featureDefinitions]);
 
   return (
     <div className="settings-card">
@@ -208,6 +371,250 @@ export default function Settings() {
           <div style={{ maxWidth: 600, margin: "0 auto" }}>
             <h3>Export Data</h3>
             <button className="button">Export as CSV</button>
+          </div>
+        )}
+        {activeTab === "Features" && (
+          <div style={{ maxWidth: 760, margin: "0 auto" }}>
+            <section
+              style={{
+                background: "#f9fafb",
+                borderRadius: 12,
+                padding: 20,
+                marginBottom: 24,
+                border: "1px solid #e5e7eb",
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+                <div>
+                  <h3 style={{ marginBottom: 6 }}>Environment mode</h3>
+                  <p style={{ margin: 0, color: "#4b5563" }}>APP_MODE: {modeMeta[appMode].label}</p>
+                  <p style={{ margin: "4px 0 0", color: "#6b7280", fontSize: 14 }}>{modeMeta[appMode].description}</p>
+                </div>
+                <div style={{ textAlign: "right" }}>
+                  <div style={{ fontSize: 12, color: "#6b7280", marginBottom: 4 }}>Switch mode</div>
+                  <div style={{ display: "flex", gap: 8 }}>
+                    {(Object.keys(modeMeta) as AppMode[]).map(mode => (
+                      <button
+                        key={mode}
+                        className="button"
+                        style={{
+                          background: mode === appMode ? modeMeta[mode].tone : "#111827",
+                          borderColor: mode === appMode ? modeMeta[mode].tone : "#111827",
+                          opacity: mode === appMode ? 1 : 0.6,
+                          cursor: mode === appMode ? "default" : "pointer",
+                        }}
+                        onClick={() => handleModeChange(mode)}
+                        type="button"
+                      >
+                        {modeMeta[mode].label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+              {!canEditFeatures && (
+                <div
+                  style={{
+                    marginTop: 16,
+                    padding: 12,
+                    borderRadius: 8,
+                    background: "#fef3c7",
+                    border: "1px solid #f59e0b",
+                    color: "#92400e",
+                    fontSize: 14,
+                  }}
+                >
+                  Production mode detected. Feature flips are locked; raise a change request to update.
+                </div>
+              )}
+            </section>
+
+            <section style={{ marginBottom: 24 }}>
+              <h3 style={{ marginBottom: 12 }}>Feature flags</h3>
+              {Object.entries(featuresByCategory).map(([category, items]) => (
+                <div
+                  key={category}
+                  style={{
+                    border: "1px solid #e5e7eb",
+                    borderRadius: 12,
+                    marginBottom: 16,
+                    background: "white",
+                  }}
+                >
+                  <div
+                    style={{
+                      padding: "12px 16px",
+                      borderBottom: "1px solid #e5e7eb",
+                      fontWeight: 600,
+                      background: "#f9fafb",
+                    }}
+                  >
+                    {category}
+                  </div>
+                  <div>
+                    {items.map(item => {
+                      const isEnabled = featureFlags[item.key];
+                      return (
+                        <div
+                          key={item.key}
+                          style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            padding: "14px 16px",
+                            borderBottom: "1px solid #f3f4f6",
+                            alignItems: "center",
+                          }}
+                        >
+                          <div style={{ maxWidth: "70%" }}>
+                            <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                              <span style={{ fontWeight: 600 }}>{item.label}</span>
+                              {item.variant === "preview" && (
+                                <span
+                                  style={{
+                                    background: "#dbeafe",
+                                    color: "#1d4ed8",
+                                    fontSize: 12,
+                                    padding: "2px 8px",
+                                    borderRadius: 9999,
+                                  }}
+                                >
+                                  Preview / shadow
+                                </span>
+                              )}
+                              {item.variant === "dryRun" && (
+                                <span
+                                  style={{
+                                    background: "#fee2e2",
+                                    color: "#b91c1c",
+                                    fontSize: 12,
+                                    padding: "2px 8px",
+                                    borderRadius: 9999,
+                                  }}
+                                >
+                                  Dry run
+                                </span>
+                              )}
+                            </div>
+                            <p style={{ margin: "6px 0 0", color: "#4b5563", fontSize: 14 }}>{item.description}</p>
+                            {item.variant === "preview" && (
+                              <p style={{ margin: "6px 0 0", color: "#2563eb", fontSize: 13 }}>
+                                Shadow flips don't impact production traffic until promoted.
+                              </p>
+                            )}
+                            {item.variant === "dryRun" && (
+                              <p style={{ margin: "6px 0 0", color: "#b91c1c", fontSize: 13 }}>
+                                Dry run skips side-effects. Confirm with operations before enabling in prod.
+                              </p>
+                            )}
+                          </div>
+                          <label style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                            <span style={{ fontSize: 13, color: "#6b7280" }}>{isEnabled ? "On" : "Off"}</span>
+                            <input
+                              type="checkbox"
+                              checked={isEnabled}
+                              onChange={() => handleToggle(item.key)}
+                              disabled={!canEditFeatures}
+                              style={{ width: 22, height: 22 }}
+                            />
+                          </label>
+                        </div>
+                      );
+                    })}
+                  </div>
+                </div>
+              ))}
+            </section>
+
+            <section
+              style={{
+                display: "grid",
+                gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+                gap: 16,
+                marginBottom: 24,
+              }}
+            >
+              <div
+                style={{
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 12,
+                  padding: 16,
+                  background: "white",
+                }}
+              >
+                <h4 style={{ margin: 0, fontSize: 16 }}>Rates</h4>
+                <p style={{ margin: "8px 0 0", color: "#4b5563", fontSize: 14 }}>RATES_VERSION</p>
+                <p style={{ margin: "4px 0 0", fontWeight: 600 }}>{ratesVersion}</p>
+                <p style={{ margin: "8px 0 0", color: "#6b7280", fontSize: 13 }}>
+                  Managed via revenue service release train. Read-only from console.
+                </p>
+              </div>
+              <div
+                style={{
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 12,
+                  padding: 16,
+                  background: "white",
+                }}
+              >
+                <h4 style={{ margin: 0, fontSize: 16 }}>Key material</h4>
+                <p style={{ margin: "8px 0 12px", color: "#4b5563", fontSize: 14 }}>Active KIDs</p>
+                <ul style={{ margin: 0, paddingLeft: 18 }}>
+                  {keyMetadata.map(key => (
+                    <li key={key.kid} style={{ marginBottom: 6, color: "#374151", fontSize: 14 }}>
+                      <div style={{ fontWeight: 600 }}>{key.kid}</div>
+                      <div style={{ color: "#6b7280", fontSize: 13 }}>{key.purpose}</div>
+                      <div style={{ color: "#6b7280", fontSize: 12 }}>Rotation due {key.rotationDue}</div>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <div
+                style={{
+                  border: "1px solid #e5e7eb",
+                  borderRadius: 12,
+                  padding: 16,
+                  background: "white",
+                }}
+              >
+                <h4 style={{ margin: 0, fontSize: 16 }}>Rule manifest</h4>
+                <p style={{ margin: "8px 0 0", color: "#4b5563", fontSize: 14 }}>{ruleManifest.id}</p>
+                <p style={{ margin: "4px 0 0", fontWeight: 600 }}>Revision {ruleManifest.revision}</p>
+                <p style={{ margin: "4px 0 0", color: "#6b7280", fontSize: 13 }}>
+                  Published {new Date(ruleManifest.publishedAt).toLocaleString()} (checksum {ruleManifest.checksum})
+                </p>
+                {ruleManifest.notes && (
+                  <p style={{ margin: "8px 0 0", color: "#4b5563", fontSize: 13 }}>{ruleManifest.notes}</p>
+                )}
+              </div>
+            </section>
+
+            <section
+              style={{
+                border: "1px solid #e5e7eb",
+                borderRadius: 12,
+                padding: 16,
+                background: "#f9fafb",
+                color: "#374151",
+                fontSize: 13,
+              }}
+            >
+              <h4 style={{ margin: "0 0 8px" }}>Last 3 console events</h4>
+              {featureAuditLog.length === 0 && (
+                <p style={{ margin: 0, color: "#6b7280" }}>No feature flips recorded yet.</p>
+              )}
+              {featureAuditLog.slice(-3).reverse().map((entry, index) => (
+                <div key={index} style={{ marginBottom: 8 }}>
+                  <div style={{ fontWeight: 600 }}>
+                    {entry.type === "feature" && `${entry.flag} → ${entry.value ? "on" : "off"}`}
+                    {entry.type === "environment" && `Mode ${entry.previous} → ${entry.next}`}
+                  </div>
+                  <div style={{ color: "#6b7280" }}>
+                    {new Date(entry.at).toLocaleString()} • {entry.actor}
+                  </div>
+                  {entry.mode && <div style={{ color: "#6b7280" }}>Mode snapshot: {entry.mode}</div>}
+                </div>
+              ))}
+            </section>
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
- add environment metadata, feature flag state, and manifest details to the shared app context
- wrap the app in AppProvider so settings can access feature flag data
- create a new Settings > Features tab with editable toggles for non-production modes, preview/dry-run warnings, and surfaced read-only metadata

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e399b92d508327aecf7c6ce83da410