### PR TITLE
Add recorder wrapper for bank adapters

### DIFF
--- a/apps/services/payments/src/bank/adapters.ts
+++ b/apps/services/payments/src/bank/adapters.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs";
+import https from "node:https";
+import axios from "axios";
+import { createHash, randomUUID } from "node:crypto";
+import { Recorder } from "../sim/recorder";
+
+export type Destination = {
+  bpay_biller?: string;
+  crn?: string;
+  bsb?: string;
+  acct?: string;
+};
+
+export type EftBpayRequest = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amount_cents: number;
+  destination: Destination;
+  idempotencyKey: string;
+};
+
+export type EftBpayResult = {
+  transfer_uuid: string;
+  bank_receipt_hash: string;
+  provider_receipt_id: string;
+};
+
+export type PayToSweepRequest = {
+  mandate_id: string;
+  amount_cents: number;
+  meta?: Record<string, unknown>;
+};
+
+const agent = new https.Agent({
+  ca: process.env.BANK_TLS_CA ? fs.readFileSync(process.env.BANK_TLS_CA) : undefined,
+  cert: process.env.BANK_TLS_CERT ? fs.readFileSync(process.env.BANK_TLS_CERT) : undefined,
+  key: process.env.BANK_TLS_KEY ? fs.readFileSync(process.env.BANK_TLS_KEY) : undefined,
+  rejectUnauthorized: true,
+});
+
+const client = axios.create({
+  baseURL: process.env.BANK_API_BASE,
+  timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
+  httpsAgent: agent,
+});
+
+async function sendEftOrBpay(req: EftBpayRequest): Promise<EftBpayResult> {
+  const transfer_uuid = randomUUID();
+  const payload = {
+    amount_cents: req.amount_cents,
+    meta: {
+      abn: req.abn,
+      taxType: req.taxType,
+      periodId: req.periodId,
+      transfer_uuid,
+    },
+    destination: req.destination,
+  };
+
+  const headers = { "Idempotency-Key": req.idempotencyKey };
+  const maxAttempts = 3;
+  let attempt = 0;
+  let lastErr: any;
+
+  while (attempt < maxAttempts) {
+    attempt += 1;
+    try {
+      const response = await client.post("/payments/eft-bpay", payload, { headers });
+      const receipt = response.data?.receipt_id || "";
+      const hash = createHash("sha256").update(receipt).digest("hex");
+      return {
+        transfer_uuid,
+        bank_receipt_hash: hash,
+        provider_receipt_id: receipt,
+      };
+    } catch (err: any) {
+      lastErr = err;
+      await new Promise((resolve) => setTimeout(resolve, attempt * 250));
+    }
+  }
+
+  throw new Error("Bank transfer failed: " + String(lastErr?.message || lastErr));
+}
+
+async function debitMandateSweep(req: PayToSweepRequest) {
+  const response = await client.post(`/payto/mandates/${req.mandate_id}/debit`, {
+    amount_cents: req.amount_cents,
+    meta: req.meta ?? {},
+  });
+  return response.data;
+}
+
+const raw = {
+  async eft(payload: EftBpayRequest) {
+    return sendEftOrBpay(payload);
+  },
+  async bpay(payload: EftBpayRequest) {
+    return sendEftOrBpay(payload);
+  },
+  async payToSweep(payload: PayToSweepRequest) {
+    return debitMandateSweep(payload);
+  },
+};
+
+const shouldWrap = process.env.SIM_RECORD === "true" || process.env.SIM_REPLAY === "true";
+const adapter = shouldWrap ? new Recorder(raw) : raw;
+
+export function eft(payload: EftBpayRequest) {
+  return adapter.eft(payload);
+}
+
+export function bpay(payload: EftBpayRequest) {
+  return adapter.bpay(payload);
+}
+
+export function payToSweep(payload: PayToSweepRequest) {
+  return adapter.payToSweep(payload);
+}
+
+export type BankAdapters = typeof adapter;

--- a/apps/services/payments/src/bank/eftBpayAdapter.ts
+++ b/apps/services/payments/src/bank/eftBpayAdapter.ts
@@ -1,51 +1,15 @@
-﻿import pg from "pg";
-import https from "https";
-import axios from "axios";
-import { createHash, randomUUID } from "crypto";
+import { bpay, eft, type EftBpayRequest, type EftBpayResult } from "./adapters";
 
-type Params = {
-  abn: string; taxType: string; periodId: string;
-  amount_cents: number;
-  destination: { bpay_biller?: string; crn?: string; bsb?: string; acct?: string };
-  idempotencyKey: string;
-};
+type Params = EftBpayRequest;
 
-const agent = new https.Agent({
-  ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
-  cert: process.env.BANK_TLS_CERT ? require("fs").readFileSync(process.env.BANK_TLS_CERT) : undefined,
-  key: process.env.BANK_TLS_KEY ? require("fs").readFileSync(process.env.BANK_TLS_KEY) : undefined,
-  rejectUnauthorized: true
-});
+type Result = EftBpayResult;
 
-const client = axios.create({
-  baseURL: process.env.BANK_API_BASE,
-  timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
-  httpsAgent: agent
-});
+const isBpayDestination = (destination: Params["destination"]) =>
+  Boolean(destination.bpay_biller || destination.crn);
 
-export async function sendEftOrBpay(p: Params): Promise<{transfer_uuid: string; bank_receipt_hash: string; provider_receipt_id: string}> {
-  const transfer_uuid = randomUUID();
-  const payload = {
-    amount_cents: p.amount_cents,
-    meta: { abn: p.abn, taxType: p.taxType, periodId: p.periodId, transfer_uuid },
-    destination: p.destination
-  };
-
-  const headers = { "Idempotency-Key": p.idempotencyKey };
-  const maxAttempts = 3;
-  let attempt = 0, lastErr: any;
-
-  while (attempt < maxAttempts) {
-    attempt++;
-    try {
-      const r = await client.post("/payments/eft-bpay", payload, { headers });
-      const receipt = r.data?.receipt_id || "";
-      const hash = createHash("sha256").update(receipt).digest("hex");
-      return { transfer_uuid, bank_receipt_hash: hash, provider_receipt_id: receipt };
-    } catch (e: any) {
-      lastErr = e;
-      await new Promise(s => setTimeout(s, attempt * 250));
-    }
+export async function sendEftOrBpay(p: Params): Promise<Result> {
+  if (isBpayDestination(p.destination)) {
+    return bpay(p);
   }
-  throw new Error("Bank transfer failed: " + String(lastErr?.message || lastErr));
+  return eft(p);
 }

--- a/apps/services/payments/src/bank/paytoAdapter.ts
+++ b/apps/services/payments/src/bank/paytoAdapter.ts
@@ -1,16 +1,18 @@
-﻿import pg from "pg";
 import axios from "axios";
 import https from "https";
+import fs from "node:fs";
+import { payToSweep, type PayToSweepRequest } from "./adapters";
+
 const agent = new https.Agent({
-  ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
-  cert: process.env.BANK_TLS_CERT ? require("fs").readFileSync(process.env.BANK_TLS_CERT) : undefined,
-  key: process.env.BANK_TLS_KEY ? require("fs").readFileSync(process.env.BANK_TLS_KEY) : undefined,
-  rejectUnauthorized: true
+  ca: process.env.BANK_TLS_CA ? fs.readFileSync(process.env.BANK_TLS_CA) : undefined,
+  cert: process.env.BANK_TLS_CERT ? fs.readFileSync(process.env.BANK_TLS_CERT) : undefined,
+  key: process.env.BANK_TLS_KEY ? fs.readFileSync(process.env.BANK_TLS_KEY) : undefined,
+  rejectUnauthorized: true,
 });
 const client = axios.create({
   baseURL: process.env.BANK_API_BASE,
   timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
-  httpsAgent: agent
+  httpsAgent: agent,
 });
 
 export async function createMandate(abn: string, periodId: string, cap_cents: number) {
@@ -22,8 +24,8 @@ export async function verifyMandate(mandate_id: string) {
   return r.data;
 }
 export async function debitMandate(mandate_id: string, amount_cents: number, meta: any) {
-  const r = await client.post(`/payto/mandates/${mandate_id}/debit`, { amount_cents, meta });
-  return r.data;
+  const payload: PayToSweepRequest = { mandate_id, amount_cents, meta };
+  return payToSweep(payload);
 }
 export async function cancelMandate(mandate_id: string) {
   const r = await client.post(`/payto/mandates/${mandate_id}/cancel`, {});

--- a/apps/services/payments/src/sim/recorder.ts
+++ b/apps/services/payments/src/sim/recorder.ts
@@ -1,0 +1,50 @@
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+
+export class Recorder<T extends object> {
+  constructor(private inner: T) {}
+
+  private cassettePath(method: string, payload: unknown) {
+    const hash = crypto
+      .createHash("sha256")
+      .update(JSON.stringify(payload))
+      .digest("hex")
+      .slice(0, 24);
+    return path.join(".sim", "cassettes", method, `${hash}.json`);
+  }
+
+  private async call(method: string, payload: unknown, fn: Function | undefined) {
+    if (typeof fn !== "function") {
+      throw new Error(`Recorder inner missing method: ${method}`);
+    }
+
+    const cassette = this.cassettePath(method, payload);
+
+    if (process.env.SIM_REPLAY === "true" && fs.existsSync(cassette)) {
+      const contents = fs.readFileSync(cassette, "utf8");
+      return JSON.parse(contents);
+    }
+
+    const result = await fn.call(this.inner, payload);
+
+    if (process.env.SIM_RECORD === "true") {
+      fs.mkdirSync(path.dirname(cassette), { recursive: true });
+      fs.writeFileSync(cassette, JSON.stringify(result, null, 2));
+    }
+
+    return result;
+  }
+
+  eft(payload: unknown) {
+    return this.call("eft", payload, (this.inner as any).eft);
+  }
+
+  bpay(payload: unknown) {
+    return this.call("bpay", payload, (this.inner as any).bpay);
+  }
+
+  payToSweep(payload: unknown) {
+    return this.call("payToSweep", payload, (this.inner as any).payToSweep);
+  }
+}


### PR DESCRIPTION
## Summary
- add a cassette Recorder utility for bank adapters to persist EFT/BPAY and PayTo responses
- centralize EFT/BPAY and PayTo sweep adapters through the recorder-aware wrapper
- update existing adapter exports to delegate through the recorder so replay uses saved payloads

## Testing
- npm test *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aeb990408327a35926e5650c08e1