### PR TITLE
Add feature switchboard configuration and UI mode banner

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Application modes and feature switches
+APP_MODE=prototype            # prototype | real
+SIM_INBOUND=true              # simulate STP/POS inputs
+SIM_OUTBOUND=true             # simulate EFT/BPAY/PayTo rails
+DRY_RUN=true                  # log intents, no network
+SHADOW_ONLY=true              # store & audit only, no release trigger
+FEATURE_KMS=false
+FEATURE_TAX_ENGINE=true
+FEATURE_EVIDENCE_V2=true
+ALLOW_SIM_IN_REAL=false       # guardrail
+
+# Mock latency/faults
+MOCK_LAT_P50_MS=120
+MOCK_LAT_P95_MS=450
+MOCK_5XX_RATE=0.01
+MOCK_TIMEOUT_RATE=0.005

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import ModeBanner from "../ui/ModeBanner";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -16,6 +17,7 @@ const navLinks = [
 export default function AppLayout() {
   return (
     <div>
+      <ModeBanner />
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,54 @@
+import dotenv from "dotenv";
+
+dotenv.config();
+
+type AppMode = "prototype" | "real";
+
+const asBoolean = (value: string | undefined, fallback: boolean): boolean => {
+  if (value === undefined) {
+    return fallback;
+  }
+
+  return value.toLowerCase() === "true";
+};
+
+const normalizeMode = (value: string | undefined): AppMode => {
+  return value === "real" ? "real" : "prototype";
+};
+
+export const FEATURES = {
+  APP_MODE: normalizeMode(process.env.APP_MODE),
+  SIM_INBOUND: asBoolean(process.env.SIM_INBOUND, true),
+  SIM_OUTBOUND: asBoolean(process.env.SIM_OUTBOUND, true),
+  DRY_RUN: asBoolean(process.env.DRY_RUN, true),
+  SHADOW_ONLY: asBoolean(process.env.SHADOW_ONLY, true),
+  FEATURE_KMS: asBoolean(process.env.FEATURE_KMS, false),
+  FEATURE_TAX_ENGINE: asBoolean(process.env.FEATURE_TAX_ENGINE, true),
+  FEATURE_EVIDENCE_V2: asBoolean(process.env.FEATURE_EVIDENCE_V2, true),
+  ALLOW_SIM_IN_REAL: asBoolean(process.env.ALLOW_SIM_IN_REAL, false),
+} as const;
+
+const hasSimulationEnabled = (): boolean => {
+  return (
+    FEATURES.SIM_INBOUND ||
+    FEATURES.SIM_OUTBOUND ||
+    FEATURES.DRY_RUN ||
+    FEATURES.SHADOW_ONLY
+  );
+};
+
+export function assertSafeBoot(): void {
+  if (
+    FEATURES.APP_MODE === "real" &&
+    hasSimulationEnabled() &&
+    !FEATURES.ALLOW_SIM_IN_REAL
+  ) {
+    throw new Error(
+      "Unsafe simulation flags set in APP_MODE=real. Set ALLOW_SIM_IN_REAL=true to override (not recommended)."
+    );
+  }
+}
+
+export function isAnySimulationEnabled(): boolean {
+  return hasSimulationEnabled();
+}

--- a/src/http/modeHeaders.ts
+++ b/src/http/modeHeaders.ts
@@ -1,0 +1,14 @@
+import { NextFunction, Request, Response } from "express";
+import { FEATURES, isAnySimulationEnabled } from "../config/features";
+
+export function modeHeaders(
+  _req: Request,
+  res: Response,
+  next: NextFunction
+): void {
+  res.setHeader("x-app-mode", FEATURES.APP_MODE);
+  res.setHeader("x-simulated", String(isAnySimulationEnabled()));
+  res.setHeader("x-dry-run", String(FEATURES.DRY_RUN));
+
+  next();
+}

--- a/src/index.css
+++ b/src/index.css
@@ -197,3 +197,57 @@ th {
   font-weight: 600;
   color: #00205b;
 }
+
+.mode-banner {
+  width: 100%;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  padding: 10px 16px;
+  font-size: 14px;
+  text-transform: uppercase;
+}
+
+.mode-prototype {
+  background: #fbbf24;
+  color: #3b2f0b;
+}
+
+.mode-live {
+  background: #047857;
+  color: #ecfdf5;
+}
+
+.mode-label {
+  display: inline-block;
+}
+
+.mode-warning {
+  display: inline-block;
+  margin-left: 12px;
+  font-weight: 500;
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.dry-run-watermark {
+  position: fixed;
+  top: 45%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(-18deg);
+  font-size: 96px;
+  color: rgba(200, 45, 45, 0.16);
+  font-weight: 800;
+  letter-spacing: 12px;
+  pointer-events: none;
+  text-transform: uppercase;
+  z-index: 1000;
+  white-space: nowrap;
+}
+
+@media (max-width: 700px) {
+  .dry-run-watermark {
+    font-size: 48px;
+    letter-spacing: 6px;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,36 @@
-﻿// src/index.ts
+// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import {
+  closeAndIssue,
+  payAto,
+  paytoSweep,
+  settlementWebhook,
+  evidence,
+} from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { api } from "./api"; // your existing API router(s)
+import { FEATURES, assertSafeBoot } from "./config/features";
+import { modeHeaders } from "./http/modeHeaders";
 
 dotenv.config();
+assertSafeBoot();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
+app.use(modeHeaders);
 
 // (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+app.use((req, _res, next) => {
+  console.log(`[app] ${req.method} ${req.url}`);
+  next();
+});
+
+console.log(
+  `[boot] APP_MODE=${FEATURES.APP_MODE} simulated=${FEATURES.SIM_INBOUND || FEATURES.SIM_OUTBOUND || FEATURES.DRY_RUN || FEATURES.SHADOW_ONLY}`
+);
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));

--- a/src/ui/ModeBanner.tsx
+++ b/src/ui/ModeBanner.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect, useState } from "react";
+
+type ModeInfo = {
+  appMode: string;
+  simulated: boolean;
+  dryRun: boolean;
+};
+
+const fallbackMode: ModeInfo = {
+  appMode: "prototype",
+  simulated: true,
+  dryRun: false,
+};
+
+const parseBoolean = (value: string | null): boolean => {
+  return value !== null && value.toLowerCase() === "true";
+};
+
+export default function ModeBanner() {
+  const [mode, setMode] = useState<ModeInfo>(fallbackMode);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const readModeFromHeaders = (response: Response) => {
+      if (!isMounted) {
+        return;
+      }
+
+      const appMode = response.headers.get("x-app-mode") ?? fallbackMode.appMode;
+      const simulated = parseBoolean(response.headers.get("x-simulated"));
+      const dryRun = parseBoolean(response.headers.get("x-dry-run"));
+
+      setMode({
+        appMode,
+        simulated,
+        dryRun,
+      });
+    };
+
+    fetch("/health", { cache: "no-store" })
+      .then(readModeFromHeaders)
+      .catch(() => {
+        if (isMounted) {
+          setMode(fallbackMode);
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const isRealMode = mode.appMode === "real";
+  const isSimulated = mode.simulated;
+  const bannerLabel = isRealMode
+    ? "Live (Real)"
+    : isSimulated
+    ? "Prototype (Simulated)"
+    : "Prototype";
+
+  return (
+    <>
+      <div
+        className={`mode-banner ${isRealMode ? "mode-live" : "mode-prototype"}`}
+        role="status"
+        aria-live="polite"
+      >
+        <span className="mode-label">{bannerLabel}</span>
+        {isRealMode && isSimulated ? (
+          <span className="mode-warning">Simulation flags active</span>
+        ) : null}
+      </div>
+      {mode.dryRun ? <div className="dry-run-watermark">DRY RUN</div> : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a documented `.env` template covering app mode, simulation flags, and mock latency settings
- centralize feature toggles with a safe boot assertion and middleware that exposes mode headers on every response
- surface the current mode in the React layout with a banner and DRY RUN watermark driven by the new headers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3ae4eeddc8327b44e42ac02688e02