### PR TITLE
Add Vale prose linting configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ Thumbs.db
 .DS_Store
 
 # IDE
-.vscode/
+.vscode/*
+!.vscode/extensions.json
 .idea/

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,5 @@
+StylesPath = content/vale/styles
+MinAlertLevel = suggestion
+
+[*.{md,mdx,txt,adoc}]
+BasedOnStyles = APGMS

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "errata-ai.vale-server"
+  ]
+}

--- a/content/vale/styles/APGMS/Jargon.yml
+++ b/content/vale/styles/APGMS/Jargon.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Prefer 'bank transfer' or wrap in <Gloss>."
+level: warning
+scope: text
+ignorecase: true
+tokens:
+  - '\begress\b'

--- a/content/vale/styles/APGMS/LongSentences.yml
+++ b/content/vale/styles/APGMS/LongSentences.yml
@@ -1,0 +1,6 @@
+extends: occurrence
+message: "Keep sentences under 25 words."
+level: warning
+scope: sentence
+max: 25
+token: '\b\\w+\b'

--- a/content/vale/styles/APGMS/PassiveVoice.yml
+++ b/content/vale/styles/APGMS/PassiveVoice.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: "Use active voice."
+level: warning
+scope: sentence
+ignorecase: true
+tokens:
+  - '\b(?:am|is|are|was|were|be|been|being)\b[^.!?]*\bby\b'

--- a/content/vale/styles/APGMS/PlainLanguage.yml
+++ b/content/vale/styles/APGMS/PlainLanguage.yml
@@ -1,0 +1,19 @@
+extends: substitution
+message: "Prefer '%s'."
+level: warning
+ignorecase: true
+swap:
+  initiate: start
+  initiated: started
+  initiating: starting
+  initiation: start
+  terminate: stop
+  terminated: stopped
+  terminating: stopping
+  termination: stop
+  utilize: use
+  utilization: use
+  commence: start
+  facilitates: helps
+  facilitate: help
+  facilitation: help


### PR DESCRIPTION
## Summary
- add a VS Code recommendation for the Vale prose linter
- configure Vale to flag passive voice, long sentences, and jargon with suggested replacements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39f29d6f883278150c2c623f320fd