### PR TITLE
feat: add design tokens theme provider and documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "check:tokens": "node scripts/check-design-tokens.cjs"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/check-design-tokens.cjs
+++ b/scripts/check-design-tokens.cjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+
+const status = execSync("git status --porcelain src/ui/tokens.ts", {
+  encoding: "utf8",
+}).trim();
+
+const references = [
+  process.env.DESIGN_TOKENS_BASE,
+  "origin/main",
+  "main",
+  "HEAD^",
+];
+
+const diffs = [];
+
+if (status) {
+  const isUntracked = status.includes("??");
+  const command = isUntracked
+    ? "git diff --no-index -- /dev/null src/ui/tokens.ts"
+    : "git diff -- src/ui/tokens.ts";
+  try {
+    diffs.push(execSync(command, { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }));
+  } catch (error) {
+    if (error.stdout) {
+      diffs.push(error.stdout.toString());
+    } else {
+      throw error;
+    }
+  }
+}
+
+for (const ref of references) {
+  if (!ref) continue;
+  try {
+    const mergeBase = execSync(`git merge-base ${ref} HEAD`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const output = execSync(`git diff ${mergeBase}...HEAD -- src/ui/tokens.ts`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    if (output.trim()) {
+      diffs.push(output);
+      break;
+    }
+  } catch (error) {
+    // Ignore missing refs and keep trying fallbacks.
+  }
+}
+
+const diff = diffs.join("\n");
+
+if (!diff.trim()) {
+  process.exit(0);
+}
+
+console.log("Design token changes detected. Attach design sign-off before merging.\n");
+console.log(diff);
+if (process.env.DESIGN_SIGN_OFF === "approved") {
+  console.log("Design sign-off override detected. Proceeding despite token diff.\n");
+  process.exit(0);
+}
+
+console.log("\n⬆️ Include approval from the design system team in this PR before merging.");
+process.exit(1);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Audit from "./pages/Audit";
 import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
+import DesignSystemPage from "./pages/DesignSystem";
 
 export default function App() {
   return (
@@ -25,6 +26,7 @@ export default function App() {
           <Route path="/fraud" element={<Fraud />} />
           <Route path="/integrations" element={<Integrations />} />
           <Route path="/help" element={<Help />} />
+          <Route path="/help/design-system" element={<DesignSystemPage />} />
         </Route>
       </Routes>
     </Router>

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -11,6 +11,7 @@ const navLinks = [
   { to: "/fraud", label: "Fraud" },
   { to: "/integrations", label: "Integrations" },
   { to: "/help", label: "Help" },
+  { to: "/help/design-system", label: "Design System" },
 ];
 
 export default function AppLayout() {

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,54 @@
 /* General App Container */
 body {
-  background: #f5f7fa;
+  background: var(--color-background);
   font-family: 'Segoe UI', 'Roboto', Arial, sans-serif;
   margin: 0;
-  color: #222;
+  color: var(--color-foreground);
+  transition: background-color var(--duration-slow) ease,
+    color var(--duration-fast) ease;
+}
+
+:root {
+  --space-0: 0px;
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-5: 1.5rem;
+  --space-6: 2rem;
+  --space-7: 3rem;
+  --space-8: 4rem;
+  --radius-none: 0px;
+  --radius-xs: 2px;
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-full: 999px;
+  --shadow-none: none;
+  --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.05);
+  --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.12);
+  --shadow-md: 0 10px 30px rgba(15, 23, 42, 0.12);
+  --duration-instant: 0ms;
+  --duration-fast: 100ms;
+  --duration-base: 200ms;
+  --duration-slow: 350ms;
+  --breakpoint-xs: 320px;
+  --breakpoint-sm: 640px;
+  --breakpoint-md: 768px;
+  --breakpoint-lg: 1024px;
+  --breakpoint-xl: 1280px;
+  --color-background: #f5f7fa;
+  --color-foreground: #1f2937;
+  --color-subtle: #e2e8f0;
+  --color-muted: #64748b;
+  --color-border: #cbd5f5;
+  --color-primary: #00716b;
+  --color-primaryContrast: #ffffff;
+  --color-critical: #ef4444;
+  --color-warning: #f59e0b;
+  --color-success: #10b981;
+  --color-info: #2563eb;
 }
 
 .app-header {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
+import { ThemeProvider } from "./ui";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
-root.render(<App />);
+root.render(
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>,
+);

--- a/src/pages/DesignSystem.tsx
+++ b/src/pages/DesignSystem.tsx
@@ -1,0 +1,168 @@
+import React from "react";
+import { themeNames, tokens, useTheme } from "../ui";
+
+const Section: React.FC<{ title: string; description?: string; children: React.ReactNode }> = ({
+  title,
+  description,
+  children,
+}) => (
+  <section style={{ marginBottom: "var(--space-6)" }}>
+    <header style={{ marginBottom: "var(--space-3)" }}>
+      <h2 style={{ margin: 0 }}>{title}</h2>
+      {description ? (
+        <p style={{ marginTop: "var(--space-1)", color: "var(--color-muted)" }}>{description}</p>
+      ) : null}
+    </header>
+    {children}
+  </section>
+);
+
+const TokenSwatch: React.FC<{ label: string; value: string; example?: React.ReactNode }> = ({
+  label,
+  value,
+  example,
+}) => (
+  <div
+    style={{
+      padding: "var(--space-3)",
+      borderRadius: "var(--radius-lg)",
+      background: "var(--color-subtle)",
+      display: "flex",
+      flexDirection: "column",
+      gap: "var(--space-2)",
+      minWidth: 160,
+    }}
+  >
+    <div style={{ fontSize: 12, textTransform: "uppercase", letterSpacing: 0.5 }}>{label}</div>
+    <code style={{ fontSize: 14 }}>{value}</code>
+    {example}
+  </div>
+);
+
+export default function DesignSystemPage() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div
+      style={{
+        padding: "var(--space-5)",
+        background: "var(--color-background)",
+        color: "var(--color-foreground)",
+      }}
+    >
+      <header style={{ marginBottom: "var(--space-5)" }}>
+        <h1 style={{ marginBottom: "var(--space-2)" }}>Design Tokens</h1>
+        <p style={{ margin: 0, color: "var(--color-muted)" }}>
+          Tokenized spacing, typography and color primitives for the APGMS console. Tokens are
+          applied globally as CSS variables and power our Tailwind theme.
+        </p>
+        <div style={{ marginTop: "var(--space-3)", display: "flex", gap: "var(--space-2)" }}>
+          {themeNames.map((name) => (
+            <button
+              key={name}
+              type="button"
+              onClick={() => setTheme(name)}
+              style={{
+                padding: "var(--space-2) var(--space-3)",
+                borderRadius: "var(--radius-md)",
+                border: `1px solid ${
+                  theme.name === name ? "var(--color-primary)" : "var(--color-border)"
+                }`,
+                background:
+                  theme.name === name ? "var(--color-primary)" : "transparent",
+                color:
+                  theme.name === name
+                    ? "var(--color-primaryContrast)"
+                    : "var(--color-foreground)",
+                cursor: "pointer",
+                transition: `background var(--duration-base) ease, color var(--duration-fast) ease`,
+              }}
+            >
+              {name === "light" ? "Light" : "Dark"} theme
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <Section title="Spacing" description="Consistent spacing scale based on 4px increments.">
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
+          {Object.entries(tokens.space).map(([key, value]) => (
+            <TokenSwatch
+              key={key}
+              label={`space.${key}`}
+              value={value}
+              example={
+                <div
+                  style={{
+                    height: "var(--space-2)",
+                    width: value,
+                    background: "var(--color-primary)",
+                    borderRadius: "var(--radius-sm)",
+                  }}
+                />
+              }
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Radii" description="Corner radii for surfaces and controls.">
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
+          {Object.entries(tokens.radius).map(([key, value]) => (
+            <TokenSwatch
+              key={key}
+              label={`radius.${key}`}
+              value={value}
+              example={
+                <div
+                  style={{
+                    height: "3rem",
+                    width: "100%",
+                    background: "var(--color-primary)",
+                    borderRadius: value,
+                  }}
+                />
+              }
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Color palette" description="Semantic colors adapt between light and dark themes.">
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
+          {Object.entries(theme.palette).map(([key, value]) => (
+            <TokenSwatch
+              key={key}
+              label={`color.${key}`}
+              value={value}
+              example={
+                <div
+                  style={{
+                    background: value,
+                    height: "3rem",
+                    borderRadius: "var(--radius-md)",
+                    border:
+                      key === "background"
+                        ? "1px solid var(--color-border)"
+                        : "1px solid transparent",
+                  }}
+                />
+              }
+            />
+          ))}
+        </div>
+      </Section>
+
+      <Section
+        title="Motion"
+        description="Standard durations ensure consistent easing and animation feel."
+      >
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "var(--space-3)" }}>
+          {Object.entries(tokens.durations).map(([key, value]) => (
+            <TokenSwatch key={key} label={`duration.${key}`} value={value} />
+          ))}
+        </div>
+      </Section>
+    </div>
+  );
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -1,0 +1,1 @@
+export * from "./tokens";

--- a/src/ui/tokens.ts
+++ b/src/ui/tokens.ts
@@ -1,0 +1,201 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+type ThemeName = "light" | "dark";
+
+type TokenDictionary = {
+  space: Record<string, string>;
+  radius: Record<string, string>;
+  shadow: Record<string, string>;
+  zIndex: Record<string, number>;
+  durations: Record<string, string>;
+  breakpoints: Record<string, string>;
+};
+
+type ThemePalette = {
+  background: string;
+  foreground: string;
+  subtle: string;
+  muted: string;
+  border: string;
+  primary: string;
+  primaryContrast: string;
+  critical: string;
+  warning: string;
+  success: string;
+  info: string;
+};
+
+type ThemeConfig = {
+  name: ThemeName;
+  palette: ThemePalette;
+};
+
+export const tokens: TokenDictionary = {
+  space: {
+    0: "0px",
+    1: "0.25rem",
+    2: "0.5rem",
+    3: "0.75rem",
+    4: "1rem",
+    5: "1.5rem",
+    6: "2rem",
+    7: "3rem",
+    8: "4rem",
+  },
+  radius: {
+    none: "0px",
+    xs: "2px",
+    sm: "4px",
+    md: "8px",
+    lg: "12px",
+    xl: "16px",
+    full: "999px",
+  },
+  shadow: {
+    none: "none",
+    xs: "0 1px 2px rgba(15, 23, 42, 0.05)",
+    sm: "0 1px 3px rgba(15, 23, 42, 0.12)",
+    md: "0 10px 30px rgba(15, 23, 42, 0.12)",
+  },
+  zIndex: {
+    base: 0,
+    dropdown: 10,
+    overlay: 20,
+    modal: 30,
+    toast: 40,
+  },
+  durations: {
+    instant: "0ms",
+    fast: "100ms",
+    base: "200ms",
+    slow: "350ms",
+  },
+  breakpoints: {
+    xs: "320px",
+    sm: "640px",
+    md: "768px",
+    lg: "1024px",
+    xl: "1280px",
+  },
+};
+
+const themePalette: Record<ThemeName, ThemePalette> = {
+  light: {
+    background: "#f5f7fa",
+    foreground: "#1f2937",
+    subtle: "#e2e8f0",
+    muted: "#64748b",
+    border: "#cbd5f5",
+    primary: "#00716b",
+    primaryContrast: "#ffffff",
+    critical: "#ef4444",
+    warning: "#f59e0b",
+    success: "#10b981",
+    info: "#2563eb",
+  },
+  dark: {
+    background: "#0f172a",
+    foreground: "#f8fafc",
+    subtle: "#1e293b",
+    muted: "#94a3b8",
+    border: "#1e3a8a",
+    primary: "#38bdf8",
+    primaryContrast: "#02131d",
+    critical: "#f87171",
+    warning: "#fbbf24",
+    success: "#34d399",
+    info: "#60a5fa",
+  },
+};
+
+const themes: Record<ThemeName, ThemeConfig> = {
+  light: { name: "light", palette: themePalette.light },
+  dark: { name: "dark", palette: themePalette.dark },
+};
+
+type ThemeContextValue = {
+  theme: ThemeConfig;
+  setTheme: (theme: ThemeName) => void;
+  tokens: TokenDictionary;
+};
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+const prefersDark = () =>
+  typeof window !== "undefined" &&
+  window.matchMedia?.("(prefers-color-scheme: dark)").matches;
+
+const applyTokensToDocument = (theme: ThemeConfig) => {
+  if (typeof document === "undefined") return;
+
+  const root = document.documentElement;
+  root.dataset.theme = theme.name;
+
+  Object.entries(tokens.space).forEach(([key, value]) => {
+    root.style.setProperty(`--space-${key}`, value);
+  });
+
+  Object.entries(tokens.radius).forEach(([key, value]) => {
+    root.style.setProperty(`--radius-${key}`, value);
+  });
+
+  Object.entries(tokens.shadow).forEach(([key, value]) => {
+    root.style.setProperty(`--shadow-${key}`, value);
+  });
+
+  Object.entries(tokens.durations).forEach(([key, value]) => {
+    root.style.setProperty(`--duration-${key}`, value);
+  });
+
+  Object.entries(tokens.breakpoints).forEach(([key, value]) => {
+    root.style.setProperty(`--breakpoint-${key}`, value);
+  });
+
+  Object.entries(theme.palette).forEach(([key, value]) => {
+    root.style.setProperty(`--color-${key}`, value);
+  });
+};
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [themeName, setThemeName] = useState<ThemeName>(() =>
+    prefersDark() ? "dark" : "light",
+  );
+
+  useEffect(() => {
+    const listener = (event: MediaQueryListEvent) => {
+      setThemeName(event.matches ? "dark" : "light");
+    };
+
+    const media = window.matchMedia?.("(prefers-color-scheme: dark)");
+    media?.addEventListener("change", listener);
+    return () => media?.removeEventListener("change", listener);
+  }, []);
+
+  const theme = useMemo(() => themes[themeName], [themeName]);
+
+  useEffect(() => {
+    applyTokensToDocument(theme);
+  }, [theme]);
+
+  const value = useMemo<ThemeContextValue>(
+    () => ({
+      theme,
+      tokens,
+      setTheme: (name: ThemeName) => setThemeName(name),
+    }),
+    [theme],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used inside ThemeProvider");
+  }
+  return context;
+}
+
+export const themeNames: ThemeName[] = ["light", "dark"];
+export type { ThemeName, ThemeConfig, TokenDictionary, ThemePalette };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,42 @@
+require("ts-node").register({ transpileOnly: true });
+const { tokens } = require("./src/ui/tokens");
+
+const spacing = tokens.space;
+const borderRadius = tokens.radius;
+const boxShadow = tokens.shadow;
+const zIndex = tokens.zIndex;
+const transitionDuration = tokens.durations;
+const screens = tokens.breakpoints;
+
+const colors = Object.fromEntries(
+  [
+    "background",
+    "foreground",
+    "subtle",
+    "muted",
+    "border",
+    "primary",
+    "primaryContrast",
+    "critical",
+    "warning",
+    "success",
+    "info",
+  ].map((token) => [token, `var(--color-${token})`]),
+);
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: [],
+  content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
   theme: {
-    extend: {},
+    extend: {
+      spacing,
+      borderRadius,
+      boxShadow,
+      zIndex,
+      transitionDuration,
+      colors,
+    },
+    screens,
   },
   plugins: [],
-}
-
+};


### PR DESCRIPTION
## Summary
- introduce centralized design tokens with a runtime ThemeProvider that syncs CSS variables and tailwind theme
- expose token documentation at /help/design-system with interactive swatches and theme toggles
- add a CI helper script to diff design token changes and require explicit design sign-off

## Testing
- npm run lint
- DESIGN_SIGN_OFF=approved npm run check:tokens

------
https://chatgpt.com/codex/tasks/task_e_68e39da0851c8327b5b5b7c0624fd162