### PR TITLE
Add contextual help panel for each page

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
-import { NavLink, Outlet } from "react-router-dom";
+import { NavLink, Outlet, useLocation } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import ContextPanel from "../help/ContextPanel";
+import { getContextForPath } from "../help/contextMap";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -14,12 +16,58 @@ const navLinks = [
 ];
 
 export default function AppLayout() {
+  const location = useLocation();
+  const [isHelpOpen, setIsHelpOpen] = React.useState(false);
+  const [isHelpHovered, setIsHelpHovered] = React.useState(false);
+  const context = getContextForPath(location.pathname);
+
+  React.useEffect(() => {
+    setIsHelpOpen(false);
+  }, [location.pathname]);
+
+  const helpButtonStyle: React.CSSProperties = {
+    position: "absolute",
+    top: 24,
+    right: 24,
+    width: 40,
+    height: 40,
+    borderRadius: "50%",
+    border: "1px solid rgba(255, 255, 255, 0.7)",
+    backgroundColor: isHelpHovered
+      ? "rgba(30, 64, 175, 0.6)"
+      : "rgba(15, 23, 42, 0.4)",
+    color: "#fff",
+    fontSize: 22,
+    fontWeight: 600,
+    cursor: "pointer",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    transition: "background-color 0.2s ease, transform 0.2s ease",
+    transform: isHelpHovered ? "translateY(-1px)" : "none",
+  };
+
   return (
     <div>
-      <header className="app-header">
+      <header
+        className="app-header"
+        style={{ position: "relative", paddingRight: 72 }}
+      >
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>
         <p>ATO-Compliant Tax Management System</p>
+        {context && (
+          <button
+            type="button"
+            onClick={() => setIsHelpOpen(true)}
+            onMouseEnter={() => setIsHelpHovered(true)}
+            onMouseLeave={() => setIsHelpHovered(false)}
+            aria-label="Open page help"
+            style={helpButtonStyle}
+          >
+            ?
+          </button>
+        )}
         <nav style={{ marginTop: 16 }}>
           {navLinks.map((link) => (
             <NavLink
@@ -44,7 +92,6 @@ export default function AppLayout() {
         </nav>
       </header>
 
-      {/* 👇 This tells React Router where to render the child pages */}
       <main style={{ padding: 20 }}>
         <Outlet />
       </main>
@@ -52,6 +99,16 @@ export default function AppLayout() {
       <footer className="app-footer">
         <p>© 2025 APGMS | Compliant with Income Tax Assessment Act 1997 & GST Act 1999</p>
       </footer>
+
+      {context && isHelpOpen && (
+        <ContextPanel
+          title={context.title}
+          description={context.description}
+          steps={context.steps}
+          links={context.links}
+          onClose={() => setIsHelpOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/src/help/ContextPanel.tsx
+++ b/src/help/ContextPanel.tsx
@@ -1,0 +1,143 @@
+import React from "react";
+
+type HelpLink = {
+  label: string;
+  href: string;
+};
+
+type ContextPanelProps = {
+  title: string;
+  description: string;
+  steps: string[];
+  links: HelpLink[];
+  onClose?: () => void;
+};
+
+const overlayStyle: React.CSSProperties = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0, 0, 0, 0.35)",
+  display: "flex",
+  justifyContent: "flex-end",
+  alignItems: "flex-start",
+  padding: 24,
+  zIndex: 1000,
+};
+
+const panelStyle: React.CSSProperties = {
+  backgroundColor: "#fff",
+  borderRadius: 12,
+  boxShadow: "0 12px 32px rgba(15, 23, 42, 0.25)",
+  width: "min(420px, 100%)",
+  maxHeight: "90vh",
+  overflowY: "auto",
+  padding: "24px 28px",
+  position: "relative",
+};
+
+const closeButtonStyle: React.CSSProperties = {
+  position: "absolute",
+  top: 16,
+  right: 16,
+  background: "none",
+  border: "none",
+  fontSize: 20,
+  cursor: "pointer",
+  color: "#334155",
+};
+
+const titleStyle: React.CSSProperties = {
+  fontSize: 20,
+  fontWeight: 600,
+  marginBottom: 12,
+  color: "#0f172a",
+};
+
+const descriptionStyle: React.CSSProperties = {
+  marginBottom: 20,
+  lineHeight: 1.5,
+  color: "#1e293b",
+};
+
+const sectionTitleStyle: React.CSSProperties = {
+  fontSize: 14,
+  fontWeight: 600,
+  textTransform: "uppercase",
+  letterSpacing: 1,
+  marginBottom: 8,
+  color: "#475569",
+};
+
+const listStyle: React.CSSProperties = {
+  margin: "0 0 16px 18px",
+  padding: 0,
+  color: "#0f172a",
+  lineHeight: 1.5,
+};
+
+const linkListStyle: React.CSSProperties = {
+  margin: "0 0 0 18px",
+  padding: 0,
+  color: "#2563eb",
+  lineHeight: 1.6,
+};
+
+const ContextPanel: React.FC<ContextPanelProps> = ({
+  title,
+  description,
+  steps,
+  links,
+  onClose,
+}) => {
+  return (
+    <div style={overlayStyle} role="presentation" onClick={onClose}>
+      <div
+        style={panelStyle}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="context-panel-title"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <button
+          type="button"
+          aria-label="Close help panel"
+          onClick={onClose}
+          style={closeButtonStyle}
+        >
+          ×
+        </button>
+        <h2 id="context-panel-title" style={titleStyle}>
+          {title}
+        </h2>
+        <p style={descriptionStyle}>{description}</p>
+        <div>
+          <div style={sectionTitleStyle}>Do this now</div>
+          <ol style={listStyle}>
+            {steps.map((step, index) => (
+              <li key={index}>{step}</li>
+            ))}
+          </ol>
+        </div>
+        {links.length > 0 && (
+          <div>
+            <div style={sectionTitleStyle}>Need more detail?</div>
+            <ul style={linkListStyle}>
+              {links.map((link) => (
+                <li key={link.href}>
+                  <a
+                    href={link.href}
+                    style={{ color: "#2563eb", textDecoration: "none" }}
+                  >
+                    {link.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default ContextPanel;

--- a/src/help/contextMap.ts
+++ b/src/help/contextMap.ts
@@ -1,0 +1,144 @@
+export type ContextLink = {
+  label: string;
+  href: string;
+};
+
+export type ContextEntry = {
+  title: string;
+  description: string;
+  steps: string[];
+  links: ContextLink[];
+};
+
+const contextMap: Record<string, ContextEntry> = {
+  "/": {
+    title: "Dashboard overview",
+    description:
+      "The dashboard highlights your PAYGW and GST health at a glance so you know what needs attention right now.",
+    steps: [
+      "Scan the alerts and trend cards to confirm there are no urgent anomalies.",
+      "Review cash flow and lodgement dates to see what is coming due.",
+      "Open the flagged widgets for anything that needs immediate follow-up.",
+    ],
+    links: [
+      { label: "Dashboard tour", href: "/help#dashboard" },
+      { label: "Understanding alerts", href: "/help#alerts" },
+    ],
+  },
+  "/bas": {
+    title: "Business Activity Statement prep",
+    description:
+      "This page consolidates BAS obligations, outstanding tasks, and reconciliations so you can lodge with confidence.",
+    steps: [
+      "Check the BAS summary cards to verify PAYGW and GST balances are current.",
+      "Work through the outstanding action list and tick off reconciliations.",
+      "Generate the BAS draft and review for any variances before lodging.",
+    ],
+    links: [
+      { label: "Prepare your BAS", href: "/help#bas" },
+      { label: "Reconcile payroll and GST", href: "/help#reconciliation" },
+    ],
+  },
+  "/settings": {
+    title: "Workspace settings",
+    description:
+      "Settings keeps your practice information, lodgement credentials, and automation rules aligned with ATO requirements.",
+    steps: [
+      "Confirm business identifiers and lodgement agents are correct.",
+      "Review automation preferences for reminders and escalations.",
+      "Save any updates so they apply to your next reporting cycle.",
+    ],
+    links: [
+      { label: "Manage practice details", href: "/help#settings" },
+      { label: "Automation controls", href: "/help#automation" },
+    ],
+  },
+  "/wizard": {
+    title: "Onboarding wizard",
+    description:
+      "The wizard walks new clients through mandatory setup steps so payroll and GST feeds stay accurate from day one.",
+    steps: [
+      "Complete each checklist stage and provide the requested documents.",
+      "Connect bank, payroll, and accounting sources when prompted.",
+      "Finish the confirmation step to activate monitoring.",
+    ],
+    links: [
+      { label: "Client onboarding guide", href: "/help#onboarding" },
+    ],
+  },
+  "/audit": {
+    title: "Audit trail",
+    description:
+      "Audit shows a chronological log of PAYGW and GST events so you can substantiate every decision made in the platform.",
+    steps: [
+      "Filter by entity, user, or obligation to focus the activity stream.",
+      "Open any entry to review the supporting data and attachments.",
+      "Export the filtered log if you need to brief stakeholders.",
+    ],
+    links: [
+      { label: "Audit trail FAQ", href: "/help#audit" },
+      { label: "Export records", href: "/help#exporting" },
+    ],
+  },
+  "/fraud": {
+    title: "Fraud monitoring",
+    description:
+      "Use the fraud dashboard to spot payroll and GST anomalies that could indicate compromise before they escalate.",
+    steps: [
+      "Check the risk heat map for entities trending towards high alert.",
+      "Review the flagged transactions list and assign follow-up owners.",
+      "Log remediation notes once the anomaly is resolved.",
+    ],
+    links: [
+      { label: "Fraud response playbook", href: "/help#fraud" },
+      { label: "Assign investigations", href: "/help#investigations" },
+    ],
+  },
+  "/integrations": {
+    title: "Integrations hub",
+    description:
+      "This hub manages your connections to payroll, banking, and ERP systems so the platform stays in sync.",
+    steps: [
+      "Review connection health and refresh any that show as stale.",
+      "Add new data sources or edit credentials as your systems change.",
+      "Confirm sync schedules so data keeps flowing automatically.",
+    ],
+    links: [
+      { label: "Connect data sources", href: "/help#integrations" },
+      { label: "Sync troubleshooting", href: "/help#sync" },
+    ],
+  },
+  "/help": {
+    title: "Help centre",
+    description:
+      "The help centre collects walkthroughs, FAQs, and contact options when you need deeper support.",
+    steps: [
+      "Browse the topic list or search for the workflow you need.",
+      "Follow the detailed guides to complete complex tasks.",
+      "Reach out to support if you cannot find the answer.",
+    ],
+    links: [
+      { label: "Contact support", href: "/help#contact" },
+      { label: "Product updates", href: "/help#releases" },
+    ],
+  },
+};
+
+export const getContextForPath = (pathname: string): ContextEntry | undefined => {
+  if (contextMap[pathname]) {
+    return contextMap[pathname];
+  }
+
+  const normalizedPath = pathname.replace(/\/$/, "");
+  if (contextMap[normalizedPath]) {
+    return contextMap[normalizedPath];
+  }
+
+  const match = Object.keys(contextMap).find((key) =>
+    key !== "/" && normalizedPath.startsWith(key)
+  );
+
+  return match ? contextMap[match] : contextMap["/"];
+};
+
+export default contextMap;


### PR DESCRIPTION
## Summary
- add a reusable ContextPanel component with description, steps, and help links
- define context help copy for each top-level route via a central map
- surface a route-aware help button in the App layout that opens the contextual panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e39efc19788327a629f4c1f82dc4b7