### PR TITLE
feat: add KMS-backed RPT signing with rotation drill

### DIFF
--- a/src/api/ops/crypto.ts
+++ b/src/api/ops/crypto.ts
@@ -1,0 +1,101 @@
+import { Router } from "express";
+import { appendAudit } from "../../audit/appendOnly";
+import {
+  addKey,
+  activateKey,
+  retireKey,
+  listKeys,
+  getPublicKeys,
+  runRotationDrill,
+  getLastRotationDrill,
+} from "../../crypto/kms";
+
+const OPS_TOKEN = process.env.OPS_ROTATE_TOKEN;
+
+function ensureOpsAuth(req: any) {
+  const token = req.headers["x-ops-auth"];
+  const mfa = req.headers["x-ops-mfa"];
+  const actor = req.headers["x-ops-actor"];
+  const approver = req.headers["x-ops-approver"];
+  if (!OPS_TOKEN || token !== OPS_TOKEN) {
+    const err: any = new Error("Unauthorized");
+    err.status = 403;
+    throw err;
+  }
+  if (!mfa || String(mfa).length < 6) {
+    const err: any = new Error("MFA required");
+    err.status = 403;
+    throw err;
+  }
+  if (!actor || !approver || String(actor) === String(approver)) {
+    const err: any = new Error("SoD violation");
+    err.status = 403;
+    throw err;
+  }
+  return { actor: String(actor), approver: String(approver) };
+}
+
+export const opsCryptoRouter = Router();
+
+opsCryptoRouter.get("/keyset", async (_req, res) => {
+  const keys = await getPublicKeys();
+  res.json({ keys });
+});
+
+opsCryptoRouter.get("/keys", async (_req, res) => {
+  const keys = await listKeys();
+  res.json({ keys });
+});
+
+opsCryptoRouter.get("/drill", async (_req, res) => {
+  const last = await getLastRotationDrill();
+  if (!last) return res.status(404).json({ error: "NO_ROTATION_DRILL" });
+  res.json(last);
+});
+
+opsCryptoRouter.post("/rotate", async (req, res) => {
+  try {
+    const { actor, approver } = ensureOpsAuth(req);
+    const stage = (req.body?.stage ?? "drill") as string;
+    const graceDays = Number(req.body?.graceDays ?? process.env.RPT_KID_GRACE_DAYS ?? "7");
+
+    if (stage === "prepare") {
+      const created = await addKey();
+      await appendAudit(actor, "kms.rotate.prepare", { approver, kid: created.kid });
+      return res.json({ ok: true, pendingKid: created.kid });
+    }
+
+    if (stage === "cutover") {
+      const kid = req.body?.kid as string;
+      if (!kid) return res.status(400).json({ error: "Missing kid" });
+      const graceUntil = new Date(Date.now() + graceDays * 86400000);
+      const result = await activateKey(kid, graceUntil);
+      await appendAudit(actor, "kms.rotate.cutover", {
+        approver,
+        kid,
+        previousKid: result?.previousKid ?? null,
+        graceUntil: graceUntil.toISOString(),
+      });
+      return res.json({ ok: true, kid, previousKid: result?.previousKid ?? null, graceUntil: graceUntil.toISOString() });
+    }
+
+    if (stage === "retire") {
+      const kid = req.body?.kid as string;
+      if (!kid) return res.status(400).json({ error: "Missing kid" });
+      await retireKey(kid);
+      await appendAudit(actor, "kms.rotate.retire", { approver, kid });
+      return res.json({ ok: true, retiredKid: kid });
+    }
+
+    if (stage === "drill") {
+      const summary = await runRotationDrill();
+      await appendAudit(actor, "kms.rotate.drill", { approver, summary });
+      return res.json({ ok: true, summary });
+    }
+
+    return res.status(400).json({ error: "Unknown stage" });
+  } catch (err: any) {
+    const status = err?.status ?? 500;
+    return res.status(status).json({ error: String(err?.message || err) });
+  }
+});

--- a/src/crypto/kms.ts
+++ b/src/crypto/kms.ts
@@ -1,0 +1,307 @@
+import path from "path";
+import { promises as fs } from "fs";
+import { createHash } from "crypto";
+import nacl from "tweetnacl";
+
+import { LocalEd25519Provider, LocalStoredKey, KmsPublicKeyRecord } from "./providers/localEd25519";
+import { AwsKmsProvider } from "./providers/awsKms";
+
+export interface SignResult {
+  kid: string;
+  signature: Uint8Array;
+}
+
+export interface PublicKeyDescriptor {
+  kid: string;
+  publicKey: Uint8Array;
+  status?: string;
+  graceEndsAt?: string | null;
+}
+
+export interface RotationDrillArtifact {
+  kidOld?: string | null;
+  kidNew: string;
+  start: string;
+  end: string;
+  sampleTokens: Array<{
+    id: string;
+    kid: string;
+    payloadHash: string;
+    verifiedDuringGrace: boolean;
+    verifiedPostGrace: boolean;
+  }>;
+  verificationSummary: {
+    duringGrace: boolean;
+    afterGrace: boolean;
+  };
+  artifactPath: string;
+}
+
+let providerPromise: Promise<any> | null = null;
+
+function featureEnabled(): boolean {
+  return String(process.env.FEATURE_KMS ?? "false").toLowerCase() === "true";
+}
+
+function resolveBackend(): "aws" | "local" {
+  const backend = (process.env.KMS_PROVIDER ?? process.env.KMS_BACKEND ?? "local").toLowerCase();
+  if (backend === "aws") return "aws";
+  return "local";
+}
+
+async function buildProvider() {
+  if (!featureEnabled()) {
+    return new LocalEd25519Provider();
+  }
+  const backend = resolveBackend();
+  switch (backend) {
+    case "aws":
+      return new AwsKmsProvider();
+    case "local":
+    default:
+      return new LocalEd25519Provider();
+  }
+}
+
+async function getProvider<T = any>(): Promise<T> {
+  if (!providerPromise) {
+    providerPromise = buildProvider();
+  }
+  return providerPromise as Promise<T>;
+}
+
+export async function resetProviderForTests() {
+  providerPromise = null;
+}
+
+export async function sign(payload: Uint8Array, kid?: string): Promise<SignResult> {
+  const provider = await getProvider<any>();
+  if (!provider?.sign) throw new Error("KMS_PROVIDER_SIGN_UNDEFINED");
+  return provider.sign(payload, kid);
+}
+
+export async function getPublicKeys(): Promise<PublicKeyDescriptor[]> {
+  const provider = await getProvider<any>();
+  const records: KmsPublicKeyRecord[] | PublicKeyDescriptor[] = await provider.getPublicKeys();
+  return records.map((rec: any) => ({
+    kid: rec.kid,
+    publicKey: rec.publicKey,
+    status: rec.status,
+    graceEndsAt: rec.graceEndsAt ?? null,
+  }));
+}
+
+export async function listKeys(): Promise<PublicKeyDescriptor[]> {
+  const provider = await getProvider<any>();
+  if (!provider?.listKeys) {
+    const current = await getPublicKeys();
+    return current;
+  }
+  const records = await provider.listKeys();
+  return records.map((rec: any) => ({
+    kid: rec.kid,
+    publicKey: rec.publicKey,
+    status: rec.status,
+    graceEndsAt: rec.graceEndsAt ?? null,
+  }));
+}
+
+export async function getActiveKid(): Promise<string> {
+  const provider = await getProvider<any>();
+  if (provider?.getActiveKid) {
+    return provider.getActiveKid();
+  }
+  const keys = await getPublicKeys();
+  if (!keys.length) throw new Error("KMS_NO_ACTIVE_KEY");
+  return keys[0].kid;
+}
+
+export async function addKey(): Promise<LocalStoredKey> {
+  const provider = await getProvider<any>();
+  if (!provider?.addKey) throw new Error("KMS_PROVIDER_ADD_KEY_UNSUPPORTED");
+  return provider.addKey();
+}
+
+export async function activateKey(kid: string, graceUntil: Date | null) {
+  const provider = await getProvider<any>();
+  if (!provider?.activateKey) throw new Error("KMS_PROVIDER_ACTIVATE_UNSUPPORTED");
+  return provider.activateKey(kid, graceUntil);
+}
+
+export async function retireKey(kid: string) {
+  const provider = await getProvider<any>();
+  if (!provider?.retireKey) throw new Error("KMS_PROVIDER_RETIRE_UNSUPPORTED");
+  return provider.retireKey(kid);
+}
+
+export function decodeSignature(signatureB64: string): Uint8Array {
+  const normalized = signatureB64.includes("-") || signatureB64.includes("_")
+    ? signatureB64
+    : signatureB64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+  return new Uint8Array(Buffer.from(normalized, "base64url"));
+}
+
+export async function verifySignature(payload: Uint8Array, signature: Uint8Array, kid: string): Promise<boolean> {
+  const keys = await getPublicKeys();
+  const key = keys.find((k) => k.kid === kid);
+  if (!key) return false;
+  return nacl.sign.detached.verify(payload, signature, key.publicKey);
+}
+
+async function ensureArtifactsDir(): Promise<string> {
+  const dir = path.resolve(process.cwd(), "ops/artifacts");
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+function escapePdfText(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/\(/g, "\\(").replace(/\)/g, "\\)");
+}
+
+function buildPdf(lines: string[]): Buffer {
+  const contentLines = lines
+    .map((line, idx) => (idx === 0 ? `(${escapePdfText(line)}) Tj` : `T* (${escapePdfText(line)}) Tj`))
+    .join("\n");
+  const content = [`BT`, `/F1 12 Tf`, `72 720 Td`, contentLines, `ET`].join("\n");
+  const contentBuffer = Buffer.from(content, "utf8");
+  const objects: string[] = [];
+  objects.push("1 0 obj<< /Type /Catalog /Pages 2 0 R >>endobj");
+  objects.push("2 0 obj<< /Type /Pages /Kids [3 0 R] /Count 1 >>endobj");
+  objects.push("3 0 obj<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>endobj");
+  objects.push(`4 0 obj<< /Length ${contentBuffer.length} >>stream\n${content}\nendstreamendobj`);
+  objects.push("5 0 obj<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>endobj");
+  const offsets: number[] = [];
+  let cursor = "%PDF-1.4\n".length;
+  const pieces = ["%PDF-1.4\n"];
+  objects.forEach((obj) => {
+    offsets.push(cursor);
+    pieces.push(obj + "\n");
+    cursor += obj.length + 1;
+  });
+  const xrefOffset = cursor;
+  const xrefLines = ["xref", `0 ${objects.length + 1}`, "0000000000 65535 f "];
+  offsets.forEach((offset) => {
+    xrefLines.push(offset.toString().padStart(10, "0") + " 00000 n ");
+  });
+  const trailer = [
+    "trailer",
+    `<< /Size ${objects.length + 1} /Root 1 0 R >>`,
+    "startxref",
+    String(xrefOffset),
+    "%%EOF",
+  ];
+  const pdf = pieces.join("") + xrefLines.join("\n") + "\n" + trailer.join("\n") + "\n";
+  return Buffer.from(pdf, "utf8");
+}
+
+async function writePdf(summary: RotationDrillArtifact): Promise<string> {
+  const dir = await ensureArtifactsDir();
+  const filename = `kms-rotation-${summary.start.replace(/[:T]/g, "-").replace(/\..*/, "")}.pdf`;
+  const fullPath = path.join(dir, filename);
+  const lines: string[] = [
+    "APGMS KMS Rotation Drill",
+    `Started: ${summary.start}`,
+    `Completed: ${summary.end}`,
+    `New KID: ${summary.kidNew}`,
+    `Old KID: ${summary.kidOld ?? "n/a"}`,
+    `Grace verification: ${summary.verificationSummary.duringGrace ? "pass" : "fail"}`,
+    `Post-grace verification: ${summary.verificationSummary.afterGrace ? "pass" : "fail"}`,
+    "Sample tokens:",
+  ];
+  summary.sampleTokens.forEach((sample, idx) => {
+    lines.push(` ${idx + 1}. ${sample.id} [kid=${sample.kid}] grace=${sample.verifiedDuringGrace} post=${sample.verifiedPostGrace}`);
+  });
+  const pdf = buildPdf(lines);
+  await fs.writeFile(fullPath, pdf);
+  return fullPath;
+}
+
+async function writeSummary(summary: RotationDrillArtifact): Promise<void> {
+  const dir = await ensureArtifactsDir();
+  const jsonPath = path.join(dir, "last-rotation.json");
+  await fs.writeFile(jsonPath, JSON.stringify(summary, null, 2));
+}
+
+export async function runRotationDrill(): Promise<RotationDrillArtifact> {
+  const start = new Date();
+  const graceDays = Number(process.env.RPT_KID_GRACE_DAYS ?? "7");
+  const graceUntil = new Date(start.getTime() + graceDays * 86400000);
+
+  const created = await addKey();
+  const activation = await activateKey(created.kid, graceUntil);
+  const kidOld = activation?.previousKid ?? null;
+
+  const sampleTokens: RotationDrillArtifact["sampleTokens"] = [];
+
+  const sampleNewPayload = Buffer.from(`drill-new-${created.kid}`);
+  const signedNew = await sign(sampleNewPayload, created.kid);
+  const hashNew = createHash("sha256").update(sampleNewPayload).digest("hex");
+  const sampleNewId = `sample-${created.kid}`;
+
+  const graceVerifiedNew = await verifySignature(sampleNewPayload, signedNew.signature, signedNew.kid);
+  let postGraceVerifiedNew = graceVerifiedNew;
+
+  sampleTokens.push({
+    id: sampleNewId,
+    kid: signedNew.kid,
+    payloadHash: hashNew,
+    verifiedDuringGrace: graceVerifiedNew,
+    verifiedPostGrace: postGraceVerifiedNew,
+  });
+
+  if (kidOld) {
+    const sampleOldPayload = Buffer.from(`drill-old-${kidOld}`);
+    const signedOld = await sign(sampleOldPayload, kidOld);
+    const hashOld = createHash("sha256").update(sampleOldPayload).digest("hex");
+    const sampleOldId = `sample-${kidOld}`;
+    const graceVerifiedOld = await verifySignature(sampleOldPayload, signedOld.signature, kidOld);
+
+    await retireKey(kidOld);
+
+    const postGraceOld = await verifySignature(sampleOldPayload, signedOld.signature, kidOld);
+
+    sampleTokens.push({
+      id: sampleOldId,
+      kid: kidOld,
+      payloadHash: hashOld,
+      verifiedDuringGrace: graceVerifiedOld,
+      verifiedPostGrace: postGraceOld,
+    });
+
+    postGraceVerifiedNew = await verifySignature(sampleNewPayload, signedNew.signature, signedNew.kid);
+    sampleTokens[0].verifiedPostGrace = postGraceVerifiedNew;
+  }
+
+  const end = new Date();
+
+  const summary: RotationDrillArtifact = {
+    kidOld,
+    kidNew: created.kid,
+    start: start.toISOString(),
+    end: end.toISOString(),
+    sampleTokens,
+    verificationSummary: {
+      duringGrace: sampleTokens.every((t) => t.verifiedDuringGrace),
+      afterGrace: sampleTokens.every((t) => t.verifiedPostGrace),
+    },
+    artifactPath: "",
+  };
+
+  const artifactPath = await writePdf(summary);
+  summary.artifactPath = artifactPath;
+  await writeSummary(summary);
+
+  return summary;
+}
+
+export async function getLastRotationDrill(): Promise<RotationDrillArtifact | null> {
+  try {
+    const dir = await ensureArtifactsDir();
+    const file = path.join(dir, "last-rotation.json");
+    const raw = await fs.readFile(file, "utf8");
+    return JSON.parse(raw) as RotationDrillArtifact;
+  } catch (err: any) {
+    if (err?.code === "ENOENT") return null;
+    throw err;
+  }
+}

--- a/src/crypto/providers/awsKms.ts
+++ b/src/crypto/providers/awsKms.ts
@@ -1,0 +1,73 @@
+export interface AwsKmsConfig {
+  keyIds: string[];
+}
+
+export interface AwsKmsPublicKey {
+  kid: string;
+  publicKey: Uint8Array;
+}
+
+export class AwsKmsProvider {
+  private keyIds: string[];
+  private client: any;
+
+  constructor(config?: AwsKmsConfig) {
+    const envIds = process.env.RPT_KMS_KEY_IDS?.split(",").map((id) => id.trim()).filter(Boolean) ?? [];
+    this.keyIds = config?.keyIds?.length ? config.keyIds : envIds;
+    if (!this.keyIds.length && process.env.RPT_KMS_KEY_ID) {
+      this.keyIds = [process.env.RPT_KMS_KEY_ID];
+    }
+  }
+
+  private async loadModule(): Promise<any> {
+    try {
+      return await import("@aws-sdk/client-kms");
+    } catch (err) {
+      throw new Error("AWS_KMS_MODULE_NOT_INSTALLED");
+    }
+  }
+
+  private async ensureClient(): Promise<any> {
+    if (this.client) return this.client;
+    const mod = await this.loadModule();
+    this.client = new mod.KMSClient({ region: process.env.AWS_REGION });
+    return this.client;
+  }
+
+  async sign(payload: Uint8Array, kid?: string): Promise<{ kid: string; signature: Uint8Array }> {
+    const keyId = kid ?? this.keyIds[0];
+    if (!keyId) throw new Error("AWS_KMS_NO_KEY_ID");
+    const mod = await this.loadModule();
+    const client = await this.ensureClient();
+    const { Signature } = await client.send(
+      new mod.SignCommand({
+        KeyId: keyId,
+        Message: payload,
+        MessageType: "RAW",
+        SigningAlgorithm: "EDDSA",
+      })
+    );
+    if (!Signature) throw new Error("AWS_KMS_NO_SIGNATURE");
+    return { kid: keyId, signature: new Uint8Array(Signature) };
+  }
+
+  async getPublicKeys(): Promise<AwsKmsPublicKey[]> {
+    const ids = this.keyIds;
+    const mod = await this.loadModule();
+    const client = await this.ensureClient();
+    const outputs = await Promise.all(
+      ids.map(async (keyId) => {
+        const { PublicKey } = await client.send(new mod.GetPublicKeyCommand({ KeyId: keyId }));
+        if (!PublicKey) throw new Error(`AWS_KMS_NO_PUBLIC_KEY:${keyId}`);
+        return { kid: keyId, publicKey: new Uint8Array(PublicKey) };
+      })
+    );
+    return outputs;
+  }
+
+  async getActiveKid(): Promise<string> {
+    const keyId = this.keyIds[0];
+    if (!keyId) throw new Error("AWS_KMS_NO_KEY_ID");
+    return keyId;
+  }
+}

--- a/src/crypto/providers/localEd25519.ts
+++ b/src/crypto/providers/localEd25519.ts
@@ -1,0 +1,218 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { randomUUID } from "crypto";
+import nacl from "tweetnacl";
+
+export type LocalKeyStatus = "PENDING" | "ACTIVE" | "GRACE" | "RETIRED";
+
+export interface LocalStoredKey {
+  kid: string;
+  publicKey: string; // base64url
+  secretKey: string; // base64url
+  status: LocalKeyStatus;
+  createdAt: string;
+  graceEndsAt?: string | null;
+}
+
+export interface LocalKmsStore {
+  activeKid?: string;
+  keys: LocalStoredKey[];
+  pendingKid?: string;
+}
+
+export interface RotationResult {
+  previousKid?: string | null;
+  activeKid: string;
+}
+
+export interface LocalProviderOptions {
+  storePath?: string;
+}
+
+export interface KmsPublicKeyRecord {
+  kid: string;
+  publicKey: Uint8Array;
+  status: LocalKeyStatus;
+  graceEndsAt?: string | null;
+}
+
+export class LocalEd25519Provider {
+  private storePath: string;
+  private store: LocalKmsStore | null = null;
+
+  constructor(options: LocalProviderOptions = {}) {
+    const fromEnv = process.env.LOCAL_KMS_STORE_PATH;
+    const chosen = options.storePath || fromEnv || path.resolve(process.cwd(), "ops/local-kms.json");
+    this.storePath = chosen;
+  }
+
+  private async ensureStore(): Promise<LocalKmsStore> {
+    if (this.store) {
+      return this.store;
+    }
+
+    try {
+      const raw = await fs.readFile(this.storePath, "utf8");
+      const parsed = JSON.parse(raw) as LocalKmsStore;
+      this.store = this.normalizeStore(parsed);
+    } catch (err: any) {
+      if (err?.code !== "ENOENT") throw err;
+      const keyPair = nacl.sign.keyPair();
+      const kid = `local-${randomUUID()}`;
+      const createdAt = new Date().toISOString();
+      this.store = {
+        activeKid: kid,
+        keys: [
+          {
+            kid,
+            createdAt,
+            status: "ACTIVE",
+            publicKey: Buffer.from(keyPair.publicKey).toString("base64url"),
+            secretKey: Buffer.from(keyPair.secretKey).toString("base64url"),
+          },
+        ],
+      };
+      await this.persist();
+    }
+
+    return this.store!;
+  }
+
+  private normalizeStore(store: LocalKmsStore): LocalKmsStore {
+    const keys = Array.isArray(store.keys) ? store.keys : [];
+    const normalized: LocalStoredKey[] = keys.map((key) => ({
+      ...key,
+      graceEndsAt: key.graceEndsAt ?? null,
+    }));
+    return { ...store, keys: normalized };
+  }
+
+  private async persist(): Promise<void> {
+    if (!this.store) return;
+    await fs.mkdir(path.dirname(this.storePath), { recursive: true });
+    await fs.writeFile(this.storePath, JSON.stringify(this.store, null, 2));
+  }
+
+  private getKeyFromStore(store: LocalKmsStore, kid: string): LocalStoredKey | undefined {
+    return store.keys.find((k) => k.kid === kid);
+  }
+
+  async getActiveKid(): Promise<string> {
+    const store = await this.ensureStore();
+    if (!store.activeKid) {
+      const active = store.keys.find((k) => k.status === "ACTIVE");
+      if (!active) throw new Error("LOCAL_KMS_NO_ACTIVE_KID");
+      store.activeKid = active.kid;
+      await this.persist();
+    }
+    return store.activeKid!;
+  }
+
+  async sign(payload: Uint8Array, kid?: string): Promise<{ kid: string; signature: Uint8Array }> {
+    const store = await this.ensureStore();
+    const targetKid = kid ?? (await this.getActiveKid());
+    const key = this.getKeyFromStore(store, targetKid);
+    if (!key) throw new Error(`LOCAL_KMS_KID_UNKNOWN:${targetKid}`);
+    if (key.status === "RETIRED") throw new Error(`LOCAL_KMS_KID_RETIRED:${targetKid}`);
+
+    const secret = Buffer.from(key.secretKey, "base64url");
+    const sig = nacl.sign.detached(payload, new Uint8Array(secret));
+    return { kid: targetKid, signature: new Uint8Array(sig) };
+  }
+
+  async getPublicKeys(): Promise<KmsPublicKeyRecord[]> {
+    const store = await this.ensureStore();
+    const now = Date.now();
+    let mutated = false;
+
+    const keys = store.keys.map((key) => {
+      if (key.status === "GRACE" && key.graceEndsAt) {
+        const graceMs = Date.parse(key.graceEndsAt);
+        if (Number.isFinite(graceMs) && graceMs < now) {
+          key.status = "RETIRED";
+          mutated = true;
+        }
+      }
+      return key;
+    });
+
+    if (mutated) {
+      await this.persist();
+    }
+
+    return keys
+      .filter((key) => key.status === "ACTIVE" || key.status === "GRACE")
+      .map((key) => ({
+        kid: key.kid,
+        status: key.status,
+        graceEndsAt: key.graceEndsAt ?? null,
+        publicKey: new Uint8Array(Buffer.from(key.publicKey, "base64url")),
+      }));
+  }
+
+  async listKeys(): Promise<KmsPublicKeyRecord[]> {
+    const store = await this.ensureStore();
+    return store.keys.map((key) => ({
+      kid: key.kid,
+      status: key.status,
+      graceEndsAt: key.graceEndsAt ?? null,
+      publicKey: new Uint8Array(Buffer.from(key.publicKey, "base64url")),
+    }));
+  }
+
+  async addKey(): Promise<LocalStoredKey> {
+    const store = await this.ensureStore();
+    const keyPair = nacl.sign.keyPair();
+    const kid = `local-${randomUUID()}`;
+    const createdAt = new Date().toISOString();
+    const record: LocalStoredKey = {
+      kid,
+      createdAt,
+      status: "PENDING",
+      graceEndsAt: null,
+      publicKey: Buffer.from(keyPair.publicKey).toString("base64url"),
+      secretKey: Buffer.from(keyPair.secretKey).toString("base64url"),
+    };
+    store.keys.push(record);
+    store.pendingKid = kid;
+    await this.persist();
+    return record;
+  }
+
+  async activateKey(kid: string, graceEndsAt: Date | null): Promise<RotationResult> {
+    const store = await this.ensureStore();
+    const target = this.getKeyFromStore(store, kid);
+    if (!target) throw new Error(`LOCAL_KMS_KID_UNKNOWN:${kid}`);
+    if (target.status === "RETIRED") throw new Error(`LOCAL_KMS_KID_RETIRED:${kid}`);
+
+    const previousKid = store.activeKid;
+    store.activeKid = kid;
+    target.status = "ACTIVE";
+    target.graceEndsAt = null;
+
+    if (previousKid && previousKid !== kid) {
+      const prev = this.getKeyFromStore(store, previousKid);
+      if (prev) {
+        prev.status = "GRACE";
+        prev.graceEndsAt = graceEndsAt ? graceEndsAt.toISOString() : null;
+      }
+    }
+
+    store.pendingKid = undefined;
+    await this.persist();
+
+    return { previousKid, activeKid: kid };
+  }
+
+  async retireKey(kid: string): Promise<void> {
+    const store = await this.ensureStore();
+    const target = this.getKeyFromStore(store, kid);
+    if (!target) return;
+    target.status = "RETIRED";
+    target.graceEndsAt = null;
+    if (store.activeKid === kid) {
+      store.activeKid = undefined;
+    }
+    await this.persist();
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { opsCryptoRouter } from "./api/ops/crypto";
 
 dotenv.config();
 
@@ -24,6 +25,9 @@ app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
+
+// Ops crypto endpoints
+app.use("/api/ops/crypto", opsCryptoRouter);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,9 +1,8 @@
 ﻿import { Pool } from "pg";
 import crypto from "crypto";
-import { signRpt, RptPayload } from "../crypto/ed25519";
+import { sign, getActiveKid } from "../crypto/kms";
 import { exceeds } from "../anomaly/deterministic";
 const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
   const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
@@ -22,14 +21,33 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
-  const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+  const issuedAt = new Date();
+  const expiresAt = new Date(issuedAt.getTime() + 15 * 60 * 1000);
+  const ratesVersion = process.env.RATES_VERSION || process.env.RPT_RATES_VERSION || "default";
+  const kid = await getActiveKid();
+
+  const payload = {
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root,
+    running_balance_hash: row.running_balance_hash,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT" as const,
+    reference: process.env.ATO_PRN || "",
+    exp: expiresAt.toISOString(),
+    issued_at: issuedAt.toISOString(),
+    nonce: crypto.randomUUID(),
+    kid,
+    rates_version: ratesVersion,
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
+
+  const payloadJson = JSON.stringify(payload);
+  const signed = await sign(new TextEncoder().encode(payloadJson), kid);
+  const signature = Buffer.from(signed.signature).toString("base64url");
+
   await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
     [abn, taxType, periodId, payload, signature]);
   await pool.query("update periods set state='READY_RPT' where id=", [row.id]);

--- a/tests/rptGrace.test.ts
+++ b/tests/rptGrace.test.ts
@@ -1,0 +1,102 @@
+import assert from "assert";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import path from "path";
+import nacl from "tweetnacl";
+
+import { LocalEd25519Provider } from "../src/crypto/providers/localEd25519";
+import {
+  addKey,
+  activateKey,
+  retireKey,
+  getPublicKeys,
+  resetProviderForTests,
+  sign,
+  verifySignature,
+} from "../src/crypto/kms";
+
+function withTempStore(fn: (storePath: string) => Promise<void>) {
+  const dir = mkdtempSync(path.join(tmpdir(), "kms-test-"));
+  const storePath = path.join(dir, "store.json");
+  return fn(storePath).finally(() => {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch (err) {
+      // ignore cleanup errors
+    }
+  });
+}
+
+async function unitTestGraceAcceptance() {
+  await withTempStore(async (storePath) => {
+    const provider = new LocalEd25519Provider({ storePath });
+    const initial = await provider.sign(new TextEncoder().encode("baseline"));
+    const newKey = await provider.addKey();
+    const graceUntil = new Date(Date.now() + 3 * 24 * 3600 * 1000);
+    await provider.activateKey(newKey.kid, graceUntil);
+
+    const msgOld = new TextEncoder().encode("old-grace");
+    const msgNew = new TextEncoder().encode("new-active");
+    const sigOld = await provider.sign(msgOld, initial.kid);
+    const sigNew = await provider.sign(msgNew, newKey.kid);
+
+    const keysetDuring = await provider.getPublicKeys();
+    assert(keysetDuring.some((k) => k.kid === initial.kid), "old key missing during grace");
+    assert(keysetDuring.some((k) => k.kid === newKey.kid), "new key missing during grace");
+    assert(nacl.sign.detached.verify(msgOld, sigOld.signature, keysetDuring.find((k) => k.kid === initial.kid)!.publicKey));
+    assert(nacl.sign.detached.verify(msgNew, sigNew.signature, keysetDuring.find((k) => k.kid === newKey.kid)!.publicKey));
+
+    await provider.retireKey(initial.kid);
+    const after = await provider.getPublicKeys();
+    assert(!after.some((k) => k.kid === initial.kid), "old key still present after retirement");
+    assert(after.some((k) => k.kid === newKey.kid), "new key missing after retirement");
+  });
+}
+
+async function integrationTestGraceWindow() {
+  await withTempStore(async (storePath) => {
+    process.env.LOCAL_KMS_STORE_PATH = storePath;
+    process.env.FEATURE_KMS = "true";
+    process.env.KMS_PROVIDER = "local";
+    await resetProviderForTests();
+
+    const initialMsg = new TextEncoder().encode("integration-old");
+    const initialSign = await sign(initialMsg);
+    const oldKid = initialSign.kid;
+
+    const newKey = await addKey();
+    const graceUntil = new Date(Date.now() + 5 * 24 * 3600 * 1000);
+    await activateKey(newKey.kid, graceUntil);
+
+    const duringOldPayload = new TextEncoder().encode("during-grace-old");
+    const duringOldSig = await sign(duringOldPayload, oldKid);
+    const duringNewPayload = new TextEncoder().encode("during-grace-new");
+    const duringNewSig = await sign(duringNewPayload, newKey.kid);
+
+    const keysetDuring = await getPublicKeys();
+    const oldKeyRecord = keysetDuring.find((k) => k.kid === oldKid);
+    const newKeyRecord = keysetDuring.find((k) => k.kid === newKey.kid);
+    assert(oldKeyRecord, "old kid absent during grace");
+    assert(newKeyRecord, "new kid absent during grace");
+    assert(nacl.sign.detached.verify(duringOldPayload, duringOldSig.signature, oldKeyRecord!.publicKey), "old signature invalid during grace");
+    assert(nacl.sign.detached.verify(duringNewPayload, duringNewSig.signature, newKeyRecord!.publicKey), "new signature invalid during grace");
+
+    await retireKey(oldKid);
+    const keysetAfter = await getPublicKeys();
+    const oldAfter = keysetAfter.find((k) => k.kid === oldKid);
+    const newAfter = keysetAfter.find((k) => k.kid === newKey.kid);
+    assert(!oldAfter, "old key still available after grace");
+    assert(newAfter, "new key missing after grace");
+    const okAfter = await verifySignature(duringOldPayload, duringOldSig.signature, oldKid);
+    assert(!okAfter, "old signature still verifies after retirement");
+  });
+}
+
+(async () => {
+  await unitTestGraceAcceptance();
+  await integrationTestGraceWindow();
+  console.log("rptGrace.test.ts passed");
+})().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a shared KMS facade with local ed25519 storage plus an optional AWS adapter
- sign RPT payloads with KMS-backed keys, embed kid/rates metadata, and verify via published keysets
- expose /api/ops/crypto endpoints to manage rotation drills and persist audit/artifact outputs
- add automated grace-window tests covering dual-key acceptance and post-grace rejection

## Testing
- npx tsx tests/rptGrace.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68e39c373bcc8327a002011e69d5ae7e