### PR TITLE
Add simulated banking service with settlements and release integration

### DIFF
--- a/apps/services/payments/db/migrations/003_settlements.sql
+++ b/apps/services/payments/db/migrations/003_settlements.sql
@@ -1,0 +1,13 @@
+CREATE TABLE IF NOT EXISTS settlements (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  period_id UUID NOT NULL,
+  rail TEXT NOT NULL,
+  provider_ref TEXT NOT NULL,
+  amount_cents BIGINT NOT NULL,
+  paid_at TIMESTAMPTZ NOT NULL,
+  simulated BOOLEAN NOT NULL DEFAULT true,
+  meta JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE INDEX IF NOT EXISTS settlements_period_rail_idx
+  ON settlements(period_id, rail, provider_ref);

--- a/apps/services/payments/src/bank/eftBpayAdapter.ts
+++ b/apps/services/payments/src/bank/eftBpayAdapter.ts
@@ -1,51 +1,59 @@
-﻿import pg from "pg";
 import https from "https";
 import axios from "axios";
-import { createHash, randomUUID } from "crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { getMockBanking } from "../sim/bank/MockBanking.js";
 
 type Params = {
-  abn: string; taxType: string; periodId: string;
+  abn: string;
+  taxType: string;
+  periodId: string;
   amount_cents: number;
   destination: { bpay_biller?: string; crn?: string; bsb?: string; acct?: string };
   idempotencyKey: string;
+};
+
+type TransferResult = {
+  transfer_uuid: string;
+  bank_receipt_hash: string;
+  provider_receipt_id: string;
+  rail: "EFT" | "BPAY";
+  paid_at?: Date;
 };
 
 const agent = new https.Agent({
   ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
   cert: process.env.BANK_TLS_CERT ? require("fs").readFileSync(process.env.BANK_TLS_CERT) : undefined,
   key: process.env.BANK_TLS_KEY ? require("fs").readFileSync(process.env.BANK_TLS_KEY) : undefined,
-  rejectUnauthorized: true
+  rejectUnauthorized: true,
 });
 
 const client = axios.create({
   baseURL: process.env.BANK_API_BASE,
   timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
-  httpsAgent: agent
+  httpsAgent: agent,
 });
 
-export async function sendEftOrBpay(p: Params): Promise<{transfer_uuid: string; bank_receipt_hash: string; provider_receipt_id: string}> {
+function useMockBank(): boolean {
+  return !process.env.BANK_API_BASE || process.env.BANK_API_BASE === "mock";
+}
+
+export async function sendEftOrBpay(p: Params): Promise<TransferResult> {
+  if (useMockBank()) {
+    const mock = getMockBanking();
+    return mock.sendEftOrBpay(p);
+  }
+
   const transfer_uuid = randomUUID();
   const payload = {
     amount_cents: p.amount_cents,
     meta: { abn: p.abn, taxType: p.taxType, periodId: p.periodId, transfer_uuid },
-    destination: p.destination
+    destination: p.destination,
   };
 
   const headers = { "Idempotency-Key": p.idempotencyKey };
-  const maxAttempts = 3;
-  let attempt = 0, lastErr: any;
-
-  while (attempt < maxAttempts) {
-    attempt++;
-    try {
-      const r = await client.post("/payments/eft-bpay", payload, { headers });
-      const receipt = r.data?.receipt_id || "";
-      const hash = createHash("sha256").update(receipt).digest("hex");
-      return { transfer_uuid, bank_receipt_hash: hash, provider_receipt_id: receipt };
-    } catch (e: any) {
-      lastErr = e;
-      await new Promise(s => setTimeout(s, attempt * 250));
-    }
-  }
-  throw new Error("Bank transfer failed: " + String(lastErr?.message || lastErr));
+  const r = await client.post("/payments/eft-bpay", payload, { headers });
+  const receipt = r.data?.receipt_id || "";
+  const hash = createHash("sha256").update(receipt).digest("hex");
+  const rail = p.destination?.bpay_biller ? "BPAY" : "EFT";
+  return { transfer_uuid, bank_receipt_hash: hash, provider_receipt_id: receipt, rail, paid_at: new Date() };
 }

--- a/apps/services/payments/src/bank/paytoAdapter.ts
+++ b/apps/services/payments/src/bank/paytoAdapter.ts
@@ -1,31 +1,56 @@
-﻿import pg from "pg";
 import axios from "axios";
 import https from "https";
+import { getMockBanking } from "../sim/bank/MockBanking.js";
+
 const agent = new https.Agent({
   ca: process.env.BANK_TLS_CA ? require("fs").readFileSync(process.env.BANK_TLS_CA) : undefined,
   cert: process.env.BANK_TLS_CERT ? require("fs").readFileSync(process.env.BANK_TLS_CERT) : undefined,
   key: process.env.BANK_TLS_KEY ? require("fs").readFileSync(process.env.BANK_TLS_KEY) : undefined,
-  rejectUnauthorized: true
+  rejectUnauthorized: true,
 });
+
 const client = axios.create({
   baseURL: process.env.BANK_API_BASE,
   timeout: Number(process.env.BANK_TIMEOUT_MS || "8000"),
-  httpsAgent: agent
+  httpsAgent: agent,
 });
 
+function useMockBank(): boolean {
+  return !process.env.BANK_API_BASE || process.env.BANK_API_BASE === "mock";
+}
+
 export async function createMandate(abn: string, periodId: string, cap_cents: number) {
+  if (useMockBank()) {
+    const mock = getMockBanking();
+    return mock.createMandate(abn, periodId, cap_cents);
+  }
   const r = await client.post("/payto/mandates", { abn, periodId, cap_cents });
   return r.data;
 }
+
 export async function verifyMandate(mandate_id: string) {
+  if (useMockBank()) {
+    const mock = getMockBanking();
+    return mock.verifyMandate(mandate_id);
+  }
   const r = await client.post(`/payto/mandates/${mandate_id}/verify`, {});
   return r.data;
 }
+
 export async function debitMandate(mandate_id: string, amount_cents: number, meta: any) {
+  if (useMockBank()) {
+    const mock = getMockBanking();
+    return mock.debitMandate(mandate_id, amount_cents, meta);
+  }
   const r = await client.post(`/payto/mandates/${mandate_id}/debit`, { amount_cents, meta });
   return r.data;
 }
+
 export async function cancelMandate(mandate_id: string) {
+  if (useMockBank()) {
+    const mock = getMockBanking();
+    return mock.cancelMandate(mandate_id);
+  }
   const r = await client.post(`/payto/mandates/${mandate_id}/cancel`, {});
   return r.data;
 }

--- a/apps/services/payments/src/release/service.ts
+++ b/apps/services/payments/src/release/service.ts
@@ -1,0 +1,186 @@
+import { randomUUID } from "node:crypto";
+import type { PoolClient } from "pg";
+import { pool } from "../index.js";
+import { isAllowlisted } from "../utils/allowlist.js";
+import { sendEftOrBpay } from "../bank/eftBpayAdapter.js";
+import { buildEvidenceBundle } from "../evidence/evidenceBundle.js";
+
+type Destination = { bpay_biller?: string; crn?: string; bsb?: string; acct?: string };
+
+type ReleaseRequest = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: number;
+  destination: Destination;
+  idempotencyKey: string;
+  rpt?: { rpt_id: number; nonce?: string; payload_sha256: string } | null;
+};
+
+type LedgerRow = {
+  id: number;
+  transfer_uuid: string;
+  release_uuid: string;
+  amount_cents: number;
+  balance_after_cents: number;
+  bank_receipt_id: string;
+  created_at: Date;
+  hash_after?: string | null;
+};
+
+export class ReleaseError extends Error {
+  status: number;
+  constructor(message: string, status = 400) {
+    super(message);
+    this.name = "ReleaseError";
+    this.status = status;
+  }
+}
+
+async function selectExistingLedger(client: PoolClient, abn: string, taxType: string, periodId: string, receiptId: string) {
+  const q = `
+    SELECT id, transfer_uuid, release_uuid, amount_cents, balance_after_cents, bank_receipt_id, created_at, hash_after
+    FROM owa_ledger
+    WHERE abn=$1 AND tax_type=$2 AND period_id=$3 AND bank_receipt_id=$4
+    ORDER BY id DESC
+    LIMIT 1
+  `;
+  const { rows } = await client.query<LedgerRow>(q, [abn, taxType, periodId, receiptId]);
+  return rows[0] || null;
+}
+
+async function computeLastBalance(client: PoolClient, abn: string, taxType: string, periodId: string) {
+  const q = `
+    SELECT balance_after_cents
+    FROM owa_ledger
+    WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+    ORDER BY id DESC
+    LIMIT 1
+  `;
+  const { rows } = await client.query<{ balance_after_cents: string | number | null }>(q, [abn, taxType, periodId]);
+  return rows.length ? Number(rows[0].balance_after_cents || 0) : 0;
+}
+
+async function insertLedgerEntry(client: PoolClient, params: {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amount: number;
+  balanceAfter: number;
+  transferUuid: string;
+  releaseUuid: string;
+  receiptId: string;
+}) {
+  const q = `
+    INSERT INTO owa_ledger (
+      abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents,
+      rpt_verified, release_uuid, bank_receipt_id, created_at
+    ) VALUES ($1,$2,$3,$4,$5,$6,TRUE,$7,$8,now())
+    RETURNING id, transfer_uuid, release_uuid, amount_cents, balance_after_cents, bank_receipt_id, created_at, hash_after
+  `;
+  const { rows } = await client.query<LedgerRow>(q, [
+    params.abn,
+    params.taxType,
+    params.periodId,
+    params.transferUuid,
+    params.amount,
+    params.balanceAfter,
+    params.releaseUuid,
+    params.receiptId,
+  ]);
+  return rows[0];
+}
+
+export async function processRelease(req: ReleaseRequest) {
+  const { abn, taxType, periodId, amountCents, destination, idempotencyKey, rpt } = req;
+  if (!abn || !taxType || !periodId) throw new ReleaseError("Missing abn/taxType/periodId", 400);
+  if (!destination || typeof destination !== "object") throw new ReleaseError("Missing destination", 400);
+  if (!idempotencyKey) throw new ReleaseError("Missing Idempotency-Key", 400);
+
+  const amt = Number(amountCents);
+  if (!Number.isFinite(amt) || amt >= 0) throw new ReleaseError("amountCents must be negative for a release", 400);
+
+  const debit = Math.abs(Math.round(amt));
+
+  if (!isAllowlisted(abn, destination)) {
+    throw new ReleaseError("Destination not allowlisted", 403);
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const lastBal = await computeLastBalance(client, abn, taxType, periodId);
+    if (debit > lastBal) {
+      throw new ReleaseError("Insufficient OWA balance", 409);
+    }
+
+    let transfer;
+    try {
+      transfer = await sendEftOrBpay({
+        abn,
+        taxType,
+        periodId,
+        amount_cents: debit,
+        destination,
+        idempotencyKey,
+      });
+    } catch (e: any) {
+      const status = (e as any)?.status ?? 400;
+      throw new ReleaseError(String(e?.message || e), status);
+    }
+
+    const receiptId = transfer.provider_receipt_id;
+    let ledger = await selectExistingLedger(client, abn, taxType, periodId, receiptId);
+    let wasExisting = true;
+    if (!ledger) {
+      wasExisting = false;
+      const newBalance = lastBal + amt; // amt is negative
+      const releaseUuid = randomUUID();
+      ledger = await insertLedgerEntry(client, {
+        abn,
+        taxType,
+        periodId,
+        amount: amt,
+        balanceAfter: newBalance,
+        transferUuid: transfer.transfer_uuid,
+        releaseUuid,
+        receiptId,
+      });
+    }
+
+    const bundleId = await buildEvidenceBundle(client, {
+      abn,
+      taxType,
+      periodId,
+      bankReceipts: [
+        { provider: transfer.rail === "BPAY" ? "BPAY" : "EFT", receipt_id: receiptId },
+      ],
+      atoReceipts: [],
+      operatorOverrides: [],
+      owaAfterHash: ledger?.hash_after || String(ledger?.balance_after_cents ?? ""),
+    });
+
+    await client.query("COMMIT");
+
+    return {
+      ok: true as const,
+      wasExisting,
+      ledger_id: ledger?.id,
+      transfer_uuid: ledger?.transfer_uuid ?? transfer.transfer_uuid,
+      release_uuid: ledger?.release_uuid,
+      bank_receipt_id: receiptId,
+      bank_receipt_hash: transfer.bank_receipt_hash,
+      provider_ref: receiptId,
+      balance_after_cents: ledger?.balance_after_cents,
+      bank_paid_at: transfer.paid_at ? new Date(transfer.paid_at).toISOString() : undefined,
+      evidence_bundle_id: bundleId,
+      rpt_ref: rpt ? { rpt_id: rpt.rpt_id, nonce: rpt.nonce, payload_sha256: rpt.payload_sha256 } : undefined,
+    };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -1,93 +1,45 @@
-﻿// apps/services/payments/src/routes/payAto.ts
-import { Request, Response } from 'express';
-import crypto from 'crypto';
-import pg from 'pg'; const { Pool } = pg;
-import { pool } from '../index.js';
+import type { Request, Response } from "express";
+import { processRelease, ReleaseError } from "../release/service.js";
 
-function genUUID() {
-  return crypto.randomUUID();
-}
+type Destination = { bpay_biller?: string; crn?: string; bsb?: string; acct?: string };
 
-/**
- * Minimal release path:
- * - Requires rptGate to have attached req.rpt
- * - Inserts a single negative ledger entry for the given period
- * - Sets rpt_verified=true and a unique release_uuid to satisfy constraints
- */
 export async function payAtoRelease(req: Request, res: Response) {
-  const { abn, taxType, periodId, amountCents } = req.body || {};
+  const { abn, taxType, periodId, amountCents, destination } = req.body || {};
   if (!abn || !taxType || !periodId) {
-    return res.status(400).json({ error: 'Missing abn/taxType/periodId' });
+    return res.status(400).json({ error: "Missing abn/taxType/periodId" });
   }
 
-  // default a tiny test debit if not provided
-  const amt = Number.isFinite(Number(amountCents)) ? Number(amountCents) : -100;
-
-  // must be negative for a release
-  if (amt >= 0) {
-    return res.status(400).json({ error: 'amountCents must be negative for a release' });
-  }
-
-  // rptGate attaches req.rpt when verification succeeds
   const rpt = (req as any).rpt;
   if (!rpt) {
-    return res.status(403).json({ error: 'RPT not verified' });
+    return res.status(403).json({ error: "RPT not verified" });
   }
 
-  const client = await pool.connect();
+  const amt = Number(amountCents);
+  if (!Number.isFinite(amt) || amt >= 0) {
+    return res.status(400).json({ error: "amountCents must be negative for a release" });
+  }
+
+  const dest: Destination | undefined = destination;
+  if (!dest || typeof dest !== "object") {
+    return res.status(400).json({ error: "Missing destination" });
+  }
+
+  const idempotencyKey = req.header("Idempotency-Key") || req.body?.idempotencyKey || "";
+
   try {
-    await client.query('BEGIN');
-
-    // compute running balance AFTER this entry:
-    // fetch last balance in this period (by id order), default 0
-    const { rows: lastRows } = await client.query<{
-      balance_after_cents: string | number;
-    }>(
-      `SELECT balance_after_cents
-       FROM owa_ledger
-       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-       ORDER BY id DESC
-       LIMIT 1`,
-      [abn, taxType, periodId]
-    );
-    const lastBal = lastRows.length ? Number(lastRows[0].balance_after_cents) : 0;
-    const newBal = lastBal + amt;
-
-    const release_uuid = genUUID();
-
-    const insert = `
-      INSERT INTO owa_ledger
-        (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents,
-         rpt_verified, release_uuid, created_at)
-      VALUES ($1,$2,$3,$4,$5,$6, TRUE, $7, now())
-      RETURNING id, transfer_uuid, balance_after_cents
-    `;
-    const transfer_uuid = genUUID();
-    const { rows: ins } = await client.query(insert, [
+    const result = await processRelease({
       abn,
       taxType,
       periodId,
-      transfer_uuid,
-      amt,
-      newBal,
-      release_uuid,
-    ]);
-
-    await client.query('COMMIT');
-
-    return res.json({
-      ok: true,
-      ledger_id: ins[0].id,
-      transfer_uuid,
-      release_uuid,
-      balance_after_cents: ins[0].balance_after_cents,
-      rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
+      amountCents: amt,
+      destination: dest,
+      idempotencyKey,
+      rpt,
     });
-  } catch (e: any) {
-    await client.query('ROLLBACK');
-    // common failures: unique single-release-per-period, allow-list, etc.
-    return res.status(400).json({ error: 'Release failed', detail: String(e?.message || e) });
-  } finally {
-    client.release();
+
+    return res.json(result);
+  } catch (err: any) {
+    const status = err instanceof ReleaseError ? err.status : err?.status ?? 400;
+    return res.status(status).json({ error: err?.message || "Release failed" });
   }
 }

--- a/apps/services/payments/src/sim/bank/MockBanking.ts
+++ b/apps/services/payments/src/sim/bank/MockBanking.ts
@@ -1,0 +1,434 @@
+import { randomUUID, createHash } from "node:crypto";
+import type { PoolClient } from "pg";
+import { pool } from "../../index.js";
+import { canonicalJson, sha256Hex } from "../../utils/crypto.js";
+
+const BSB_REGEX = /^\d{6}$/;
+const ACCOUNT_REGEX = /^\d{5,9}$/;
+const CRN_REGEX = /^[A-Za-z0-9]{2,20}$/;
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const GLOBAL_KEY = "__apgms_mock_banking";
+
+type Destination = {
+  bpay_biller?: string;
+  crn?: string;
+  bsb?: string;
+  acct?: string;
+};
+
+type EftBpayParams = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amount_cents: number;
+  destination: Destination;
+  idempotencyKey: string;
+};
+
+type SettlementRow = {
+  provider_ref: string;
+  amount_cents: number;
+  paid_at: Date;
+  meta: any;
+};
+
+type Mandate = {
+  id: string;
+  abn: string;
+  periodId: string;
+  cap_cents: number;
+  status: "pending" | "active" | "cancelled";
+  created_at: string;
+  verified_at?: string;
+  cancelled_at?: string;
+};
+
+export class MockBankingError extends Error {
+  status?: number;
+  code?: string;
+
+  constructor(message: string, status?: number, code?: string) {
+    super(message);
+    this.name = "MockBankingError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function clampNumber(value: number, fallback: number) {
+  if (!Number.isFinite(value) || value < 0) return fallback;
+  return value;
+}
+
+function toUuid(input: string): string {
+  if (UUID_REGEX.test(input)) {
+    return input.toLowerCase();
+  }
+  const hash = createHash("sha1").update(input).digest();
+  const bytes = hash.subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8] & 0x3f) | 0x80; // variant RFC4122
+  const hex: string[] = [];
+  for (let i = 0; i < bytes.length; i++) {
+    const h = bytes[i].toString(16).padStart(2, "0");
+    hex.push(h);
+  }
+  return (
+    hex.slice(0, 4).join("") +
+    "-" +
+    hex.slice(4, 6).join("") +
+    "-" +
+    hex.slice(6, 8).join("") +
+    "-" +
+    hex.slice(8, 10).join("") +
+    "-" +
+    hex.slice(10, 16).join("")
+  );
+}
+
+function parseFloatEnv(name: string, fallback: number) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const num = Number(raw);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function parseRail(dest: Destination): "EFT" | "BPAY" {
+  if (dest.bpay_biller) return "BPAY";
+  return "EFT";
+}
+
+function normaliseDestination(dest: Destination): Destination {
+  const trimmed: Destination = {};
+  if (dest.bpay_biller) trimmed.bpay_biller = String(dest.bpay_biller).trim();
+  if (dest.crn) trimmed.crn = String(dest.crn).trim();
+  if (dest.bsb) trimmed.bsb = String(dest.bsb).trim();
+  if (dest.acct) trimmed.acct = String(dest.acct).trim();
+  return trimmed;
+}
+
+function validateDestination(dest: Destination) {
+  const d = normaliseDestination(dest);
+  const isBpay = !!d.bpay_biller || !!d.crn;
+  const isEft = !!d.bsb || !!d.acct;
+
+  if (!isBpay && !isEft) {
+    throw new MockBankingError("Destination must include EFT or BPAY details", 400);
+  }
+
+  if (isBpay) {
+    if (!d.crn || !CRN_REGEX.test(d.crn)) {
+      throw new MockBankingError("Invalid BPAY CRN", 400);
+    }
+    if (!d.bpay_biller) {
+      throw new MockBankingError("Missing BPAY biller", 400);
+    }
+  }
+
+  if (isEft) {
+    if (!d.bsb || !BSB_REGEX.test(d.bsb)) {
+      throw new MockBankingError("Invalid BSB", 400);
+    }
+    if (!d.acct || !ACCOUNT_REGEX.test(d.acct)) {
+      throw new MockBankingError("Invalid account", 400);
+    }
+  }
+}
+
+function payloadHash(idempotencyKey: string, payload: any) {
+  const body = canonicalJson(payload);
+  return {
+    hash: sha256Hex(idempotencyKey + body).slice(0, 16).toUpperCase(),
+    canonical: body,
+  };
+}
+
+async function queryExisting(periodUuid: string, rail: string, idempotencyKey: string) {
+  const q = `
+    SELECT provider_ref, amount_cents, paid_at, meta
+    FROM settlements
+    WHERE period_id = $1
+      AND rail = $2
+      AND meta ->> 'idempotencyKey' = $3
+    ORDER BY paid_at DESC
+    LIMIT 1
+  `;
+  const { rows } = await pool.query(q, [periodUuid, rail, idempotencyKey]);
+  if (!rows.length) return null;
+  return rows[0] as SettlementRow;
+}
+
+async function insertSettlement(client: PoolClient | null, values: {
+  period_uuid: string;
+  rail: "EFT" | "BPAY" | "PAYTO";
+  provider_ref: string;
+  amount_cents: number;
+  paid_at: Date;
+  meta: Record<string, any>;
+}) {
+  const target = client ?? pool;
+  const q = `
+    INSERT INTO settlements (period_id, rail, provider_ref, amount_cents, paid_at, simulated, meta)
+    VALUES ($1,$2,$3,$4,$5,TRUE,$6::jsonb)
+    ON CONFLICT (id) DO NOTHING
+  `;
+  await target.query(q, [
+    values.period_uuid,
+    values.rail,
+    values.provider_ref,
+    values.amount_cents,
+    values.paid_at,
+    JSON.stringify(values.meta),
+  ]);
+}
+
+function getMandateStore() {
+  const g = globalThis as any;
+  if (!g.__apgms_mock_mandates) {
+    g.__apgms_mock_mandates = new Map<string, Mandate>();
+  }
+  return g.__apgms_mock_mandates as Map<string, Mandate>;
+}
+
+export class MockBanking {
+  private mandates: Map<string, Mandate>;
+
+  constructor() {
+    this.mandates = getMandateStore();
+  }
+
+  private async injectFaults() {
+    const p50 = clampNumber(parseFloatEnv("BANK_SIM_P50_MS", 300), 300);
+    const p95 = Math.max(p50, clampNumber(parseFloatEnv("BANK_SIM_P95_MS", 1200), 1200));
+    const baseDelay = Math.random() < 0.5
+      ? Math.random() * p50
+      : p50 + Math.random() * (p95 - p50);
+    if (baseDelay > 0) {
+      await sleep(baseDelay);
+    }
+
+    const timeoutRate = clampNumber(parseFloatEnv("BANK_SIM_TIMEOUT_RATE", 0), 0);
+    if (timeoutRate > 0 && Math.random() < timeoutRate) {
+      const timeoutMs = clampNumber(parseFloatEnv("BANK_SIM_TIMEOUT_MS", 15000), 15000);
+      await sleep(timeoutMs);
+      throw new MockBankingError("Simulated bank timeout", 504, "ETIMEDOUT");
+    }
+
+    const errRate = clampNumber(parseFloatEnv("BANK_SIM_5XX_RATE", 0), 0);
+    if (errRate > 0 && Math.random() < errRate) {
+      throw new MockBankingError("Simulated bank 5xx", 502);
+    }
+  }
+
+  private async withFaults<T>(fn: () => Promise<T>): Promise<T> {
+    await this.injectFaults();
+    return fn();
+  }
+
+  async sendEftOrBpay(params: EftBpayParams) {
+    const dest = normaliseDestination(params.destination || {});
+    validateDestination(dest);
+
+    if (!params.idempotencyKey) {
+      throw new MockBankingError("Missing idempotency key", 400);
+    }
+
+    const amount = Math.abs(Number(params.amount_cents));
+    if (!Number.isFinite(amount) || amount <= 0) {
+      throw new MockBankingError("Invalid amount", 400);
+    }
+
+    const rail = parseRail(dest);
+    const periodUuid = toUuid(params.periodId);
+    const payload = {
+      abn: params.abn,
+      taxType: params.taxType,
+      periodId: params.periodId,
+      amount_cents: amount,
+      destination: dest,
+    };
+    const { hash, canonical } = payloadHash(params.idempotencyKey, payload);
+    const providerRef = `SIM-${hash}`;
+
+    return this.withFaults(async () => {
+      const existing = await queryExisting(periodUuid, rail, params.idempotencyKey);
+      if (existing) {
+        const meta = existing.meta || {};
+        if (meta.payloadCanonical && meta.payloadCanonical !== canonical) {
+          throw new MockBankingError("Idempotency key collision", 409);
+        }
+        return {
+          rail,
+          provider_receipt_id: existing.provider_ref,
+          provider_ref: existing.provider_ref,
+          bank_receipt_hash: sha256Hex(existing.provider_ref),
+          transfer_uuid: meta.transferUuid || meta.transfer_uuid || meta.transferUUID || randomUUID(),
+          paid_at: existing.paid_at,
+          settlement_amount_cents: existing.amount_cents,
+          settlement_meta: meta,
+        };
+      }
+
+      const transferUuid = randomUUID();
+      const paidAt = new Date();
+      const settlementMeta = {
+        idempotencyKey: params.idempotencyKey,
+        payloadCanonical: canonical,
+        abn: params.abn,
+        taxType: params.taxType,
+        transferUuid,
+        destination: dest,
+      };
+
+      await insertSettlement(null, {
+        period_uuid: periodUuid,
+        rail,
+        provider_ref: providerRef,
+        amount_cents: amount,
+        paid_at: paidAt,
+        meta: settlementMeta,
+      });
+
+      return {
+        rail,
+        provider_receipt_id: providerRef,
+        provider_ref: providerRef,
+        bank_receipt_hash: sha256Hex(providerRef),
+        transfer_uuid: transferUuid,
+        paid_at: paidAt,
+        settlement_amount_cents: amount,
+        settlement_meta: settlementMeta,
+      };
+    });
+  }
+
+  async createMandate(abn: string, periodId: string, cap_cents: number) {
+    if (!abn || !periodId) {
+      throw new MockBankingError("Missing mandate details", 400);
+    }
+    if (!Number.isFinite(cap_cents) || cap_cents <= 0) {
+      throw new MockBankingError("Invalid cap", 400);
+    }
+    return this.withFaults(async () => {
+      const mandate: Mandate = {
+        id: `SIM-MAN-${randomUUID().replace(/-/g, "").slice(0, 12).toUpperCase()}`,
+        abn,
+        periodId,
+        cap_cents: Math.floor(cap_cents),
+        status: "pending",
+        created_at: new Date().toISOString(),
+      };
+      this.mandates.set(mandate.id, mandate);
+      return { mandate_id: mandate.id, status: mandate.status, created_at: mandate.created_at };
+    });
+  }
+
+  async verifyMandate(mandate_id: string) {
+    return this.withFaults(async () => {
+      const mandate = this.mandates.get(mandate_id);
+      if (!mandate) throw new MockBankingError("Mandate not found", 404);
+      if (mandate.status === "cancelled") throw new MockBankingError("Mandate cancelled", 400);
+      mandate.status = "active";
+      mandate.verified_at = new Date().toISOString();
+      return { mandate_id, status: mandate.status, verified_at: mandate.verified_at };
+    });
+  }
+
+  async cancelMandate(mandate_id: string) {
+    return this.withFaults(async () => {
+      const mandate = this.mandates.get(mandate_id);
+      if (!mandate) throw new MockBankingError("Mandate not found", 404);
+      mandate.status = "cancelled";
+      mandate.cancelled_at = new Date().toISOString();
+      return { mandate_id, status: mandate.status, cancelled_at: mandate.cancelled_at };
+    });
+  }
+
+  async debitMandate(mandate_id: string, amount_cents: number, meta: any = {}) {
+    if (!Number.isFinite(amount_cents) || amount_cents <= 0) {
+      throw new MockBankingError("Invalid debit amount", 400);
+    }
+    const idempotencyKey = String(meta?.idempotencyKey || meta?.idempotency_key || "");
+    if (!idempotencyKey) {
+      throw new MockBankingError("Missing PayTo idempotency key", 400);
+    }
+    return this.withFaults(async () => {
+      const mandate = this.mandates.get(mandate_id);
+      if (!mandate) throw new MockBankingError("Mandate not found", 404);
+      if (mandate.status !== "active") {
+        throw new MockBankingError("Mandate not active", 400);
+      }
+      if (amount_cents > mandate.cap_cents) {
+        throw new MockBankingError("Amount exceeds mandate cap", 400);
+      }
+
+      const periodUuid = toUuid(meta?.periodId || mandate.periodId);
+      const payload = {
+        mandate_id,
+        amount_cents,
+        meta,
+      };
+      const { hash, canonical } = payloadHash(idempotencyKey, payload);
+      const providerRef = `SIM-${hash}`;
+
+      const existing = await queryExisting(periodUuid, "PAYTO", idempotencyKey);
+      if (existing) {
+        const existingMeta = existing.meta || {};
+        if (existingMeta.payloadCanonical && existingMeta.payloadCanonical !== canonical) {
+          throw new MockBankingError("Idempotency key collision", 409);
+        }
+        return {
+          mandate_id,
+          provider_receipt_id: existing.provider_ref,
+          provider_ref: existing.provider_ref,
+          bank_receipt_hash: sha256Hex(existing.provider_ref),
+          transfer_uuid: existingMeta.transferUuid || randomUUID(),
+          paid_at: existing.paid_at,
+          settlement_amount_cents: existing.amount_cents,
+        };
+      }
+
+      const transferUuid = randomUUID();
+      const paidAt = new Date();
+      const settlementMeta = {
+        idempotencyKey,
+        payloadCanonical: canonical,
+        mandateId: mandate_id,
+        transferUuid,
+        meta,
+      };
+
+      await insertSettlement(null, {
+        period_uuid: periodUuid,
+        rail: "PAYTO",
+        provider_ref: providerRef,
+        amount_cents: Math.floor(amount_cents),
+        paid_at: paidAt,
+        meta: settlementMeta,
+      });
+
+      return {
+        mandate_id,
+        provider_receipt_id: providerRef,
+        provider_ref: providerRef,
+        bank_receipt_hash: sha256Hex(providerRef),
+        transfer_uuid: transferUuid,
+        paid_at: paidAt,
+        settlement_amount_cents: Math.floor(amount_cents),
+      };
+    });
+  }
+}
+
+export function getMockBanking(): MockBanking {
+  const g = globalThis as any;
+  if (!g[GLOBAL_KEY]) {
+    g[GLOBAL_KEY] = new MockBanking();
+  }
+  return g[GLOBAL_KEY] as MockBanking;
+}

--- a/pages/api/release/index.ts
+++ b/pages/api/release/index.ts
@@ -7,14 +7,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: "Method Not Allowed" });
   }
   try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
-    if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
+    const { abn, taxType, periodId, amountCents, destination } = req.body || {};
+    if (!abn || !taxType || !periodId || typeof amountCents !== "number" || !destination) {
       return res.status(400).json({ error: "Missing fields" });
     }
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
-    const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
+    const idem = req.headers["idempotency-key"];
+    const headers: Record<string, string> = {};
+    if (typeof idem === "string" && idem) headers["Idempotency-Key"] = idem;
+    if (Array.isArray(idem) && idem.length) headers["Idempotency-Key"] = idem[0];
+    const opts = Object.keys(headers).length ? { headers } : undefined;
+    const data = await Payments.payAto({ abn, taxType, periodId, amountCents, destination }, opts);
     return res.status(200).json(data);
   } catch (err: any) {
     return res.status(400).json({ error: err?.message || "Release failed" });

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -52,14 +52,18 @@ paymentsApi.post("/deposit", async (req, res) => {
 // POST /api/release  (calls payAto)
 paymentsApi.post("/release", async (req, res) => {
   try {
-    const { abn, taxType, periodId, amountCents } = req.body || {};
-    if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
+    const { abn, taxType, periodId, amountCents, destination } = req.body || {};
+    if (!abn || !taxType || !periodId || typeof amountCents !== "number" || !destination) {
       return res.status(400).json({ error: "Missing fields" });
     }
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
-    const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
+    const idem = req.header("Idempotency-Key");
+    const headers: Record<string, string> = {};
+    if (idem) headers["Idempotency-Key"] = idem;
+    const opts = Object.keys(headers).length ? { headers } : undefined;
+    const data = await Payments.payAto({ abn, taxType, periodId, amountCents, destination }, opts);
     res.json(data);
   } catch (err: any) {
     res.status(400).json({ error: err?.message || "Release failed" });


### PR DESCRIPTION
## Summary
- add a settlements table for recording simulated payouts
- implement a mock banking layer with validation, idempotency, and PayTo support
- update the release flow and API clients to pass idempotency keys, call the banking adapter, and persist provider references to evidence

## Testing
- npx tsc -p apps/services/payments/tsconfig.json *(fails: module must be NodeNext when moduleResolution=NodeNext)*

------
https://chatgpt.com/codex/tasks/task_e_68e3ae8121dc8327b4d32241190062b8