### PR TITLE
Add seed/smoke demo flow and evidence evidence zip bundle

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,44 @@
+name: Smoke
+
+on:
+  push:
+    branches: ["main", "master", "develop", "dev", "release/*"]
+  pull_request:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_DB: apgms
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d apgms" --health-interval 10s --health-timeout 5s --health-retries 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Seed database
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/apgms
+        run: npm run seed
+
+      - name: Smoke test
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/apgms
+        run: npm run smoke

--- a/apps/services/payments/src/routes/deposit.ts
+++ b/apps/services/payments/src/routes/deposit.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from "express";
 import { pool } from "../index.js";
 import { randomUUID } from "node:crypto";
+import { sha256Hex } from "../utils/crypto";
 
 export async function deposit(req: Request, res: Response) {
   try {
@@ -14,20 +15,22 @@ export async function deposit(req: Request, res: Response) {
       await client.query("BEGIN");
 
       const { rows: last } = await client.query(
-        `SELECT balance_after_cents FROM owa_ledger
+        `SELECT balance_after_cents, hash_after FROM owa_ledger
          WHERE abn=$1 AND tax_type=$2 AND period_id=$3
          ORDER BY id DESC LIMIT 1`,
         [abn, taxType, periodId]
       );
       const prevBal = last[0]?.balance_after_cents ?? 0;
+      const prevHash = last[0]?.hash_after ?? "";
       const newBal = prevBal + amt;
+      const hashAfter = sha256Hex(`${prevHash}|${amt}|${newBal}`);
 
       const { rows: ins } = await client.query(
         `INSERT INTO owa_ledger
-           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,created_at)
-         VALUES ($1,$2,$3,$4,$5,$6,now())
-         RETURNING id,transfer_uuid,balance_after_cents`,
-        [abn, taxType, periodId, randomUUID(), amt, newBal]
+           (abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,prev_hash,hash_after,created_at)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,now())
+         RETURNING id,transfer_uuid,balance_after_cents,hash_after`,
+        [abn, taxType, periodId, randomUUID(), amt, newBal, prevHash, hashAfter]
       );
 
       await client.query("COMMIT");

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -34,6 +34,23 @@ export async function payAtoRelease(req: Request, res: Response) {
     return res.status(403).json({ error: 'RPT not verified' });
   }
 
+  const dryFlag = (req.query?.dry_run ?? req.query?.dryRun ?? '').toString().toLowerCase();
+  const dryRun = dryFlag === '1' || dryFlag === 'true';
+
+  if (dryRun) {
+    return res.json({
+      ok: true,
+      dry_run: true,
+      release_preview: {
+        abn,
+        taxType,
+        periodId,
+        amountCents: amt,
+      },
+      rpt_ref: { rpt_id: rpt.rpt_id, payload_sha256: rpt.payload_sha256 },
+    });
+  }
+
   const client = await pool.connect();
   try {
     await client.query('BEGIN');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "seed": "ts-node --transpile-only scripts/seed.ts",
+        "smoke": "ts-node --transpile-only scripts/smoke.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,178 @@
+import { Client } from "pg";
+import crypto from "crypto";
+
+function buildConnectionString(): string {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const user = process.env.PGUSER ?? "postgres";
+  const password = encodeURIComponent(process.env.PGPASSWORD ?? "postgres");
+  const host = process.env.PGHOST ?? "127.0.0.1";
+  const port = process.env.PGPORT ?? "5432";
+  const db = process.env.PGDATABASE ?? "apgms";
+  return `postgresql://${user}:${password}@${host}:${port}/${db}`;
+}
+
+async function ensureSchema(client: Client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS periods (
+      id SERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      state TEXT NOT NULL DEFAULT 'OPEN',
+      basis TEXT DEFAULT 'ACCRUAL',
+      accrued_cents BIGINT DEFAULT 0,
+      credited_to_owa_cents BIGINT DEFAULT 0,
+      final_liability_cents BIGINT DEFAULT 0,
+      merkle_root TEXT,
+      running_balance_hash TEXT,
+      anomaly_vector JSONB DEFAULT '{}'::jsonb,
+      thresholds JSONB DEFAULT '{}'::jsonb,
+      UNIQUE (abn, tax_type, period_id)
+    );
+  `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS owa_ledger (
+      id BIGSERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      transfer_uuid UUID,
+      amount_cents BIGINT NOT NULL,
+      balance_after_cents BIGINT NOT NULL,
+      bank_receipt_hash TEXT,
+      prev_hash TEXT,
+      hash_after TEXT,
+      rpt_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      release_uuid UUID,
+      bank_receipt_id TEXT,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS rpt_tokens (
+      id BIGSERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      tax_type TEXT NOT NULL,
+      period_id TEXT NOT NULL,
+      payload JSONB NOT NULL,
+      signature TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'ISSUED',
+      payload_c14n TEXT,
+      payload_sha256 TEXT,
+      nonce TEXT,
+      expires_at TIMESTAMPTZ,
+      created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+
+  await client.query(`
+    ALTER TABLE rpt_tokens
+      ADD COLUMN IF NOT EXISTS payload_c14n TEXT,
+      ADD COLUMN IF NOT EXISTS payload_sha256 TEXT,
+      ADD COLUMN IF NOT EXISTS nonce TEXT,
+      ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ,
+      ADD COLUMN IF NOT EXISTS status TEXT DEFAULT 'ISSUED';
+  `);
+
+  await client.query(`
+    ALTER TABLE owa_ledger
+      ADD COLUMN IF NOT EXISTS rpt_verified BOOLEAN NOT NULL DEFAULT FALSE,
+      ADD COLUMN IF NOT EXISTS release_uuid UUID,
+      ADD COLUMN IF NOT EXISTS bank_receipt_id TEXT,
+      ADD COLUMN IF NOT EXISTS transfer_uuid UUID,
+      ADD COLUMN IF NOT EXISTS bank_receipt_hash TEXT,
+      ADD COLUMN IF NOT EXISTS prev_hash TEXT,
+      ADD COLUMN IF NOT EXISTS hash_after TEXT;
+  `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS remittance_destinations (
+      id SERIAL PRIMARY KEY,
+      abn TEXT NOT NULL,
+      label TEXT NOT NULL,
+      rail TEXT NOT NULL,
+      reference TEXT NOT NULL,
+      account_bsb TEXT,
+      account_number TEXT,
+      UNIQUE (abn, rail, reference)
+    );
+  `);
+
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS idempotency_keys (
+      key TEXT PRIMARY KEY,
+      created_at TIMESTAMPTZ DEFAULT NOW(),
+      last_status TEXT,
+      response_hash TEXT
+    );
+  `);
+}
+
+function hashLabel(value: string): string {
+  return crypto.createHash("sha256").update(value).digest("hex").slice(0, 32);
+}
+
+async function main() {
+  const connectionString = buildConnectionString();
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  const abn = process.env.DEMO_ABN ?? "53004085616";
+  const taxType = process.env.DEMO_TAX_TYPE ?? "GST";
+  const periodId = process.env.DEMO_PERIOD_ID ?? "2025-09";
+  const depositCents = Number(process.env.DEMO_DEPOSIT_CENTS ?? 125_00);
+  const prn = process.env.ATO_PRN ?? "ATO-DEMO-PRN";
+
+  await ensureSchema(client);
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      "DELETE FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
+    await client.query(
+      "DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
+    await client.query(
+      "DELETE FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
+
+    const merkle = `seed-${hashLabel(`${abn}:${periodId}:merkle`)}`;
+    const runningHash = crypto.createHash("sha256").update(`|${depositCents}|${depositCents}`).digest("hex");
+
+    await client.query(
+      `INSERT INTO periods (
+         abn, tax_type, period_id, state,
+         accrued_cents, credited_to_owa_cents, final_liability_cents,
+         merkle_root, running_balance_hash, anomaly_vector, thresholds
+       ) VALUES ($1,$2,$3,'CLOSING',$4,$4,$4,$5,$6,'{}'::jsonb,'{}'::jsonb)`,
+      [abn, taxType, periodId, depositCents, merkle, runningHash]
+    );
+
+    await client.query(
+      `INSERT INTO remittance_destinations (abn,label,rail,reference,account_bsb,account_number)
+       VALUES ($1,'Demo EFT','EFT',$2,'000000','00000000')
+       ON CONFLICT (abn, rail, reference)
+       DO UPDATE SET label=EXCLUDED.label, account_bsb=EXCLUDED.account_bsb, account_number=EXCLUDED.account_number`,
+      [abn, prn]
+    );
+
+    await client.query("COMMIT");
+    console.log("Seed complete", { abn, taxType, periodId, depositCents });
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("Seed failed", err);
+  process.exitCode = 1;
+});

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert";
+import { spawn } from "node:child_process";
+import path from "node:path";
+import process from "node:process";
+import { setTimeout as wait } from "node:timers/promises";
+
+const DEFAULT_DB = "postgresql://postgres:postgres@127.0.0.1:5432/apgms";
+const DATABASE_URL = process.env.DATABASE_URL ?? DEFAULT_DB;
+const PORT = Number(process.env.SMOKE_PORT ?? 4010);
+const BASE_URL = `http://127.0.0.1:${PORT}`;
+
+const SECRET_BASE64 = process.env.RPT_ED25519_SECRET_BASE64 ??
+  "AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQGKiOPddAnxlf1S2y08ul1yymcJvx2UEhvzdIgBtA9vXA==";
+const PUBLIC_BASE64 = process.env.ED25519_PUBLIC_KEY_BASE64 ??
+  "iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w=";
+const PRN = process.env.ATO_PRN ?? "ATO-DEMO-PRN";
+
+const DEMO_ABN = process.env.DEMO_ABN ?? "53004085616";
+const DEMO_TAX_TYPE = process.env.DEMO_TAX_TYPE ?? "GST";
+const DEMO_PERIOD_ID = process.env.DEMO_PERIOD_ID ?? "2025-09";
+const DEPOSIT_CENTS = Number(process.env.DEMO_DEPOSIT_CENTS ?? 125_00);
+
+const tsxBin = path.join(
+  process.cwd(),
+  "node_modules",
+  ".bin",
+  process.platform === "win32" ? "tsx.cmd" : "tsx"
+);
+
+function spawnServer() {
+  const env = {
+    ...process.env,
+    PORT: String(PORT),
+    DATABASE_URL,
+    RPT_ED25519_SECRET_BASE64: SECRET_BASE64,
+    ED25519_PUBLIC_KEY_BASE64: PUBLIC_BASE64,
+    ATO_PRN: PRN,
+  };
+
+  const child = spawn(tsxBin, ["src/index.ts"], {
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  child.stdout.on("data", (chunk) => {
+    process.stdout.write(chunk);
+  });
+  child.stderr.on("data", (chunk) => {
+    process.stderr.write(chunk);
+  });
+
+  return child;
+}
+
+async function waitForHealth(signal: AbortSignal) {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (signal.aborted) throw new Error("Aborted while waiting for health");
+    try {
+      const res = await fetch(`${BASE_URL}/health`);
+      if (res.ok) return;
+    } catch {
+      // ignore until ready
+    }
+    await wait(200);
+  }
+  throw new Error("Server did not become healthy in time");
+}
+
+async function postJson(pathname: string, body: unknown) {
+  const res = await fetch(`${BASE_URL}${pathname}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST ${pathname} failed: ${res.status} ${text}`);
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+async function getBuffer(pathname: string) {
+  const res = await fetch(`${BASE_URL}${pathname}`);
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`GET ${pathname} failed: ${res.status} ${text}`);
+  }
+  const arr = await res.arrayBuffer();
+  return Buffer.from(arr);
+}
+
+function extractStoredFile(buffer: Buffer, expectedName: string): Buffer {
+  if (buffer.readUInt32LE(0) !== 0x04034b50) {
+    throw new Error("ZIP local header signature missing");
+  }
+  const compSize = buffer.readUInt32LE(18);
+  const nameLen = buffer.readUInt16LE(26);
+  const extraLen = buffer.readUInt16LE(28);
+  const nameStart = 30;
+  const dataStart = nameStart + nameLen + extraLen;
+  const name = buffer.slice(nameStart, nameStart + nameLen).toString("utf8");
+  if (name !== expectedName) {
+    throw new Error(`Unexpected zip entry: ${name}`);
+  }
+  return buffer.slice(dataStart, dataStart + compSize);
+}
+
+async function main() {
+  const controller = new AbortController();
+  const server = spawnServer();
+
+  const onExit = (code: number | null) => {
+    if (code !== null && code !== 0) {
+      controller.abort();
+      throw new Error(`Server exited early with code ${code}`);
+    }
+  };
+  server.on("exit", onExit);
+
+  try {
+    await waitForHealth(controller.signal);
+
+    console.log("→ POST /payments/deposit");
+    const depositResp = await postJson("/payments/deposit", {
+      abn: DEMO_ABN,
+      taxType: DEMO_TAX_TYPE,
+      periodId: DEMO_PERIOD_ID,
+      amountCents: DEPOSIT_CENTS,
+    });
+    assert.ok(depositResp.ok ?? depositResp.balance_after_cents !== undefined, "deposit response missing ok/balance");
+
+    console.log("→ POST /reconcile/close-and-issue");
+    const rptResp = await postJson("/reconcile/close-and-issue", {
+      abn: DEMO_ABN,
+      taxType: DEMO_TAX_TYPE,
+      periodId: DEMO_PERIOD_ID,
+    });
+    assert.ok(rptResp.signature, "close-and-issue did not return signature");
+
+    console.log("→ POST /payments/release?rail=EFT&dry_run=1");
+    const releaseResp = await postJson(`/payments/release?rail=EFT&dry_run=1`, {
+      abn: DEMO_ABN,
+      taxType: DEMO_TAX_TYPE,
+      periodId: DEMO_PERIOD_ID,
+      amountCents: -DEPOSIT_CENTS,
+    });
+    assert.ok(releaseResp.dry_run ?? releaseResp.ok, "release response missing ok/dry_run flag");
+
+    console.log("→ GET /evidence/:periodId/zip");
+    const zipBuffer = await getBuffer(`/evidence/${encodeURIComponent(DEMO_PERIOD_ID)}/zip?abn=${encodeURIComponent(DEMO_ABN)}&taxType=${encodeURIComponent(DEMO_TAX_TYPE)}`);
+    assert.ok(zipBuffer.length > 0, "zip download empty");
+
+    const evidenceBuf = extractStoredFile(zipBuffer, "evidence.json");
+    const evidenceJson = JSON.parse(evidenceBuf.toString("utf8"));
+    assert.ok(evidenceJson.rpt, "evidence bundle missing rpt");
+    assert.ok(evidenceJson.ledger_hash ?? evidenceJson.ledger?.running_hash, "evidence bundle missing ledger hash");
+    assert.strictEqual(evidenceJson.narrative, "Demo run", "narrative mismatch");
+
+    console.log("Smoke test complete ✅");
+  } finally {
+    controller.abort();
+    server.off("exit", onExit);
+    server.kill("SIGINT");
+    await wait(250);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -1,19 +1,82 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
+
 const pool = new Pool();
 
+type PeriodRow = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  final_liability_cents: number | string | null;
+  merkle_root: string | null;
+  running_balance_hash: string | null;
+};
+
+type RptRow = {
+  payload: any;
+  signature: string;
+  payload_c14n?: string | null;
+  payload_sha256?: string | null;
+  created_at?: Date;
+};
+
+type LedgerTail = {
+  hash_after: string | null;
+};
+
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
-  const last = deltas[deltas.length-1];
-  const bundle = {
-    bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate
-    rpt_payload: rpt?.payload ?? null,
-    rpt_signature: rpt?.signature ?? null,
-    owa_ledger_deltas: deltas,
-    bank_receipt_hash: last?.bank_receipt_hash ?? null,
-    anomaly_thresholds: p?.thresholds ?? {},
-    discrepancy_log: []  // TODO: populate from recon diffs
-  };
-  return bundle;
+  const client = await pool.connect();
+  try {
+    const periodQ = await client.query<PeriodRow>(
+      `SELECT abn, tax_type, period_id, state, final_liability_cents, merkle_root, running_balance_hash
+         FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    const periodRow = periodQ.rows[0];
+    if (!periodRow) {
+      throw new Error("PERIOD_NOT_FOUND");
+    }
+
+    const rptQ = await client.query<RptRow>(
+      `SELECT payload, signature, payload_c14n, payload_sha256, created_at
+         FROM rpt_tokens
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY created_at DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const rpt = rptQ.rows[0] ?? null;
+
+    const ledgerQ = await client.query<LedgerTail>(
+      `SELECT hash_after FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC
+        LIMIT 1`,
+      [abn, taxType, periodId]
+    );
+    const ledgerHash = ledgerQ.rows[0]?.hash_after ?? periodRow.running_balance_hash ?? null;
+
+    return {
+      period: {
+        abn: periodRow.abn,
+        tax_type: periodRow.tax_type,
+        period_id: periodRow.period_id,
+        state: periodRow.state,
+        final_liability_cents: Number(periodRow.final_liability_cents ?? 0),
+        merkle_root: periodRow.merkle_root,
+        running_balance_hash: periodRow.running_balance_hash,
+      },
+      rpt,
+      ledger: {
+        merkle_root: periodRow.merkle_root,
+        running_hash: ledgerHash,
+      },
+      ledger_hash: ledgerHash,
+      approvals: [] as Array<unknown>,
+      narrative: "Demo run",
+      rules_version: "prototype",
+    };
+  } finally {
+    client.release();
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { evidenceZip } from "./routes/evidenceZip";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -25,8 +26,13 @@ app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
 
+// Demo reconciliation + evidence routes
+app.post("/reconcile/close-and-issue", closeAndIssue);
+app.get("/evidence/:periodId/zip", evidenceZip);
+
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+app.use("/payments", paymentsApi);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "SELECT * FROM remittance_destinations WHERE abn=$1 AND rail=$2 AND reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,26 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("INSERT INTO idempotency_keys(key,last_status) VALUES($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    "SELECT balance_after_cents, hash_after FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
+    "INSERT INTO owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
     [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
+  await pool.query("UPDATE idempotency_keys SET last_status=$1 WHERE key=$2", ["DONE", transfer_uuid]);
   return { transfer_uuid, bank_receipt_hash };
 }

--- a/src/routes/evidenceZip.ts
+++ b/src/routes/evidenceZip.ts
@@ -1,0 +1,101 @@
+import type { Request, Response } from "express";
+import { buildEvidenceBundle } from "../evidence/bundle";
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let c = i;
+    for (let j = 0; j < 8; j++) {
+      c = (c & 1) ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[i] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i++) {
+    crc = CRC_TABLE[(crc ^ buffer[i]) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createZip(entries: Array<{ name: string; data: Buffer }>): Buffer {
+  const locals: Buffer[] = [];
+  const centrals: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = Buffer.from(entry.name, "utf8");
+    const crc = crc32(entry.data);
+    const localHeader = Buffer.alloc(30);
+    localHeader.writeUInt32LE(0x04034b50, 0);
+    localHeader.writeUInt16LE(20, 4);
+    localHeader.writeUInt16LE(0, 6);
+    localHeader.writeUInt16LE(0, 8);
+    localHeader.writeUInt16LE(0, 10);
+    localHeader.writeUInt16LE(0, 12);
+    localHeader.writeUInt32LE(crc, 14);
+    localHeader.writeUInt32LE(entry.data.length, 18);
+    localHeader.writeUInt32LE(entry.data.length, 22);
+    localHeader.writeUInt16LE(nameBytes.length, 26);
+    localHeader.writeUInt16LE(0, 28);
+    locals.push(Buffer.concat([localHeader, nameBytes, entry.data]));
+
+    const centralHeader = Buffer.alloc(46);
+    centralHeader.writeUInt32LE(0x02014b50, 0);
+    centralHeader.writeUInt16LE(20, 4);
+    centralHeader.writeUInt16LE(20, 6);
+    centralHeader.writeUInt16LE(0, 8);
+    centralHeader.writeUInt16LE(0, 10);
+    centralHeader.writeUInt16LE(0, 12);
+    centralHeader.writeUInt32LE(crc, 16);
+    centralHeader.writeUInt32LE(entry.data.length, 20);
+    centralHeader.writeUInt32LE(entry.data.length, 24);
+    centralHeader.writeUInt16LE(nameBytes.length, 28);
+    centralHeader.writeUInt16LE(0, 30);
+    centralHeader.writeUInt16LE(0, 32);
+    centralHeader.writeUInt16LE(0, 34);
+    centralHeader.writeUInt16LE(0, 36);
+    centralHeader.writeUInt32LE(0, 38);
+    centralHeader.writeUInt32LE(offset, 42);
+    centrals.push(Buffer.concat([centralHeader, nameBytes]));
+
+    offset += localHeader.length + nameBytes.length + entry.data.length;
+  }
+
+  const centralSize = centrals.reduce((sum, buf) => sum + buf.length, 0);
+  const end = Buffer.alloc(22);
+  end.writeUInt32LE(0x06054b50, 0);
+  end.writeUInt16LE(0, 4);
+  end.writeUInt16LE(0, 6);
+  end.writeUInt16LE(entries.length, 8);
+  end.writeUInt16LE(entries.length, 10);
+  end.writeUInt32LE(centralSize, 12);
+  end.writeUInt32LE(offset, 16);
+  end.writeUInt16LE(0, 20);
+
+  return Buffer.concat([...locals, ...centrals, end]);
+}
+
+export async function evidenceZip(req: Request, res: Response) {
+  try {
+    const { abn, taxType } = req.query as Record<string, string | undefined>;
+    const { periodId } = req.params as { periodId: string };
+
+    if (!abn || !taxType) {
+      return res.status(400).json({ error: "Missing abn/taxType query params" });
+    }
+
+    const bundle = await buildEvidenceBundle(abn, taxType, periodId);
+    const payload = Buffer.from(JSON.stringify(bundle, null, 2), "utf8");
+    const archive = createZip([{ name: "evidence.json", data: payload }]);
+
+    res.setHeader("Content-Type", "application/zip");
+    res.setHeader("Content-Disposition", `attachment; filename="evidence_${abn}_${periodId}.zip"`);
+    return res.send(archive);
+  } catch (err: any) {
+    return res.status(500).json({ error: "EVIDENCE_ZIP_FAILED", detail: String(err?.message ?? err) });
+  }
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "SELECT * FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY id DESC LIMIT 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "UPDATE periods SET state='RELEASED' WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -1,25 +1,46 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import crypto from "crypto";
 import { signRpt, RptPayload } from "../crypto/ed25519";
 import { exceeds } from "../anomaly/deterministic";
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
+function canonicalize(value: any): string {
+  if (value === null || typeof value !== "object") {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return "[" + value.map((item) => canonicalize(item)).join(",") + "]";
+  }
+  const keys = Object.keys(value).sort();
+  const inner = keys
+    .map((key) => `${JSON.stringify(key)}:${canonicalize(value[key])}`)
+    .join(",");
+  return `{${inner}}`;
+}
+
 export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+  const p = await pool.query(
+    "SELECT * FROM periods WHERE abn=$1 AND tax_type=$2 AND period_id=$3",
+    [abn, taxType, periodId]
+  );
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
   if (row.state !== "CLOSING") throw new Error("BAD_STATE");
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_ANOMALY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("UPDATE periods SET state='BLOCKED_DISCREPANCY' WHERE id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
+  }
+
+  if (secretKey.length !== 64) {
+    throw new Error("RPT_SECRET_NOT_CONFIGURED");
   }
 
   const payload: RptPayload = {
@@ -29,9 +50,15 @@ export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: st
     anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
     expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
   };
-  const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+  const signatureUrl = signRpt(payload, new Uint8Array(secretKey));
+  const signature = Buffer.from(signatureUrl, "base64url").toString("base64");
+  const payload_c14n = canonicalize(payload);
+  const payload_sha256 = crypto.createHash("sha256").update(payload_c14n).digest("hex");
+
+  await pool.query(
+    "INSERT INTO rpt_tokens(abn,tax_type,period_id,payload,signature,status,payload_c14n,payload_sha256,nonce,expires_at) VALUES ($1,$2,$3,$4,$5,'active',$6,$7,$8,$9)",
+    [abn, taxType, periodId, payload, signature, payload_c14n, payload_sha256, payload.nonce, payload.expiry_ts]
+  );
+  await pool.query("UPDATE periods SET state='READY_RPT' WHERE id=$1", [row.id]);
   return { payload, signature };
 }


### PR DESCRIPTION
## Summary
- add TypeScript seed and smoke scripts to exercise the deposit → close → release → evidence flow
- persist ledger hashing and canonical RPT metadata so the payments release path and evidence bundle share consistent state
- expose an evidence zip download route and wire a GitHub Actions job to run seed + smoke against ephemeral Postgres

## Testing
- npm run seed *(fails locally without Postgres service)*
- npm run smoke *(fails locally without Postgres service)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ad25013483279215fe9fd0eef83b