### PR TITLE
Add centralized feature flag configuration and safety check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Prototype defaults (safe for local development)
+APP_MODE=prototype
+FEATURE_TAX_ENGINE=true
+FEATURE_ATO_TABLES=false
+FEATURE_BANKING=false
+FEATURE_STP=false
+FEATURE_SECURITY_MIN=true
+FEATURE_SIM_OUTBOUND=true
+
+# Real mode example (uncomment to enable and adjust as needed)
+# APP_MODE=real
+# FEATURE_TAX_ENGINE=true
+# FEATURE_ATO_TABLES=true
+# FEATURE_BANKING=true
+# FEATURE_STP=true
+# FEATURE_SECURITY_MIN=true
+# FEATURE_SIM_OUTBOUND=false

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -1,0 +1,29 @@
+const env = (typeof process !== "undefined" && process.env) ? process.env : {} as Record<string, string | undefined>;
+
+function envBool(key: string, defaultValue: boolean): boolean {
+  const raw = env[key];
+  if (raw == null) return defaultValue;
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === "") return defaultValue;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return defaultValue;
+}
+
+export const FEATURES = {
+  APP_MODE: (env.APP_MODE ?? "prototype") as "prototype" | "real",
+  FEATURE_TAX_ENGINE: envBool("FEATURE_TAX_ENGINE", true),
+  FEATURE_ATO_TABLES: envBool("FEATURE_ATO_TABLES", false),
+  FEATURE_BANKING: envBool("FEATURE_BANKING", false),
+  FEATURE_STP: envBool("FEATURE_STP", false),
+  FEATURE_SECURITY_MIN: envBool("FEATURE_SECURITY_MIN", true),
+  FEATURE_SIM_OUTBOUND: envBool("FEATURE_SIM_OUTBOUND", true),
+} as const;
+
+export function assertSafeCombo(): void {
+  if (FEATURES.APP_MODE === "real" && FEATURES.FEATURE_SIM_OUTBOUND) {
+    throw new Error("Unsafe: real mode with SIM outbound");
+  }
+}
+
+export type FeatureFlags = typeof FEATURES;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,10 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { assertSafeCombo } from "./config/features";
 
 dotenv.config();
+assertSafeCombo();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));


### PR DESCRIPTION
## Summary
- add a shared feature flag configuration module with safe defaults and assertion helper
- fail server startup when unsafe real-mode SIM outbound combination is detected
- document prototype and real environment settings in a new .env.example file

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3b9ecdbe0832792e0e365069a2fed