### PR TITLE
Add request tracing and consent gating for live rails

### DIFF
--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -1,6 +1,7 @@
 // src/api/payments.ts
 import express from "express";
 import { Payments } from "../../libs/paymentsClient"; // adjust if your libs path differs
+import { sendError } from "../http/error";
 
 export const paymentsApi = express.Router();
 
@@ -9,12 +10,12 @@ paymentsApi.get("/balance", async (req, res) => {
   try {
     const { abn, taxType, periodId } = req.query as Record<string, string>;
     if (!abn || !taxType || !periodId) {
-      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+      return sendError(res, 400, "BadRequest", "Missing abn/taxType/periodId");
     }
     const data = await Payments.balance({ abn, taxType, periodId });
     res.json(data);
   } catch (err: any) {
-    res.status(500).json({ error: err?.message || "Balance failed" });
+    return sendError(res, 500, "BalanceFailed", err?.message || "Balance failed");
   }
 });
 
@@ -23,12 +24,12 @@ paymentsApi.get("/ledger", async (req, res) => {
   try {
     const { abn, taxType, periodId } = req.query as Record<string, string>;
     if (!abn || !taxType || !periodId) {
-      return res.status(400).json({ error: "Missing abn/taxType/periodId" });
+      return sendError(res, 400, "BadRequest", "Missing abn/taxType/periodId");
     }
     const data = await Payments.ledger({ abn, taxType, periodId });
     res.json(data);
   } catch (err: any) {
-    res.status(500).json({ error: err?.message || "Ledger failed" });
+    return sendError(res, 500, "LedgerFailed", err?.message || "Ledger failed");
   }
 });
 
@@ -37,15 +38,15 @@ paymentsApi.post("/deposit", async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body || {};
     if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
-      return res.status(400).json({ error: "Missing fields" });
+      return sendError(res, 400, "BadRequest", "Missing fields");
     }
     if (amountCents <= 0) {
-      return res.status(400).json({ error: "Deposit must be positive" });
+      return sendError(res, 400, "BadRequest", "Deposit must be positive");
     }
     const data = await Payments.deposit({ abn, taxType, periodId, amountCents });
     res.json(data);
   } catch (err: any) {
-    res.status(400).json({ error: err?.message || "Deposit failed" });
+    return sendError(res, 400, "DepositFailed", err?.message || "Deposit failed");
   }
 });
 
@@ -54,14 +55,14 @@ paymentsApi.post("/release", async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body || {};
     if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
-      return res.status(400).json({ error: "Missing fields" });
+      return sendError(res, 400, "BadRequest", "Missing fields");
     }
     if (amountCents >= 0) {
-      return res.status(400).json({ error: "Release must be negative" });
+      return sendError(res, 400, "BadRequest", "Release must be negative");
     }
     const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
     res.json(data);
   } catch (err: any) {
-    res.status(400).json({ error: err?.message || "Release failed" });
+    return sendError(res, 400, "ReleaseFailed", err?.message || "Release failed");
   }
 });

--- a/src/consent/consentText.md
+++ b/src/consent/consentText.md
@@ -1,0 +1,12 @@
+# APGMS Payment Rails Consent
+
+Before we move funds over live payment rails, we need your explicit confirmation that:
+
+1. You understand the prototype will initiate real debits and credits on behalf of the business when live mode is enabled.
+2. You agree that test transactions may appear on bank statements and that you are responsible for reconciling them.
+3. You acknowledge that safeguards (thresholds, allow lists, and anomaly checks) have been reviewed and are acceptable for your use case.
+4. You consent to audit logging of every release, including the operator account that triggered it.
+
+**By enabling live rails you confirm the above and authorise APGMS to execute payments using your configured banking credentials.**
+
+Record the operator name or email, the time consent was provided, and store this confirmation before setting `RAILS_MODE=real`.

--- a/src/consent/service.ts
+++ b/src/consent/service.ts
@@ -1,0 +1,63 @@
+import { Pool } from "pg";
+import { HttpError } from "../http/error";
+
+export type ConsentAcceptance = {
+  acceptedAt: Date;
+  acceptedBy: string;
+};
+
+const pool = new Pool();
+let tableEnsured = false;
+
+async function ensureTable() {
+  if (tableEnsured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS rails_consent (
+      id SERIAL PRIMARY KEY,
+      accepted_by TEXT NOT NULL,
+      accepted_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )
+  `);
+  tableEnsured = true;
+}
+
+export async function recordConsent(acceptedBy: string): Promise<ConsentAcceptance> {
+  if (!acceptedBy || !acceptedBy.trim()) {
+    throw new HttpError(400, "InvalidConsent", "acceptedBy is required");
+  }
+  await ensureTable();
+  const { rows } = await pool.query(
+    "INSERT INTO rails_consent (accepted_by) VALUES ($1) RETURNING accepted_by, accepted_at",
+    [acceptedBy.trim()]
+  );
+  return {
+    acceptedBy: rows[0].accepted_by,
+    acceptedAt: new Date(rows[0].accepted_at),
+  };
+}
+
+export async function latestConsent(): Promise<ConsentAcceptance | null> {
+  await ensureTable();
+  const { rows } = await pool.query(
+    "SELECT accepted_by, accepted_at FROM rails_consent ORDER BY accepted_at DESC LIMIT 1"
+  );
+  if (!rows.length) return null;
+  return {
+    acceptedBy: rows[0].accepted_by,
+    acceptedAt: new Date(rows[0].accepted_at),
+  };
+}
+
+export class ConsentRequiredError extends HttpError {
+  constructor(detail = "Explicit consent is required before enabling live rails.") {
+    super(412, "ConsentRequired", detail);
+  }
+}
+
+export async function requireConsent(): Promise<ConsentAcceptance> {
+  const consent = await latestConsent();
+  if (!consent) {
+    throw new ConsentRequiredError();
+  }
+  return consent;
+}

--- a/src/http/error.ts
+++ b/src/http/error.ts
@@ -1,0 +1,60 @@
+import type { Request, Response, NextFunction } from "express";
+
+export interface ErrorResponseBody {
+  title: string;
+  detail?: string;
+  requestId: string;
+  simulated: boolean;
+}
+
+export class HttpError extends Error {
+  public readonly status: number;
+  public readonly title: string;
+  public readonly detail?: string;
+
+  constructor(status: number, title: string, detail?: string, options?: ErrorOptions) {
+    super(detail ?? title, options);
+    this.status = status;
+    this.title = title;
+    this.detail = detail;
+    this.name = "HttpError";
+  }
+}
+
+export function sendError(res: Response, status: number, title: string, detail?: string) {
+  const body: ErrorResponseBody = {
+    title,
+    requestId: res.locals.requestId ?? "unknown",
+    simulated: res.locals.simulated ?? true,
+    ...(detail ? { detail } : {}),
+  };
+  return res.status(status).json(body);
+}
+
+export function respondWithError(res: Response, error: HttpError) {
+  return sendError(res, error.status, error.title, error.detail ?? error.message);
+}
+
+export function errorHandler(err: unknown, req: Request, res: Response, _next: NextFunction) {
+  if (res.headersSent) {
+    return;
+  }
+
+  const requestId = res.locals.requestId ?? req.requestId ?? "unknown";
+  const simulated = res.locals.simulated ?? true;
+
+  if (err instanceof HttpError) {
+    const logLine = `[${requestId}] ${err.title}: ${err.detail ?? err.message}`;
+    if (err.status >= 500) {
+      console.error(logLine);
+    } else {
+      console.warn(logLine);
+    }
+    return sendError(res, err.status, err.title, err.detail ?? err.message);
+  }
+
+  const message = err instanceof Error ? err.message : "Unexpected error";
+  console.error(`[${requestId}] Unhandled error`, err);
+  res.locals.simulated = simulated;
+  return sendError(res, 500, "InternalServerError", message);
+}

--- a/src/http/requestId.ts
+++ b/src/http/requestId.ts
@@ -1,0 +1,41 @@
+import type { Request, Response, NextFunction } from "express";
+import { randomUUID } from "node:crypto";
+
+declare global {
+  namespace Express {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface Request {
+      requestId?: string;
+    }
+  }
+}
+
+export function requestId() {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const headerId = req.headers["x-request-id"];
+    const id = typeof headerId === "string" && headerId.trim() ? headerId.trim() : randomUUID();
+    req.requestId = id;
+    res.locals.requestId = id;
+    if (typeof res.locals.simulated === "undefined") {
+      res.locals.simulated = true;
+    }
+    res.setHeader("x-request-id", id);
+
+    const started = process.hrtime.bigint();
+    res.on("finish", () => {
+      const end = process.hrtime.bigint();
+      const durationMs = Number(end - started) / 1_000_000;
+      const status = res.statusCode;
+      const logLine = `[${id}] ${req.method} ${req.originalUrl} -> ${status} (${durationMs.toFixed(1)}ms)`;
+      if (status >= 500) {
+        console.error(logLine);
+      } else if (status >= 400) {
+        console.warn(logLine);
+      } else {
+        console.info(logLine);
+      }
+    });
+
+    next();
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,14 +6,16 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { requestId } from "./http/requestId";
+import { railsContext } from "./rails/mode";
+import { errorHandler, sendError } from "./http/error";
 
 dotenv.config();
 
 const app = express();
+app.use(requestId());
 app.use(express.json({ limit: "2mb" }));
-
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+app.use(railsContext());
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
@@ -31,8 +33,10 @@ app.use("/api", paymentsApi);
 // Existing API router(s) after
 app.use("/api", api);
 
-// 404 fallback (must be last)
-app.use((_req, res) => res.status(404).send("Not found"));
+// 404 fallback (must be last before error handler)
+app.use((_req, res) => sendError(res, 404, "NotFound", "Resource not found"));
+
+app.use(errorHandler);
 
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => console.log("APGMS server listening on", port));

--- a/src/rails/mode.ts
+++ b/src/rails/mode.ts
@@ -1,0 +1,51 @@
+import type { Request, Response, NextFunction } from "express";
+import { latestConsent, requireConsent, ConsentRequiredError, type ConsentAcceptance } from "../consent/service";
+
+export type RailsMode = {
+  simulated: boolean;
+  consent?: ConsentAcceptance | null;
+};
+
+const MODE = (process.env.RAILS_MODE || "simulated").toLowerCase();
+
+async function resolveMode(): Promise<RailsMode> {
+  switch (MODE) {
+    case "force-real":
+    case "live":
+    case "real": {
+      const consent = await requireConsent();
+      return { simulated: false, consent };
+    }
+    case "force-simulated":
+    case "simulated":
+    default:
+      return { simulated: true, consent: await latestConsent() };
+  }
+}
+
+export async function isSimulatedRails(): Promise<boolean> {
+  const { simulated } = await resolveMode();
+  return simulated;
+}
+
+export function railsContext() {
+  return async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const ctx = await resolveMode();
+      res.locals.simulated = ctx.simulated;
+      res.locals.railsConsent = ctx.consent;
+      next();
+    } catch (error) {
+      if (error instanceof ConsentRequiredError) {
+        res.locals.simulated = true;
+      }
+      next(error);
+    }
+  };
+}
+
+export async function ensureRealRailsAllowed() {
+  if (MODE === "real" || MODE === "force-real" || MODE === "live") {
+    await requireConsent();
+  }
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -4,6 +4,9 @@ import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+import { sendError, HttpError } from "../http/error";
+import { ensureRealRailsAllowed } from "../rails/mode";
+
 const pool = new Pool();
 
 export async function closeAndIssue(req:any, res:any) {
@@ -14,22 +17,26 @@ export async function closeAndIssue(req:any, res:any) {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
   } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+    return sendError(res, 400, "CloseIssueFailed", e.message);
   }
 }
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
   const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  if (pr.rowCount === 0) return sendError(res, 400, "NoRpt", "No RPT token available");
   const payload = pr.rows[0].payload;
   try {
+    await ensureRealRailsAllowed();
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
   } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+    const detail = e instanceof HttpError ? e.detail ?? e.message : e.message;
+    const title = e instanceof HttpError ? e.title : "PayAtoFailed";
+    const status = e instanceof HttpError ? e.status : 400;
+    return sendError(res, status, title, detail);
   }
 }
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,7 @@
+declare namespace Express {
+  interface Locals {
+    requestId?: string;
+    simulated?: boolean;
+    railsConsent?: import("../consent/service").ConsentAcceptance | null;
+  }
+}


### PR DESCRIPTION
## Summary
- add request ID middleware to stamp requests, surface the header, and drive structured logging
- standardize API error responses so they always include a title, detail, requestId, and simulated flag
- capture operator consent metadata for live rails and gate real-rails mode on recorded consent, with clear consent copy

## Testing
- npm run typecheck
- npx tsc --noEmit *(fails: pre-existing syntax error in src/recon/stateMachine.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e3af017dc88327bfc56405562ee8bb