### PR TITLE
Improve console route performance with lazy loading and virtualized history table

### DIFF
--- a/apps/gui/styles.css
+++ b/apps/gui/styles.css
@@ -16,3 +16,36 @@ table{ width:100%; border-collapse:collapse }
 th,td{ padding:8px; border-bottom:1px solid var(--border) }
 .kbd{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; background:var(--card); border:1px solid var(--border); border-radius:6px; padding:2px 6px }
 .footer{ margin-top:24px; color:var(--muted) }
+.hidden{ display:none !important }
+.muted{ color:var(--muted) }
+.font-mono{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace }
+.truncate{ overflow:hidden; white-space:nowrap; text-overflow:ellipsis }
+.space-y-4 > * + *{ margin-top:16px }
+.space-y-6 > * + *{ margin-top:24px }
+.skeleton{ position:relative; overflow:hidden; background:var(--border); border-radius:8px }
+.skeleton::after{ content:""; position:absolute; inset:0; transform:translateX(-100%); background:linear-gradient(120deg, transparent 0%, rgba(255,255,255,0.6) 45%, rgba(255,255,255,0.6) 55%, transparent 100%); animation:skeleton-sheen 1.1s ease-in-out infinite }
+.skeleton-card .skeleton + .skeleton{ margin-top:12px }
+@media (prefers-reduced-motion: reduce){ .skeleton::after{ animation-duration:2s } }
+@keyframes skeleton-sheen{ from{ transform:translateX(-100%) } to{ transform:translateX(100%) } }
+.virtual-table{ margin-top:12px; border:1px solid var(--border); border-radius:12px; overflow:hidden; background:var(--card) }
+.virtual-table table{ width:100%; border-collapse:collapse }
+.virtual-table thead{ display:table; width:100%; table-layout:fixed; background:var(--card) }
+.virtual-table thead th{ padding:10px 12px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; text-align:left; color:var(--muted); border-bottom:1px solid var(--border) }
+.virtual-table tbody{ display:block; max-height:360px; overflow-y:auto; background:var(--bg) }
+.virtual-table tbody::-webkit-scrollbar{ width:8px }
+.virtual-table tbody::-webkit-scrollbar-thumb{ background:var(--border); border-radius:999px }
+.virtual-table tbody::-webkit-scrollbar-track{ background:transparent }
+.virtual-table tbody tr{ display:table; width:100%; table-layout:fixed; height:var(--row-height, 44px) }
+.virtual-table tbody td{ padding:8px 12px; border-bottom:1px solid var(--border); vertical-align:middle; white-space:nowrap }
+.virtual-table tbody tr:last-child td{ border-bottom:none }
+.virtual-table tbody tr.spacer td{ padding:0; border:none }
+.virtual-table tbody tr.error td{ padding:16px 12px }
+.virtual-table tbody td.mono{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace }
+.virtual-table tbody td.num{ text-align:right; font-variant-numeric:tabular-nums }
+.virtual-table tbody td.actions{ text-align:right }
+.virtual-table tbody td.actions a{ color:var(--focus); text-decoration:none }
+.virtual-table tbody td.actions a:hover{ text-decoration:underline }
+.virtual-status{ margin-top:8px; font-size:12px; color:var(--muted) }
+.virtual-empty{ margin-top:12px; color:var(--muted); font-size:13px }
+.skeleton-row td{ padding:12px 12px; border-bottom:1px solid transparent }
+.skeleton-row .skeleton{ display:block; height:14px; border-radius:999px }

--- a/apps/gui/views/History.js
+++ b/apps/gui/views/History.js
@@ -1,6 +1,9 @@
 import { api } from "../lib/utils.js";
 
-export default async function History(root){
+const ROW_HEIGHT = 44;
+const BUFFER = 6;
+
+export default async function History(root) {
   root.innerHTML = `
   <section class="bg-white rounded-2xl shadow p-6">
     <h2 class="text-lg font-semibold">History</h2>
@@ -11,29 +14,272 @@ export default async function History(root){
       <button id="reload" class="px-3 py-2 rounded bg-gray-900 text-white text-sm">Refresh</button>
     </div>
 
-    <table class="mt-3 w-full text-sm">
-      <thead><tr class="text-left text-gray-500">
-        <th class="py-2">ID</th><th>When</th><th>Status</th><th>Items</th><th></th>
-      </tr></thead>
-      <tbody id="rows"><tr><td class="py-2" colspan="5">Loadingâ€¦</td></tr></tbody>
-    </table>
+    <div class="virtual-status" id="historyStatus" aria-live="polite"></div>
+    <div class="virtual-table" id="historyShell" aria-busy="false">
+      <table>
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th>When</th>
+            <th>Status</th>
+            <th>Items</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="rows"></tbody>
+      </table>
+    </div>
+    <p id="historyEmpty" class="virtual-empty hidden">Nothing here yet.</p>
   </section>`;
 
-  async function load(){
-    const q = document.getElementById("q").value.trim();
-    const res = await api(`/jobs${q?`?q=${encodeURIComponent(q)}`:""}`);
-    const rows = document.getElementById("rows"); rows.innerHTML="";
-    if (res.ok && Array.isArray(res.body) && res.body.length){
-      for (const j of res.body){
-        const tr = document.createElement("tr");
-        tr.innerHTML = `<td class="py-1">${j.id||"â€”"}</td><td>${j.created_at||"â€”"}</td><td>${j.status||"â€”"}</td><td>${j.count??"â€”"}</td>
-          <td><a class="text-sky-700 hover:underline" href="#/results">Open</a></td>`;
-        rows.appendChild(tr);
-      }
-    } else {
-      rows.innerHTML = `<tr><td class="py-2 text-gray-500" colspan="5">Nothing here yet.</td></tr>`;
-    }
+  const qInput = root.querySelector("#q");
+  const reloadBtn = root.querySelector("#reload");
+  const rowsEl = root.querySelector("#rows");
+  const statusEl = root.querySelector("#historyStatus");
+  const shellEl = root.querySelector("#historyShell");
+  const emptyEl = root.querySelector("#historyEmpty");
+
+  if (!rowsEl || !statusEl || !shellEl || !reloadBtn || !qInput || !emptyEl) {
+    return;
   }
-  document.getElementById("reload").onclick = load;
-  load();
+
+  rowsEl.style.setProperty("--row-height", `${ROW_HEIGHT}px`);
+
+  let jobs = [];
+  let firstLoad = true;
+  let requestToken = 0;
+  let debounceTimer = 0;
+  let raf = 0;
+  let cleaned = false;
+  let observer;
+
+  const updateStatus = (text) => {
+    statusEl.textContent = text;
+  };
+
+  const renderSkeleton = () => {
+    shellEl.setAttribute("aria-busy", "true");
+    rowsEl.replaceChildren();
+    for (let i = 0; i < 6; i += 1) {
+      const tr = document.createElement("tr");
+      tr.className = "skeleton-row";
+      const td = document.createElement("td");
+      td.colSpan = 5;
+      const block = document.createElement("div");
+      block.className = "skeleton";
+      block.style.height = "14px";
+      block.style.width = `${40 + (i % 3) * 15}%`;
+      td.appendChild(block);
+      tr.appendChild(td);
+      rowsEl.appendChild(tr);
+    }
+  };
+
+  const renderError = (message) => {
+    rowsEl.replaceChildren();
+    const tr = document.createElement("tr");
+    tr.className = "error";
+    const td = document.createElement("td");
+    td.colSpan = 5;
+    td.textContent = message;
+    tr.appendChild(td);
+    rowsEl.appendChild(tr);
+    shellEl.setAttribute("aria-busy", "false");
+  };
+
+  const makeSpacer = (count) => {
+    const tr = document.createElement("tr");
+    tr.className = "spacer";
+    const td = document.createElement("td");
+    td.colSpan = 5;
+    td.style.height = `${count * ROW_HEIGHT}px`;
+    tr.appendChild(td);
+    return tr;
+  };
+
+  const createCell = (value, classNames = []) => {
+    const td = document.createElement("td");
+    td.textContent = value;
+    classNames.forEach((name) => td.classList.add(name));
+    return td;
+  };
+
+  const makeRow = (job) => {
+    const tr = document.createElement("tr");
+
+    const idCell = createCell(job?.id ?? "—", ["mono", "truncate"]);
+    if (job?.id) idCell.title = job.id;
+
+    const whenCell = createCell(job?.created_at ?? "—");
+    if (job?.created_at) whenCell.title = job.created_at;
+
+    const statusCell = createCell(job?.status ?? "—");
+    const countCell = createCell(String(job?.count ?? "—"), ["num"]);
+
+    const actionCell = document.createElement("td");
+    actionCell.classList.add("actions");
+    const link = document.createElement("a");
+    link.href = "#/results";
+    link.textContent = "Open";
+    actionCell.appendChild(link);
+
+    tr.append(idCell, whenCell, statusCell, countCell, actionCell);
+    return tr;
+  };
+
+  const renderVirtual = (resetScroll = false) => {
+    if (!jobs.length) {
+      rowsEl.replaceChildren();
+      shellEl.setAttribute("aria-busy", "false");
+      return;
+    }
+
+    if (resetScroll) {
+      rowsEl.scrollTop = 0;
+    }
+
+    const viewportHeight = rowsEl.clientHeight || 360;
+    const scrollTop = rowsEl.scrollTop;
+    const maxScroll = Math.max(0, jobs.length * ROW_HEIGHT - viewportHeight);
+    if (!resetScroll && scrollTop > maxScroll) {
+      rowsEl.scrollTop = maxScroll;
+      return renderVirtual(false);
+    }
+    const start = Math.max(0, Math.floor(scrollTop / ROW_HEIGHT) - BUFFER);
+    const end = Math.min(jobs.length, Math.ceil((scrollTop + viewportHeight) / ROW_HEIGHT) + BUFFER);
+
+    const fragment = document.createDocumentFragment();
+
+    if (start > 0) {
+      fragment.appendChild(makeSpacer(start));
+    }
+
+    for (let i = start; i < end; i += 1) {
+      fragment.appendChild(makeRow(jobs[i]));
+    }
+
+    if (end < jobs.length) {
+      fragment.appendChild(makeSpacer(jobs.length - end));
+    }
+
+    rowsEl.replaceChildren(fragment);
+    shellEl.setAttribute("aria-busy", "false");
+  };
+
+  const scheduleRender = () => {
+    if (!jobs.length) return;
+    if (raf) return;
+    raf = requestAnimationFrame(() => {
+      raf = 0;
+      renderVirtual();
+    });
+  };
+
+  const onScroll = () => {
+    scheduleRender();
+  };
+
+  const onResize = () => {
+    if (!jobs.length) return;
+    renderVirtual();
+  };
+
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    rowsEl.removeEventListener("scroll", onScroll);
+    window.removeEventListener("resize", onResize);
+    if (observer) observer.disconnect();
+    if (raf) {
+      cancelAnimationFrame(raf);
+      raf = 0;
+    }
+  };
+
+  rowsEl.addEventListener("scroll", onScroll, { passive: true });
+  window.addEventListener("resize", onResize);
+
+  const parentNode = root.parentNode;
+  if (parentNode instanceof Node) {
+    observer = new MutationObserver(() => {
+      if (!root.isConnected) {
+        cleanup();
+      }
+    });
+    observer.observe(parentNode, { childList: true });
+  }
+
+  const load = async ({ resetScroll = true } = {}) => {
+    const query = qInput.value.trim();
+    const token = ++requestToken;
+
+    reloadBtn.disabled = true;
+    shellEl.setAttribute("aria-busy", "true");
+
+    if (firstLoad) {
+      renderSkeleton();
+      emptyEl.classList.add("hidden");
+      updateStatus("Loading history…");
+    } else {
+      updateStatus("Refreshing…");
+    }
+
+    try {
+      const res = await api(`/jobs${query ? `?q=${encodeURIComponent(query)}` : ""}`);
+      if (token !== requestToken) return;
+
+      firstLoad = false;
+
+      if (!res.ok || !Array.isArray(res.body)) {
+        throw new Error(`Unexpected response: ${res.status}`);
+      }
+
+      jobs = res.body;
+
+      if (!jobs.length) {
+        rowsEl.replaceChildren();
+        emptyEl.classList.remove("hidden");
+        shellEl.setAttribute("aria-busy", "false");
+        updateStatus(query ? "No history matches your filter." : "No history yet.");
+        return;
+      }
+
+      emptyEl.classList.add("hidden");
+      updateStatus(`Showing ${jobs.length} entr${jobs.length === 1 ? "y" : "ies"}${query ? " (filtered)" : ""}.`);
+      renderVirtual(resetScroll);
+    } catch (error) {
+      if (token !== requestToken) return;
+      firstLoad = false;
+      jobs = [];
+      emptyEl.classList.add("hidden");
+      updateStatus("Unable to load history.");
+      renderError("We couldn’t load history. Try again in a moment.");
+      console.error(error);
+    } finally {
+      if (token === requestToken) {
+        shellEl.setAttribute("aria-busy", "false");
+        reloadBtn.disabled = false;
+      }
+    }
+  };
+
+  reloadBtn.addEventListener("click", () => load({ resetScroll: false }));
+
+  qInput.addEventListener("input", () => {
+    window.clearTimeout(debounceTimer);
+    debounceTimer = window.setTimeout(() => load({ resetScroll: true }), 220);
+  });
+
+  qInput.addEventListener("keydown", (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      window.clearTimeout(debounceTimer);
+      load({ resetScroll: true });
+    }
+  });
+
+  await load({ resetScroll: true });
+
+  // Ensure listeners are cleaned up if the view is removed without navigation (e.g. hot reload).
+  root.addEventListener("destroy", cleanup, { once: true });
 }


### PR DESCRIPTION
## Summary
- lazy load console route modules and render a skeleton placeholder while views load
- add shared skeleton and virtual table styles for smoother perceived performance
- virtualize the history table with debounced filtering, skeleton states, and optimistic refresh messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e399eb687c83278cda2af6485229e2