### PR TITLE
Add simulation seed/smoke scripts and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,116 @@
+name: CI
+
+on:
+  push:
+    branches: ["main", "master"]
+  pull_request:
+
+jobs:
+  sim:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        ports:
+          - 5432:5432
+        env:
+          POSTGRES_DB: apgms
+          POSTGRES_USER: apgms
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd "pg_isready -U apgms"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgres://apgms:postgres@localhost:5432/apgms
+      PGHOST: localhost
+      PGPORT: 5432
+      PGDATABASE: apgms
+      PGUSER: apgms
+      PGPASSWORD: postgres
+      SIM_ABN: "12345678901"
+      SIM_TAX_TYPE: "GST"
+      SIM_PERIOD_ID: "2025-09"
+      ATO_PRN: "1234567890"
+      RPT_ED25519_SECRET_BASE64: "+90YovItUf8zO04zikYkYVE/Y3zDV5eWmDpYmb59WCbo3PdtKfp4T91ezzFkKrEFCrXIeUR/FaAwhrHg3xtOwg=="
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install PostgreSQL client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run migrations
+        run: |
+          for file in $(ls migrations/*.sql | sort); do
+            echo "Running migration $file"
+            psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$file"
+          done
+
+      - name: Seed simulation data
+        run: npm run seed:sim
+
+      - name: Start API server
+        run: |
+          npm run dev > server.log 2>&1 &
+          echo $! > server.pid
+
+      - name: Wait for API readiness
+        run: |
+          for i in {1..30}; do
+            if curl -fsS http://localhost:3000/health > /dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Server failed to become ready"
+          cat server.log
+          exit 1
+
+      - name: Run simulation smoke
+        env:
+          SMOKE_BASE_URL: http://localhost:3000
+        run: npm run smoke:sim
+
+      - name: Stop API server
+        if: always()
+        run: |
+          if [ -f server.pid ]; then
+            kill $(cat server.pid) || true
+            rm server.pid
+          fi
+          if [ -f server.log ]; then
+            echo "===== server.log ====="
+            cat server.log
+          fi
+
+  live:
+    if: ${{ vars.SMOKE_LIVE_BASE_URL != '' }}
+    runs-on: ubuntu-latest
+    needs: sim
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Run live smoke
+        env:
+          SMOKE_LIVE_BASE_URL: ${{ vars.SMOKE_LIVE_BASE_URL }}
+          SMOKE_LIVE_ABN: ${{ vars.SMOKE_LIVE_ABN || '12345678901' }}
+          SMOKE_LIVE_PERIOD_ID: ${{ vars.SMOKE_LIVE_PERIOD_ID || 'SIM-PERIOD' }}
+          SMOKE_LIVE_TAX_TYPE: ${{ vars.SMOKE_LIVE_TAX_TYPE || 'GST' }}
+          SMOKE_LIVE_CLIENT_CERT: ${{ secrets.SMOKE_LIVE_CLIENT_CERT_PATH }}
+          SMOKE_LIVE_CLIENT_KEY: ${{ secrets.SMOKE_LIVE_CLIENT_KEY_PATH }}
+          SMOKE_LIVE_CA: ${{ secrets.SMOKE_LIVE_CA_PATH }}
+        run: npm run smoke:live

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "seed:sim": "ts-node --transpile-only scripts/seed:sim.ts",
+        "smoke:sim": "ts-node --transpile-only scripts/smoke:sim.ts",
+        "smoke:live": "ts-node --transpile-only scripts/smoke:live.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/seed:sim.ts
+++ b/scripts/seed:sim.ts
@@ -1,0 +1,161 @@
+import { Client } from "pg";
+import { randomUUID } from "node:crypto";
+
+function env(name: string, fallback?: string): string {
+  const value = process.env[name];
+  if (value && value.trim() !== "") return value;
+  if (fallback !== undefined) return fallback;
+  throw new Error(`Missing required env var ${name}`);
+}
+
+function buildConnectionString() {
+  const url = process.env.DATABASE_URL;
+  if (url && url.trim() !== "") return url;
+  const host = process.env.PGHOST || "127.0.0.1";
+  const port = process.env.PGPORT || "5432";
+  const db = process.env.PGDATABASE || "apgms";
+  const user = process.env.PGUSER || "apgms";
+  const password = process.env.PGPASSWORD || "";
+  const encodedPassword = encodeURIComponent(password);
+  return `postgres://${user}:${encodedPassword}@${host}:${port}/${db}`;
+}
+
+async function main() {
+  const connectionString = buildConnectionString();
+  const client = new Client({ connectionString });
+  await client.connect();
+
+  const abn = env("SIM_ABN", "12345678901");
+  const taxType = env("SIM_TAX_TYPE", "GST");
+  const periodId = env("SIM_PERIOD_ID", "2025-09");
+
+  const ledgerCredits = (process.env.SIM_LEDGER_CREDITS || "50000,40000,33456")
+    .split(",")
+    .map((v) => Number(v.trim()))
+    .filter((v) => Number.isFinite(v) && v > 0);
+  if (ledgerCredits.length === 0) throw new Error("SIM_LEDGER_CREDITS produced no positive entries");
+
+  const merkleRoot = process.env.SIM_MERKLE_ROOT || "merkle_demo_root";
+  const runningBalanceHash = process.env.SIM_RUNNING_BALANCE_HASH || "rbh_demo";
+  const thresholds = {
+    epsilon_cents: Number(process.env.SIM_THRESHOLD_EPSILON || 50),
+    variance_ratio: Number(process.env.SIM_THRESHOLD_VARIANCE || 0.25),
+    dup_rate: Number(process.env.SIM_THRESHOLD_DUP_RATE || 0.01),
+    gap_minutes: Number(process.env.SIM_THRESHOLD_GAP_MINUTES || 60),
+    delta_vs_baseline: Number(process.env.SIM_THRESHOLD_DELTA || 0.2),
+  };
+  const anomalyVector = {
+    variance_ratio: Number(process.env.SIM_ANOMALY_VARIANCE || 0.1),
+    dup_rate: Number(process.env.SIM_ANOMALY_DUP_RATE || 0.0),
+    gap_minutes: Number(process.env.SIM_ANOMALY_GAP_MINUTES || 10),
+    delta_vs_baseline: Number(process.env.SIM_ANOMALY_DELTA || 0.05),
+  };
+
+  const creditedTotal = ledgerCredits.reduce((sum, amount) => sum + amount, 0);
+
+  console.log("Connecting to", connectionString.replace(/:[^:@]+@/, ":***@"));
+  console.log(`Seeding ABN=${abn} taxType=${taxType} period=${periodId}`);
+
+  await client.query("BEGIN");
+  try {
+    await client.query(
+      `DELETE FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+    await client.query(
+      `DELETE FROM rpt_tokens WHERE abn=$1 AND tax_type=$2 AND period_id=$3`,
+      [abn, taxType, periodId]
+    );
+
+    await client.query(
+      `INSERT INTO remittance_destinations (abn,label,rail,reference,account_bsb,account_number)
+       VALUES ($1,$2,'EFT',$3,$4,$5)
+       ON CONFLICT (abn, rail, reference) DO UPDATE
+         SET label = EXCLUDED.label,
+             account_bsb = EXCLUDED.account_bsb,
+             account_number = EXCLUDED.account_number`,
+      [
+        abn,
+        process.env.SIM_EFT_LABEL || "ATO_EFT",
+        process.env.SIM_EFT_REFERENCE || "1234567890",
+        process.env.SIM_EFT_BSB || "092-009",
+        process.env.SIM_EFT_ACCOUNT || "12345678",
+      ]
+    );
+
+    await client.query(
+      `INSERT INTO remittance_destinations (abn,label,rail,reference)
+       VALUES ($1,$2,'BPAY',$3)
+       ON CONFLICT (abn, rail, reference) DO UPDATE
+         SET label = EXCLUDED.label`,
+      [abn, process.env.SIM_BP_LABEL || "ATO_BPAY", process.env.SIM_BP_REFERENCE || "987654321"]
+    );
+
+    await client.query(
+      `INSERT INTO periods (
+         abn,tax_type,period_id,state,basis,
+         accrued_cents,credited_to_owa_cents,final_liability_cents,
+         merkle_root,running_balance_hash,anomaly_vector,thresholds
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
+       ON CONFLICT (abn,tax_type,period_id) DO UPDATE SET
+         state = EXCLUDED.state,
+         basis = EXCLUDED.basis,
+         accrued_cents = EXCLUDED.accrued_cents,
+         credited_to_owa_cents = EXCLUDED.credited_to_owa_cents,
+         final_liability_cents = EXCLUDED.final_liability_cents,
+         merkle_root = EXCLUDED.merkle_root,
+         running_balance_hash = EXCLUDED.running_balance_hash,
+         anomaly_vector = EXCLUDED.anomaly_vector,
+         thresholds = EXCLUDED.thresholds`,
+      [
+        abn,
+        taxType,
+        periodId,
+        "CLOSING",
+        process.env.SIM_BASIS || "ACCRUAL",
+        creditedTotal,
+        creditedTotal,
+        creditedTotal,
+        merkleRoot,
+        runningBalanceHash,
+        anomalyVector,
+        thresholds,
+      ]
+    );
+
+    let runningBalance = 0;
+    for (const amount of ledgerCredits) {
+      runningBalance += amount;
+      await client.query(
+        `INSERT INTO owa_ledger (
+           abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,
+           bank_receipt_hash,prev_hash,hash_after,created_at
+         ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,now())`,
+        [
+          abn,
+          taxType,
+          periodId,
+          randomUUID(),
+          amount,
+          runningBalance,
+          process.env.SIM_BANK_RECEIPT_PREFIX ? `${process.env.SIM_BANK_RECEIPT_PREFIX}${randomUUID().slice(0,8)}` : `rcpt:${randomUUID().slice(0,8)}`,
+          null,
+          null,
+        ]
+      );
+    }
+
+    await client.query("COMMIT");
+    console.log("Seed complete: credited cents", creditedTotal);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error("seed:sim failed", err);
+  process.exitCode = 1;
+});

--- a/scripts/smoke:live.ts
+++ b/scripts/smoke:live.ts
@@ -1,0 +1,57 @@
+import { existsSync, readFileSync } from "node:fs";
+import { runSmoke } from "./smoke:sim";
+
+async function main() {
+  const baseUrl = process.env.SMOKE_LIVE_BASE_URL || process.env.LIVE_BASE_URL;
+  if (!baseUrl) {
+    console.log("[smoke-live] SMOKE_LIVE_BASE_URL not set; skipping live smoke");
+    return;
+  }
+
+  const abn = process.env.SMOKE_LIVE_ABN;
+  const periodId = process.env.SMOKE_LIVE_PERIOD_ID;
+  const taxType = process.env.SMOKE_LIVE_TAX_TYPE || "GST";
+  if (!abn || !periodId) {
+    console.error("[smoke-live] SMOKE_LIVE_ABN and SMOKE_LIVE_PERIOD_ID must be set for live smoke");
+    process.exitCode = 1;
+    return;
+  }
+
+  let dispatcher: any;
+  const certPath = process.env.SMOKE_LIVE_CLIENT_CERT;
+  const keyPath = process.env.SMOKE_LIVE_CLIENT_KEY;
+  const caPath = process.env.SMOKE_LIVE_CA;
+  const load = (source?: string) => {
+    if (!source) return undefined;
+    if (source.startsWith("base64:")) return Buffer.from(source.slice(7), "base64");
+    if (source.includes("-----BEGIN")) return Buffer.from(source);
+    if (existsSync(source)) return readFileSync(source);
+    return Buffer.from(source);
+  };
+
+  if (certPath && keyPath) {
+    const { Agent } = await import("undici");
+    dispatcher = new Agent({
+      connect: {
+        cert: load(certPath),
+        key: load(keyPath),
+        ca: caPath ? load(caPath) : undefined,
+        rejectUnauthorized: process.env.SMOKE_LIVE_REJECT_TLS === "false" ? false : true,
+      },
+    });
+  }
+
+  try {
+    await runSmoke({ baseUrl, abn, taxType, periodId, dispatcher });
+    console.log("[smoke-live] Smoke test completed against live sandbox");
+  } catch (err) {
+    console.error("[smoke-live] Smoke test failed", err);
+    process.exitCode = 1;
+  } finally {
+    if (dispatcher?.close) {
+      await dispatcher.close();
+    }
+  }
+}
+
+main();

--- a/scripts/smoke:sim.ts
+++ b/scripts/smoke:sim.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+import { setTimeout as wait } from "node:timers/promises";
+
+export interface SmokeOptions {
+  baseUrl: string;
+  abn: string;
+  taxType: string;
+  periodId: string;
+  dispatcher?: any;
+}
+
+type Json = Record<string, any>;
+
+async function http(method: string, url: URL, dispatcher: any, body?: Json) {
+  const init: any = { method, headers: { "accept": "application/json" } };
+  if (dispatcher) init.dispatcher = dispatcher;
+  if (body) {
+    init.body = JSON.stringify(body);
+    (init.headers as Record<string, string>)["content-type"] = "application/json";
+  }
+  const res = await fetch(url, init);
+  const text = await res.text();
+  let json: any;
+  if (text) {
+    try { json = JSON.parse(text); } catch { /* keep raw text */ }
+  }
+  if (!res.ok) {
+    const msg = json?.error || json?.detail || text || `${res.status} ${res.statusText}`;
+    throw new Error(`HTTP ${res.status} ${url.pathname}: ${msg}`);
+  }
+  return json ?? null;
+}
+
+export async function runSmoke(opts: SmokeOptions) {
+  const { baseUrl, abn, taxType, periodId, dispatcher } = opts;
+  console.log(`[smoke] base=${baseUrl} abn=${abn} taxType=${taxType} period=${periodId}`);
+
+  const depositUrl = new URL("/api/deposit", baseUrl);
+  const depositAmount = Number(process.env.SMOKE_DEPOSIT_CENTS || 250_00);
+  console.log(`[smoke] POST ${depositUrl.pathname} amount=${depositAmount}`);
+  const dep = await http("POST", depositUrl, dispatcher, { abn, taxType, periodId, amountCents: depositAmount });
+  if (!dep?.ledger_id) throw new Error("Deposit response missing ledger_id");
+  console.log(`[smoke] deposit ledger_id=${dep.ledger_id} balance=${dep.balance_after_cents}`);
+
+  console.log("[smoke] Simulating upstream feeds (STP/POS) ...");
+  await wait(500);
+
+  const closeUrl = new URL("/api/close-issue", baseUrl);
+  console.log(`[smoke] POST ${closeUrl.pathname}`);
+  const rpt = await http("POST", closeUrl, dispatcher, { abn, taxType, periodId });
+  if (!rpt?.payload || !rpt?.signature) {
+    throw new Error("close-and-issue response missing payload/signature");
+  }
+  console.log(`[smoke] RPT issued kid=${rpt.payload?.rail_id ?? "EFT"}`);
+
+  const releaseUrl = new URL("/api/pay", baseUrl);
+  console.log(`[smoke] POST ${releaseUrl.pathname} rail=EFT`);
+  const release = await http("POST", releaseUrl, dispatcher, { abn, taxType, periodId, rail: "EFT" });
+  if (!release?.transfer_uuid && !release?.bank_receipt_hash && !release?.release_uuid) {
+    throw new Error("Release response missing identifiers");
+  }
+  console.log(`[smoke] release transfer=${release.transfer_uuid || release.release_uuid || "n/a"}`);
+
+  const csv = `txn_id,gst_cents,net_cents,settlement_ts\n${randomUUID()},1234,9876,${new Date().toISOString()}\n`;
+  const settlementUrl = new URL("/api/settlement/webhook", baseUrl);
+  console.log(`[smoke] POST ${settlementUrl.pathname} rows=1`);
+  const settlement = await http("POST", settlementUrl, dispatcher, { csv });
+  if (!settlement?.ingested) throw new Error("Settlement webhook did not report ingested rows");
+
+  const evidenceUrl = new URL("/api/evidence", baseUrl);
+  evidenceUrl.searchParams.set("abn", abn);
+  evidenceUrl.searchParams.set("taxType", taxType);
+  evidenceUrl.searchParams.set("periodId", periodId);
+  console.log(`[smoke] GET ${evidenceUrl.pathname}`);
+  const evidence = await http("GET", evidenceUrl, dispatcher);
+  if (!evidence?.rpt_payload || !Array.isArray(evidence?.owa_ledger_deltas)) {
+    throw new Error("Evidence response missing expected fields");
+  }
+  console.log(`[smoke] Evidence ledger entries=${evidence.owa_ledger_deltas.length}`);
+}
+
+async function main() {
+  const baseUrl = process.env.SMOKE_BASE_URL || "http://localhost:3000";
+  const abn = process.env.SMOKE_ABN || process.env.SIM_ABN || "12345678901";
+  const taxType = process.env.SMOKE_TAX_TYPE || process.env.SIM_TAX_TYPE || "GST";
+  const periodId = process.env.SMOKE_PERIOD_ID || process.env.SIM_PERIOD_ID || "2025-09";
+
+  try {
+    await runSmoke({ baseUrl, abn, taxType, periodId });
+    console.log("[smoke] Simulation smoke completed successfully");
+  } catch (err) {
+    console.error("[smoke] Simulation smoke failed", err);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -8,8 +8,8 @@ export async function appendAudit(actor: string, action: string, payload: any) {
   const payloadHash = sha256Hex(JSON.stringify(payload));
   const terminalHash = sha256Hex(prevHash + payloadHash);
   await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
-    [actor, action, payloadHash, prevHash, terminalHash]
+    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values ($1,$2,$3,$4,$5)",
+    [actor, action, payloadHash, prevHash || null, terminalHash]
   );
   return terminalHash;
 }

--- a/src/evidence/bundle.ts
+++ b/src/evidence/bundle.ts
@@ -2,9 +2,21 @@
 const pool = new Pool();
 
 export async function buildEvidenceBundle(abn: string, taxType: string, periodId: string) {
-  const p = (await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId])).rows[0];
-  const rpt = (await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId])).rows[0];
-  const deltas = (await pool.query("select created_at as ts, amount_cents, hash_after, bank_receipt_hash from owa_ledger where abn= and tax_type= and period_id= order by id", [abn, taxType, periodId])).rows;
+  const p = (
+    await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId])
+  ).rows[0];
+  const rpt = (
+    await pool.query(
+      "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+      [abn, taxType, periodId]
+    )
+  ).rows[0];
+  const deltas = (
+    await pool.query(
+      "select created_at as ts, amount_cents, balance_after_cents, hash_after, bank_receipt_hash from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id",
+      [abn, taxType, periodId]
+    )
+  ).rows;
   const last = deltas[deltas.length-1];
   const bundle = {
     bas_labels: { W1: null, W2: null, "1A": null, "1B": null }, // TODO: populate

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -7,7 +7,7 @@ const pool = new Pool();
 /** Allow-list enforcement and PRN/CRN lookup */
 export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
   const { rows } = await pool.query(
-    "select * from remittance_destinations where abn= and rail= and reference=",
+    "select * from remittance_destinations where abn=$1 and rail=$2 and reference=$3",
     [abn, rail, reference]
   );
   if (rows.length === 0) throw new Error("DEST_NOT_ALLOW_LISTED");
@@ -18,25 +18,25 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
   const transfer_uuid = uuidv4();
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("insert into idempotency_keys(key,last_status) values($1,$2)", [transfer_uuid, "INIT"]);
   } catch {
     return { transfer_uuid, status: "DUPLICATE" };
   }
   const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
 
   const { rows } = await pool.query(
-    "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
+    "select balance_after_cents, hash_after from owa_ledger where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
     [abn, taxType, periodId]);
-  const prevBal = rows[0]?.balance_after_cents ?? 0;
+  const prevBal = Number(rows[0]?.balance_after_cents ?? 0);
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
   const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values ($1,$2,$3,$4,$5,$6,$7,$8,$9)",
+    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash || null, hashAfter]
   );
   await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
+  await pool.query("update idempotency_keys set last_status=$1 where key=$2", ["DONE", transfer_uuid]);
+  return { transfer_uuid, bank_receipt_hash, balance_after_cents: newBal };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -20,13 +20,19 @@ export async function closeAndIssue(req:any, res:any) {
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
-  const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
+  const pr = await pool.query(
+    "select * from rpt_tokens where abn=$1 and tax_type=$2 and period_id=$3 order by id desc limit 1",
+    [abn, taxType, periodId]
+  );
   if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
-    await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    await pool.query(
+      "update periods set state='RELEASED' where abn=$1 and tax_type=$2 and period_id=$3",
+      [abn, taxType, periodId]
+    );
     return res.json(r);
   } catch (e:any) {
     return res.status(400).json({ error: e.message });

--- a/src/rpt/issuer.ts
+++ b/src/rpt/issuer.ts
@@ -5,33 +5,46 @@ import { exceeds } from "../anomaly/deterministic";
 const pool = new Pool();
 const secretKey = Buffer.from(process.env.RPT_ED25519_SECRET_BASE64 || "", "base64");
 
-export async function issueRPT(abn: string, taxType: "PAYGW"|"GST", periodId: string, thresholds: Record<string, number>) {
-  const p = await pool.query("select * from periods where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+export async function issueRPT(abn: string, taxType: "PAYGW" | "GST", periodId: string, thresholds: Record<string, number>) {
+  if (!secretKey.length) throw new Error("RPT_KEY_MISSING");
+
+  const p = await pool.query("select * from periods where abn=$1 and tax_type=$2 and period_id=$3", [abn, taxType, periodId]);
   if (p.rowCount === 0) throw new Error("PERIOD_NOT_FOUND");
   const row = p.rows[0];
-  if (row.state !== "CLOSING") throw new Error("BAD_STATE");
+  if (row.state !== "CLOSING") throw new Error(`BAD_STATE_${row.state}`);
 
   const v = row.anomaly_vector || {};
   if (exceeds(v, thresholds)) {
-    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_ANOMALY' where id=$1", [row.id]);
     throw new Error("BLOCKED_ANOMALY");
   }
+
   const epsilon = Math.abs(Number(row.final_liability_cents) - Number(row.credited_to_owa_cents));
   if (epsilon > (thresholds["epsilon_cents"] ?? 0)) {
-    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=", [row.id]);
+    await pool.query("update periods set state='BLOCKED_DISCREPANCY' where id=$1", [row.id]);
     throw new Error("BLOCKED_DISCREPANCY");
   }
 
   const payload: RptPayload = {
-    entity_id: row.abn, period_id: row.period_id, tax_type: row.tax_type,
+    entity_id: row.abn,
+    period_id: row.period_id,
+    tax_type: row.tax_type,
     amount_cents: Number(row.final_liability_cents),
-    merkle_root: row.merkle_root, running_balance_hash: row.running_balance_hash,
-    anomaly_vector: v, thresholds, rail_id: "EFT", reference: process.env.ATO_PRN || "",
-    expiry_ts: new Date(Date.now() + 15*60*1000).toISOString(), nonce: crypto.randomUUID()
+    merkle_root: row.merkle_root || null,
+    running_balance_hash: row.running_balance_hash || null,
+    anomaly_vector: v,
+    thresholds,
+    rail_id: "EFT",
+    reference: process.env.ATO_PRN || "",
+    expiry_ts: new Date(Date.now() + 15 * 60 * 1000).toISOString(),
+    nonce: crypto.randomUUID(),
   };
   const signature = signRpt(payload, new Uint8Array(secretKey));
-  await pool.query("insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values (,,,,)",
-    [abn, taxType, periodId, payload, signature]);
-  await pool.query("update periods set state='READY_RPT' where id=", [row.id]);
+
+  await pool.query(
+    "insert into rpt_tokens(abn,tax_type,period_id,payload,signature) values ($1,$2,$3,$4,$5)",
+    [abn, taxType, periodId, payload, signature]
+  );
+  await pool.query("update periods set state='READY_RPT' where id=$1", [row.id]);
   return { payload, signature };
 }


### PR DESCRIPTION
## Summary
- add TypeScript seed and smoke scripts to exercise the simulated GST period end-to-end
- fix database access helpers so release, evidence, and RPT issuance work with the new smoke flow
- provision a GitHub Actions workflow that migrates, seeds, and runs the simulation smoke, with an optional live job

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3aef2502c83279434268123d800fe