### PR TITLE
Add in-app Help Center and docs quality gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2025-10-06
+- Added in-app Help Center with contextual search and Shift+/ shortcut.
+- Documented PAYGW RPT tokens and dashboard analytics in MDX help docs.
+- Captured payments API endpoints in docs and wired CI coverage scripts.

--- a/docs/help/dashboard-bas.mdx
+++ b/docs/help/dashboard-bas.mdx
@@ -1,0 +1,20 @@
+---
+slug: /help/dashboard-bas
+title: Understand the BAS dashboard
+modes:
+  - web
+summary: How to read BAS obligations, upcoming due dates, and compliance score in the dashboard.
+lastUpdated: 2025-10-06
+---
+
+## Overview
+
+The Business Activity Statement (BAS) dashboard surfaces PAYGW and GST lodgment milestones alongside payment status in one consolidated view. Each card tracks:
+
+- **Lodgments** — upcoming or overdue forms for each quarter.
+- **Payments** — PAYGW and GST remittances that remain outstanding.
+- **Compliance score** — weighted indicator of lodging and paying on time.
+
+## Actions
+
+Select **View BAS** to open the BAS workspace with prefilled activity statements. APGMS syncs your latest transactions nightly so the dashboard reflects the last reconciliation cutover.

--- a/docs/help/public-api.mdx
+++ b/docs/help/public-api.mdx
@@ -1,0 +1,17 @@
+---
+slug: /help/public-api
+title: Public API surface
+modes:
+  - api
+summary: Reference table of publicly supported REST endpoints exposed by APGMS.
+lastUpdated: 2025-10-06
+---
+
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| /api/payments/balance | GET | Returns the PAYGW or GST account balance for the requested BAS period. |
+| /api/payments/ledger | GET | Streams the transaction ledger for the requested BAS period. |
+| /api/payments/deposit | POST | Registers an incoming client deposit that increases the ATO payable balance. |
+| /api/payments/release | POST | Sends a PAYGW or GST release to the ATO when the amount is negative. |
+
+All public endpoints require an API key created from **Settings → API Access**.

--- a/docs/help/rpt-tokens.mdx
+++ b/docs/help/rpt-tokens.mdx
@@ -1,0 +1,18 @@
+---
+slug: /help/rpt-tokens
+title: RPT (Real-time PAYGW Tokens)
+modes:
+  - web
+summary: Glossary entry explaining the Real-time PAYGW Token (RPT) integration.
+lastUpdated: 2025-10-06
+---
+
+Real-time PAYGW Tokens (RPT) authenticate secure exchange of withholding remittance totals with APGMS. Each token represents a daily PAYGW package signed with your AUSkey-equivalent certificate.
+
+### Lifecycle
+
+1. The payroll connector generates the token payload hourly.
+2. APGMS validates the signature against your registered AUSkey.
+3. When accepted, the PAYGW remittance queue updates immediately, allowing just-in-time BAS submissions.
+
+> Tip: Rotate RPT credentials on the same cadence as your AUSkey rotation policy. Use the **Integrations → Security** page to issue new client secrets.

--- a/docs/public-endpoints.json
+++ b/docs/public-endpoints.json
@@ -1,0 +1,6 @@
+[
+  { "method": "GET", "path": "/api/payments/balance" },
+  { "method": "GET", "path": "/api/payments/ledger" },
+  { "method": "POST", "path": "/api/payments/deposit" },
+  { "method": "POST", "path": "/api/payments/release" }
+]

--- a/package.json
+++ b/package.json
@@ -1,15 +1,19 @@
 {
     "scripts": {
         "start": "node dist/index.js",
-        "build": "echo build root",
+        "build": "pnpm docs:index && echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "docs:index": "tsx scripts/build-doc-index.ts",
+        "docs:lastUpdated": "tsx scripts/docs-last-updated.ts",
+        "docs:coverage": "tsx scripts/docs-coverage.ts",
+        "docs:links": "tsx scripts/docs-links.ts"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.0.0",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",

--- a/public/help/help-index.json
+++ b/public/help/help-index.json
@@ -1,0 +1,34 @@
+{
+  "docs": [
+    {
+      "slug": "/help/dashboard-bas",
+      "title": "Understand the BAS dashboard",
+      "summary": "How to read BAS obligations, upcoming due dates, and compliance score in the dashboard.",
+      "modes": [
+        "web"
+      ],
+      "updatedAt": "2025-10-06",
+      "content": "## Overview\n\nThe Business Activity Statement (BAS) dashboard surfaces PAYGW and GST lodgment milestones alongside payment status in one consolidated view. Each card tracks:\n\n- **Lodgments** — upcoming or overdue forms for each quarter.\n- **Payments** — PAYGW and GST remittances that remain outstanding.\n- **Compliance score** — weighted indicator of lodging and paying on time.\n\n## Actions\n\nSelect **View BAS** to open the BAS workspace with prefilled activity statements. APGMS syncs your latest transactions nightly so the dashboard reflects the last reconciliation cutover."
+    },
+    {
+      "slug": "/help/public-api",
+      "title": "Public API surface",
+      "summary": "Reference table of publicly supported REST endpoints exposed by APGMS.",
+      "modes": [
+        "api"
+      ],
+      "updatedAt": "2025-10-06",
+      "content": "| Endpoint | Method | Description |\n| --- | --- | --- |\n| /api/payments/balance | GET | Returns the PAYGW or GST account balance for the requested BAS period. |\n| /api/payments/ledger | GET | Streams the transaction ledger for the requested BAS period. |\n| /api/payments/deposit | POST | Registers an incoming client deposit that increases the ATO payable balance. |\n| /api/payments/release | POST | Sends a PAYGW or GST release to the ATO when the amount is negative. |\n\nAll public endpoints require an API key created from **Settings → API Access**."
+    },
+    {
+      "slug": "/help/rpt-tokens",
+      "title": "RPT (Real-time PAYGW Tokens)",
+      "summary": "Glossary entry explaining the Real-time PAYGW Token (RPT) integration.",
+      "modes": [
+        "web"
+      ],
+      "updatedAt": "2025-10-06",
+      "content": "Real-time PAYGW Tokens (RPT) authenticate secure exchange of withholding remittance totals with APGMS. Each token represents a daily PAYGW package signed with your AUSkey-equivalent certificate.\n\n### Lifecycle\n\n1. The payroll connector generates the token payload hourly.\n2. APGMS validates the signature against your registered AUSkey.\n3. When accepted, the PAYGW remittance queue updates immediately, allowing just-in-time BAS submissions.\n\n> Tip: Rotate RPT credentials on the same cadence as your AUSkey rotation policy. Use the **Integrations → Security** page to issue new client secrets."
+    }
+  ]
+}

--- a/scripts/build-doc-index.ts
+++ b/scripts/build-doc-index.ts
@@ -1,0 +1,72 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { splitFrontMatter } from "./frontmatter";
+
+type DocRecord = {
+  slug: string;
+  title: string;
+  summary?: string;
+  modes?: string[];
+  content: string;
+  updatedAt?: string;
+};
+
+const DOCS_DIR = path.resolve("docs/help");
+const OUT_FILE = path.resolve("public/help/help-index.json");
+
+async function readDocs(): Promise<DocRecord[]> {
+  const entries: DocRecord[] = [];
+  const filenames = await fs.readdir(DOCS_DIR);
+  for (const filename of filenames) {
+    if (!filename.endsWith(".mdx")) continue;
+    const filePath = path.join(DOCS_DIR, filename);
+    const raw = await fs.readFile(filePath, "utf8");
+    const record = parseMdx(raw, filePath);
+    entries.push(record);
+  }
+  entries.sort((a, b) => a.slug.localeCompare(b.slug));
+  return entries;
+}
+
+function parseMdx(source: string, filePath: string): DocRecord {
+  const { frontMatter, body } = splitFrontMatter(source);
+  const slug = (frontMatter.slug as string) ?? raise(`Missing slug in ${filePath}`);
+  const title = (frontMatter.title as string) ?? raise(`Missing title in ${filePath}`);
+  const summary = frontMatter.summary as string | undefined;
+  const modes = Array.isArray(frontMatter.modes)
+    ? (frontMatter.modes as string[])
+    : frontMatter.modes
+    ? [String(frontMatter.modes)]
+    : undefined;
+  const updatedAt = frontMatter.lastUpdated as string | undefined;
+
+  return {
+    slug,
+    title,
+    summary,
+    modes,
+    updatedAt,
+    content: body.trim(),
+  };
+}
+
+function raise(message: string): never {
+  throw new Error(message);
+}
+
+async function ensureOutDir() {
+  const dir = path.dirname(OUT_FILE);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function main() {
+  await ensureOutDir();
+  const docs = await readDocs();
+  await fs.writeFile(OUT_FILE, JSON.stringify({ docs }, null, 2));
+  console.log(`Wrote ${docs.length} help docs to ${OUT_FILE}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/docs-coverage.ts
+++ b/scripts/docs-coverage.ts
@@ -1,0 +1,62 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+type Endpoint = { method: string; path: string };
+
+const DOCS_DIR = path.resolve("docs/help");
+const REGISTRY_FILE = path.resolve("docs/public-endpoints.json");
+
+async function main() {
+  const [docs, registry] = await Promise.all([collectDocs(), readRegistry()]);
+  const missing: Endpoint[] = [];
+
+  for (const endpoint of registry) {
+    const covered = docs.some((doc) => doc.includes(endpoint.path));
+    if (!covered) {
+      missing.push(endpoint);
+      continue;
+    }
+    if (!docs.some((doc) => lineMentionsEndpoint(doc, endpoint))) {
+      missing.push(endpoint);
+    }
+  }
+
+  if (missing.length) {
+    console.error("Missing documentation for endpoints:");
+    for (const endpoint of missing) {
+      console.error(` - ${endpoint.method.toUpperCase()} ${endpoint.path}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`All ${registry.length} public endpoints referenced in docs.`);
+}
+
+function lineMentionsEndpoint(doc: string, endpoint: Endpoint): boolean {
+  const pattern = new RegExp(`${escapeForRegExp(endpoint.path)}[^\n]*${endpoint.method}`, "i");
+  const reversePattern = new RegExp(`${endpoint.method}[^\n]*${escapeForRegExp(endpoint.path)}`, "i");
+  return pattern.test(doc) || reversePattern.test(doc);
+}
+
+function escapeForRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+async function collectDocs(): Promise<string[]> {
+  const files = (await fs.readdir(DOCS_DIR)).filter((file) => file.endsWith(".mdx"));
+  return Promise.all(files.map((file) => fs.readFile(path.join(DOCS_DIR, file), "utf8")));
+}
+
+async function readRegistry(): Promise<Endpoint[]> {
+  const raw = await fs.readFile(REGISTRY_FILE, "utf8");
+  const data = JSON.parse(raw) as Endpoint[];
+  return data.map((endpoint) => ({
+    method: endpoint.method.toUpperCase(),
+    path: endpoint.path,
+  }));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/docs-last-updated.ts
+++ b/scripts/docs-last-updated.ts
@@ -1,0 +1,40 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { execSync } from "child_process";
+import { splitFrontMatter, serializeFrontMatter, FrontMatter } from "./frontmatter";
+
+const DOCS_DIR = path.resolve("docs/help");
+
+async function main() {
+  const files = (await fs.readdir(DOCS_DIR)).filter((file) => file.endsWith(".mdx"));
+  for (const filename of files) {
+    const filePath = path.join(DOCS_DIR, filename);
+    const raw = await fs.readFile(filePath, "utf8");
+    const { frontMatter, body } = splitFrontMatter(raw);
+    const lastUpdated = resolveGitDate(filePath);
+    const updatedFrontMatter: FrontMatter = { ...frontMatter, lastUpdated };
+    const fmBlock = `---\n${serializeFrontMatter(updatedFrontMatter)}\n---\n\n`;
+    await fs.writeFile(filePath, `${fmBlock}${body.trim()}\n`);
+    console.log(`Stamped ${filename} with lastUpdated=${lastUpdated}`);
+  }
+}
+
+function resolveGitDate(filePath: string): string {
+  try {
+    const value = execSync(`git log -1 --format=%cs -- ${JSON.stringify(filePath)}`, {
+      stdio: ["ignore", "pipe", "ignore"],
+      encoding: "utf8",
+    }).trim();
+    if (value) {
+      return value;
+    }
+  } catch (error) {
+    // Ignore and fall back to current date
+  }
+  return new Date().toISOString().split("T")[0];
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/docs-links.ts
+++ b/scripts/docs-links.ts
@@ -1,0 +1,56 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { splitFrontMatter } from "./frontmatter";
+
+const DOCS_DIR = path.resolve("docs/help");
+
+async function main() {
+  const files = (await fs.readdir(DOCS_DIR)).filter((file) => file.endsWith(".mdx"));
+  const docs = await Promise.all(
+    files.map(async (filename) => {
+      const filePath = path.join(DOCS_DIR, filename);
+      const content = await fs.readFile(filePath, "utf8");
+      const { frontMatter } = splitFrontMatter(content);
+      return { filename, filePath, content, slug: frontMatter.slug as string | undefined };
+    })
+  );
+
+  const knownSlugs = new Set(docs.map((doc) => doc.slug).filter(Boolean) as string[]);
+  const failures: string[] = [];
+
+  for (const doc of docs) {
+    const matches = doc.content.matchAll(/\[[^\]]+\]\(([^)#]+)(?:#[^)]+)?\)/g);
+    for (const match of matches) {
+      const target = match[1];
+      if (target.startsWith("http")) continue;
+      if (target.startsWith("#")) continue;
+      if (target.startsWith("/help/")) {
+        if (!knownSlugs.has(target)) {
+          failures.push(`${doc.filename} links to missing slug ${target}`);
+        }
+      } else {
+        const resolved = path.join(path.dirname(doc.filePath), target);
+        try {
+          await fs.access(resolved);
+        } catch {
+          failures.push(`${doc.filename} links to missing file ${target}`);
+        }
+      }
+    }
+  }
+
+  if (failures.length) {
+    console.error("Broken documentation links detected:");
+    for (const failure of failures) {
+      console.error(` - ${failure}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("All internal help links resolved successfully.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/frontmatter.ts
+++ b/scripts/frontmatter.ts
@@ -1,0 +1,94 @@
+export type FrontMatter = Record<string, unknown>;
+
+export function splitFrontMatter(source: string): { frontMatter: FrontMatter; body: string } {
+  const match = source.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) {
+    return { frontMatter: {}, body: source };
+  }
+  const metadata = parseBlock(match[1]);
+  const body = source.slice(match[0].length);
+  return { frontMatter: metadata, body };
+}
+
+export function parseBlock(block: string): FrontMatter {
+  const lines = block.split(/\n/);
+  const data: FrontMatter = {};
+  let currentKey: string | null = null;
+  for (const rawLine of lines) {
+    const line = rawLine.trimEnd();
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    if (/^[^\s].*:\s*/.test(line)) {
+      const [key, ...rest] = line.split(":");
+      currentKey = key.trim();
+      const value = rest.join(":").trim();
+      if (!value) {
+        data[currentKey] = [];
+        continue;
+      }
+      if (value.startsWith("[") && value.endsWith("]")) {
+        const list = value
+          .slice(1, -1)
+          .split(/,\s*/)
+          .filter(Boolean)
+          .map(unquote);
+        data[currentKey] = list;
+      } else if (value === "true" || value === "false") {
+        data[currentKey] = value === "true";
+      } else {
+        data[currentKey] = unquote(value);
+      }
+    } else if (trimmed.startsWith("-")) {
+      if (!currentKey) continue;
+      const entry = trimmed.replace(/^-\s*/, "");
+      const list = (data[currentKey] as unknown[]) ?? [];
+      if (!Array.isArray(list)) {
+        data[currentKey] = [String(data[currentKey]), unquote(entry)];
+      } else {
+        list.push(unquote(entry));
+        data[currentKey] = list;
+      }
+    }
+  }
+  return data;
+}
+
+export function serializeFrontMatter(data: FrontMatter): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(data)) {
+    if (Array.isArray(value)) {
+      parts.push(`${key}:`);
+      for (const entry of value) {
+        parts.push(`  - ${entry}`);
+      }
+    } else if (value === undefined) {
+      continue;
+    } else {
+      parts.push(`${key}: ${stringifyValue(value)}`);
+    }
+  }
+  return parts.join("\n");
+}
+
+function stringifyValue(value: unknown): string {
+  if (typeof value === "string") {
+    if (/[:#]|^\s|\s$/.test(value)) {
+      return JSON.stringify(value);
+    }
+    return value;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  return JSON.stringify(value);
+}
+
+function unquote(value: string): string {
+  if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import AppLayout from "./components/AppLayout";
+import { HelpCenterProvider } from "./help";
 
 import Dashboard from "./pages/Dashboard";
 import BAS from "./pages/BAS";
@@ -14,19 +15,21 @@ import Help from "./pages/Help";
 
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <HelpCenterProvider>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </HelpCenterProvider>
   );
 }

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import { useHelpCenter } from "../help";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -14,13 +15,14 @@ const navLinks = [
 ];
 
 export default function AppLayout() {
+  const { open } = useHelpCenter();
   return (
     <div>
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>
         <p>ATO-Compliant Tax Management System</p>
-        <nav style={{ marginTop: 16 }}>
+        <nav style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 16 }}>
           {navLinks.map((link) => (
             <NavLink
               key={link.to}
@@ -41,6 +43,22 @@ export default function AppLayout() {
               {link.label}
             </NavLink>
           ))}
+          <button
+            type="button"
+            onClick={() => open()}
+            style={{
+              marginLeft: "auto",
+              background: "rgba(255, 255, 255, 0.2)",
+              border: "1px solid rgba(255, 255, 255, 0.4)",
+              borderRadius: 8,
+              color: "#fff",
+              padding: "6px 14px",
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Help (Shift + /)
+          </button>
         </nav>
       </header>
 

--- a/src/help/HelpCenter.tsx
+++ b/src/help/HelpCenter.tsx
@@ -1,0 +1,334 @@
+import React, { useEffect, useMemo } from "react";
+import { HelpDoc, useHelpCenter } from "./HelpProvider";
+
+const drawerStyle: React.CSSProperties = {
+  position: "fixed",
+  top: 0,
+  right: 0,
+  bottom: 0,
+  width: "28rem",
+  backgroundColor: "#ffffff",
+  boxShadow: "-8px 0 24px rgba(15, 23, 42, 0.15)",
+  padding: "24px",
+  display: "flex",
+  flexDirection: "column",
+  zIndex: 1000,
+};
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(15, 23, 42, 0.4)",
+  zIndex: 999,
+};
+
+const tabButtonStyle: React.CSSProperties = {
+  flex: 1,
+  padding: "8px 12px",
+  border: "1px solid #d1d5db",
+  background: "#f8fafc",
+  cursor: "pointer",
+  fontWeight: 600,
+};
+
+const activeTabStyle: React.CSSProperties = {
+  ...tabButtonStyle,
+  background: "#0f766e",
+  color: "#ffffff",
+  borderColor: "#0f766e",
+};
+
+export default function HelpCenter() {
+  const {
+    isOpen,
+    close,
+    query,
+    setQuery,
+    docs,
+    isLoadingDocs,
+    whatsNew,
+    isLoadingChangelog,
+    pane,
+    setPane,
+    mode,
+    activeDocSlug,
+    setActiveDocSlug,
+  } = useHelpCenter();
+
+  const normalizedQuery = query.trim().toLowerCase();
+
+  const results = useMemo(() => {
+    if (!docs.length) return [] as Array<{ doc: HelpDoc; score: number }>;
+    return docs
+      .filter((doc) => {
+        if (doc.modes && doc.modes.length > 0 && !doc.modes.includes(mode)) {
+          return false;
+        }
+        if (!normalizedQuery) {
+          return true;
+        }
+        const haystack = `${doc.title} ${doc.summary ?? ""} ${doc.content}`.toLowerCase();
+        return normalizedQuery.split(/\s+/).every((term) => haystack.includes(term));
+      })
+      .map((doc) => ({ doc, score: scoreDoc(doc, normalizedQuery) }))
+      .sort((a, b) => b.score - a.score);
+  }, [docs, mode, normalizedQuery]);
+
+  const activeDoc = useMemo(() => {
+    const selected = results.find((entry) => entry.doc.slug === activeDocSlug)?.doc;
+    if (selected) return selected;
+    return results[0]?.doc;
+  }, [results, activeDocSlug]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    if (results.length === 0) {
+      setActiveDocSlug(undefined);
+      return;
+    }
+    if (!activeDoc) {
+      setActiveDocSlug(results[0].doc.slug);
+    }
+  }, [isOpen, results, activeDoc, setActiveDocSlug]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <>
+      <div style={overlayStyle} onClick={close} />
+      <aside style={drawerStyle} role="dialog" aria-modal="true" aria-label="Help Center">
+        <header style={{ display: "flex", alignItems: "center", marginBottom: 16 }}>
+          <h2 style={{ flex: 1, fontSize: 20, fontWeight: 700 }}>Help Center</h2>
+          <button
+            type="button"
+            onClick={close}
+            style={{ border: "none", background: "transparent", fontSize: 20, cursor: "pointer" }}
+            aria-label="Close help center"
+          >
+            ×
+          </button>
+        </header>
+
+        <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
+          <button
+            type="button"
+            onClick={() => setPane("search")}
+            style={pane === "search" ? activeTabStyle : tabButtonStyle}
+          >
+            Search
+          </button>
+          <button
+            type="button"
+            onClick={() => setPane("whatsNew")}
+            style={pane === "whatsNew" ? activeTabStyle : tabButtonStyle}
+          >
+            What’s New
+          </button>
+        </div>
+
+        {pane === "search" ? (
+          <>
+            <div style={{ marginBottom: 16 }}>
+              <input
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search help articles"
+                autoFocus
+                style={{
+                  width: "100%",
+                  padding: "10px 12px",
+                  borderRadius: 8,
+                  border: "1px solid #cbd5f5",
+                  fontSize: 14,
+                }}
+              />
+              <div style={{ fontSize: 12, color: "#64748b", marginTop: 4 }}>Press Shift + / for quick access</div>
+            </div>
+
+            {isLoadingDocs ? (
+              <p style={{ fontSize: 14, color: "#475569" }}>Loading documentation…</p>
+            ) : results.length === 0 ? (
+              <p style={{ fontSize: 14, color: "#475569" }}>
+                {normalizedQuery
+                  ? `No help topics matched “${query}”.`
+                  : "No help topics available for the current mode."}
+              </p>
+            ) : (
+              <div style={{ display: "flex", gap: 12, flex: 1, overflow: "hidden" }}>
+                <nav style={{ width: "45%", overflowY: "auto", borderRight: "1px solid #e2e8f0" }}>
+                  <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+                    {results.map(({ doc }) => (
+                      <li key={doc.slug}>
+                        <button
+                          type="button"
+                          onClick={() => setActiveDocSlug(doc.slug)}
+                          style={{
+                            width: "100%",
+                            textAlign: "left",
+                            padding: "10px 8px",
+                            border: "none",
+                            background: doc.slug === activeDoc?.slug ? "#ecfeff" : "transparent",
+                            cursor: "pointer",
+                          }}
+                        >
+                          <div style={{ fontWeight: 600, color: "#0f172a" }}>{doc.title}</div>
+                          {doc.summary ? (
+                            <div style={{ fontSize: 12, color: "#475569" }}>{doc.summary}</div>
+                          ) : null}
+                          {doc.updatedAt ? (
+                            <div style={{ fontSize: 11, color: "#94a3b8", marginTop: 4 }}>
+                              Updated {doc.updatedAt}
+                            </div>
+                          ) : null}
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </nav>
+                <article
+                  style={{ flex: 1, overflowY: "auto", paddingRight: 4 }}
+                  aria-live="polite"
+                  aria-label={activeDoc?.title ?? "Help details"}
+                >
+                  {activeDoc ? renderDoc(activeDoc) : null}
+                </article>
+              </div>
+            )}
+          </>
+        ) : (
+          <section style={{ flex: 1, overflowY: "auto" }}>
+            {isLoadingChangelog ? (
+              <p style={{ fontSize: 14, color: "#475569" }}>Loading release notes…</p>
+            ) : (
+              <pre
+                style={{
+                  background: "#f8fafc",
+                  padding: 12,
+                  borderRadius: 8,
+                  whiteSpace: "pre-wrap",
+                  fontFamily: "inherit",
+                  fontSize: 13,
+                  lineHeight: 1.5,
+                }}
+              >
+                {whatsNew}
+              </pre>
+            )}
+          </section>
+        )}
+      </aside>
+    </>
+  );
+}
+
+function scoreDoc(doc: HelpDoc, normalizedQuery: string): number {
+  if (!normalizedQuery) return 0;
+  const haystack = `${doc.title} ${doc.summary ?? ""}`.toLowerCase();
+  let score = 0;
+  const terms = normalizedQuery.split(/\s+/).filter(Boolean);
+  for (const term of terms) {
+    if (doc.slug.toLowerCase().includes(term)) score += 4;
+    if (doc.title.toLowerCase().includes(term)) score += 6;
+    if ((doc.summary ?? "").toLowerCase().includes(term)) score += 3;
+    if (doc.content.toLowerCase().includes(term)) score += 1;
+  }
+  if (normalizedQuery && haystack.startsWith(normalizedQuery)) {
+    score += 10;
+  }
+  return score;
+}
+
+function renderDoc(doc: HelpDoc) {
+  return (
+    <div>
+      <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 8 }}>{doc.title}</h3>
+      {doc.summary ? (
+        <p style={{ fontSize: 13, color: "#475569", marginBottom: 12 }}>{doc.summary}</p>
+      ) : null}
+      <DocBody content={doc.content} />
+    </div>
+  );
+}
+
+function DocBody({ content }: { content: string }) {
+  const blocks = useMemo(() => content.split(/\n\n+/), [content]);
+  return (
+    <div style={{ fontSize: 13, color: "#0f172a", lineHeight: 1.6 }}>
+      {blocks.map((block, index) => {
+        if (block.startsWith("## ")) {
+          return (
+            <h4 key={index} style={{ fontSize: 15, fontWeight: 700, marginTop: 16 }}>
+              {block.replace(/^##\s+/, "")}
+            </h4>
+          );
+        }
+        if (block.startsWith("### ")) {
+          return (
+            <h5 key={index} style={{ fontSize: 14, fontWeight: 700, marginTop: 12 }}>
+              {block.replace(/^###\s+/, "")}
+            </h5>
+          );
+        }
+        if (block.trim().startsWith("- ")) {
+          const items = block.split(/\n/).map((line) => line.replace(/^-\s*/, ""));
+          return (
+            <ul key={index} style={{ paddingLeft: 18, marginBottom: 12 }}>
+              {items.map((item, itemIndex) => (
+                <li key={itemIndex}>{item}</li>
+              ))}
+            </ul>
+          );
+        }
+        if (block.trim().match(/^\d+\.\s/)) {
+          const items = block.split(/\n/).map((line) => line.replace(/^\d+\.\s*/, ""));
+          return (
+            <ol key={index} style={{ paddingLeft: 18, marginBottom: 12 }}>
+              {items.map((item, itemIndex) => (
+                <li key={itemIndex}>{item}</li>
+              ))}
+            </ol>
+          );
+        }
+        if (block.trim().startsWith(">")) {
+          return (
+            <blockquote
+              key={index}
+              style={{
+                borderLeft: "3px solid #0f766e",
+                paddingLeft: 12,
+                color: "#0f172a",
+                fontStyle: "italic",
+                marginBottom: 12,
+              }}
+            >
+              {block.replace(/^>\s*/, "")}
+            </blockquote>
+          );
+        }
+        if (block.includes("|") && block.includes("---")) {
+          return (
+            <pre
+              key={index}
+              style={{
+                background: "#f1f5f9",
+                padding: 12,
+                borderRadius: 8,
+                overflowX: "auto",
+                marginBottom: 12,
+              }}
+            >
+              {block}
+            </pre>
+          );
+        }
+        return (
+          <p key={index} style={{ marginBottom: 12 }}>
+            {block}
+          </p>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/help/HelpProvider.tsx
+++ b/src/help/HelpProvider.tsx
@@ -1,0 +1,280 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+import HelpCenter from "./HelpCenter";
+
+export type HelpDoc = {
+  slug: string;
+  title: string;
+  summary?: string;
+  modes?: string[];
+  content: string;
+  updatedAt?: string;
+};
+
+export type HelpPane = "search" | "whatsNew";
+
+export interface HelpOpenOptions {
+  query?: string;
+  pane?: HelpPane;
+  docSlug?: string;
+}
+
+export interface HelpContextValue {
+  isOpen: boolean;
+  open: (options?: HelpOpenOptions) => void;
+  close: () => void;
+  toggle: () => void;
+  query: string;
+  setQuery: (value: string) => void;
+  contextKey?: string;
+  contextQuery?: string;
+  setContextKey: (key?: string, options?: { mode?: string }) => void;
+  docs: HelpDoc[];
+  isLoadingDocs: boolean;
+  whatsNew: string;
+  isLoadingChangelog: boolean;
+  mode: string;
+  setMode: (mode: string) => void;
+  pane: HelpPane;
+  setPane: (pane: HelpPane) => void;
+  activeDocSlug?: string;
+  setActiveDocSlug: (slug?: string) => void;
+}
+
+const HelpContext = createContext<HelpContextValue | undefined>(undefined);
+
+const HELP_INDEX_PATH = "/help/help-index.json";
+const CHANGELOG_PATH = "/CHANGELOG.md";
+
+export function HelpCenterProvider({ children }: { children: React.ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [contextKey, setContextKeyState] = useState<string | undefined>();
+  const [contextQuery, setContextQuery] = useState<string | undefined>();
+  const [docs, setDocs] = useState<HelpDoc[]>([]);
+  const [isLoadingDocs, setIsLoadingDocs] = useState(true);
+  const [whatsNew, setWhatsNew] = useState("");
+  const [isLoadingChangelog, setIsLoadingChangelog] = useState(true);
+  const [mode, setMode] = useState("web");
+  const [pane, setPane] = useState<HelpPane>("search");
+  const [activeDocSlug, setActiveDocSlug] = useState<string | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadDocs() {
+      try {
+        setIsLoadingDocs(true);
+        const response = await fetch(HELP_INDEX_PATH, { cache: "no-cache" });
+        if (!response.ok) throw new Error(`Unable to load ${HELP_INDEX_PATH}`);
+        const payload = (await response.json()) as { docs?: HelpDoc[] };
+        if (!cancelled) {
+          setDocs(payload.docs ?? []);
+        }
+      } catch (error) {
+        console.error("Failed to load help index", error);
+        if (!cancelled) {
+          setDocs([]);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingDocs(false);
+        }
+      }
+    }
+    loadDocs();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadChangelog() {
+      try {
+        setIsLoadingChangelog(true);
+        const response = await fetch(CHANGELOG_PATH, { cache: "no-cache" });
+        if (!response.ok) throw new Error(`Unable to load ${CHANGELOG_PATH}`);
+        const text = await response.text();
+        if (!cancelled) {
+          setWhatsNew(text);
+        }
+      } catch (error) {
+        console.error("Failed to load changelog", error);
+        if (!cancelled) {
+          setWhatsNew("No changelog entries available.");
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingChangelog(false);
+        }
+      }
+    }
+    loadChangelog();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!contextKey) {
+      setContextQuery(undefined);
+      return;
+    }
+    const queryFromKey = contextKey
+      .split(/[._]/)
+      .filter(Boolean)
+      .join(" ");
+    setContextQuery(queryFromKey);
+  }, [contextKey]);
+
+  useEffect(() => {
+    if (!contextKey || !docs.length) return;
+    const normalized = normalize(contextKey);
+    const match = docs.find((doc) => {
+      const haystack = `${doc.slug} ${doc.title} ${doc.summary ?? ""}`;
+      return normalize(haystack).includes(normalized);
+    });
+    if (match) {
+      setActiveDocSlug(match.slug);
+    }
+  }, [contextKey, docs]);
+
+  const open = useCallback(
+    (options?: HelpOpenOptions) => {
+      const targetPane = options?.pane ?? "search";
+      setPane(targetPane);
+      if (options?.query !== undefined) {
+        setQuery(options.query);
+      } else if (options?.docSlug) {
+        const doc = docs.find((entry) => entry.slug === options.docSlug);
+        setQuery(doc?.title ?? options.docSlug);
+      } else if (contextQuery) {
+        setQuery(contextQuery);
+      }
+      if (options?.docSlug) {
+        setActiveDocSlug(options.docSlug);
+      } else if (contextKey && targetPane === "search") {
+        const normalized = normalize(contextKey);
+        const matchedDoc = docs.find((doc) => normalize(doc.slug).includes(normalized));
+        if (matchedDoc) {
+          setActiveDocSlug(matchedDoc.slug);
+        }
+      }
+      setIsOpen(true);
+    },
+    [contextKey, contextQuery, docs]
+  );
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const toggle = useCallback(() => {
+    setIsOpen((value) => !value);
+  }, []);
+
+  const registerContext = useCallback(
+    (key?: string, options?: { mode?: string }) => {
+      setContextKeyState(key);
+      if (options?.mode) {
+        setMode(options.mode);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    const handleKeydown = (event: KeyboardEvent) => {
+      const isShiftSlash = event.code === "Slash" && event.shiftKey;
+      const isQuestion = event.key === "?";
+      if (isShiftSlash || isQuestion) {
+        event.preventDefault();
+        open();
+      }
+      if (event.key === "Escape") {
+        if (isOpen) {
+          event.preventDefault();
+          close();
+        }
+      }
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [open, close, isOpen]);
+
+  const value = useMemo<HelpContextValue>(
+    () => ({
+      isOpen,
+      open,
+      close,
+      toggle,
+      query,
+      setQuery,
+      contextKey,
+      contextQuery,
+      setContextKey: registerContext,
+      docs,
+      isLoadingDocs,
+      whatsNew,
+      isLoadingChangelog,
+      mode,
+      setMode,
+      pane,
+      setPane,
+      activeDocSlug,
+      setActiveDocSlug,
+    }),
+    [
+      isOpen,
+      open,
+      close,
+      toggle,
+      query,
+      contextKey,
+      contextQuery,
+      registerContext,
+      docs,
+      isLoadingDocs,
+      whatsNew,
+      isLoadingChangelog,
+      mode,
+      pane,
+      activeDocSlug,
+    ]
+  );
+
+  return (
+    <HelpContext.Provider value={value}>
+      {children}
+      <HelpCenter />
+    </HelpContext.Provider>
+  );
+}
+
+export function useHelpCenter(): HelpContextValue {
+  const context = useContext(HelpContext);
+  if (!context) {
+    throw new Error("useHelpCenter must be used within HelpCenterProvider");
+  }
+  return context;
+}
+
+export function useContextHelp(key?: string, options?: { mode?: string }) {
+  const { setContextKey } = useHelpCenter();
+  useEffect(() => {
+    setContextKey(key, options);
+  }, [key, options?.mode, setContextKey]);
+}
+
+function normalize(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}

--- a/src/help/HelpTip.tsx
+++ b/src/help/HelpTip.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { useHelpCenter } from "./HelpProvider";
+
+type HelpTipProps = {
+  slug: string;
+  children: React.ReactNode;
+  description?: string;
+};
+
+export default function HelpTip({ slug, children, description }: HelpTipProps) {
+  const { open } = useHelpCenter();
+  return (
+    <button
+      type="button"
+      onClick={(event) => {
+        event.preventDefault();
+        open({ pane: "search", docSlug: slug });
+      }}
+      title={description ?? "Open contextual help"}
+      style={{
+        border: "none",
+        background: "rgba(15, 118, 110, 0.1)",
+        color: "#0f766e",
+        borderRadius: "999px",
+        padding: "2px 10px",
+        fontSize: "0.8rem",
+        cursor: "pointer",
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/help/index.ts
+++ b/src/help/index.ts
@@ -1,0 +1,3 @@
+export { HelpCenterProvider, useHelpCenter, useContextHelp } from "./HelpProvider";
+export type { HelpDoc, HelpPane, HelpOpenOptions } from "./HelpProvider";
+export { default as HelpTip } from "./HelpTip";

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,8 +1,10 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import { HelpTip, useContextHelp } from '../help';
 
 export default function Dashboard() {
+  useContextHelp('dashboard.bas', { mode: 'web' });
   const complianceStatus = {
     lodgmentsUpToDate: false,
     paymentsUpToDate: false,
@@ -19,6 +21,8 @@ export default function Dashboard() {
         <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
         <p className="text-sm opacity-90">
           Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
+          {' '}
+          <HelpTip slug="/help/rpt-tokens">RPT tokens</HelpTip> keep PAYGW data synchronized hourly.
         </p>
         <div className="mt-4">
           <Link to="/wizard" className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100">

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -1,6 +1,8 @@
 import React from "react";
+import { HelpTip, useContextHelp } from "../help";
 
 export default function Integrations() {
+  useContextHelp("integrations.api", { mode: "api" });
   return (
     <div className="main-card">
       <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
@@ -12,7 +14,8 @@ export default function Integrations() {
         <li>Vend (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
       </ul>
       <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
-        (More integrations coming soon.)
+        (More integrations coming soon. See{' '}
+        <HelpTip slug="/help/public-api">public API surface</HelpTip> for REST endpoints.)
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add HelpCenterProvider, drawer UI, and header shortcut for contextual search
- seed dashboard and integrations screens with context-aware help tips and glossary tags
- generate MDX-backed help index and add docs freshness/coverage/link validation scripts for CI

## Testing
- npx tsx scripts/build-doc-index.ts
- npx tsx scripts/docs-last-updated.ts
- npx tsx scripts/docs-coverage.ts
- npx tsx scripts/docs-links.ts

------
https://chatgpt.com/codex/tasks/task_e_68e39948da908327bf38887c6b030b11