### PR TITLE
Add glossary tooltip support and linting for jargon terms

### DIFF
--- a/apps/web/console/package.json
+++ b/apps/web/console/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview --port 5173",
-    "lint": "echo lint web"
+    "lint": "node scripts/lint-glossary.mjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/apps/web/console/scripts/lint-glossary.mjs
+++ b/apps/web/console/scripts/lint-glossary.mjs
@@ -1,0 +1,94 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const projectRoot = process.cwd();
+const repoRoot = path.resolve(projectRoot, "../../..");
+const glossaryPath = path.resolve(repoRoot, "content", "glossary.json");
+
+if (!fs.existsSync(glossaryPath)) {
+  console.error(`Glossary file not found at ${glossaryPath}`);
+  process.exit(1);
+}
+
+const glossary = JSON.parse(fs.readFileSync(glossaryPath, "utf8"));
+const terms = Object.keys(glossary);
+
+const sourceDir = path.resolve(projectRoot, "src");
+
+function walk(dir) {
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      files.push(...walk(path.join(dir, entry.name)));
+    } else if (entry.isFile() && entry.name.endsWith(".tsx")) {
+      files.push(path.join(dir, entry.name));
+    }
+  }
+  return files;
+}
+
+const files = fs.existsSync(sourceDir) ? walk(sourceDir) : [];
+
+const errors = [];
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+for (const file of files) {
+  const raw = fs.readFileSync(file, "utf8");
+  const withoutBlockComments = raw.replace(/\/\*[\s\S]*?\*\//g, " ");
+  const withoutLineComments = withoutBlockComments.replace(/\/\/.*$/gm, " ");
+
+  for (const term of terms) {
+    const escaped = escapeRegExp(term);
+    const termRegex = new RegExp(`(?<![A-Za-z0-9])${escaped}(?![A-Za-z0-9])`, "g");
+
+    let match;
+    while ((match = termRegex.exec(withoutLineComments)) !== null) {
+      const index = match.index;
+      const precedingChar = withoutLineComments[index - 1];
+      const followingChar = withoutLineComments[index + term.length];
+
+      if (precedingChar && "'\"`".includes(precedingChar)) continue;
+      if (followingChar && "'\"`".includes(followingChar)) continue;
+
+      const originalIndex = match.index;
+      const before = withoutLineComments.lastIndexOf("<Gloss", originalIndex);
+      const after = withoutLineComments.indexOf("</Gloss>", originalIndex);
+      let wrapped = false;
+
+      if (before !== -1 && after !== -1 && before < originalIndex && after > originalIndex) {
+        const openTagEnd = withoutLineComments.indexOf(">", before);
+        if (openTagEnd !== -1 && openTagEnd < originalIndex) {
+          const openTag = withoutLineComments.slice(before, openTagEnd + 1);
+          const attrRegex = new RegExp(`term=[\"']${escaped}[\"']`);
+          if (attrRegex.test(openTag)) {
+            wrapped = true;
+          }
+        }
+      }
+
+      if (!wrapped) {
+        const line = withoutLineComments.slice(0, index).split(/\r?\n/).length;
+        errors.push({
+          file,
+          line,
+          term,
+        });
+      }
+    }
+  }
+}
+
+if (errors.length > 0) {
+  for (const error of errors) {
+    const relative = path.relative(projectRoot, error.file);
+    console.error(`${relative}:${error.line} — term "${error.term}" must be wrapped with <Gloss term="${error.term}">`);
+  }
+  process.exit(1);
+}
+
+console.log(`Glossary lint passed on ${files.length} file(s).`);

--- a/apps/web/console/src/main.tsx
+++ b/apps/web/console/src/main.tsx
@@ -1,12 +1,16 @@
-﻿import React from "react";
+import React from "react";
 import { createRoot } from "react-dom/client";
+import { Gloss } from "./ui/Gloss";
 
 function App() {
   return (
-    <div style={{padding:16,fontFamily:"system-ui"}}>
+    <div style={{ padding: 16, fontFamily: "system-ui" }}>
       <h1>APGMS Console</h1>
-      <p>Status tiles and RPT widgets will appear here. (P40, P41, P42)</p>
+      <p>
+        Status tiles and <Gloss term="RPT">RPT</Gloss> widgets will appear here. (P40, P41, P42)
+      </p>
     </div>
   );
 }
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/apps/web/console/src/ui/Gloss.tsx
+++ b/apps/web/console/src/ui/Gloss.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useId, useState, type ReactNode } from "react";
+import glossary from "../../../../../content/glossary.json";
+
+type GlossaryEntry = {
+  short: string;
+  more: string;
+};
+
+type Glossary = Record<string, GlossaryEntry>;
+
+const glossaryData: Glossary = glossary as Glossary;
+
+export interface GlossProps {
+  term: string;
+  children: ReactNode;
+}
+
+export function Gloss({ term, children }: GlossProps) {
+  const entry = glossaryData[term];
+  const [open, setOpen] = useState(false);
+  const tooltipId = useId();
+
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  if (!entry) {
+    return <>{children}</>;
+  }
+
+  const show = () => setOpen(true);
+  const hide = () => setOpen(false);
+
+  return (
+    <span
+      style={{
+        position: "relative",
+        display: "inline-flex",
+        alignItems: "center",
+      }}
+    >
+      <button
+        type="button"
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-describedby={open ? tooltipId : undefined}
+        onMouseEnter={show}
+        onMouseLeave={hide}
+        onFocus={show}
+        onBlur={hide}
+        onClick={() => setOpen(value => !value)}
+        style={{
+          background: "none",
+          border: 0,
+          padding: 0,
+          margin: 0,
+          font: "inherit",
+          color: "inherit",
+          cursor: "help",
+          display: "inline",
+        }}
+      >
+        <span
+          style={{
+            textDecorationLine: "underline",
+            textDecorationStyle: "dotted",
+            textDecorationColor: "currentColor",
+          }}
+        >
+          {children}
+        </span>
+      </button>
+      <span
+        id={tooltipId}
+        role="tooltip"
+        style={{
+          position: "absolute",
+          top: "100%",
+          left: "50%",
+          transform: "translateX(-50%)",
+          marginTop: 4,
+          padding: "8px 12px",
+          maxWidth: 260,
+          borderRadius: 8,
+          backgroundColor: "rgba(15, 23, 42, 0.96)",
+          color: "#ffffff",
+          fontSize: 12,
+          lineHeight: 1.4,
+          boxShadow: "0 6px 18px rgba(15, 23, 42, 0.2)",
+          opacity: open ? 1 : 0,
+          visibility: open ? "visible" : "hidden",
+          transition: "opacity 120ms ease, visibility 120ms ease",
+          pointerEvents: open ? "auto" : "none",
+          zIndex: 20,
+          textAlign: "left",
+        }}
+      >
+        <span>{entry.short} </span>
+        <a
+          href={entry.more}
+          style={{
+            color: "#bfdbfe",
+            marginLeft: 4,
+            textDecoration: "underline",
+          }}
+        >
+          Learn more
+        </a>
+      </span>
+    </span>
+  );
+}

--- a/apps/web/console/tsconfig.json
+++ b/apps/web/console/tsconfig.json
@@ -7,7 +7,8 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "skipLibCheck": true,
-    "types": []
+    "types": [],
+    "resolveJsonModule": true
   },
   "include": ["src"]
 }

--- a/content/glossary.json
+++ b/content/glossary.json
@@ -1,0 +1,14 @@
+{
+  "PAYG-W": {
+    "short": "Pay As You Go – tax you withhold from wages.",
+    "more": "/help/paygw"
+  },
+  "RPT": {
+    "short": "Release token that proves a period is ready to pay.",
+    "more": "/help/rpt"
+  },
+  "PayTo": {
+    "short": "Pre-approved bank payment instruction.",
+    "more": "/help/payto"
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared content/glossary.json with definitions for PAYG-W, RPT, and PayTo
- implement a reusable Gloss tooltip component and wrap the console RPT reference
- add a glossary lint script so npm run lint enforces wrapping glossary terms

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e39eb558ec8327bf02ede10ef4900d