### PR TITLE
Add tooltip-equipped mode badge to clarify prototype vs real modes

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import ModeBadge from "./ModeBadge";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -20,6 +21,7 @@ export default function AppLayout() {
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>
         <p>ATO-Compliant Tax Management System</p>
+        <ModeBadge mode="Prototype" />
         <nav style={{ marginTop: 16 }}>
           {navLinks.map((link) => (
             <NavLink

--- a/src/components/ModeBadge.tsx
+++ b/src/components/ModeBadge.tsx
@@ -1,0 +1,34 @@
+import React, { useId } from "react";
+
+export type ModeVariant = "Prototype" | "Real";
+
+const TOOLTIP_COPY: Record<ModeVariant, string> = {
+  Prototype:
+    "Safe demo mode. Bank calls are simulated; you can explore without moving real money.",
+  Real:
+    "Live mode with your bank connections, security checks, and real payments.",
+};
+
+interface ModeBadgeProps {
+  mode?: ModeVariant;
+}
+
+export default function ModeBadge({ mode = "Prototype" }: ModeBadgeProps) {
+  const tooltipId = useId();
+  const tooltip = TOOLTIP_COPY[mode];
+
+  return (
+    <div
+      className="mode-badge"
+      tabIndex={0}
+      role="status"
+      aria-label={`${mode} mode`}
+      aria-describedby={tooltipId}
+    >
+      <span className="mode-badge__label">{mode}</span>
+      <span id={tooltipId} className="mode-badge__tooltip" role="tooltip">
+        {tooltip}
+      </span>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -33,6 +33,70 @@ body {
   font-weight: 400;
 }
 
+.mode-badge {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin-top: 18px;
+  padding: 6px 16px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  cursor: default;
+  outline: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.mode-badge:focus {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.45);
+  transform: translateY(-1px);
+}
+
+.mode-badge__tooltip {
+  position: absolute;
+  top: calc(100% + 12px);
+  left: 50%;
+  transform: translate(-50%, 4px);
+  padding: 10px 14px;
+  max-width: 260px;
+  width: max-content;
+  background: rgba(9, 15, 35, 0.94);
+  color: #f5f7fa;
+  border-radius: 10px;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+  font-size: 0.85rem;
+  line-height: 1.45;
+  text-align: left;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.18s ease, transform 0.18s ease;
+  z-index: 2;
+}
+
+.mode-badge__tooltip::before {
+  content: "";
+  position: absolute;
+  top: -8px;
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 8px;
+  border-style: solid;
+  border-color: transparent transparent rgba(9, 15, 35, 0.94) transparent;
+}
+
+.mode-badge:hover .mode-badge__tooltip,
+.mode-badge:focus .mode-badge__tooltip,
+.mode-badge:focus-within .mode-badge__tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .app-footer {
   color: #888;
   text-align: center;


### PR DESCRIPTION
## Summary
- add a reusable `ModeBadge` component that surfaces the new prototype and real tooltip copy
- mount the badge in the main layout so the app header explains the current mode
- style the badge and tooltip for hover/focus clarity while keeping the copy non-technical

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e39f4876fc832798a3733d90c355e6