### PR TITLE
Add EFT sandbox rail integration and KMS tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "smoke:rail": "tsx scripts/smoke/rail.ts",
+        "ci:verify": "node scripts/ci/checkRatesVersion.js && npm run --silent smoke:rail"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/ci/checkRatesVersion.js
+++ b/scripts/ci/checkRatesVersion.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+import { execSync } from "node:child_process";
+
+function getChangedFiles() {
+  try {
+    const output = execSync("git diff --name-only HEAD", { encoding: "utf8" });
+    return output.split(/\r?\n/).filter(Boolean);
+  } catch (err) {
+    return [];
+  }
+}
+
+function diffContains(pattern) {
+  try {
+    const diff = execSync("git diff --unified=0 HEAD", { encoding: "utf8" });
+    return pattern.test(diff);
+  } catch (err) {
+    return false;
+  }
+}
+
+const changed = getChangedFiles();
+const touchedRules = changed.filter((f) => f.startsWith("apps/rules/"));
+
+if (touchedRules.length === 0) {
+  process.exit(0);
+}
+
+if (!changed.some((f) => f.toLowerCase().includes("changelog"))) {
+  console.error("[ci] CHANGELOG update required when apps/rules changes");
+  process.exit(1);
+}
+
+if (!diffContains(/RATES_VERSION/)) {
+  console.error("[ci] RATES_VERSION must be bumped when apps/rules changes");
+  process.exit(1);
+}
+
+console.log("[ci] rules change validated");

--- a/scripts/crypto/rotate.ts
+++ b/scripts/crypto/rotate.ts
@@ -1,0 +1,39 @@
+#!/usr/bin/env tsx
+import fs from "fs";
+import path from "path";
+import { selectKmsProvider } from "../../src/crypto/kms";
+
+async function main() {
+  const kms = selectKmsProvider();
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const base = path.resolve("artifacts", "kms_rotation", timestamp);
+  fs.mkdirSync(base, { recursive: true });
+
+  const signing = await kms.getSigningMaterial();
+  const publicKeys = await kms.listPublicKeys();
+
+  fs.writeFileSync(
+    path.join(base, "signing.json"),
+    JSON.stringify({ kid: signing.kid, rates_version: signing.ratesVersion }, null, 2)
+  );
+
+  fs.writeFileSync(
+    path.join(base, "public_keys.json"),
+    JSON.stringify(
+      publicKeys.map((pk) => ({
+        kid: pk.kid,
+        rates_version: pk.ratesVersion,
+        public_key_base64: Buffer.from(pk.publicKey).toString("base64"),
+      })),
+      null,
+      2
+    )
+  );
+
+  console.log(`[rotate] artifacts written to ${base}`);
+}
+
+main().catch((err) => {
+  console.error("[rotate] failed", err);
+  process.exitCode = 1;
+});

--- a/scripts/smoke/rail.ts
+++ b/scripts/smoke/rail.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env tsx
+import { submitSandboxPayment } from "../../src/adapters/bank/eftSandbox";
+
+async function main() {
+  if (process.env.DRY_RUN === "true") {
+    throw new Error("smoke:rail must run with DRY_RUN=false");
+  }
+  const periodId = process.env.SMOKE_PERIOD_ID || "TEST_PERIOD";
+  const reference = process.env.SMOKE_PROVIDER_REF || "TEST_REF";
+  const bsb = process.env.SMOKE_BSB || "000000";
+  const account = process.env.SMOKE_ACCOUNT || "00000000";
+  const amount = Number(process.env.SMOKE_AMOUNT_CENTS || "100");
+
+  const result = await submitSandboxPayment({
+    periodId,
+    reference,
+    bsb,
+    account,
+    amountCents: amount,
+  });
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((err) => {
+  console.error("[smoke:rail] failed", err);
+  process.exitCode = 1;
+});

--- a/src/adapters/bank/eftSandbox.ts
+++ b/src/adapters/bank/eftSandbox.ts
@@ -1,0 +1,134 @@
+import https from "https";
+import fs from "fs";
+import { URL } from "url";
+import { createHash } from "crypto";
+import { Pool } from "pg";
+
+export interface SandboxPaymentRequest {
+  periodId: string;
+  amountCents: number;
+  reference: string;
+  bsb: string;
+  account: string;
+  narration?: string;
+}
+
+export interface SandboxPaymentResponse {
+  settlementId: number;
+  providerRef: string;
+  paidAt: string;
+  bankReceiptHash: string;
+}
+
+const pool = new Pool();
+
+function loadFile(path?: string) {
+  if (!path) return undefined;
+  return fs.readFileSync(path);
+}
+
+const agent = new https.Agent({
+  cert: loadFile(process.env.MTLS_CERT),
+  key: loadFile(process.env.MTLS_KEY),
+  ca: loadFile(process.env.MTLS_CA),
+  rejectUnauthorized: true,
+});
+
+function ensureBsb(value: string) {
+  if (!/^\d{6}$/.test(value)) {
+    throw new Error("INVALID_BSB");
+  }
+}
+
+function ensureAccount(value: string) {
+  if (!/^\d{6,10}$/.test(value)) {
+    throw new Error("INVALID_ACCOUNT");
+  }
+}
+
+async function postJson(url: string, payload: unknown) {
+  const target = new URL(url);
+  const body = JSON.stringify(payload);
+
+  const options: https.RequestOptions = {
+    method: "POST",
+    protocol: target.protocol,
+    hostname: target.hostname,
+    port: target.port,
+    path: target.pathname + target.search,
+    headers: {
+      "content-type": "application/json",
+      "content-length": Buffer.byteLength(body).toString(),
+    },
+    agent,
+  };
+
+  return new Promise<any>((resolve, reject) => {
+    const req = https.request(options, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (c) => chunks.push(Buffer.from(c)));
+      res.on("end", () => {
+        const text = Buffer.concat(chunks).toString("utf8");
+        if ((res.statusCode || 500) >= 400) {
+          return reject(new Error(`EFT_SANDBOX_${res.statusCode}: ${text}`));
+        }
+        try {
+          resolve(text ? JSON.parse(text) : {});
+        } catch (err) {
+          reject(new Error("EFT_SANDBOX_BAD_JSON"));
+        }
+      });
+    });
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+export async function submitSandboxPayment(request: SandboxPaymentRequest): Promise<SandboxPaymentResponse> {
+  ensureBsb(request.bsb);
+  ensureAccount(request.account);
+
+  const baseUrl = process.env.EFT_SANDBOX_URL;
+  if (!baseUrl) {
+    throw new Error("EFT_SANDBOX_URL_NOT_SET");
+  }
+
+  const response = await postJson(baseUrl, {
+    amount_cents: request.amountCents,
+    destination: { bsb: request.bsb, account: request.account },
+    reference: request.reference,
+    narration: request.narration ?? "ATO EFT release",
+  });
+
+  const providerRef: string =
+    response?.provider_ref || response?.receipt_id || response?.receipt?.id || "";
+  if (!providerRef) {
+    throw new Error("EFT_SANDBOX_NO_RECEIPT");
+  }
+
+  const paidAt = new Date(response?.paid_at || response?.receipt?.paid_at || Date.now()).toISOString();
+  const bankReceiptHash = createHash("sha256").update(providerRef).digest("hex");
+
+  const upsert = `
+    INSERT INTO settlements (period_id, rail, provider_ref, amount_cents, paid_at)
+    VALUES ($1, $2, $3, $4, $5)
+    ON CONFLICT (provider_ref)
+    DO UPDATE SET amount_cents = EXCLUDED.amount_cents, paid_at = EXCLUDED.paid_at
+    RETURNING id
+  `;
+  const { rows } = await pool.query<{ id: number }>(upsert, [
+    request.periodId,
+    "EFT",
+    providerRef,
+    request.amountCents,
+    paidAt,
+  ]);
+
+  return {
+    settlementId: rows[0]?.id ?? 0,
+    providerRef,
+    paidAt,
+    bankReceiptHash,
+  };
+}

--- a/src/crypto/awskms.ts
+++ b/src/crypto/awskms.ts
@@ -1,0 +1,42 @@
+import fs from "fs";
+import path from "path";
+import { KmsProvider, KmsSigningMaterial, KmsPublicKey } from "./kms";
+
+interface KeysetEntry {
+  kid: string;
+  publicKeyBase64: string;
+  ratesVersion: string;
+}
+
+export class AwsKmsProvider implements KmsProvider {
+  private signing?: KmsSigningMaterial;
+  private keyset?: KmsPublicKey[];
+
+  async getSigningMaterial(): Promise<KmsSigningMaterial> {
+    if (this.signing) return this.signing;
+    const secretFile = process.env.AWS_KMS_SECRET_BASE64_FILE;
+    if (!secretFile) throw new Error("AWS_KMS_SECRET_BASE64_FILE not configured");
+    const kid = process.env.AWS_KMS_KID || "aws-kms";
+    const ratesVersion = process.env.RATES_VERSION || "v0";
+    const raw = fs.readFileSync(path.resolve(secretFile), "utf8").trim();
+    this.signing = {
+      kid,
+      ratesVersion,
+      secretKey: new Uint8Array(Buffer.from(raw, "base64")),
+    };
+    return this.signing;
+  }
+
+  async listPublicKeys(): Promise<KmsPublicKey[]> {
+    if (this.keyset) return this.keyset;
+    const file = process.env.AWS_KMS_KEYSET_FILE;
+    if (!file) throw new Error("AWS_KMS_KEYSET_FILE not configured");
+    const parsed: KeysetEntry[] = JSON.parse(fs.readFileSync(path.resolve(file), "utf8"));
+    this.keyset = parsed.map((entry) => ({
+      kid: entry.kid,
+      ratesVersion: entry.ratesVersion,
+      publicKey: new Uint8Array(Buffer.from(entry.publicKeyBase64, "base64")),
+    }));
+    return this.keyset;
+  }
+}

--- a/src/crypto/ed25519.ts
+++ b/src/crypto/ed25519.ts
@@ -5,6 +5,7 @@ export interface RptPayload {
   amount_cents: number; merkle_root: string; running_balance_hash: string;
   anomaly_vector: Record<string, number>; thresholds: Record<string, number>;
   rail_id: "EFT"|"BPAY"|"PayTo"; reference: string; expiry_ts: string; nonce: string;
+  kid: string; rates_version: string;
 }
 
 export function signRpt(payload: RptPayload, secretKey: Uint8Array): string {

--- a/src/crypto/gcpkms.ts
+++ b/src/crypto/gcpkms.ts
@@ -1,0 +1,3 @@
+import { LocalEd25519Provider } from "./localEd25519";
+
+export class GcpKmsProvider extends LocalEd25519Provider {}

--- a/src/crypto/kms.ts
+++ b/src/crypto/kms.ts
@@ -1,0 +1,31 @@
+import { AwsKmsProvider } from "./awskms";
+import { GcpKmsProvider } from "./gcpkms";
+import { LocalEd25519Provider } from "./localEd25519";
+
+export interface KmsSigningMaterial {
+  kid: string;
+  ratesVersion: string;
+  secretKey: Uint8Array;
+}
+
+export interface KmsPublicKey {
+  kid: string;
+  ratesVersion: string;
+  publicKey: Uint8Array;
+}
+
+export interface KmsProvider {
+  getSigningMaterial(): Promise<KmsSigningMaterial>;
+  listPublicKeys(): Promise<KmsPublicKey[]>;
+}
+
+export function selectKmsProvider(): KmsProvider {
+  const feature = (process.env.FEATURE_KMS || "local").toLowerCase();
+  if (feature === "aws" || feature === "awskms") {
+    return new AwsKmsProvider();
+  }
+  if (feature === "gcp" || feature === "gcpkms") {
+    return new GcpKmsProvider();
+  }
+  return new LocalEd25519Provider();
+}

--- a/src/crypto/localEd25519.ts
+++ b/src/crypto/localEd25519.ts
@@ -1,0 +1,45 @@
+import { KmsProvider, KmsSigningMaterial, KmsPublicKey } from "./kms";
+
+function decodeBase64(value: string, label: string): Uint8Array {
+  try {
+    return new Uint8Array(Buffer.from(value, "base64"));
+  } catch {
+    throw new Error(`${label}_INVALID_BASE64`);
+  }
+}
+
+export class LocalEd25519Provider implements KmsProvider {
+  private readonly kid: string;
+  private readonly ratesVersion: string;
+  private readonly secretKey: Uint8Array;
+  private readonly publicKey: Uint8Array;
+
+  constructor() {
+    const secret = process.env.RPT_ED25519_SECRET_BASE64 || "";
+    const pub = process.env.RPT_ED25519_PUBLIC_BASE64 || "";
+    if (!secret) throw new Error("RPT_ED25519_SECRET_BASE64 not configured");
+    if (!pub) throw new Error("RPT_ED25519_PUBLIC_BASE64 not configured");
+    this.secretKey = decodeBase64(secret, "RPT_ED25519_SECRET_BASE64");
+    this.publicKey = decodeBase64(pub, "RPT_ED25519_PUBLIC_BASE64");
+    this.kid = process.env.RPT_KID || "local-ed25519";
+    this.ratesVersion = process.env.RATES_VERSION || "v0";
+  }
+
+  async getSigningMaterial(): Promise<KmsSigningMaterial> {
+    return {
+      kid: this.kid,
+      ratesVersion: this.ratesVersion,
+      secretKey: this.secretKey,
+    };
+  }
+
+  async listPublicKeys(): Promise<KmsPublicKey[]> {
+    return [
+      {
+        kid: this.kid,
+        ratesVersion: this.ratesVersion,
+        publicKey: this.publicKey,
+      },
+    ];
+  }
+}

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -6,6 +6,15 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
   const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
   const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
   const last = deltas[deltas.length-1];
+  const settlement = (await pool.query("select rail, provider_ref, paid_at from settlements where period_id= order by paid_at desc limit 1", [periodId])).rows[0] || null;
+  const approvals = (await pool.query("select gate, actor, state, created_at from approvals where period_id= order by created_at", [periodId])).rows;
+  const gates = (await pool.query("select gate, state, reason from gate_transitions where period_id= order by updated_at", [periodId])).rows;
+  const narrative = gates.length
+    ? gates.map((g:any) => {
+        const reason = g.reason ? `(${g.reason})` : "";
+        return `${g.gate}:${g.state}${reason}`;
+      }).join(" -> ")
+    : `No gate transitions recorded for period ${periodId}`;
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
     rpt_payload: rpt?.payload ?? null,
@@ -13,7 +22,14 @@ export async function buildEvidenceBundle(abn: string, taxType: string, periodId
     owa_ledger_deltas: deltas,
     bank_receipt_hash: last?.bank_receipt_hash ?? null,
     anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
+    discrepancy_log: [],  // TODO: populate from recon diffs
+    settlement,
+    rules: {
+      manifest_sha256: process.env.RULES_MANIFEST_SHA256 || null,
+      rates_version: rpt?.rates_version ?? null,
+    },
+    approvals,
+    narrative,
   };
   return bundle;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import express from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
-import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { closeAndIssue, payAto, paytoSweep, settlementWebhook, importSettlement, evidence } from "./routes/reconcile";
+import { ingestStp, ingestPos, gateTransition } from "./routes/reconGate";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -23,7 +24,11 @@ app.post("/api/pay", idempotency(), payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
+app.post("/api/settlement/import", importSettlement);
 app.get("/api/evidence", evidence);
+app.post("/ingest/stp", express.json({ type: "application/json" }), ingestStp);
+app.post("/ingest/pos", express.json({ type: "application/json" }), ingestPos);
+app.get("/gate/transition", gateTransition);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);

--- a/src/routes/reconGate.ts
+++ b/src/routes/reconGate.ts
@@ -1,0 +1,105 @@
+import crypto from "crypto";
+import { Pool } from "pg";
+import { Request, Response } from "express";
+
+const pool = new Pool();
+const HMAC_HEADER = "x-signature";
+
+function safeCompare(a: string, b: string) {
+  return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+}
+
+function validateHmac(req: Request, rawBody: string) {
+  const secret = process.env.RECON_HMAC_SECRET || "";
+  if (!secret) throw new Error("RECON_HMAC_SECRET not configured");
+  const sent = (req.headers[HMAC_HEADER] as string | undefined)?.toString() || "";
+  const expected = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  if (!sent || sent.length !== expected.length) {
+    throw new Error("HMAC_INVALID");
+  }
+  try {
+    if (!safeCompare(sent, expected)) {
+      throw new Error("HMAC_INVALID");
+    }
+  } catch {
+    throw new Error("HMAC_INVALID");
+  }
+}
+
+async function upsertReconInput(source: "STP" | "POS", periodId: string, providerRef: string, payload: any) {
+  const stmt = `
+    INSERT INTO recon_inputs (source, period_id, provider_ref, payload)
+    VALUES ($1, $2, $3, $4)
+    ON CONFLICT (source, provider_ref)
+    DO UPDATE SET payload = EXCLUDED.payload, period_id = EXCLUDED.period_id, updated_at = now()
+  `;
+  await pool.query(stmt, [source, periodId, providerRef, JSON.stringify(payload)]);
+}
+
+async function recomputeGate(periodId: string) {
+  const { rows } = await pool.query(
+    "select source, payload from recon_inputs where period_id=$1",
+    [periodId]
+  );
+  const sources = new Set(rows.map((r: any) => r.source));
+  if (sources.has("STP") && sources.has("POS")) {
+    await pool.query(
+      "insert into gate_transitions(period_id, gate, state, reason, updated_at) values ($1,$2,$3,$4, now())",
+      [periodId, "RECON", "RECON_OK", "STP and POS matched"]
+    );
+    return { state: "RECON_OK", reason: "STP and POS matched" };
+  }
+  const reason = sources.size === 0 ? "NO_RECON_INPUT" : "MISSING_COUNTERPART";
+  await pool.query(
+    "insert into gate_transitions(period_id, gate, state, reason, updated_at) values ($1,$2,$3,$4, now())",
+    [periodId, "RECON", "RECON_FAIL", reason]
+  );
+  return { state: "RECON_FAIL", reason };
+}
+
+export async function ingestStp(req: Request, res: Response) {
+  const raw = JSON.stringify(req.body || {});
+  try {
+    validateHmac(req, raw);
+  } catch (err: any) {
+    return res.status(401).json({ error: err.message });
+  }
+  const { period_id, provider_ref } = req.body || {};
+  if (!period_id || !provider_ref) {
+    return res.status(400).json({ error: "period_id/provider_ref required" });
+  }
+  await upsertReconInput("STP", period_id, provider_ref, req.body);
+  const result = await recomputeGate(period_id);
+  res.json({ ok: true, gate: result });
+}
+
+export async function ingestPos(req: Request, res: Response) {
+  const raw = JSON.stringify(req.body || {});
+  try {
+    validateHmac(req, raw);
+  } catch (err: any) {
+    return res.status(401).json({ error: err.message });
+  }
+  const { period_id, provider_ref } = req.body || {};
+  if (!period_id || !provider_ref) {
+    return res.status(400).json({ error: "period_id/provider_ref required" });
+  }
+  await upsertReconInput("POS", period_id, provider_ref, req.body);
+  const result = await recomputeGate(period_id);
+  res.json({ ok: true, gate: result });
+}
+
+export async function gateTransition(req: Request, res: Response) {
+  const { periodId } = req.query as any;
+  if (!periodId) {
+    return res.status(400).json({ error: "periodId required" });
+  }
+  const { rows } = await pool.query(
+    "select gate, state, reason, updated_at from gate_transitions where period_id=$1 order by updated_at desc limit 1",
+    [periodId]
+  );
+  if (!rows.length) {
+    return res.status(404).json({ error: "NO_TRANSITIONS" });
+  }
+  res.json(rows[0]);
+}

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,9 +1,10 @@
 ﻿import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
+import { selectKmsProvider } from "../crypto/kms";
 import { exceeds } from "../anomaly/deterministic";
 const pool = new Pool();
-const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
+const kms = selectKmsProvider();
 
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
   const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
@@ -22,16 +23,20 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
+  const signing = await kms.getSigningMaterial();
+
   const payload: RptPayload = {
     entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
     merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
     anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID(),
+    kid: signing.kid,
+    rates_version: signing.ratesVersion,
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
+  const signature = signRpt(payload, signing.secretKey);
+  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature,kid,rates_version) values (,,,,,,)",
+    [abn, taxType, periodId, payload, signature, signing.kid, signing.ratesVersion]);
   await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
-  return { payload, signature };
+  return { payload, signature, kid: signing.kid, rates_version: signing.ratesVersion };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "scripts/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add an EFT sandbox adapter that validates bank details, persists settlement receipts, and exposes an import path for matching provider references
- introduce recon ingestion endpoints, evidence bundle enrichment, and KMS-based signing with rotation artifacts and smoke/CI scripts
- wire new routes and scripts into the app along with configurable smoke and CI checks

## Testing
- npm run lint
- npm run smoke:rail *(fails: EFT_SANDBOX_URL_NOT_SET)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ad3eadf48327818792bd2d9b6ac7