### PR TITLE
feat: add ports and adapter composition

### DIFF
--- a/src/compose/adapters.ts
+++ b/src/compose/adapters.ts
@@ -1,0 +1,27 @@
+import { FEATURES } from "../config/features";
+import { BankingPort } from "../ports/banking";
+import { MockBanking } from "../sim/bank/MockBanking";
+import { MtlsBanking } from "../adapters/bank/MtlsBanking";
+import { Recorder } from "../sim/recorder";
+import { PayrollPort } from "../ports/payroll";
+import { SimPayroll } from "../sim/payroll/SimPayroll";
+import { WebhookPayroll } from "../adapters/payroll/WebhookPayroll";
+import { PosPort } from "../ports/pos";
+import { SimPOS } from "../sim/pos/SimPOS";
+import { WebhookPOS } from "../adapters/pos/WebhookPOS";
+
+export const banking: BankingPort =
+  process.env.SIM_REPLAY === "true"
+    ? new Recorder(
+        FEATURES.SIM_OUTBOUND ? new MockBanking() : new MtlsBanking()
+      )
+    : FEATURES.SIM_OUTBOUND
+    ? new MockBanking()
+    : new MtlsBanking();
+
+export const payroll: PayrollPort = FEATURES.SIM_INBOUND
+  ? new SimPayroll()
+  : new WebhookPayroll();
+export const pos: PosPort = FEATURES.SIM_INBOUND
+  ? new SimPOS()
+  : new WebhookPOS();

--- a/src/ports/banking.ts
+++ b/src/ports/banking.ts
@@ -1,0 +1,37 @@
+export interface BankingPort {
+  eft(p: {
+    bsb: string;
+    account: string;
+    name: string;
+    amountCents: number;
+    idemKey: string;
+  }): Promise<{
+    providerRef: string;
+    paidAt: string;
+    channel: "EFT";
+    simulated: boolean;
+  }>;
+
+  bpay(p: {
+    billerCode: string;
+    crn: string;
+    amountCents: number;
+    idemKey: string;
+  }): Promise<{
+    providerRef: string;
+    paidAt: string;
+    channel: "BPAY";
+    simulated: boolean;
+  }>;
+
+  payToSweep(p: {
+    mandateId: string;
+    amountCents: number;
+    idemKey: string;
+  }): Promise<{
+    providerRef: string;
+    paidAt: string;
+    channel: "PayTo";
+    simulated: boolean;
+  }>;
+}

--- a/src/ports/payroll.ts
+++ b/src/ports/payroll.ts
@@ -1,0 +1,3 @@
+export interface PayrollPort {
+  ingest(evt: any): Promise<void>;
+}

--- a/src/ports/pos.ts
+++ b/src/ports/pos.ts
@@ -1,0 +1,3 @@
+export interface PosPort {
+  ingest(evt: any): Promise<void>;
+}


### PR DESCRIPTION
## Summary
- define clean port interfaces for banking, payroll, and POS integrations
- compose adapters that swap between simulated and real implementations based on feature flags and replay mode

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3ae6ad5988327ab94e2bf68b4e95d