### PR TITLE
Add recon workbench and DLQ replay console

### DIFF
--- a/apps/gui/app.js
+++ b/apps/gui/app.js
@@ -3,7 +3,7 @@
   const base = (cfg.baseUrl || "/api").replace(/\/+$/, "");
   const $ = (sel, root=document) => root.querySelector(sel);
 
-  const routes = ["home","connections","transactions","tax-bas","help","settings"];
+  const routes = ["home","connections","transactions","recon","tax-bas","help","settings"];
   function currentRoute(){ const h = location.hash.replace(/^#\/?/, "").toLowerCase(); return routes.includes(h) ? h : "home"; }
   window.addEventListener("hashchange", () => render());
 
@@ -21,6 +21,7 @@
           <a href="#/home"        class="${active==='home'?'active':''}">Home</a>
           <a href="#/connections" class="${active==='connections'?'active':''}">Connections</a>
           <a href="#/transactions"class="${active==='transactions'?'active':''}">Transactions</a>
+          <a href="#/recon"        class="${active==='recon'?'active':''}">Ops</a>
           <a href="#/tax-bas"     class="${active==='tax-bas'?'active':''}">Tax & BAS</a>
           <a href="#/help"        class="${active==='help'?'active':''}">Help</a>
           <a href="#/settings"    class="${active==='settings'?'active':''}">Settings</a>
@@ -103,6 +104,147 @@
           </div>
           <table id="txTable"><thead><tr><th>Date</th><th>Source</th><th>Description</th><th>Amount</th><th>Category</th></tr></thead><tbody></tbody></table>
         </div>
+      `;
+    },
+
+    recon(){
+      return `
+        ${this.nav('recon')}
+        <div id="opsToast" class="ops-toast hidden" role="status" aria-live="polite"></div>
+        <section class="grid" style="grid-template-columns:minmax(0,2fr) minmax(0,1fr); gap:12px; margin-top:12px">
+          <div class="card" id="reconWorkbench">
+            <div class="flex" style="display:flex; flex-wrap:wrap; gap:12px; align-items:flex-end">
+              <div style="flex:1 1 160px; min-width:150px">
+                <label for="filterAge">Age window <span class="hint" title="Limit the queue by how long an anomaly has been waiting">i</span></label>
+                <select id="filterAge">
+                  <option value="all">Any age</option>
+                  <option value="lt:15">Less than 15 minutes</option>
+                  <option value="lt:60">Less than 1 hour</option>
+                  <option value="lt:240">Less than 4 hours</option>
+                  <option value="lt:1440">Less than 1 day</option>
+                  <option value="gte:1440">Older than a day</option>
+                </select>
+              </div>
+              <div style="flex:1 1 200px; min-width:180px">
+                <span class="label">Severity bands <span class="hint" title="Operational impact based on policy thresholds">i</span></span>
+                <div class="chip-list" id="severityFilters">
+                  <label><input type="checkbox" value="critical" checked> Critical</label>
+                  <label><input type="checkbox" value="high" checked> High</label>
+                  <label><input type="checkbox" value="medium" checked> Medium</label>
+                  <label><input type="checkbox" value="low" checked> Low</label>
+                </div>
+              </div>
+              <div style="flex:1 1 200px; min-width:180px">
+                <label>ML score <span class="hint" title="Model confidence 0-100. Narrow to focus triage.">i</span></label>
+                <div class="range">
+                  <input id="mlMin" type="number" min="0" max="100" value="0" aria-label="Minimum ML score"/>
+                  <span>to</span>
+                  <input id="mlMax" type="number" min="0" max="100" value="100" aria-label="Maximum ML score"/>
+                </div>
+              </div>
+              <div style="flex:1 1 220px; min-width:200px">
+                <label for="reconSearch">Quick search</label>
+                <input id="reconSearch" type="search" placeholder="ID, account, narrative"/>
+              </div>
+            </div>
+
+            <div class="inline-info">
+              <p><strong>Inline explainers:</strong> Hover severity badges or ML scores to see why the model flagged the anomaly.</p>
+            </div>
+
+            <div class="bulk-row">
+              <div>
+                <strong id="reconCount">0</strong> anomalies in view · <span id="selectedSummary">0 selected</span>
+                <button type="button" id="clearSelection" class="link-btn">Clear</button>
+              </div>
+              <div class="bulk-actions">
+                <button class="btn" id="bulkResolve" disabled>Resolve selected</button>
+                <button class="btn" id="bulkSnooze" disabled>Snooze 24h</button>
+                <button class="btn" id="bulkEscalate" disabled>Escalate to L2</button>
+              </div>
+            </div>
+
+            <div class="virtual-wrap">
+              <div class="virtual-header">
+                <div><input type="checkbox" id="reconSelectAll" aria-label="Select all anomalies"/></div>
+                <div>Anomaly</div>
+                <div>Age</div>
+                <div>Severity</div>
+                <div>Why it matters</div>
+                <div>ML score</div>
+              </div>
+              <div id="reconScroller" class="virtual-scroller" aria-label="Recon anomalies" role="grid">
+                <div id="reconCanvas" class="virtual-canvas"></div>
+              </div>
+              <div id="reconEmpty" class="empty-state">No anomalies match the filters.</div>
+            </div>
+          </div>
+
+          <div class="card" id="detailPanel">
+            <h3 class="detail-title">Review details</h3>
+            <p id="detailSubtitle" class="detail-sub">Select an anomaly or DLQ entry to see raw inputs and guidance.</p>
+            <div class="detail-section">
+              <div class="detail-heading">Summary</div>
+              <div id="detailSummary" class="detail-body muted">Waiting for a selection.</div>
+            </div>
+            <div class="detail-section">
+              <div class="detail-heading">Raw payload</div>
+              <pre id="detailPayload" class="detail-pre muted">â€”</pre>
+            </div>
+            <div class="detail-section">
+              <div class="detail-heading">Validation errors</div>
+              <ul id="detailErrors" class="detail-list muted"><li>â€”</li></ul>
+            </div>
+            <div class="detail-section">
+              <div class="detail-heading">Suggested fixes</div>
+              <ul id="detailFixes" class="detail-list muted"><li>Use the help links to resolve anomalies faster.</li></ul>
+            </div>
+          </div>
+        </section>
+
+        <section class="grid" style="margin-top:12px; gap:12px">
+          <div class="card" id="dlqConsole">
+            <div class="header-row">
+              <div>
+                <h3>Dead-letter replay console</h3>
+                <p class="muted">Replay failures with pacing and observe live feedback.</p>
+              </div>
+              <div class="header-actions">
+                <label class="rate-label">Rate limit</label>
+                <input id="dlqRate" type="number" min="1" value="50" aria-label="Replay rate per minute"/>
+                <button class="btn" id="reloadDlq">Refresh</button>
+              </div>
+            </div>
+            <div class="bulk-row">
+              <div><strong id="dlqCount">0</strong> messages · <span id="dlqSelected">0 selected</span></div>
+              <div class="bulk-actions">
+                <button class="btn" id="dlqReplay" disabled>Replay selected</button>
+                <button class="btn" id="dlqDrop" disabled>Drop selected</button>
+              </div>
+            </div>
+            <table class="dlq-table">
+              <thead>
+                <tr>
+                  <th><input type="checkbox" id="dlqSelectAll" aria-label="Select all DLQ messages"/></th>
+                  <th>Failure</th>
+                  <th>When</th>
+                  <th>Reason</th>
+                  <th>Attempts</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody id="dlqRows">
+                <tr><td colspan="6" class="muted">Loadingâ€¦</td></tr>
+              </tbody>
+            </table>
+          </div>
+
+          <div class="card" id="auditLog">
+            <h3>Audit trail</h3>
+            <p class="muted">Actions taken in this workbench are journaled for traceability.</p>
+            <ol id="auditEntries" class="audit-list"></ol>
+          </div>
+        </section>
       `;
     },
 
@@ -230,6 +372,643 @@
       $('#btnRefresh').onclick = load;
       load();
     }
+
+    if (view==='recon') {
+      const toastEl = $('#opsToast');
+      let toastTimer;
+      const notify = (msg, ok=true) => {
+        if (!toastEl) return;
+        toastEl.textContent = msg;
+        toastEl.className = `ops-toast ${ok ? 'success' : 'error'} show`;
+        clearTimeout(toastTimer);
+        toastTimer = setTimeout(()=>{ toastEl.className = 'ops-toast hidden'; }, 2600);
+      };
+
+      const state = {
+        anomalies: [],
+        filtered: [],
+        selected: new Set(),
+        dlq: [],
+        dlqSelected: new Set(),
+        rowHeight: 64,
+        activeRecon: null,
+        activeDlq: null,
+        audit: []
+      };
+
+      const severityMap = {
+        critical: { label: 'Critical', explain: 'Breaches tolerance or creates regulatory exposure.' },
+        high: { label: 'High', explain: 'Material financial impact; escalate if not cleared promptly.' },
+        medium: { label: 'Medium', explain: 'Needs follow-up to keep ledgers in sync.' },
+        low: { label: 'Low', explain: 'Informational or automatically recoverable drift.' }
+      };
+
+      const scroller = $('#reconScroller');
+      const canvas = $('#reconCanvas');
+      const empty = $('#reconEmpty');
+      const countEl = $('#reconCount');
+      const selectedLabel = $('#selectedSummary');
+      const clearButton = $('#clearSelection');
+      const selectAll = $('#reconSelectAll');
+      const severityInputs = Array.from(document.querySelectorAll('#severityFilters input[type="checkbox"]'));
+      const ageSelect = $('#filterAge');
+      const mlMin = $('#mlMin');
+      const mlMax = $('#mlMax');
+      const searchInput = $('#reconSearch');
+      const bulkResolve = $('#bulkResolve');
+      const bulkSnooze = $('#bulkSnooze');
+      const bulkEscalate = $('#bulkEscalate');
+      const detailHeading = document.querySelector('#detailPanel .detail-title');
+      const detailSubtitle = $('#detailSubtitle');
+      const detailSummary = $('#detailSummary');
+      const detailPayload = $('#detailPayload');
+      const detailErrors = $('#detailErrors');
+      const detailFixes = $('#detailFixes');
+      const auditList = $('#auditEntries');
+      const dlqRows = $('#dlqRows');
+      const dlqSelectAll = $('#dlqSelectAll');
+      const dlqCount = $('#dlqCount');
+      const dlqSelectedLabel = $('#dlqSelected');
+      const dlqRate = $('#dlqRate');
+      const dlqReplay = $('#dlqReplay');
+      const dlqDrop = $('#dlqDrop');
+      const reloadDlq = $('#reloadDlq');
+
+      const defaultHeading = detailHeading?.textContent || 'Review details';
+
+      const escapeHtml = (value='') => {
+        return String(value ?? '').replace(/[&<>'"]/g, c => {
+          switch (c) {
+            case '&': return '&amp;';
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '"': return '&quot;';
+            case "'": return '&#39;';
+            default: return c;
+          }
+        });
+      };
+
+      const parseDate = (val) => {
+        if (!val) return null;
+        const d = val instanceof Date ? val : new Date(val);
+        return Number.isNaN(d.getTime()) ? null : d;
+      };
+
+      const ageMinutes = (item) => {
+        if (typeof item?.ageMinutes === 'number') return item.ageMinutes;
+        if (typeof item?.age_minutes === 'number') return item.age_minutes;
+        if (typeof item?.age === 'number') return item.age;
+        const dt = parseDate(item?.__occurred || item?.detected_at || item?.created_at || item?.timestamp || item?.first_seen);
+        if (!dt) return null;
+        const diff = (Date.now() - dt.getTime()) / 60000;
+        return diff < 0 ? 0 : diff;
+      };
+
+      const formatAge = (item) => {
+        const mins = ageMinutes(item);
+        if (mins == null) return '—';
+        if (mins < 60) return `${Math.round(mins)}m`;
+        const hours = Math.floor(mins / 60);
+        if (hours < 48) {
+          const rem = Math.round(mins - hours * 60);
+          return rem ? `${hours}h ${rem}m` : `${hours}h`;
+        }
+        const days = Math.floor(hours / 24);
+        const remHours = hours % 24;
+        return remHours ? `${days}d ${remHours}h` : `${days}d`;
+      };
+
+      const formatRelative = (date) => {
+        if (!date) return '—';
+        const diff = Date.now() - date.getTime();
+        if (diff < 60000 && diff > -60000) return 'Just now';
+        const mins = Math.round(Math.abs(diff) / 60000);
+        if (mins < 60) return diff >= 0 ? `${mins}m ago` : `in ${mins}m`;
+        const hours = Math.round(mins / 60);
+        if (hours < 48) return diff >= 0 ? `${hours}h ago` : `in ${hours}h`;
+        const days = Math.round(hours / 24);
+        return diff >= 0 ? `${days}d ago` : `in ${days}d`;
+      };
+
+      const formatScore = (score) => {
+        if (!Number.isFinite(score)) return '—';
+        const rounded = Math.round(score * 10) / 10;
+        return `${rounded.toFixed(1)}`;
+      };
+
+      const clampScoreInput = (input) => {
+        if (!input) return 0;
+        let val = parseFloat(input.value);
+        if (!Number.isFinite(val)) val = 0;
+        val = Math.min(100, Math.max(0, val));
+        input.value = String(val);
+        return val;
+      };
+
+      const stringLabel = (str) => {
+        if (!str) return 'Unknown';
+        return String(str).replace(/[_-]/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+      };
+
+      const severityMeta = (item) => {
+        const key = String(item?.severity || item?.level || item?.priority || 'unknown').toLowerCase();
+        const meta = severityMap[key] || { label: stringLabel(key), explain: 'Severity not provided.' };
+        return { key: key || 'unknown', label: meta.label, explain: meta.explain };
+      };
+
+      const getScore = (item) => {
+        const raw = item?.mlScore ?? item?.ml_score ?? item?.score ?? item?.model_score ?? item?.prediction ?? item?.ml ?? item?.probability;
+        if (typeof raw === 'number') return Math.min(100, Math.max(0, raw));
+        const num = parseFloat(raw);
+        return Number.isFinite(num) ? Math.min(100, Math.max(0, num)) : 0;
+      };
+
+      const matchAge = (item, filter) => {
+        if (!filter || filter === 'all') return true;
+        const mins = ageMinutes(item);
+        if (mins == null) return true;
+        if (filter.startsWith('lt:')) return mins < parseFloat(filter.split(':')[1] || '0');
+        if (filter.startsWith('gte:')) return mins >= parseFloat(filter.split(':')[1] || '0');
+        return true;
+      };
+
+      const normalizeAnomaly = (raw, idx) => {
+        const base = raw || {};
+        const id = base.id ?? base.anomaly_id ?? base.reference ?? base.event_id ?? `anomaly-${Date.now()}-${idx}`;
+        const payload = base.payload ?? base.raw ?? base.body ?? base.message ?? base.event ?? null;
+        const validation = Array.isArray(base.validationErrors) ? base.validationErrors : Array.isArray(base.validation) ? base.validation : [];
+        const fixes = Array.isArray(base.suggestedFixes) ? base.suggestedFixes : Array.isArray(base.fix_suggestions) ? base.fix_suggestions : Array.isArray(base.remediation) ? base.remediation : [];
+        const explain = Array.isArray(base.explainers) ? base.explainers.join(', ') : base.explainer || base.explanation || base.model_reason || base.why || '';
+        const summary = base.summary || base.title || base.reason || base.description || base.message || `Anomaly ${id}`;
+        const occurred = base.detected_at || base.created_at || base.occurred_at || base.timestamp || base.first_seen;
+        return { ...base, __id: id, __originalId: base.id ?? base.anomaly_id ?? base.reference ?? id, __payload: payload, __validation: validation, __fixes: fixes, __explain: explain, __summary: summary, __occurred: occurred };
+      };
+
+      const normalizeDlq = (raw, idx) => {
+        const base = raw || {};
+        const id = base.id ?? base.messageId ?? base.event_id ?? `dlq-${Date.now()}-${idx}`;
+        const occurred = base.failed_at || base.received_at || base.timestamp || base.created_at;
+        const payload = base.payload ?? base.body ?? base.message ?? base.event ?? null;
+        const validation = Array.isArray(base.validationErrors) ? base.validationErrors : [];
+        const fixes = Array.isArray(base.remediation) ? base.remediation : Array.isArray(base.suggestedFixes) ? base.suggestedFixes : [];
+        const reason = base.reason || base.error || base.message || base.failure || 'Unknown failure';
+        const attempts = base.attempts ?? base.deliveryAttempts ?? base.retries ?? base.retry_count ?? 0;
+        return { ...base, __id: id, __originalId: base.id ?? base.messageId ?? id, __occurred: occurred, __payload: payload, __validation: validation, __fixes: fixes, __reason: reason, __attempts: attempts };
+      };
+
+      const resetDetail = () => {
+        if (detailHeading) detailHeading.textContent = defaultHeading;
+        if (detailSubtitle) detailSubtitle.textContent = 'Select an anomaly or DLQ entry to see raw inputs and guidance.';
+        if (detailSummary) { detailSummary.textContent = 'Waiting for a selection.'; detailSummary.classList.add('muted'); }
+        if (detailPayload) { detailPayload.textContent = '—'; detailPayload.classList.add('muted'); }
+        if (detailErrors) { detailErrors.innerHTML = '<li>—</li>'; detailErrors.classList.add('muted'); }
+        if (detailFixes) { detailFixes.innerHTML = '<li>Use the help links to resolve anomalies faster.</li>'; detailFixes.classList.add('muted'); }
+      };
+
+      const populateList = (listEl, items, mapper) => {
+        if (!listEl) return;
+        listEl.innerHTML = '';
+        if (!items || !items.length) {
+          const li = document.createElement('li');
+          li.textContent = 'None reported.';
+          listEl.appendChild(li);
+          listEl.classList.add('muted');
+          return;
+        }
+        listEl.classList.remove('muted');
+        for (const item of items) {
+          listEl.appendChild(mapper(item));
+        }
+      };
+
+      const showDetail = (kind, item) => {
+        if (!item) { resetDetail(); return; }
+        const occurredDate = parseDate(item.__occurred || item.detected_at || item.created_at || item.timestamp);
+        const badge = severityMeta(item);
+        if (detailHeading) detailHeading.textContent = kind === 'dlq' ? `DLQ message · ${item.__originalId}` : `Recon anomaly · ${item.__originalId}`;
+        if (detailSubtitle) detailSubtitle.textContent = kind === 'dlq' ? 'Replay payload, inspect validation feedback, and confirm fixes.' : `${badge.label} impact · ${formatAge(item)} old`;
+        if (detailSummary) {
+          detailSummary.textContent = item.__summary || item.__reason || '—';
+          detailSummary.classList.remove('muted');
+        }
+        if (detailPayload) {
+          const payload = item.__payload ?? item.payload ?? item.body ?? item.message ?? null;
+          if (payload == null) {
+            detailPayload.textContent = '—';
+            detailPayload.classList.add('muted');
+          } else {
+            detailPayload.textContent = typeof payload === 'string' ? payload : JSON.stringify(payload, null, 2);
+            detailPayload.classList.remove('muted');
+          }
+        }
+        if (detailErrors) {
+          const errors = item.__validation ?? item.validationErrors ?? item.validation ?? [];
+          populateList(detailErrors, errors, (err) => {
+            const li = document.createElement('li');
+            if (typeof err === 'string') { li.textContent = err; }
+            else if (err?.message) { li.textContent = err.message; }
+            else { li.textContent = JSON.stringify(err); }
+            return li;
+          });
+        }
+        if (detailFixes) {
+          const fixes = item.__fixes ?? item.suggestedFixes ?? [];
+          populateList(detailFixes, fixes.length ? fixes : null, (fix) => {
+            const li = document.createElement('li');
+            if (typeof fix === 'string') {
+              li.textContent = fix;
+            } else {
+              const link = document.createElement('a');
+              if (fix?.href) {
+                link.href = fix.href;
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+              } else {
+                link.href = '#/help';
+              }
+              link.textContent = fix?.label || fix?.title || fix?.href || 'View guidance';
+              li.appendChild(link);
+              if (fix?.note) {
+                const span = document.createElement('span');
+                span.textContent = ` — ${fix.note}`;
+                li.appendChild(span);
+              }
+            }
+            return li;
+          });
+        }
+        if (detailPayload && occurredDate) detailPayload.setAttribute('title', occurredDate.toLocaleString());
+      };
+
+      const updateSelection = () => {
+        if (selectedLabel) selectedLabel.textContent = `${state.selected.size} selected`;
+        const disable = state.selected.size === 0;
+        [bulkResolve, bulkSnooze, bulkEscalate].forEach(btn => { if (btn) btn.disabled = disable; });
+        if (selectAll) {
+          const total = state.filtered.length;
+          if (!total) {
+            selectAll.checked = false;
+            selectAll.indeterminate = false;
+          } else {
+            let all = true;
+            for (const item of state.filtered) {
+              if (!state.selected.has(item.__id)) { all = false; break; }
+            }
+            selectAll.checked = all && total > 0;
+            selectAll.indeterminate = !all && state.selected.size > 0;
+          }
+        }
+      };
+
+      const reconcileSelection = () => {
+        const ids = new Set(state.anomalies.map(a => a.__id));
+        for (const id of Array.from(state.selected)) {
+          if (!ids.has(id)) state.selected.delete(id);
+        }
+        if (state.activeRecon && !ids.has(state.activeRecon)) {
+          state.activeRecon = null;
+          if (!state.activeDlq) resetDetail();
+        }
+        updateSelection();
+      };
+
+      const renderVirtual = () => {
+        if (!canvas || !scroller) return;
+        const total = state.filtered.length;
+        canvas.innerHTML = '';
+        canvas.style.height = `${total * state.rowHeight}px`;
+        if (!total) return;
+        const viewHeight = scroller.clientHeight || 0;
+        const start = Math.max(0, Math.floor((scroller.scrollTop || 0) / state.rowHeight) - 3);
+        const end = Math.min(total, start + Math.ceil((viewHeight || 0) / state.rowHeight) + 6);
+        const frag = document.createDocumentFragment();
+        for (let i = start; i < end; i++) {
+          const item = state.filtered[i];
+          const row = document.createElement('div');
+          row.className = 'virtual-row';
+          if (i % 2) row.classList.add('alt');
+          if (state.selected.has(item.__id)) row.classList.add('selected');
+          if (state.activeRecon === item.__id) row.classList.add('active');
+          row.style.top = `${i * state.rowHeight}px`;
+          row.style.height = `${state.rowHeight}px`;
+          row.dataset.id = item.__id;
+          const severity = severityMeta(item);
+          const score = getScore(item);
+          const occurred = parseDate(item.__occurred || item.detected_at || item.created_at || item.timestamp);
+          const reason = escapeHtml(item.__summary || item.__reason || 'Review required');
+          const explain = escapeHtml(item.__explain || 'Model contribution details unavailable.');
+          const tooltipAge = occurred ? occurred.toLocaleString() : 'Timestamp unavailable';
+          row.innerHTML = `
+            <label class="virtual-cell chk"><input type="checkbox" data-id="${escapeHtml(item.__id)}" ${state.selected.has(item.__id)?'checked':''}/></label>
+            <div class="virtual-cell code" title="${escapeHtml(item.__originalId)}">${escapeHtml(item.__originalId)}</div>
+            <div class="virtual-cell" title="${escapeHtml(tooltipAge)}">${formatAge(item)}</div>
+            <div class="virtual-cell"><span class="pill pill-${escapeHtml(severity.key)}" title="${escapeHtml(severity.explain)}">${escapeHtml(severity.label)}</span></div>
+            <div class="virtual-cell reason"><div class="reason-title">${reason}</div>${item.__explain ? `<div class="reason-note">${explain}</div>` : ''}</div>
+            <div class="virtual-cell score" title="${escapeHtml(explain)}">${formatScore(score)}</div>
+          `;
+          row.addEventListener('click', (ev) => {
+            if (ev.target.closest('input')) return;
+            state.activeRecon = item.__id;
+            state.activeDlq = null;
+            showDetail('recon', item);
+            renderVirtual();
+          });
+          const cb = row.querySelector('input[type="checkbox"]');
+          cb?.addEventListener('change', ev => {
+            ev.stopPropagation();
+            if (cb.checked) state.selected.add(item.__id); else state.selected.delete(item.__id);
+            updateSelection();
+            if (!cb.checked && state.activeRecon === item.__id) state.activeRecon = null;
+            row.classList.toggle('selected', cb.checked);
+          });
+          frag.appendChild(row);
+        }
+        canvas.appendChild(frag);
+      };
+
+      const renderAudit = () => {
+        if (!auditList) return;
+        if (!state.audit.length) {
+          auditList.innerHTML = '<li class="muted">No actions yet.</li>';
+          return;
+        }
+        auditList.innerHTML = state.audit.map(entry => {
+          const when = entry.time instanceof Date ? entry.time.toLocaleString() : entry.time;
+          const detail = entry.detail ? ` <span class="audit-detail">${escapeHtml(entry.detail)}</span>` : '';
+          return `<li><span class="audit-time">${escapeHtml(when)}</span> <span class="audit-status ${entry.ok ? 'ok' : 'fail'}">${escapeHtml(entry.action)}</span>${detail}</li>`;
+        }).join('');
+      };
+
+      const addAudit = (action, detail, ok=true) => {
+        state.audit.unshift({ time: new Date(), action, detail, ok });
+        if (state.audit.length > 50) state.audit.pop();
+        renderAudit();
+      };
+
+      const applyFilters = () => {
+        let minScore = clampScoreInput(mlMin);
+        let maxScore = clampScoreInput(mlMax);
+        if (minScore > maxScore) {
+          if (document.activeElement === mlMin) { maxScore = minScore; if (mlMax) mlMax.value = String(maxScore); }
+          else { minScore = maxScore; if (mlMin) mlMin.value = String(minScore); }
+        }
+        const selectedSev = severityInputs.filter(cb => cb.checked).map(cb => cb.value.toLowerCase());
+        const restrictSeverity = selectedSev.length && selectedSev.length < severityInputs.length;
+        const ageVal = ageSelect?.value || 'all';
+        const query = (searchInput?.value || '').trim().toLowerCase();
+        const matchesQuery = (item) => {
+          if (!query) return true;
+          const fields = [item.__originalId, item.__summary, item.__reason, item.account, item.counterparty, item.reference, item.owner];
+          return fields.some(val => val && String(val).toLowerCase().includes(query));
+        };
+        state.filtered = state.anomalies.filter(item => {
+          if (restrictSeverity) {
+            const sev = severityMeta(item).key;
+            if (!selectedSev.includes(sev)) return false;
+          }
+          const score = getScore(item);
+          if (score < minScore || score > maxScore) return false;
+          if (!matchAge(item, ageVal)) return false;
+          if (!matchesQuery(item)) return false;
+          return true;
+        });
+        if (countEl) countEl.textContent = state.filtered.length;
+        if (empty) empty.classList.toggle('hidden', !!state.filtered.length);
+        if (scroller) scroller.classList.toggle('hidden', !state.filtered.length);
+        reconcileSelection();
+        renderVirtual();
+      };
+
+      const idsToPayload = (ids) => ids.map(id => {
+        const found = state.anomalies.find(a => a.__id === id);
+        return found?.__originalId || id;
+      });
+
+      const runBulk = async (label, path, extra={}) => {
+        if (!state.selected.size) { notify('Select at least one anomaly first.', false); return; }
+        const ids = Array.from(state.selected);
+        try {
+          const res = await api(path, { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify({ ids: idsToPayload(ids), ...extra }) });
+          if (res.ok) {
+            notify(`${label} ${ids.length} anomaly${ids.length===1?'':'ies'}.`);
+            addAudit(label, `${ids.length} anomaly${ids.length===1?'':'ies'}`, true);
+            const removed = new Set(ids);
+            state.anomalies = state.anomalies.filter(item => !removed.has(item.__id));
+            state.selected.clear();
+            if (removed.has(state.activeRecon)) { state.activeRecon = null; if (!state.activeDlq) resetDetail(); }
+            applyFilters();
+          } else {
+            notify(`${label} failed (HTTP ${res.status}).`, false);
+            addAudit(`${label} failed`, `HTTP ${res.status}`, false);
+          }
+        } catch (err) {
+          notify(`${label} failed: ${err.message}`, false);
+          addAudit(`${label} error`, err.message || 'Network error', false);
+        }
+      };
+
+      const renderDlq = () => {
+        if (!dlqRows) return;
+        dlqRows.innerHTML = '';
+        if (dlqCount) dlqCount.textContent = state.dlq.length;
+        if (!state.dlq.length) {
+          const tr = document.createElement('tr');
+          const td = document.createElement('td');
+          td.colSpan = 6;
+          td.className = 'muted';
+          td.textContent = 'DLQ is empty.';
+          tr.appendChild(td);
+          dlqRows.appendChild(tr);
+          return;
+        }
+        const frag = document.createDocumentFragment();
+        for (const item of state.dlq) {
+          const tr = document.createElement('tr');
+          tr.dataset.id = item.__id;
+          if (state.dlqSelected.has(item.__id)) tr.classList.add('selected');
+          if (state.activeDlq === item.__id) tr.classList.add('active');
+          const occurred = parseDate(item.__occurred || item.failed_at || item.timestamp);
+          const reason = item.__reason || '—';
+          tr.innerHTML = `
+            <td><input type="checkbox" data-id="${escapeHtml(item.__id)}" ${state.dlqSelected.has(item.__id)?'checked':''}/></td>
+            <td title="${escapeHtml(item.__originalId)}">${escapeHtml(item.__originalId)}</td>
+            <td title="${occurred ? escapeHtml(occurred.toLocaleString()) : 'Timestamp unavailable'}">${formatRelative(occurred)}</td>
+            <td title="${escapeHtml(reason)}">${escapeHtml(reason.length > 96 ? reason.slice(0,93) + '…' : reason)}</td>
+            <td>${item.__attempts ?? '—'}</td>
+            <td><button class="link-btn" data-inspect="${escapeHtml(item.__id)}">Inspect</button></td>
+          `;
+          frag.appendChild(tr);
+        }
+        dlqRows.appendChild(frag);
+      };
+
+      const updateDlqSelection = () => {
+        if (dlqSelectedLabel) dlqSelectedLabel.textContent = `${state.dlqSelected.size} selected`;
+        const disable = state.dlqSelected.size === 0;
+        [dlqReplay, dlqDrop].forEach(btn => { if (btn) btn.disabled = disable; });
+        if (dlqSelectAll) {
+          const total = state.dlq.length;
+          if (!total) {
+            dlqSelectAll.checked = false;
+            dlqSelectAll.indeterminate = false;
+          } else {
+            let all = true;
+            for (const item of state.dlq) {
+              if (!state.dlqSelected.has(item.__id)) { all = false; break; }
+            }
+            dlqSelectAll.checked = all;
+            dlqSelectAll.indeterminate = !all && state.dlqSelected.size > 0;
+          }
+        }
+      };
+
+      const idsFromDlq = (ids) => ids.map(id => {
+        const found = state.dlq.find(d => d.__id === id);
+        return found?.__originalId || id;
+      });
+
+      const runDlqAction = async (label, path, { includeRate=true } = {}) => {
+        if (!state.dlqSelected.size) { notify('Select at least one message first.', false); return; }
+        const ids = Array.from(state.dlqSelected);
+        const payload = { ids: idsFromDlq(ids) };
+        if (includeRate) payload.rateLimit = parseInt(dlqRate?.value || '1', 10) || 1;
+        try {
+          const res = await api(path, { method:'POST', headers:{ 'Content-Type':'application/json' }, body: JSON.stringify(payload) });
+          if (res.ok) {
+            notify(`${label} ${ids.length} message${ids.length===1?'':'s'}.`);
+            addAudit(`DLQ ${label.toLowerCase()}`, `${ids.length} message${ids.length===1?'':'s'}`, true);
+            const removed = new Set(ids);
+            state.dlq = state.dlq.filter(item => !removed.has(item.__id));
+            state.dlqSelected.clear();
+            if (state.activeDlq && removed.has(state.activeDlq)) { state.activeDlq = null; if (!state.activeRecon) resetDetail(); }
+            renderDlq();
+            updateDlqSelection();
+          } else {
+            notify(`${label} failed (HTTP ${res.status}).`, false);
+            addAudit(`DLQ ${label.toLowerCase()} failed`, `HTTP ${res.status}`, false);
+          }
+        } catch (err) {
+          notify(`${label} failed: ${err.message}`, false);
+          addAudit(`DLQ ${label.toLowerCase()} error`, err.message || 'Network error', false);
+        }
+      };
+
+      const loadRecon = async () => {
+        try {
+          const res = await api('/recon/anomalies');
+          const body = res?.body;
+          const items = Array.isArray(body?.items) ? body.items : Array.isArray(body) ? body : [];
+          state.anomalies = items.map((item, idx) => normalizeAnomaly(item, idx));
+          applyFilters();
+          addAudit('Recon queue refreshed', `${state.anomalies.length} items`, res.ok);
+          if (!res.ok) notify(`Recon fetch failed (HTTP ${res.status}).`, false);
+        } catch (err) {
+          state.anomalies = [];
+          applyFilters();
+          notify(`Recon fetch failed: ${err.message}`, false);
+          addAudit('Recon fetch error', err.message || 'Network error', false);
+        }
+      };
+
+      const loadDlq = async () => {
+        try {
+          const res = await api('/dlq/messages');
+          const body = res?.body;
+          const items = Array.isArray(body?.items) ? body.items : Array.isArray(body) ? body : [];
+          state.dlq = items.map((item, idx) => normalizeDlq(item, idx));
+          state.dlqSelected.clear();
+          renderDlq();
+          updateDlqSelection();
+          addAudit('DLQ refreshed', `${state.dlq.length} messages`, res.ok);
+          if (!res.ok) notify(`DLQ fetch failed (HTTP ${res.status}).`, false);
+        } catch (err) {
+          state.dlq = [];
+          renderDlq();
+          updateDlqSelection();
+          notify(`DLQ fetch failed: ${err.message}`, false);
+          addAudit('DLQ fetch error', err.message || 'Network error', false);
+        }
+      };
+
+      clearButton?.addEventListener('click', () => {
+        state.selected.clear();
+        updateSelection();
+        renderVirtual();
+      });
+
+      selectAll?.addEventListener('change', (ev) => {
+        if (ev.target.checked) {
+          state.filtered.forEach(item => state.selected.add(item.__id));
+        } else {
+          state.filtered.forEach(item => state.selected.delete(item.__id));
+        }
+        updateSelection();
+        renderVirtual();
+      });
+
+      severityInputs.forEach(cb => cb.addEventListener('change', applyFilters));
+      ageSelect?.addEventListener('change', applyFilters);
+      mlMin?.addEventListener('change', applyFilters);
+      mlMax?.addEventListener('change', applyFilters);
+      let searchTimer;
+      searchInput?.addEventListener('input', () => {
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(applyFilters, 180);
+      });
+
+      scroller?.addEventListener('scroll', () => {
+        requestAnimationFrame(renderVirtual);
+      });
+
+      window.addEventListener('resize', renderVirtual);
+
+      bulkResolve?.addEventListener('click', () => runBulk('Resolved', '/recon/resolve'));
+      bulkSnooze?.addEventListener('click', () => runBulk('Snoozed 24h', '/recon/snooze', { durationMinutes: 1440 }));
+      bulkEscalate?.addEventListener('click', () => runBulk('Escalated to L2', '/recon/escalate', { target: 'L2' }));
+
+      dlqRows?.addEventListener('change', ev => {
+        if (!ev.target.matches('input[type="checkbox"]')) return;
+        const id = ev.target.dataset.id;
+        if (!id) return;
+        if (ev.target.checked) state.dlqSelected.add(id); else state.dlqSelected.delete(id);
+        ev.target.closest('tr')?.classList.toggle('selected', ev.target.checked);
+        updateDlqSelection();
+      });
+
+      dlqRows?.addEventListener('click', ev => {
+        const btn = ev.target.closest('button[data-inspect]');
+        if (!btn) return;
+        const id = btn.dataset.inspect;
+        const item = state.dlq.find(d => d.__id === id);
+        if (!item) return;
+        state.activeDlq = id;
+        state.activeRecon = null;
+        showDetail('dlq', item);
+        renderDlq();
+      });
+
+      dlqSelectAll?.addEventListener('change', ev => {
+        if (ev.target.checked) {
+          state.dlq.forEach(item => state.dlqSelected.add(item.__id));
+        } else {
+          state.dlqSelected.clear();
+        }
+        renderDlq();
+        updateDlqSelection();
+      });
+
+      dlqReplay?.addEventListener('click', () => runDlqAction('Replayed', '/dlq/replay', { includeRate: true }));
+      dlqDrop?.addEventListener('click', () => runDlqAction('Dropped', '/dlq/drop', { includeRate: false }));
+      reloadDlq?.addEventListener('click', () => loadDlq());
+
+      renderAudit();
+      resetDetail();
+      applyFilters();
+      loadRecon();
+      loadDlq();
+    }
+
 
     if (view==='tax-bas') {
       $('#btnPreviewBas').onclick = async () => {

--- a/apps/gui/styles.css
+++ b/apps/gui/styles.css
@@ -16,3 +16,67 @@ table{ width:100%; border-collapse:collapse }
 th,td{ padding:8px; border-bottom:1px solid var(--border) }
 .kbd{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; background:var(--card); border:1px solid var(--border); border-radius:6px; padding:2px 6px }
 .footer{ margin-top:24px; color:var(--muted) }
+.hidden{ display:none !important }
+.ops-toast{ position:fixed; right:32px; bottom:32px; background:rgba(15,23,42,0.92); color:#fff; padding:12px 16px; border-radius:14px; box-shadow:0 18px 45px rgba(15,23,42,0.25); max-width:340px; font-size:13px; line-height:1.4; opacity:0; transform:translateY(10px); transition:opacity .2s ease, transform .2s ease; pointer-events:none; z-index:30 }
+.ops-toast.show{ opacity:1; transform:translateY(0); pointer-events:auto }
+.ops-toast.success{ background:rgba(17,24,39,0.95) }
+.ops-toast.error{ background:#b91c1c }
+.hint{ display:inline-flex; align-items:center; justify-content:center; width:16px; height:16px; border-radius:50%; background:var(--card); color:var(--muted); font-size:11px; margin-left:4px; border:1px solid var(--border); cursor:help }
+.chip-list{ display:flex; flex-wrap:wrap; gap:6px; margin-top:4px }
+.chip-list label{ display:inline-flex; align-items:center; gap:6px; padding:4px 10px; border:1px solid var(--border); border-radius:999px; font-size:12px; background:var(--bg); color:var(--fg) }
+.chip-list input{ width:auto; margin:0 }
+.range{ display:flex; align-items:center; gap:6px }
+.range input{ width:100% }
+.range span{ font-size:12px; color:var(--muted) }
+.inline-info{ margin-top:12px; font-size:12px; color:var(--muted); border:1px dashed var(--border); border-radius:10px; padding:10px 12px; background:var(--bg) }
+.bulk-row{ display:flex; align-items:center; justify-content:space-between; gap:12px; flex-wrap:wrap; margin-top:12px }
+.bulk-actions{ display:flex; gap:8px; flex-wrap:wrap }
+.btn:disabled{ opacity:0.5; cursor:not-allowed }
+.link-btn{ border:none; background:none; color:#2563eb; cursor:pointer; padding:0; font-size:13px; text-decoration:underline }
+.link-btn:hover{ color:#1d4ed8 }
+.link-btn:focus{ outline:3px solid var(--focus); outline-offset:2px }
+.virtual-wrap{ margin-top:12px; border:1px solid var(--border); border-radius:12px; background:var(--bg); overflow:hidden }
+.virtual-header{ display:grid; grid-template-columns:56px 140px 100px 120px 1fr 100px; font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:0.04em; color:var(--muted); background:var(--card); padding:10px 16px }
+.virtual-scroller{ position:relative; height:360px; overflow:auto; background:var(--bg) }
+.virtual-canvas{ position:relative; min-height:0 }
+.virtual-row{ position:absolute; left:0; right:0; display:grid; grid-template-columns:56px 140px 100px 120px 1fr 100px; align-items:center; padding:0 16px; border-bottom:1px solid var(--border); font-size:13px; background:var(--bg); cursor:pointer; transition:background .15s ease, box-shadow .15s ease }
+.virtual-row.alt{ background:rgba(148,163,184,0.08) }
+.virtual-row.selected{ box-shadow:inset 0 0 0 2px var(--primary) }
+.virtual-row.active{ background:rgba(37,99,235,0.1) }
+.virtual-cell{ display:flex; flex-direction:column; gap:2px }
+.virtual-cell.chk{ justify-content:center }
+.virtual-cell.code{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; font-size:12px }
+.reason-title{ font-weight:500 }
+.reason-note{ font-size:12px; color:var(--muted) }
+.pill{ display:inline-flex; align-items:center; padding:2px 10px; border-radius:999px; font-size:12px; font-weight:600 }
+.pill-critical{ background:#fee2e2; color:#991b1b }
+.pill-high{ background:#fef3c7; color:#92400e }
+.pill-medium{ background:#bae6fd; color:#0f172a }
+.pill-low{ background:#dcfce7; color:#166534 }
+.pill-unknown{ background:var(--card); color:var(--muted) }
+.empty-state{ padding:16px; text-align:center; font-size:13px; color:var(--muted) }
+.detail-title{ font-size:16px; font-weight:600; margin:0 }
+.detail-sub{ font-size:12px; color:var(--muted); margin:4px 0 12px }
+.detail-section{ margin-top:12px }
+.detail-heading{ font-size:13px; font-weight:600; color:var(--fg); margin-bottom:6px }
+.detail-body{ font-size:13px }
+.detail-pre{ font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; background:var(--bg); border:1px solid var(--border); border-radius:8px; padding:10px; max-height:200px; overflow:auto }
+.detail-list{ margin:0; padding-left:18px; font-size:13px }
+.detail-list li{ margin-bottom:4px }
+.muted{ color:var(--muted) }
+.header-row{ display:flex; justify-content:space-between; align-items:flex-end; gap:12px; flex-wrap:wrap }
+.header-actions{ display:flex; gap:8px; align-items:center }
+.header-actions input{ width:90px }
+.rate-label{ font-size:12px; color:var(--muted) }
+.dlq-table th{ font-size:12px; text-transform:uppercase; color:var(--muted) }
+.dlq-table td{ font-size:13px }
+.dlq-table tr.active{ background:rgba(37,99,235,0.1) }
+.dlq-table tr.selected{ background:rgba(34,197,94,0.12) }
+.audit-list{ list-style:none; margin:16px 0 0; padding:0; display:flex; flex-direction:column; gap:8px; font-size:12px }
+.audit-list li{ display:flex; gap:8px; align-items:baseline }
+.audit-time{ color:var(--muted); font-family:ui-monospace, SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace; font-size:11px }
+.audit-status{ font-weight:600 }
+.audit-status.ok{ color:var(--primary) }
+.audit-status.fail{ color:#b91c1c }
+.audit-detail{ color:var(--muted) }
+.label{ display:block; font-size:12px; font-weight:600; color:var(--muted); margin-bottom:4px }


### PR DESCRIPTION
## Summary
- add an Ops view that virtualizes the recon backlog with filters, selection and guided detail panel
- enable bulk resolve, snooze and escalate actions with audit logging and toast feedback
- build a DLQ replay console with rate limiting, inspection controls and shared styling updates

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e399c8f0308327955daecad4d3a8dd