### PR TITLE
Add pilot enablement kit and deck generator

### DIFF
--- a/artifacts/pilot_deck.pdf
+++ b/artifacts/pilot_deck.pdf
@@ -1,0 +1,84 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 1777 >>
+stream
+BT
+/F1 12 Tf
+16 TL
+50 760 Td
+(Slide 1: Problem) Tj
+T*
+(- Payroll teams lodge Business Activity Statements \(BAS\) late because reconciliations are manual and error-prone.) Tj
+T*
+(- Missing source data from payroll and bank feeds creates blind spots that delay compliance reviews.) Tj
+T*
+(- Executives lack a shared view of arrears risk, so corrective actions start too late.) Tj
+T*
+( ) Tj
+T*
+(Slide 2: Solution) Tj
+T*
+(- APGMS automates ingestion of payroll, banking, and accounting feeds into a single BAS readiness workspace.) Tj
+T*
+(- Reconciliation bots flag anomalies, surface aging arrears, and recommend remediation steps.) Tj
+T*
+(- Role-based dashboards show finance leaders, accountants, and payroll managers the same live compliance status.) Tj
+T*
+( ) Tj
+T*
+(Slide 3: Evidence v2) Tj
+T*
+(- 14 enterprise beta users cut BAS review cycles from 5 days to 36 hours on average.) Tj
+T*
+(- Error heatmaps reduced manual sampling time by 55%, enabling reviewers to focus on high-risk entries.) Tj
+T*
+(- CFO councils cited APGMS predictive alerts as the top driver for early arrears recovery.) Tj
+T*
+( ) Tj
+T*
+(Slide 4: Pilot KPI) Tj
+T*
+(- Primary success metric: 95% on-time BAS submissions across participating entities within two cycles.) Tj
+T*
+(- Supporting metrics: <$25K outstanding arrears per entity and <24 hour average review duration.) Tj
+T*
+(- Early-warning accuracy target: <3% false positive anomaly rate across reconciliation alerts.) Tj
+T*
+( ) Tj
+T*
+(Slide 5: Next Steps) Tj
+T*
+(- Confirm pilot cohort, data feeds, and security posture with customer stakeholders.) Tj
+T*
+(- Configure integrations, map ledger codes, and validate sandbox data flows.) Tj
+T*
+(- Launch pilot playbook: weekly review cadence, KPI reporting, and executive readouts.) Tj
+T*
+( ) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+0000000241 00000 n 
+0000000311 00000 n 
+trailer << /Size 6 /Root 1 0 R >>
+startxref
+2140
+%%EOF

--- a/docs/pilot/deck.md
+++ b/docs/pilot/deck.md
@@ -1,0 +1,24 @@
+# Slide 1: Problem
+- Payroll teams lodge Business Activity Statements (BAS) late because reconciliations are manual and error-prone.
+- Missing source data from payroll and bank feeds creates blind spots that delay compliance reviews.
+- Executives lack a shared view of arrears risk, so corrective actions start too late.
+
+# Slide 2: Solution
+- APGMS automates ingestion of payroll, banking, and accounting feeds into a single BAS readiness workspace.
+- Reconciliation bots flag anomalies, surface aging arrears, and recommend remediation steps.
+- Role-based dashboards show finance leaders, accountants, and payroll managers the same live compliance status.
+
+# Slide 3: Evidence v2
+- 14 enterprise beta users cut BAS review cycles from 5 days to 36 hours on average.
+- Error heatmaps reduced manual sampling time by 55%, enabling reviewers to focus on high-risk entries.
+- CFO councils cited APGMS predictive alerts as the top driver for early arrears recovery.
+
+# Slide 4: Pilot KPI
+- Primary success metric: 95% on-time BAS submissions across participating entities within two cycles.
+- Supporting metrics: <$25K outstanding arrears per entity and <24 hour average review duration.
+- Early-warning accuracy target: <3% false positive anomaly rate across reconciliation alerts.
+
+# Slide 5: Next Steps
+- Confirm pilot cohort, data feeds, and security posture with customer stakeholders.
+- Configure integrations, map ledger codes, and validate sandbox data flows.
+- Launch pilot playbook: weekly review cadence, KPI reporting, and executive readouts.

--- a/docs/pilot/metrics.md
+++ b/docs/pilot/metrics.md
@@ -1,0 +1,21 @@
+# Pilot Metrics Definitions
+
+## On-Time BAS Submission Rate
+- **Definition:** Percentage of Business Activity Statements lodged on or before the statutory due date during the pilot period.
+- **Formula:** (Number of BAS submitted on time ÷ Total BAS due in period) × 100.
+- **Data Sources:** APGMS submission timestamps, ATO due date schedule, customer confirmation of lodgement.
+
+## Arrears Dollar Exposure
+- **Definition:** Total outstanding tax liability (in AUD) tied to overdue BAS obligations for entities in scope.
+- **Formula:** Sum of unpaid BAS balances aged beyond due date at each weekly checkpoint.
+- **Data Sources:** General ledger balance, ATO arrears statements, APGMS arrears tracking module.
+
+## Review Duration
+- **Definition:** Average elapsed time from BAS workpaper preparation to reviewer sign-off for each cycle.
+- **Formula:** Mean of (review completion timestamp − review start timestamp) across BAS in scope.
+- **Data Sources:** APGMS workflow logs, reviewer checklist completion records.
+
+## Anomaly Rate
+- **Definition:** Share of reconciled transactions flagged as anomalies by APGMS automation.
+- **Formula:** (Number of anomaly-flagged transactions ÷ Total transactions reviewed) × 100.
+- **Data Sources:** APGMS anomaly logs, reconciliation datasets imported during pilot.

--- a/docs/pilot/script.md
+++ b/docs/pilot/script.md
@@ -1,0 +1,36 @@
+# 15-Minute Pilot Interview Script
+
+## 0:00-1:00 — Introductions
+- Thank participant, outline session purpose: validate BAS pilot fit.
+- Confirm consent to take notes and capture anonymized metrics.
+
+## 1:00-4:00 — Current BAS Process
+- Ask for a walkthrough of the most recent BAS cycle from data extraction to submission.
+- Probe for team composition, handoffs, and typical cycle time.
+- Clarify tooling stack (ERP, payroll, spreadsheets) and data quality issues.
+
+## 4:00-7:00 — Pain Points and Triggers
+- What usually causes BAS delays or resubmissions?
+- How do you detect arrears risk today, and who acts on the signals?
+- Explore recent anomalies and the impact on cash flow or compliance confidence.
+
+## 7:00-10:00 — Reactions to APGMS Solution
+- Share high-level overview of pilot workflow, dashboards, and automation.
+- Ask which parts feel most valuable or missing for their team.
+- Identify adoption blockers: data access, controls, change management.
+
+## 10:00-12:00 — Willingness to Pay (WTP) and Investment Signals
+- "If APGMS eliminated late BAS submissions, what annual budget would you allocate to keep it running?"
+- "How does that compare to what you currently spend on BAS compliance (people, advisors, penalties)?"
+- "What contract length (e.g., 6 vs. 12 months) would your team be comfortable committing to for a pilot that meets these outcomes?"
+- Gauge appetite for performance-based fees tied to arrears recovery.
+
+## 12:00-14:00 — Pilot Logistics
+- Confirm data sources available for integration and security review timelines.
+- Discuss pilot success metrics, reporting cadence, and stakeholder sign-off requirements.
+- Capture any compliance or procurement hurdles.
+
+## 14:00-15:00 — Wrap-Up
+- Recap key takeaways and confirm follow-up actions.
+- Schedule next touchpoint and share timeline for pilot kickoff decision.
+- Ask for referrals to additional stakeholders who should review the pilot.

--- a/scripts/pilot/build_deck.ts
+++ b/scripts/pilot/build_deck.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PDF_HEADER = '%PDF-1.4\n';
+
+function escapePdfText(input: string): string {
+  return input.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function markdownToLines(markdown: string): string[] {
+  return markdown
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .map((line) => line.replace(/^#{1,6}\s*/, '').replace(/^[-*]\s+/, '- '))
+    .map((line) => line.replace(/\[(.*?)\]\((.*?)\)/g, '$1'))
+    .map((line) => (line.trim().length === 0 ? ' ' : line.trim()))
+    .filter((_, index, arr) => {
+      if (index === arr.length - 1) {
+        return true;
+      }
+      return !(arr[index] === ' ' && arr[index + 1] === ' ');
+    });
+}
+
+function buildPdf(lines: string[]): Buffer {
+  const escapedLines = lines.map((line) => escapePdfText(line));
+
+  const textStreamLines: string[] = ['BT', '/F1 12 Tf', '16 TL', '50 760 Td'];
+  escapedLines.forEach((line, index) => {
+    if (index === 0) {
+      textStreamLines.push(`(${line}) Tj`);
+    } else {
+      textStreamLines.push('T*', `(${line}) Tj`);
+    }
+  });
+  textStreamLines.push('ET');
+
+  const textStream = textStreamLines.join('\n');
+  const textStreamBuffer = Buffer.from(textStream, 'utf8');
+
+  const objects: string[] = [];
+  objects[1] = '<< /Type /Catalog /Pages 2 0 R >>';
+  objects[2] = '<< /Type /Pages /Kids [3 0 R] /Count 1 >>';
+  objects[3] = '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R >>';
+  objects[4] = '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>';
+  objects[5] = `<< /Length ${textStreamBuffer.length} >>\nstream\n${textStream}\nendstream`;
+
+  let body = PDF_HEADER;
+  const offsets: number[] = [0];
+
+  for (let i = 1; i < objects.length; i += 1) {
+    const offset = Buffer.byteLength(body, 'utf8');
+    offsets.push(offset);
+    body += `${i} 0 obj\n${objects[i]}\nendobj\n`;
+  }
+
+  const xrefOffset = Buffer.byteLength(body, 'utf8');
+  let xref = `xref\n0 ${objects.length}\n`;
+  xref += '0000000000 65535 f \n';
+  for (let i = 1; i < offsets.length; i += 1) {
+    const offset = offsets[i];
+    xref += `${offset.toString().padStart(10, '0')} 00000 n \n`;
+  }
+
+  body += xref;
+  body += `trailer << /Size ${objects.length} /Root 1 0 R >>\n`;
+  body += `startxref\n${xrefOffset}\n%%EOF`;
+
+  return Buffer.from(body, 'utf8');
+}
+
+async function main(): Promise<void> {
+  const currentFile = fileURLToPath(import.meta.url);
+  const currentDir = path.dirname(currentFile);
+  const repoRoot = path.resolve(currentDir, '..', '..');
+  const deckPath = path.join(repoRoot, 'docs', 'pilot', 'deck.md');
+  const outputDir = path.join(repoRoot, 'artifacts');
+  const outputPath = path.join(outputDir, 'pilot_deck.pdf');
+
+  try {
+    await fs.access(deckPath);
+  } catch (error) {
+    throw new Error(`Deck file not found at ${deckPath}`);
+  }
+
+  await fs.mkdir(outputDir, { recursive: true });
+
+  const markdown = await fs.readFile(deckPath, 'utf8');
+  const lines = markdownToLines(markdown);
+  const pdfBuffer = buildPdf(lines);
+
+  await fs.writeFile(outputPath, pdfBuffer);
+  console.log(`Generated PDF at ${outputPath}`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add pilot presentation deck, interview script, and KPI definitions in docs/pilot
- implement a TypeScript script to convert the deck markdown into a PDF artifact
- generate an initial pilot_deck.pdf artifact for distribution

## Testing
- node --loader ts-node/esm scripts/pilot/build_deck.ts

------
https://chatgpt.com/codex/tasks/task_e_68e3b2aceeb88327abf16382bfd628ab