### PR TITLE
Add admin feature flag toggles with MFA approvals

### DIFF
--- a/migrations/003_feature_store.sql
+++ b/migrations/003_feature_store.sql
@@ -1,0 +1,23 @@
+-- 003_feature_store.sql
+-- Feature flag store and SoD approvals for admin mode changes
+
+CREATE TABLE IF NOT EXISTS feature_flags (
+  key TEXT PRIMARY KEY,
+  value JSONB NOT NULL,
+  updated_by TEXT,
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS approvals (
+  id BIGSERIAL PRIMARY KEY,
+  request_id TEXT NOT NULL,
+  flag_key TEXT NOT NULL,
+  requested_by TEXT NOT NULL,
+  approved_by TEXT,
+  approved_at TIMESTAMPTZ,
+  status TEXT NOT NULL DEFAULT 'PENDING',
+  UNIQUE(request_id)
+);
+
+ALTER TABLE audit_log
+  ADD COLUMN IF NOT EXISTS entry JSONB;

--- a/src/admin/featureService.ts
+++ b/src/admin/featureService.ts
@@ -1,0 +1,156 @@
+import { Pool, PoolClient } from "pg";
+import { appendAudit } from "../audit/appendOnly";
+
+export type FeatureKey = "SIM_INBOUND" | "SIM_OUTBOUND" | "DRY_RUN" | "SHADOW_ONLY" | "APP_MODE";
+
+type FeatureValue = boolean | string | number | Record<string, unknown> | null;
+
+export interface Actor {
+  id: string;
+  role: string;
+  mfaVerified?: boolean;
+}
+
+export interface SecondApprover {
+  id: string;
+  approved: boolean;
+}
+
+export interface SetFeatureFlagOptions {
+  key: FeatureKey;
+  value: FeatureValue;
+  actor: Actor;
+  requestId: string;
+  reason?: string;
+  secondApprover?: SecondApprover;
+  mfaCode?: string;
+}
+
+const pool = new Pool();
+
+export const FEATURE_FLAG_KEYS: FeatureKey[] = [
+  "SIM_INBOUND",
+  "SIM_OUTBOUND",
+  "DRY_RUN",
+  "SHADOW_ONLY",
+  "APP_MODE",
+];
+
+const DEFAULT_VALUES: Record<FeatureKey, FeatureValue> = {
+  SIM_INBOUND: true,
+  SIM_OUTBOUND: true,
+  DRY_RUN: true,
+  SHADOW_ONLY: false,
+  APP_MODE: "sandbox",
+};
+
+async function withClient<T>(fn: (client: PoolClient) => Promise<T>) {
+  const client = await pool.connect();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}
+
+export async function getFeatureFlags(): Promise<Record<FeatureKey, FeatureValue>> {
+  return withClient(async client => {
+    const { rows } = await client.query<{ key: FeatureKey; value: FeatureValue }>(
+      "SELECT key, value FROM feature_flags"
+    );
+
+    const flags = { ...DEFAULT_VALUES } as Record<FeatureKey, FeatureValue>;
+    for (const row of rows) {
+      if (FEATURE_FLAG_KEYS.includes(row.key)) {
+        flags[row.key] = row.value;
+      }
+    }
+    return flags;
+  });
+}
+
+function ensureAdmin(actor: Actor) {
+  if (actor.role !== "admin") {
+    throw Object.assign(new Error("FORBIDDEN"), { status: 403 });
+  }
+}
+
+function assertMfa(options: SetFeatureFlagOptions) {
+  if (!options.actor.mfaVerified) {
+    throw Object.assign(new Error("MFA_REQUIRED"), { status: 428 });
+  }
+  if (!options.mfaCode) {
+    throw Object.assign(new Error("MFA_CODE_REQUIRED"), { status: 400 });
+  }
+  if (!options.secondApprover || !options.secondApprover.approved) {
+    throw Object.assign(new Error("APPROVAL_REQUIRED"), { status: 428 });
+  }
+  if (options.secondApprover.id === options.actor.id) {
+    throw Object.assign(new Error("APPROVER_MUST_DIFFER"), { status: 400 });
+  }
+}
+
+async function recordApproval(client: PoolClient, options: SetFeatureFlagOptions) {
+  const approvalStatus = options.secondApprover?.approved ? "APPROVED" : "PENDING";
+  await client.query(
+    `INSERT INTO approvals (request_id, flag_key, requested_by, approved_by, approved_at, status)
+     VALUES ($1,$2,$3,$4, CASE WHEN $5 = 'APPROVED' THEN NOW() ELSE NULL END, $5)
+     ON CONFLICT (request_id) DO UPDATE
+     SET flag_key = EXCLUDED.flag_key,
+         requested_by = EXCLUDED.requested_by,
+         approved_by = EXCLUDED.approved_by,
+         approved_at = CASE WHEN EXCLUDED.status = 'APPROVED' THEN NOW() ELSE approvals.approved_at END,
+         status = EXCLUDED.status`,
+    [
+      options.requestId,
+      options.key,
+      options.actor.id,
+      options.secondApprover?.id ?? null,
+      approvalStatus,
+    ]
+  );
+}
+
+export async function setFeatureFlag(options: SetFeatureFlagOptions) {
+  ensureAdmin(options.actor);
+  return withClient(async client => {
+    await client.query("BEGIN");
+    try {
+      const existing = await client.query<{ value: FeatureValue }>(
+        "SELECT value FROM feature_flags WHERE key = $1 FOR UPDATE",
+        [options.key]
+      );
+      const oldValue = existing.rows[0]?.value ?? DEFAULT_VALUES[options.key];
+
+      if (options.key === "APP_MODE" && options.value === "real") {
+        assertMfa(options);
+        await recordApproval(client, options);
+      }
+
+      const upsert = await client.query<{ value: FeatureValue }>(
+        `INSERT INTO feature_flags(key, value, updated_by, updated_at)
+         VALUES ($1,$2,$3,NOW())
+         ON CONFLICT (key) DO UPDATE
+         SET value = EXCLUDED.value,
+             updated_by = EXCLUDED.updated_by,
+             updated_at = EXCLUDED.updated_at
+         RETURNING value`,
+        [options.key, options.value, options.actor.id]
+      );
+
+      await appendAudit({
+        who: options.actor.id,
+        what: `feature:${options.key}`,
+        old: oldValue,
+        new: upsert.rows[0].value,
+        requestId: options.requestId,
+      });
+
+      await client.query("COMMIT");
+      return upsert.rows[0].value;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    }
+  });
+}

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,15 +1,53 @@
-﻿import { sha256Hex } from "../crypto/merkle";
-import { Pool } from "pg";
+import { Pool, PoolClient } from "pg";
+import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
-export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
-  const prevHash = rows[0]?.terminal_hash || "";
-  const payloadHash = sha256Hex(JSON.stringify(payload));
-  const terminalHash = sha256Hex(prevHash + payloadHash);
-  await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
-    [actor, action, payloadHash, prevHash, terminalHash]
-  );
-  return terminalHash;
+export interface AuditEntry {
+  who: string;
+  what: string;
+  old: unknown;
+  new: unknown;
+  requestId: string;
+}
+
+async function withClient<T>(fn: (client: PoolClient) => Promise<T>) {
+  const client = await pool.connect();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}
+
+export async function appendAudit(entry: AuditEntry) {
+  return withClient(async client => {
+    await client.query("BEGIN");
+    try {
+      const { rows } = await client.query<{ terminal_hash: string | null }>(
+        "SELECT terminal_hash FROM audit_log ORDER BY seq DESC LIMIT 1 FOR UPDATE"
+      );
+      const prevHash = rows[0]?.terminal_hash ?? null;
+      const payload = {
+        who: entry.who,
+        what: entry.what,
+        old: entry.old,
+        new: entry.new,
+        requestId: entry.requestId,
+      };
+      const payloadHash = sha256Hex(JSON.stringify(payload));
+      const terminalHash = sha256Hex((prevHash ?? "") + payloadHash);
+
+      await client.query(
+        `INSERT INTO audit_log(actor, action, payload_hash, prev_hash, terminal_hash, entry)
+         VALUES ($1,$2,$3,$4,$5,$6)`,
+        [entry.who, entry.what, payloadHash, prevHash, terminalHash, payload]
+      );
+      await client.query("COMMIT");
+      return terminalHash;
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    }
+  });
 }

--- a/src/pages/admin/Modes.tsx
+++ b/src/pages/admin/Modes.tsx
@@ -1,0 +1,236 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+type FeatureKey = "SIM_INBOUND" | "SIM_OUTBOUND" | "DRY_RUN" | "SHADOW_ONLY" | "APP_MODE";
+
+type FeatureValue = boolean | string | null;
+
+type FlagState = Record<FeatureKey, FeatureValue>;
+
+type FlagDescriptor = {
+  label: string;
+  description: string;
+  type: "boolean" | "mode";
+};
+
+const FLAG_DESCRIPTORS: Record<FeatureKey, FlagDescriptor> = {
+  SIM_INBOUND: {
+    label: "Inbound simulator",
+    description: "Mock inbound feeds from payroll, point-of-sale, and gateways.",
+    type: "boolean",
+  },
+  SIM_OUTBOUND: {
+    label: "Outbound simulator",
+    description: "Fake disbursements and ATO lodgement responses.",
+    type: "boolean",
+  },
+  DRY_RUN: {
+    label: "Dry run",
+    description: "Skip irreversible writes but exercise the orchestration graph.",
+    type: "boolean",
+  },
+  SHADOW_ONLY: {
+    label: "Shadow-mode",
+    description: "Mirror production inputs without touching settlement accounts.",
+    type: "boolean",
+  },
+  APP_MODE: {
+    label: "App mode",
+    description: "Global behaviour: sandbox, pilot, or real banking.",
+    type: "mode",
+  },
+};
+
+const DEFAULT_FLAGS: FlagState = {
+  SIM_INBOUND: true,
+  SIM_OUTBOUND: true,
+  DRY_RUN: true,
+  SHADOW_ONLY: false,
+  APP_MODE: "sandbox",
+};
+
+type ServerResponse = {
+  flags: Partial<FlagState>;
+};
+
+function nextRequestId() {
+  const cryptoApi = typeof globalThis !== "undefined" ? (globalThis as any).crypto : undefined;
+  if (cryptoApi?.randomUUID) {
+    return cryptoApi.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export default function Modes() {
+  const [flags, setFlags] = useState<FlagState>(DEFAULT_FLAGS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingKey, setPendingKey] = useState<FeatureKey | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchFlags() {
+      try {
+        const res = await fetch("/api/admin/feature-flags");
+        if (!res.ok) throw new Error(`Failed to load flags (${res.status})`);
+        const body: ServerResponse = await res.json();
+        if (!cancelled) {
+          setFlags({ ...DEFAULT_FLAGS, ...body.flags });
+          setLoading(false);
+        }
+      } catch (err: any) {
+        if (!cancelled) {
+          setError(err?.message || "Failed to fetch flags");
+          setLoading(false);
+        }
+      }
+    }
+    fetchFlags();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const headerPreview = useMemo(() => {
+    return {
+      "X-APGMS-Sim-Inbound": flags.SIM_INBOUND ? "on" : "off",
+      "X-APGMS-Sim-Outbound": flags.SIM_OUTBOUND ? "on" : "off",
+      "X-APGMS-Dry-Run": flags.DRY_RUN ? "on" : "off",
+      "X-APGMS-Shadow": flags.SHADOW_ONLY ? "on" : "off",
+      "X-APGMS-Mode": flags.APP_MODE ?? "sandbox",
+    };
+  }, [flags]);
+
+  async function updateFlag(key: FeatureKey, value: FeatureValue, extras?: Record<string, unknown>) {
+    setPendingKey(key);
+    setError(null);
+    try {
+      const requestId = nextRequestId();
+      const res = await fetch(`/api/admin/feature-flags/${key}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ value, requestId, ...extras }),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || `Failed to update ${key}`);
+      }
+      const body: ServerResponse = await res.json();
+      setFlags(prev => ({ ...prev, ...body.flags }));
+    } catch (err: any) {
+      setError(err?.message || `Failed to update ${key}`);
+    } finally {
+      setPendingKey(current => (current === key ? null : current));
+    }
+  }
+
+  async function toggleBoolean(key: FeatureKey, current: boolean) {
+    const next = !current;
+    if (key === "APP_MODE") {
+      await updateFlag(key, next ? "real" : "sandbox");
+      return;
+    }
+    await updateFlag(key, next);
+  }
+
+  async function changeMode(nextMode: string) {
+    if (nextMode === "real") {
+      const mfaCode = window.prompt("Enter MFA code to continue");
+      if (!mfaCode) {
+        return;
+      }
+      const approver = window.prompt("Second approver (email or ID)");
+      if (!approver) {
+        return;
+      }
+      await updateFlag("APP_MODE", "real", {
+        mfaCode,
+        secondApprover: {
+          id: approver,
+          approved: true,
+        },
+      });
+      return;
+    }
+    await updateFlag("APP_MODE", nextMode);
+  }
+
+  function renderControl(key: FeatureKey) {
+    const descriptor = FLAG_DESCRIPTORS[key];
+    const value = flags[key];
+
+    if (descriptor.type === "boolean") {
+      const checked = Boolean(value);
+      return (
+        <label className="toggle">
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={() => toggleBoolean(key, checked)}
+            disabled={pendingKey === key}
+          />
+          <span className="slider" />
+        </label>
+      );
+    }
+
+    return (
+      <div className="mode-selector">
+        {(["sandbox", "pilot", "real"] as const).map(mode => (
+          <button
+            key={mode}
+            className={`mode-pill${value === mode ? " active" : ""}`}
+            onClick={() => changeMode(mode)}
+            disabled={pendingKey === key}
+          >
+            {mode.toUpperCase()}
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="admin-modes">
+      <header>
+        <h1>Modes &amp; Simulators</h1>
+        <p>Flip simulators, dry-run, and production mode without touching the CLI.</p>
+      </header>
+
+      {loading && <p>Loading feature flags…</p>}
+      {error && <p className="error">{error}</p>}
+
+      {!loading && (
+        <div className="flags-grid">
+          {(Object.keys(FLAG_DESCRIPTORS) as FeatureKey[]).map(key => (
+            <div key={key} className="flag-card">
+              <div className="flag-card__header">
+                <div>
+                  <h3>{FLAG_DESCRIPTORS[key].label}</h3>
+                  <p>{FLAG_DESCRIPTORS[key].description}</p>
+                </div>
+                <div>{renderControl(key)}</div>
+              </div>
+              {pendingKey === key && <p className="pending">Saving…</p>}
+            </div>
+          ))}
+        </div>
+      )}
+
+      <section className="headers-preview">
+        <h2>Live header preview</h2>
+        <table>
+          <tbody>
+            {Object.entries(headerPreview).map(([header, value]) => (
+              <tr key={header}>
+                <th>{header}</th>
+                <td>{String(value)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -36,7 +36,13 @@ export async function releasePayment(abn: string, taxType: string, periodId: str
     "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
+  await appendAudit({
+    who: "rails",
+    what: "release",
+    old: null,
+    new: { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash },
+    requestId: transfer_uuid,
+  });
   await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
   return { transfer_uuid, bank_receipt_hash };
 }


### PR DESCRIPTION
## Summary
- add a feature flag store migration along with approvals and structured audit payload storage
- implement an admin feature service that enforces MFA plus second-approver checks for APP_MODE changes and logs to the audit chain
- build an Admin Modes page for flipping simulators with live header previews and update the rails adapter to the new audit API

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3aecd5fe48327b8fb9d7691883c5a