### PR TITLE
feat(console): improve accessibility and add i18n

### DIFF
--- a/apps/web/console/index.html
+++ b/apps/web/console/index.html
@@ -1,6 +1,8 @@
-﻿<!doctype html>
-<html>
-  <head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+<!doctype html>
+<html lang="en-AU">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>APGMS Console</title>
   </head>
   <body>

--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "@apgms/console",
   "version": "0.1.0",
   "private": true,
@@ -10,14 +10,16 @@
     "lint": "echo lint web"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.51.0",
+    "i18next": "^23.11.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "@tanstack/react-query": "^5.51.0"
+    "react-i18next": "^14.1.3"
   },
   "devDependencies": {
-    "typescript": "^5.6.2",
-    "vite": "^5.4.8",
     "@types/react": "^18.3.3",
-    "@types/react-dom": "^18.3.0"
+    "@types/react-dom": "^18.3.0",
+    "typescript": "^5.6.2",
+    "vite": "^5.4.8"
   }
 }

--- a/apps/web/console/src/App.tsx
+++ b/apps/web/console/src/App.tsx
@@ -1,0 +1,552 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { formatCurrency, formatDate } from "./formatters";
+
+type SectionKey = "dashboard" | "bas" | "evidence";
+
+type CommandAction = {
+  id: string;
+  label: string;
+  description: string;
+  onSelect: () => void;
+};
+
+const isEditableElement = (element: EventTarget | null): boolean => {
+  if (!(element instanceof HTMLElement)) {
+    return false;
+  }
+  const tagName = element.tagName;
+  return (
+    element.isContentEditable ||
+    tagName === "INPUT" ||
+    tagName === "TEXTAREA" ||
+    tagName === "SELECT"
+  );
+};
+
+const CommandPalette: React.FC<{
+  isOpen: boolean;
+  label: string;
+  placeholder: string;
+  emptyLabel: (query: string) => string;
+  actions: CommandAction[];
+  onClose: () => void;
+  inputRef: React.RefObject<HTMLInputElement>;
+  closeLabel: string;
+}> = ({
+  isOpen,
+  label,
+  placeholder,
+  emptyLabel,
+  actions,
+  onClose,
+  inputRef,
+  closeLabel,
+}) => {
+  const [query, setQuery] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setQuery("");
+    }
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const filtered = actions.filter((action) =>
+    action.label.toLowerCase().includes(query.toLowerCase()) ||
+    action.description.toLowerCase().includes(query.toLowerCase())
+  );
+
+  const handleSelect = (action: CommandAction) => {
+    action.onSelect();
+    onClose();
+  };
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="command-palette-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal__header">
+          <h2 id="command-palette-title" className="modal__title">
+            {label}
+          </h2>
+          <button type="button" className="modal__close" onClick={onClose}>
+            {closeLabel}
+          </button>
+        </div>
+        <label htmlFor="command-input" className="sr-only">
+          {label}
+        </label>
+        <input
+          id="command-input"
+          ref={inputRef}
+          className="command-input"
+          placeholder={placeholder}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && filtered[0]) {
+              event.preventDefault();
+              handleSelect(filtered[0]);
+            }
+          }}
+        />
+        {filtered.length === 0 ? (
+          <p role="status">{emptyLabel(query)}</p>
+        ) : (
+          <ul className="command-list" role="listbox" aria-label={label}>
+            {filtered.map((action) => (
+              <li key={action.id} className="command-item">
+                <button
+                  type="button"
+                  className="command-action"
+                  onClick={() => handleSelect(action)}
+                >
+                  <span>{action.label}</span>
+                  <span className="section-footer">{action.description}</span>
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const HelpModal: React.FC<{
+  isOpen: boolean;
+  title: string;
+  subtitle: string;
+  headers: { action: string; keys: string };
+  rows: { action: string; keys: React.ReactNode }[];
+  onClose: () => void;
+  initialFocusRef: React.RefObject<HTMLButtonElement>;
+  closeLabel: string;
+}> = ({
+  isOpen,
+  title,
+  subtitle,
+  headers,
+  rows,
+  onClose,
+  initialFocusRef,
+  closeLabel,
+}) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+      <div
+        className="modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="help-modal-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal__header">
+          <div>
+            <h2 id="help-modal-title" className="modal__title">
+              {title}
+            </h2>
+            <p>{subtitle}</p>
+          </div>
+          <button
+            type="button"
+            className="modal__close"
+            onClick={onClose}
+            ref={initialFocusRef}
+          >
+            {closeLabel}
+          </button>
+        </div>
+        <table className="keyboard-grid">
+          <thead>
+            <tr>
+              <th scope="col">{headers.action}</th>
+              <th scope="col">{headers.keys}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row) => (
+              <tr key={row.action}>
+                <td>{row.action}</td>
+                <td>{row.keys}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};
+
+const App: React.FC = () => {
+  const { t } = useTranslation();
+  const [activeSection, setActiveSection] = useState<SectionKey>("dashboard");
+  const [isCommandOpen, setIsCommandOpen] = useState(false);
+  const [isHelpOpen, setIsHelpOpen] = useState(false);
+  const awaitingSectionKey = useRef(false);
+  const awaitingTimeout = useRef<number | null>(null);
+  const commandInputRef = useRef<HTMLInputElement>(null);
+  const helpCloseRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedCommand = useRef<HTMLElement | null>(null);
+  const previouslyFocusedHelp = useRef<HTMLElement | null>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  const metrics = useMemo(
+    () => [
+      {
+        key: "lodgement",
+        value: formatDate(new Date()),
+        description: t("metrics.lodgement.description"),
+      },
+      {
+        key: "gst",
+        value: formatCurrency(12850.4),
+        description: t("metrics.gst.description"),
+      },
+      {
+        key: "evidence",
+        value: "24 / 24",
+        description: t("metrics.evidence.description"),
+      },
+    ],
+    [t]
+  );
+
+  const announceSectionChange = useCallback(
+    (section: SectionKey) => {
+      const sectionName = t(`nav.${section}` as const);
+      setAnnouncement(t("app.navigated", { section: sectionName }));
+    },
+    [t]
+  );
+
+  useEffect(() => {
+    if (!announcement) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setAnnouncement(""), 1500);
+    return () => window.clearTimeout(timeout);
+  }, [announcement]);
+
+  const handleNavigate = useCallback(
+    (section: SectionKey) => {
+      setActiveSection(section);
+      announceSectionChange(section);
+    },
+    [announceSectionChange]
+  );
+
+  useEffect(() => {
+    if (isCommandOpen) {
+      previouslyFocusedCommand.current = document.activeElement as HTMLElement | null;
+      const timeout = window.setTimeout(() => {
+        commandInputRef.current?.focus();
+      }, 0);
+      document.body.style.overflow = "hidden";
+      return () => {
+        window.clearTimeout(timeout);
+        if (!isHelpOpen) {
+          document.body.style.overflow = "";
+        }
+        previouslyFocusedCommand.current?.focus();
+      };
+    }
+    return;
+  }, [isCommandOpen, isHelpOpen]);
+
+  useEffect(() => {
+    if (isHelpOpen) {
+      previouslyFocusedHelp.current = document.activeElement as HTMLElement | null;
+      const timeout = window.setTimeout(() => {
+        helpCloseRef.current?.focus();
+      }, 0);
+      document.body.style.overflow = "hidden";
+      return () => {
+        window.clearTimeout(timeout);
+        if (!isCommandOpen) {
+          document.body.style.overflow = "";
+        }
+        previouslyFocusedHelp.current?.focus();
+      };
+    }
+    return;
+  }, [isHelpOpen, isCommandOpen]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableElement(event.target)) {
+        return;
+      }
+
+      if ((isCommandOpen || isHelpOpen) && event.key !== "Escape") {
+        return;
+      }
+
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "k") {
+        event.preventDefault();
+        setIsCommandOpen(true);
+        awaitingSectionKey.current = false;
+        if (awaitingTimeout.current) {
+          window.clearTimeout(awaitingTimeout.current);
+          awaitingTimeout.current = null;
+        }
+        return;
+      }
+
+      if (event.shiftKey && (event.key === "?" || event.key === "/")) {
+        event.preventDefault();
+        setIsHelpOpen(true);
+        awaitingSectionKey.current = false;
+        if (awaitingTimeout.current) {
+          window.clearTimeout(awaitingTimeout.current);
+          awaitingTimeout.current = null;
+        }
+        return;
+      }
+
+      if (!event.metaKey && !event.ctrlKey && !event.altKey && event.key.toLowerCase() === "g") {
+        awaitingSectionKey.current = true;
+        event.preventDefault();
+        if (awaitingTimeout.current) {
+          window.clearTimeout(awaitingTimeout.current);
+        }
+        awaitingTimeout.current = window.setTimeout(() => {
+          awaitingSectionKey.current = false;
+          awaitingTimeout.current = null;
+        }, 1500);
+        return;
+      }
+
+      if (awaitingSectionKey.current) {
+        awaitingSectionKey.current = false;
+        if (awaitingTimeout.current) {
+          window.clearTimeout(awaitingTimeout.current);
+          awaitingTimeout.current = null;
+        }
+        const key = event.key.toLowerCase();
+        if (key === "d") {
+          event.preventDefault();
+          handleNavigate("dashboard");
+        } else if (key === "b") {
+          event.preventDefault();
+          handleNavigate("bas");
+        } else if (key === "e") {
+          event.preventDefault();
+          handleNavigate("evidence");
+        }
+        return;
+      }
+
+      if (event.key === "Escape") {
+        if (isCommandOpen) {
+          event.preventDefault();
+          setIsCommandOpen(false);
+        }
+        if (isHelpOpen) {
+          event.preventDefault();
+          setIsHelpOpen(false);
+        }
+        awaitingSectionKey.current = false;
+        if (awaitingTimeout.current) {
+          window.clearTimeout(awaitingTimeout.current);
+          awaitingTimeout.current = null;
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleNavigate, isCommandOpen, isHelpOpen]);
+
+  useEffect(() => {
+    return () => {
+      if (awaitingTimeout.current) {
+        window.clearTimeout(awaitingTimeout.current);
+      }
+    };
+  }, []);
+
+  const commandActions: CommandAction[] = useMemo(
+    () => [
+      {
+        id: "dashboard",
+        label: t("nav.dashboard"),
+        description: t("commandPalette.actions.dashboard"),
+        onSelect: () => handleNavigate("dashboard"),
+      },
+      {
+        id: "bas",
+        label: t("nav.bas"),
+        description: t("commandPalette.actions.bas"),
+        onSelect: () => handleNavigate("bas"),
+      },
+      {
+        id: "evidence",
+        label: t("nav.evidence"),
+        description: t("commandPalette.actions.evidence"),
+        onSelect: () => handleNavigate("evidence"),
+      },
+      {
+        id: "help",
+        label: t("keyboard.help"),
+        description: t("commandPalette.actions.help"),
+        onSelect: () => setIsHelpOpen(true),
+      },
+    ],
+    [handleNavigate, t]
+  );
+
+  const helpRows = useMemo(
+    () => [
+      {
+        action: t("keyboard.commandPalette"),
+        keys: (
+          <span>
+            <span>
+              <kbd>⌘</kbd> or <kbd>Ctrl</kbd>
+            </span>{" "}
+            + <kbd>K</kbd>
+          </span>
+        ),
+      },
+      {
+        action: t("keyboard.help"),
+        keys: (
+          <span>
+            <kbd>Shift</kbd> + <kbd>/</kbd>
+          </span>
+        ),
+      },
+      {
+        action: t("keyboard.dashboard"),
+        keys: (
+          <span>
+            <kbd>G</kbd> then <kbd>D</kbd>
+          </span>
+        ),
+      },
+      {
+        action: t("keyboard.bas"),
+        keys: (
+          <span>
+            <kbd>G</kbd> then <kbd>B</kbd>
+          </span>
+        ),
+      },
+      {
+        action: t("keyboard.evidence"),
+        keys: (
+          <span>
+            <kbd>G</kbd> then <kbd>E</kbd>
+          </span>
+        ),
+      },
+    ],
+    [t]
+  );
+
+  const lastUpdated = useMemo(() => formatDate(new Date()), []);
+
+  return (
+    <div className="app-shell">
+      <a className="skip-link" href="#main-content">
+        {t("app.skipToContent")}
+      </a>
+      <header className="app-header" role="banner">
+        <h1 className="app-header__title">{t("app.title")}</h1>
+        <p>{t("app.tagline")}</p>
+      </header>
+      <div aria-live="polite" className="sr-only">
+        {announcement}
+      </div>
+      <main id="main-content" className="app-main">
+        <nav className="primary-nav" aria-label={t("nav.ariaLabel")}>
+          <ul className="primary-nav__list">
+            {(["dashboard", "bas", "evidence"] as SectionKey[]).map((sectionKey) => (
+              <li key={sectionKey}>
+                <a
+                  href={`#${sectionKey}`}
+                  className="primary-nav__link"
+                  aria-current={activeSection === sectionKey ? "page" : undefined}
+                  onClick={(event) => {
+                    event.preventDefault();
+                    handleNavigate(sectionKey);
+                  }}
+                >
+                  {t(`nav.${sectionKey}` as const)}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <section
+          className="section-card"
+          id={activeSection}
+          aria-labelledby={`${activeSection}-title`}
+          role="region"
+        >
+          <div className="section-card__header">
+            <h2 id={`${activeSection}-title`} className="section-card__title">
+              {t(`sections.${activeSection}.title` as const)}
+            </h2>
+            <p>{t(`sections.${activeSection}.description` as const)}</p>
+            <p className="section-footer">
+              {t("app.lastUpdated", { date: lastUpdated })}
+            </p>
+          </div>
+          <div
+            className="status-grid"
+            role="list"
+            aria-label={t("app.statusGridLabel")}
+          >
+            {metrics.map((metric) => (
+              <div key={metric.key} className="status-tile" role="listitem">
+                <h3 className="status-tile__label">{t(`metrics.${metric.key}.label` as const)}</h3>
+                <p className="status-tile__value">{metric.value}</p>
+                <p className="status-tile__description">{metric.description}</p>
+              </div>
+            ))}
+          </div>
+          <p className="section-footer">
+            {t(`sections.${activeSection}.footnote` as const)}
+          </p>
+        </section>
+      </main>
+      <CommandPalette
+        isOpen={isCommandOpen}
+        label={t("commandPalette.title")}
+        placeholder={t("commandPalette.placeholder")}
+        emptyLabel={(query) => t("commandPalette.empty", { query })}
+        actions={commandActions}
+        onClose={() => setIsCommandOpen(false)}
+        inputRef={commandInputRef}
+        closeLabel={t("common.close")}
+      />
+      <HelpModal
+        isOpen={isHelpOpen}
+        title={t("help.title")}
+        subtitle={t("help.subtitle")}
+        headers={{ action: t("help.table.action"), keys: t("help.table.keys") }}
+        rows={helpRows}
+        onClose={() => setIsHelpOpen(false)}
+        initialFocusRef={helpCloseRef}
+        closeLabel={t("common.close")}
+      />
+    </div>
+  );
+};
+
+export default App;

--- a/apps/web/console/src/formatters.ts
+++ b/apps/web/console/src/formatters.ts
@@ -1,0 +1,14 @@
+export const formatCurrency = (value: number) =>
+  new Intl.NumberFormat("en-AU", {
+    style: "currency",
+    currency: "AUD",
+    currencyDisplay: "symbol",
+    minimumFractionDigits: 2,
+  }).format(value);
+
+export const formatDate = (value: Date | string) => {
+  const date = typeof value === "string" ? new Date(value) : value;
+  return new Intl.DateTimeFormat("en-AU", {
+    dateStyle: "long",
+  }).format(date);
+};

--- a/apps/web/console/src/i18n.ts
+++ b/apps/web/console/src/i18n.ts
@@ -1,0 +1,24 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import enAU from "./locales/en-AU/common.json";
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      "en-AU": {
+        translation: enAU,
+      },
+    },
+    lng: "en-AU",
+    fallbackLng: "en-AU",
+    interpolation: {
+      escapeValue: false,
+    },
+    returnNull: false,
+  })
+  .catch((error) => {
+    console.error("i18n initialisation failed", error);
+  });
+
+export default i18n;

--- a/apps/web/console/src/locales/en-AU/common.json
+++ b/apps/web/console/src/locales/en-AU/common.json
@@ -1,0 +1,77 @@
+{
+  "app": {
+    "title": "APGMS Console",
+    "tagline": "Status tiles and RPT widgets will appear here. (P40, P41, P42)",
+    "skipToContent": "Skip to main content",
+    "lastUpdated": "Last updated on {{date}}",
+    "navigated": "Navigated to {{section}}",
+    "statusGridLabel": "Status tiles"
+  },
+  "nav": {
+    "ariaLabel": "Primary",
+    "dashboard": "Dashboard",
+    "bas": "Business Activity Statements",
+    "evidence": "Evidence library"
+  },
+  "common": {
+    "close": "Close"
+  },
+  "sections": {
+    "dashboard": {
+      "title": "Dashboard overview",
+      "description": "Monitor status tiles across programmes P40, P41, and P42.",
+      "footnote": "Figures are presented in Australian dollars (AUD)."
+    },
+    "bas": {
+      "title": "Business Activity Statements",
+      "description": "Track BAS preparation progress and upcoming lodgement windows.",
+      "footnote": "Ensure submissions are complete ahead of the ATO due date."
+    },
+    "evidence": {
+      "title": "Evidence library",
+      "description": "Review source documents and reconciliation evidence before submission.",
+      "footnote": "Upload new supporting files to keep audit trails current."
+    }
+  },
+  "metrics": {
+    "lodgement": {
+      "label": "BAS lodgement",
+      "description": "October BAS is ready to submit."
+    },
+    "gst": {
+      "label": "GST payable",
+      "description": "Reconciled against current invoices."
+    },
+    "evidence": {
+      "label": "Evidence reviewed",
+      "description": "All mandatory documents verified."
+    }
+  },
+  "commandPalette": {
+    "title": "Command palette",
+    "label": "Search for a destination",
+    "placeholder": "Type to filter destinations",
+    "empty": "No matches for \"{{query}}\"",
+    "actions": {
+      "dashboard": "Go to dashboard",
+      "bas": "Go to Business Activity Statements",
+      "evidence": "Go to evidence library",
+      "help": "Open help"
+    }
+  },
+  "help": {
+    "title": "Keyboard shortcuts",
+    "subtitle": "Use these shortcuts to move quickly without a mouse.",
+    "table": {
+      "action": "Action",
+      "keys": "Shortcut"
+    }
+  },
+  "keyboard": {
+    "commandPalette": "Open command palette",
+    "help": "Open help",
+    "dashboard": "Go to dashboard",
+    "bas": "Go to Business Activity Statements",
+    "evidence": "Go to evidence library"
+  }
+}

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,17 @@
-﻿import React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
+import App from "./App";
+import "./i18n";
+import "./styles.css";
 
-function App() {
-  return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
-      <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
-    </div>
-  );
+const container = document.getElementById("root");
+
+if (!container) {
+  throw new Error("Root element not found");
 }
-createRoot(document.getElementById("root")!).render(<App />);
+
+createRoot(container).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/apps/web/console/src/styles.css
+++ b/apps/web/console/src/styles.css
@@ -1,0 +1,278 @@
+:root {
+  color-scheme: light;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: #f4f6fb;
+  color: #0b1220;
+  line-height: 1.6;
+}
+
+a {
+  color: #0b3d91;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid #ffbf47;
+  outline-offset: 3px;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: #0b3d91;
+  color: #ffffff;
+  border-radius: 0.5rem;
+  transform: translateY(-150%);
+  transition: transform 0.2s ease;
+  z-index: 1000;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  background: #ffffff;
+  border-bottom: 1px solid #d5d9e5;
+  padding: 1rem 1.5rem;
+}
+
+.app-header__title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.app-main {
+  flex: 1;
+  display: grid;
+  gap: 1.5rem;
+  padding: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .app-main {
+    grid-template-columns: 260px 1fr;
+  }
+}
+
+.primary-nav {
+  background: #ffffff;
+  border: 1px solid #d5d9e5;
+  border-radius: 1rem;
+  padding: 1.25rem;
+}
+
+.primary-nav__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.primary-nav__link {
+  display: block;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  text-decoration: none;
+  font-weight: 600;
+  color: #0b1220;
+}
+
+.primary-nav__link[aria-current="page"] {
+  background: #0b3d91;
+  color: #ffffff;
+}
+
+.section-card {
+  background: #ffffff;
+  border: 1px solid #d5d9e5;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.section-card__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.section-card__title {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.status-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 720px) {
+  .status-grid {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+}
+
+.status-tile {
+  padding: 1.25rem;
+  border-radius: 0.85rem;
+  background: #0b3d91;
+  color: #ffffff;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.status-tile__label {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.status-tile__value {
+  font-size: 1.75rem;
+  font-weight: 700;
+}
+
+.status-tile__description {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #eef2ff;
+}
+
+.section-footer {
+  font-size: 0.95rem;
+  color: #37446b;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(6, 15, 38, 0.65);
+  display: grid;
+  place-items: center;
+  padding: 1.5rem;
+  z-index: 1100;
+}
+
+.modal {
+  background: #ffffff;
+  width: min(640px, 100%);
+  max-height: 90vh;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 18px 44px rgba(11, 18, 32, 0.22);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal__title {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.modal__close {
+  background: transparent;
+  border: 2px solid #0b3d91;
+  color: #0b3d91;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.command-input {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid #b5bdd3;
+  font-size: 1rem;
+}
+
+.command-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.command-item {
+  border: 1px solid #d5d9e5;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+  background: #f8f9fc;
+}
+
+.command-action {
+  background: transparent;
+  border: none;
+  padding: 0;
+  text-align: left;
+  font-size: 1rem;
+  color: inherit;
+  cursor: pointer;
+}
+
+.keyboard-grid {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.keyboard-grid th,
+.keyboard-grid td {
+  padding: 0.65rem 0.75rem;
+  border-bottom: 1px solid #d5d9e5;
+  text-align: left;
+}
+
+kbd {
+  display: inline-block;
+  min-width: 1.75rem;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #0b3d91;
+  background: #eef2ff;
+  color: #0b3d91;
+  font-weight: 600;
+  text-align: center;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- replace the console shell with an accessible layout that includes keyboard navigation, a command palette, and contextual announcements
- add en-AU i18n resources, initialise i18next, and provide AU currency/date format helpers
- refresh styles, metadata, and dependencies so components meet WCAG/ARIA expectations and future locales can plug in easily

## Testing
- npm install *(fails: 403 Forbidden fetching @tanstack/react-query)*

------
https://chatgpt.com/codex/tasks/task_e_68e3999b94ec832784bdeec8b7ac4aa4