### PR TITLE
feat(console): add toast-based error handling and tracing

### DIFF
--- a/apps/web/console/public/status.json
+++ b/apps/web/console/public/status.json
@@ -1,0 +1,25 @@
+{
+  "tiles": [
+    {
+      "id": "ingestion",
+      "title": "Ingestion",
+      "summary": "Event ingestion pipeline is processing 98% of messages within the SLA.",
+      "status": "healthy",
+      "helpUrl": "https://docs.apgms.local/runbooks/ingestion"
+    },
+    {
+      "id": "normalizer",
+      "title": "Normalizer",
+      "summary": "Normalizer lag is elevated for US-East tenants after the latest deploy.",
+      "status": "degraded",
+      "helpUrl": "https://docs.apgms.local/runbooks/normalizer"
+    },
+    {
+      "id": "rpt",
+      "title": "RPT Refresh",
+      "summary": "Last refresh completed 47 minutes ago. Next run scheduled at 20:15 UTC.",
+      "status": "healthy",
+      "helpUrl": "https://docs.apgms.local/runbooks/rpt"
+    }
+  ]
+}

--- a/apps/web/console/src/App.tsx
+++ b/apps/web/console/src/App.tsx
@@ -1,0 +1,398 @@
+import React from "react";
+import { QueryClient, QueryClientProvider, useMutation, useQuery } from "@tanstack/react-query";
+import { request } from "./api/client";
+import { RequestError, isRequestError } from "./api/errors";
+import { EmptyState } from "./components/EmptyState";
+import { ErrorState } from "./components/ErrorState";
+import { LoadingState } from "./components/LoadingState";
+import { ToastProvider, useToasts } from "./components/ToastProvider";
+import { ToastViewport } from "./components/ToastViewport";
+import { RequestTraceProvider, useRequestTrace } from "./providers/RequestTraceProvider";
+import { createRequestId } from "./utils/request-id";
+import { subscribeToRequestTrace } from "./tracing/trace-emitter";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+interface StatusTile {
+  id: string;
+  title: string;
+  summary: string;
+  status: "healthy" | "degraded" | "down";
+  helpUrl: string;
+}
+
+interface StatusResponse {
+  tiles: StatusTile[];
+}
+
+const CURRENT_USER = {
+  name: "Alex Parker",
+  role: "admin" as const,
+};
+
+export function AppProviders({ children }: { children: React.ReactNode }) {
+  return (
+    <RequestTraceProvider>
+      <ToastProvider>
+        <RequestFailureToasts />
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        <ToastViewport />
+      </ToastProvider>
+    </RequestTraceProvider>
+  );
+}
+
+export function AppShell() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "linear-gradient(180deg, #020617, #0f172a)",
+        color: "#e2e8f0",
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <GlobalStyles />
+      <header
+        style={{
+          padding: "24px 32px",
+          borderBottom: "1px solid rgba(148, 163, 184, 0.2)",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+        }}
+      >
+        <div>
+          <h1 style={{ margin: 0, fontSize: 28 }}>APGMS Console</h1>
+          <p style={{ margin: "6px 0 0", color: "#94a3b8" }}>Operational overview &amp; RPT insights</p>
+        </div>
+        <div style={{ textAlign: "right" }}>
+          <p style={{ margin: 0, fontSize: 13, color: "#94a3b8" }}>Signed in as</p>
+          <p style={{ margin: 0, fontWeight: 600 }}>{CURRENT_USER.name}</p>
+        </div>
+      </header>
+      <main style={{ padding: "32px", maxWidth: 960, margin: "0 auto", width: "100%" }}>
+        <div style={{ display: "grid", gap: 24 }}>
+          <StatusOverview />
+          <OperationsPanel />
+        </div>
+      </main>
+      <FooterTraces />
+    </div>
+  );
+}
+
+function StatusOverview() {
+  const {
+    data,
+    isLoading,
+    isError,
+    error,
+    refetch,
+  } = useQuery<StatusResponse, RequestError>({
+    queryKey: ["status-tiles"],
+    queryFn: async () => {
+      const result = await request<StatusResponse>("/status.json");
+      return result.data;
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <section>
+        <SectionHeader
+          title="Status tiles"
+          description="Live health indicators from APGMS subsystems"
+        />
+        <LoadingState label="Loading health summaries" />
+      </section>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <section>
+        <SectionHeader
+          title="Status tiles"
+          description="Live health indicators from APGMS subsystems"
+        />
+        <ErrorState
+          error={error}
+          onRetry={() => refetch()}
+          helpUrl="https://docs.apgms.local/status-triage"
+          helpLabel="Status triage playbook"
+        />
+      </section>
+    );
+  }
+
+  if (!data.tiles.length) {
+    return (
+      <section>
+        <SectionHeader
+          title="Status tiles"
+          description="Live health indicators from APGMS subsystems"
+        />
+        <EmptyState
+          title="No tiles configured yet"
+          description="Provision the reporting widgets in the admin portal to populate this dashboard."
+          helpUrl="https://docs.apgms.local/status-setup"
+          helpLabel="Set up status tiles"
+          action={<button style={linkButtonStyle} onClick={() => refetch()}>Refresh</button>}
+        />
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <SectionHeader
+        title="Status tiles"
+        description="Live health indicators from APGMS subsystems"
+      />
+      <div
+        style={{
+          display: "grid",
+          gap: 16,
+          gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+        }}
+      >
+        {data.tiles.map((tile) => (
+          <article
+            key={tile.id}
+            style={{
+              borderRadius: 12,
+              border: "1px solid rgba(148, 163, 184, 0.25)",
+              padding: 20,
+              background: "rgba(15, 23, 42, 0.7)",
+            }}
+          >
+            <header style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+              <h3 style={{ margin: 0 }}>{tile.title}</h3>
+              <StatusBadge status={tile.status} />
+            </header>
+            <p style={{ margin: "12px 0", color: "#94a3b8", lineHeight: 1.4 }}>{tile.summary}</p>
+            <a href={tile.helpUrl} target="_blank" rel="noreferrer" style={{ color: "#93c5fd" }}>
+              View runbook
+            </a>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function StatusBadge({ status }: { status: StatusTile["status"] }) {
+  const color =
+    status === "healthy" ? "#22c55e" : status === "degraded" ? "#facc15" : "#ef4444";
+  return (
+    <span
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        fontSize: 13,
+        color,
+        fontWeight: 600,
+      }}
+    >
+      <span
+        style={{
+          width: 8,
+          height: 8,
+          borderRadius: "50%",
+          background: color,
+          display: "inline-block",
+        }}
+      />
+      {status.toUpperCase()}
+    </span>
+  );
+}
+
+function SectionHeader({ title, description }: { title: string; description: string }) {
+  return (
+    <header style={{ marginBottom: 16 }}>
+      <h2 style={{ margin: 0, fontSize: 22 }}>{title}</h2>
+      <p style={{ margin: "6px 0 0", color: "#94a3b8" }}>{description}</p>
+    </header>
+  );
+}
+
+function OperationsPanel() {
+  const { push } = useToasts();
+  const isAdmin = CURRENT_USER.role === "admin";
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      const result = await request<{ success: boolean }>("/api/run-rpt-sync", {
+        method: "POST",
+        body: JSON.stringify({ scope: "full" }),
+        headers: { "content-type": "application/json" },
+        meta: {
+          label: "Report sync job",
+          skipGlobalErrorToast: true,
+        },
+      });
+      return result;
+    },
+    onSuccess: ({ requestId }) => {
+      push({
+        title: "Sync scheduled",
+        description: "We&apos;ll notify you when the report refresh completes.",
+        requestId,
+        variant: "success",
+        autoClose: true,
+      });
+    },
+    onError: (error: unknown) => {
+      const requestError = isRequestError(error)
+        ? error
+        : new RequestError("Failed to trigger sync", {
+            requestId: createRequestId(),
+          });
+      push({
+        title: "Failed to trigger data sync",
+        description: requestError.message,
+        requestId: requestError.requestId,
+        variant: "error",
+        action:
+          isAdmin && requestError.requestId
+            ? {
+                label: "Open trace logs",
+                href: `https://logs.apgms.local/requests/${requestError.requestId}`,
+              }
+            : undefined,
+        autoClose: false,
+      });
+    },
+  });
+
+  return (
+    <section>
+      <SectionHeader
+        title="Operations"
+        description="Run maintenance jobs and triage issues"
+      />
+      <div
+        style={{
+          display: "flex",
+          gap: 16,
+          flexWrap: "wrap",
+          alignItems: "center",
+        }}
+      >
+        <button
+          onClick={() => mutation.mutate()}
+          disabled={mutation.isPending}
+          style={{
+            padding: "12px 20px",
+            borderRadius: 10,
+            border: "none",
+            background: mutation.isPending ? "#334155" : "#2563eb",
+            color: "white",
+            fontWeight: 600,
+            cursor: mutation.isPending ? "wait" : "pointer",
+          }}
+        >
+          {mutation.isPending ? "Scheduling..." : "Schedule report sync"}
+        </button>
+        <p style={{ margin: 0, color: "#94a3b8" }}>
+          Starts a full refresh of downstream RPT datasets.
+        </p>
+      </div>
+    </section>
+  );
+}
+
+function FooterTraces() {
+  const { lastTrace } = useRequestTrace();
+  if (!lastTrace) {
+    return null;
+  }
+  return (
+    <footer
+      style={{
+        marginTop: 48,
+        padding: "16px 32px",
+        borderTop: "1px solid rgba(148, 163, 184, 0.2)",
+        fontSize: 12,
+        color: "#94a3b8",
+      }}
+    >
+      <p style={{ margin: 0 }}>
+        Last request: <span style={{ fontFamily: "ui-monospace" }}>{lastTrace.requestId}</span> · {lastTrace.method} {" "}
+        {lastTrace.url} · {lastTrace.success ? "success" : "error"}
+      </p>
+    </footer>
+  );
+}
+
+const linkButtonStyle: React.CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 8,
+  border: "1px solid rgba(148, 163, 184, 0.4)",
+  background: "transparent",
+  color: "#93c5fd",
+  cursor: "pointer",
+};
+
+function RequestFailureToasts() {
+  const { push } = useToasts();
+  const handledRef = React.useRef(new Set<string>());
+
+  React.useEffect(() => {
+    return subscribeToRequestTrace((trace) => {
+      if (trace.success) {
+        return;
+      }
+      if (trace.autoToast === false) {
+        return;
+      }
+      const handled = handledRef.current;
+      if (handled.has(trace.requestId)) {
+        return;
+      }
+      handled.add(trace.requestId);
+
+      const description = trace.label ?? `${trace.method} ${trace.url}`;
+
+      push({
+        title: trace.errorMessage ?? "Request failed",
+        description,
+        requestId: trace.requestId,
+        variant: "error",
+        action:
+          CURRENT_USER.role === "admin"
+            ? {
+                label: "Open trace logs",
+                href: `https://logs.apgms.local/requests/${trace.requestId}`,
+              }
+            : undefined,
+        autoClose: false,
+      });
+    });
+  }, [push]);
+
+  return null;
+}
+
+function GlobalStyles() {
+  return (
+    <style>
+      {`
+        :root { color-scheme: dark; }
+        body { margin: 0; background: #020617; }
+        @keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }
+        button { font-family: inherit; }
+      `}
+    </style>
+  );
+}

--- a/apps/web/console/src/api/client.ts
+++ b/apps/web/console/src/api/client.ts
@@ -1,0 +1,121 @@
+import { emitRequestTrace } from "../tracing/trace-emitter";
+import { createRequestId } from "../utils/request-id";
+import { RequestError, toRequestError } from "./errors";
+
+export interface RequestOptions extends RequestInit {
+  /**
+   * When true the helper will attempt to parse JSON responses.
+   * Defaults to true for convenience.
+   */
+  parseJson?: boolean;
+  meta?: {
+    /**
+     * Optional friendly label for observability and user facing messaging.
+     */
+    label?: string;
+    /**
+     * Skip the automatic network error toast for this request.
+     */
+    skipGlobalErrorToast?: boolean;
+  };
+}
+
+export interface RequestSuccess<T> {
+  data: T;
+  requestId: string;
+  response: Response;
+}
+
+const HELPERS = {
+  async parseResponse<T>(response: Response, parseJson: boolean): Promise<T> {
+    if (!parseJson) {
+      return (await response.text()) as unknown as T;
+    }
+    const text = await response.text();
+    if (!text) {
+      return {} as T;
+    }
+    try {
+      return JSON.parse(text) as T;
+    } catch (error) {
+      throw new Error("Response was not valid JSON");
+    }
+  },
+};
+
+export async function request<T>(input: RequestInfo | URL, options: RequestOptions = {}): Promise<RequestSuccess<T>> {
+  const requestId = createRequestId();
+  const parseJson = options.parseJson ?? true;
+  const method = (options.method ?? "GET").toUpperCase();
+  const autoToast = options.meta?.skipGlobalErrorToast ? false : method !== "GET";
+
+  const headers = new Headers(options.headers ?? {});
+  if (!headers.has("x-request-id")) {
+    headers.set("x-request-id", requestId);
+  }
+  const init: RequestInit = { ...options, headers };
+
+  let response: Response | undefined;
+  const startedAt = new Date();
+
+  try {
+    if (typeof input === "string" && input.startsWith("/api/")) {
+      // Mocked API endpoints for the demo environment. These intentionally
+      // fail to illustrate error handling flows and produce traceable IDs.
+      await delay(450);
+      throw new RequestError("Upstream service is temporarily unavailable", {
+        requestId,
+        status: 503,
+        url: input.toString(),
+      });
+    }
+
+    response = await fetch(input, init);
+    if (!response.ok) {
+      throw new RequestError(`Request failed with status ${response.status}`, {
+        requestId,
+        status: response.status,
+        url: input.toString(),
+      });
+    }
+
+    const data = await HELPERS.parseResponse<T>(response, parseJson);
+
+    emitRequestTrace({
+      requestId,
+      url: input.toString(),
+      method,
+      status: response.status,
+      success: true,
+      timestamp: startedAt.toISOString(),
+      label: options.meta?.label,
+      autoToast,
+    });
+
+    return { data, requestId, response };
+  } catch (error) {
+    const requestError = toRequestError(error, "Network request failed", {
+      requestId,
+      status: response?.status,
+      url: input.toString(),
+    });
+
+    emitRequestTrace({
+      requestId,
+      url: input.toString(),
+      method,
+      status: requestError.status,
+      success: false,
+      timestamp: startedAt.toISOString(),
+      errorMessage: requestError.message,
+      label: options.meta?.label,
+      autoToast,
+    });
+
+    throw requestError;
+  }
+}
+
+async function delay(ms: number) {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/apps/web/console/src/api/errors.ts
+++ b/apps/web/console/src/api/errors.ts
@@ -1,0 +1,40 @@
+export interface RequestErrorOptions {
+  requestId: string;
+  status?: number;
+  url?: string;
+  cause?: unknown;
+}
+
+export class RequestError extends Error {
+  readonly requestId: string;
+  readonly status?: number;
+  readonly url?: string;
+
+  constructor(message: string, options: RequestErrorOptions) {
+    super(message);
+    this.name = "RequestError";
+    this.requestId = options.requestId;
+    this.status = options.status;
+    this.url = options.url;
+    if (options.cause) {
+      // Assign cause for better stack traces when supported
+      (this as Error & { cause?: unknown }).cause = options.cause;
+    }
+  }
+}
+
+export function isRequestError(error: unknown): error is RequestError {
+  return error instanceof RequestError;
+}
+
+export function toRequestError(
+  error: unknown,
+  fallbackMessage: string,
+  options: RequestErrorOptions,
+): RequestError {
+  if (error instanceof RequestError) {
+    return error;
+  }
+  const message = error instanceof Error && error.message ? error.message : fallbackMessage;
+  return new RequestError(message, { ...options, cause: error });
+}

--- a/apps/web/console/src/components/EmptyState.tsx
+++ b/apps/web/console/src/components/EmptyState.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+
+interface EmptyStateProps {
+  title: string;
+  description: string;
+  helpUrl: string;
+  helpLabel?: string;
+  action?: React.ReactNode;
+}
+
+export function EmptyState({ title, description, helpUrl, helpLabel = "View help", action }: EmptyStateProps) {
+  return (
+    <div
+      style={{
+        border: "1px dashed #94a3b8",
+        borderRadius: 12,
+        padding: 24,
+        background: "rgba(148, 163, 184, 0.05)",
+        textAlign: "center",
+      }}
+    >
+      <h3 style={{ marginBottom: 12 }}>{title}</h3>
+      <p style={{ marginBottom: 16, color: "#64748b" }}>{description}</p>
+      <div style={{ display: "flex", justifyContent: "center", gap: 12 }}>
+        <a href={helpUrl} target="_blank" rel="noreferrer" style={{ color: "#2563eb" }}>
+          {helpLabel}
+        </a>
+        {action}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/console/src/components/ErrorBoundary.tsx
+++ b/apps/web/console/src/components/ErrorBoundary.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+
+interface ErrorBoundaryProps {
+  onReset?: () => void;
+  fallback: (args: { error: Error; resetErrorBoundary: () => void }) => React.ReactNode;
+  children: React.ReactNode;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = {
+    error: null,
+  };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    console.error("Global error boundary captured an error", error, info);
+  }
+
+  private reset = () => {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  };
+
+  render() {
+    if (this.state.error) {
+      return this.props.fallback({ error: this.state.error, resetErrorBoundary: this.reset });
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/console/src/components/ErrorState.tsx
+++ b/apps/web/console/src/components/ErrorState.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { isRequestError } from "../api/errors";
+
+interface ErrorStateProps {
+  error: unknown;
+  onRetry?: () => void;
+  helpUrl: string;
+  helpLabel?: string;
+}
+
+export function ErrorState({ error, onRetry, helpUrl, helpLabel = "View help" }: ErrorStateProps) {
+  const message = error instanceof Error ? error.message : "Unexpected error";
+  const requestId = isRequestError(error) ? error.requestId : undefined;
+
+  return (
+    <div
+      role="alert"
+      style={{
+        border: "1px solid rgba(220, 38, 38, 0.4)",
+        borderRadius: 12,
+        padding: 24,
+        background: "rgba(220, 38, 38, 0.08)",
+      }}
+    >
+      <h3 style={{ marginBottom: 12, color: "#b91c1c" }}>We couldn&apos;t load this section</h3>
+      <p style={{ marginBottom: 12 }}>{message}</p>
+      {requestId ? (
+        <p style={{ margin: "12px 0", fontSize: 13, fontFamily: "ui-monospace" }}>Request ID: {requestId}</p>
+      ) : null}
+      <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+        {onRetry ? (
+          <button
+            onClick={onRetry}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 8,
+              border: "none",
+              background: "#ef4444",
+              color: "white",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+        ) : null}
+        <a href={helpUrl} target="_blank" rel="noreferrer" style={{ color: "#2563eb", fontWeight: 600 }}>
+          {helpLabel}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/console/src/components/GlobalErrorFallback.tsx
+++ b/apps/web/console/src/components/GlobalErrorFallback.tsx
@@ -1,0 +1,115 @@
+import React from "react";
+import { isRequestError } from "../api/errors";
+import { useRequestTrace } from "../providers/RequestTraceProvider";
+
+export function GlobalErrorFallback({
+  error,
+  onRetry,
+}: {
+  error: Error;
+  onRetry: () => void;
+}) {
+  const { lastTrace } = useRequestTrace();
+  const fallbackRequestId = lastTrace?.requestId;
+  const requestId = isRequestError(error) ? error.requestId : fallbackRequestId;
+  const [copied, setCopied] = React.useState(false);
+
+  const copyId = React.useCallback(() => {
+    if (!requestId) return;
+    navigator.clipboard
+      ?.writeText(requestId)
+      .then(() => setCopied(true))
+      .catch(() => setCopied(false));
+  }, [requestId]);
+
+  React.useEffect(() => {
+    if (!copied) return;
+    const timeout = window.setTimeout(() => setCopied(false), 2000);
+    return () => window.clearTimeout(timeout);
+  }, [copied]);
+
+  return (
+    <div
+      role="alert"
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#0f172a",
+        color: "#e2e8f0",
+        padding: 32,
+        fontFamily: "system-ui, sans-serif",
+      }}
+    >
+      <div style={{ maxWidth: 420 }}>
+        <h1 style={{ fontSize: 28, marginBottom: 8 }}>Something went wrong</h1>
+        <p style={{ lineHeight: 1.5, marginBottom: 16 }}>
+          We hit an unexpected error while loading the console. You can try again, and if the issue
+          persists please share the request reference with support.
+        </p>
+        <div
+          style={{
+            background: "rgba(15, 23, 42, 0.65)",
+            border: "1px solid rgba(148, 163, 184, 0.4)",
+            borderRadius: 8,
+            padding: 16,
+            marginBottom: 16,
+          }}
+        >
+          <p style={{ margin: 0, fontWeight: 600 }}>{error.message}</p>
+          <p style={{ margin: "12px 0 0", fontSize: 12, fontFamily: "ui-monospace" }}>
+            Request ID: {requestId ?? "unavailable"}
+          </p>
+          <button
+            onClick={copyId}
+            disabled={!requestId}
+            style={{
+              marginTop: 12,
+              padding: "6px 12px",
+              borderRadius: 6,
+              background: "#1d4ed8",
+              color: "white",
+              fontSize: 13,
+              border: "none",
+              cursor: requestId ? "pointer" : "not-allowed",
+            }}
+          >
+            {copied ? "Copied" : "Copy request ID"}
+          </button>
+        </div>
+        <div style={{ display: "flex", gap: 12 }}>
+          <button
+            onClick={onRetry}
+            style={{
+              padding: "10px 18px",
+              borderRadius: 8,
+              border: "none",
+              background: "#22c55e",
+              color: "#022c22",
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            Try again
+          </button>
+          <a
+            href="https://docs.apgms.local/support/troubleshooting"
+            target="_blank"
+            rel="noreferrer"
+            style={{
+              padding: "10px 18px",
+              borderRadius: 8,
+              border: "1px solid rgba(148, 163, 184, 0.4)",
+              color: "#bfdbfe",
+              textDecoration: "none",
+              fontWeight: 600,
+            }}
+          >
+            View troubleshooting guide
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/console/src/components/LoadingState.tsx
+++ b/apps/web/console/src/components/LoadingState.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export function LoadingState({ label }: { label: string }) {
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+      <Spinner />
+      <span>{label}</span>
+    </div>
+  );
+}
+
+function Spinner() {
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: 16,
+        height: 16,
+        borderRadius: "50%",
+        border: "2px solid #cbd5f5",
+        borderTopColor: "transparent",
+        animation: "spin 1s linear infinite",
+      }}
+    />
+  );
+}

--- a/apps/web/console/src/components/ToastProvider.tsx
+++ b/apps/web/console/src/components/ToastProvider.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { createRequestId } from "../utils/request-id";
+
+export interface ToastActionLink {
+  label: string;
+  href: string;
+}
+
+export type ToastVariant = "info" | "success" | "error";
+
+export interface Toast {
+  id: string;
+  title: string;
+  description?: string;
+  requestId?: string;
+  variant?: ToastVariant;
+  action?: ToastActionLink;
+  autoClose?: boolean;
+}
+
+interface ToastContextValue {
+  toasts: Toast[];
+  push: (toast: Omit<Toast, "id"> & { id?: string }) => string;
+  dismiss: (id: string) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | undefined>(undefined);
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = React.useState<Toast[]>([]);
+
+  const dismiss = React.useCallback((id: string) => {
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const push = React.useCallback<ToastContextValue["push"]>((toast) => {
+    const id = toast.id ?? createRequestId();
+    setToasts((current) => {
+      const next = [...current, { ...toast, id }];
+      return next;
+    });
+    if (toast.autoClose !== false) {
+      window.setTimeout(() => dismiss(id), 6000);
+    }
+    return id;
+  }, [dismiss]);
+
+  const value = React.useMemo<ToastContextValue>(() => ({ toasts, push, dismiss }), [toasts, push, dismiss]);
+
+  return <ToastContext.Provider value={value}>{children}</ToastContext.Provider>;
+}
+
+export function useToasts() {
+  const context = React.useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToasts must be used within a ToastProvider");
+  }
+  return context;
+}

--- a/apps/web/console/src/components/ToastViewport.tsx
+++ b/apps/web/console/src/components/ToastViewport.tsx
@@ -1,0 +1,101 @@
+import React from "react";
+import { Toast, ToastVariant, useToasts } from "./ToastProvider";
+
+const VARIANT_STYLES: Record<ToastVariant, React.CSSProperties> = {
+  info: {
+    borderLeft: "4px solid #2563eb",
+  },
+  success: {
+    borderLeft: "4px solid #16a34a",
+  },
+  error: {
+    borderLeft: "4px solid #dc2626",
+  },
+};
+
+export function ToastViewport() {
+  const { toasts, dismiss } = useToasts();
+
+  if (toasts.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      aria-live="assertive"
+      style={{
+        position: "fixed",
+        bottom: 24,
+        right: 24,
+        display: "flex",
+        flexDirection: "column",
+        gap: 12,
+        zIndex: 1000,
+        maxWidth: 360,
+      }}
+    >
+      {toasts.map((toast) => (
+        <ToastCard key={toast.id} toast={toast} onDismiss={() => dismiss(toast.id)} />
+      ))}
+    </div>
+  );
+}
+
+function ToastCard({ toast, onDismiss }: { toast: Toast; onDismiss: () => void }) {
+  const variant = toast.variant ?? "info";
+
+  return (
+    <div
+      role="status"
+      style={{
+        backgroundColor: "#0f172a",
+        color: "#e2e8f0",
+        padding: "12px 16px",
+        borderRadius: 8,
+        boxShadow: "0 10px 25px rgba(15, 23, 42, 0.35)",
+        fontFamily: "system-ui, sans-serif",
+        ...VARIANT_STYLES[variant],
+      }}
+    >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", gap: 12 }}>
+        <div style={{ flex: 1 }}>
+          <p style={{ margin: 0, fontWeight: 600 }}>{toast.title}</p>
+          {toast.description ? (
+            <p style={{ margin: "4px 0 0", fontSize: 13, lineHeight: 1.4 }}>{toast.description}</p>
+          ) : null}
+          {toast.requestId ? (
+            <p style={{ margin: "8px 0 0", fontSize: 12, fontFamily: "ui-monospace" }}>
+              Request ID: <span>{toast.requestId}</span>
+            </p>
+          ) : null}
+          {toast.action ? (
+            <p style={{ margin: "8px 0 0" }}>
+              <a
+                href={toast.action.href}
+                target="_blank"
+                rel="noreferrer"
+                style={{ color: "#93c5fd", textDecoration: "underline" }}
+              >
+                {toast.action.label}
+              </a>
+            </p>
+          ) : null}
+        </div>
+        <button
+          onClick={onDismiss}
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#94a3b8",
+            cursor: "pointer",
+            padding: 0,
+            fontSize: 16,
+          }}
+          aria-label="Dismiss notification"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,31 @@
-﻿import React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
+import { AppProviders, AppShell } from "./App";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+import { GlobalErrorFallback } from "./components/GlobalErrorFallback";
 
-function App() {
-  return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
-    </div>
-  );
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Root element with id 'root' was not found");
 }
-createRoot(document.getElementById("root")!).render(<App />);
+
+createRoot(container).render(
+  <React.StrictMode>
+    <AppProviders>
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            onReset={reset}
+            fallback={({ error, resetErrorBoundary }) => (
+              <GlobalErrorFallback error={error} onRetry={resetErrorBoundary} />
+            )}
+          >
+            <AppShell />
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </AppProviders>
+  </React.StrictMode>,
+);

--- a/apps/web/console/src/providers/RequestTraceProvider.tsx
+++ b/apps/web/console/src/providers/RequestTraceProvider.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import { RequestTrace, subscribeToRequestTrace } from "../tracing/trace-emitter";
+
+interface RequestTraceContextValue {
+  lastTrace: RequestTrace | null;
+}
+
+const RequestTraceContext = React.createContext<RequestTraceContextValue | undefined>(undefined);
+
+export function RequestTraceProvider({ children }: { children: React.ReactNode }) {
+  const [lastTrace, setLastTrace] = React.useState<RequestTrace | null>(null);
+
+  React.useEffect(() => {
+    const unsubscribe = subscribeToRequestTrace((trace) => {
+      setLastTrace(trace);
+    });
+    return unsubscribe;
+  }, []);
+
+  const value = React.useMemo(() => ({ lastTrace }), [lastTrace]);
+
+  return <RequestTraceContext.Provider value={value}>{children}</RequestTraceContext.Provider>;
+}
+
+export function useRequestTrace() {
+  const context = React.useContext(RequestTraceContext);
+  if (!context) {
+    throw new Error("useRequestTrace must be used within a RequestTraceProvider");
+  }
+  return context;
+}

--- a/apps/web/console/src/tracing/trace-emitter.ts
+++ b/apps/web/console/src/tracing/trace-emitter.ts
@@ -1,0 +1,26 @@
+export interface RequestTrace {
+  requestId: string;
+  url: string;
+  method: string;
+  status?: number;
+  success: boolean;
+  timestamp: string;
+  errorMessage?: string;
+  label?: string;
+  autoToast?: boolean;
+}
+
+type Listener = (trace: RequestTrace) => void;
+
+const listeners = new Set<Listener>();
+
+export function emitRequestTrace(trace: RequestTrace) {
+  for (const listener of listeners) {
+    listener(trace);
+  }
+}
+
+export function subscribeToRequestTrace(listener: Listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}

--- a/apps/web/console/src/utils/request-id.ts
+++ b/apps/web/console/src/utils/request-id.ts
@@ -1,0 +1,12 @@
+export function createRequestId(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    try {
+      return crypto.randomUUID();
+    } catch (error) {
+      // fall through to manual id if randomUUID throws
+    }
+  }
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 10);
+  return `req_${timestamp}_${random}`;
+}


### PR DESCRIPTION
## Summary
- replace the barebones console shell with a dashboard layout that surfaces status tiles, mutation controls, and contextual empty/error states
- introduce a fetch helper that stamps x-request-id headers, emits trace metadata, and drives a global error boundary plus admin-friendly toast notifications
- add reusable UI primitives (toasts, error states, loading indicators) and seed demo data for local development

## Testing
- `node_modules/.bin/tsc --project apps/web/console/tsconfig.json --noEmit` *(fails: missing React/React DOM typings in the environment)*
- `pnpm --filter @apgms/console build` *(fails: repository pins packageManager to pnpm@9 without a semver version)*

------
https://chatgpt.com/codex/tasks/task_e_68e3998f9a4083278839ab8cb028e98d