### PR TITLE
Add health check metrics and request tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,12 @@
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "prom-client": "^15.1.3",
         "pg": "^8.16.3",
         "tweetnacl": "^1.0.3",
-        "uuid": "^13.0.0"
+        "uuid": "^13.0.0",
+        "@opentelemetry/sdk-node": "^0.52.1",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
+        "@opentelemetry/api": "^1.9.0"
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,60 @@
 ﻿// src/index.ts
-import express from "express";
+import express, { ErrorRequestHandler } from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { requestIdMiddleware } from "./middleware/requestId";
+import { initTracing } from "./observability/tracing";
+import { gatherHealth } from "./observability/health";
+import { registry } from "./observability/metrics";
 
 dotenv.config();
+void initTracing();
 
 const app = express();
+app.use(requestIdMiddleware);
 app.use(express.json({ limit: "2mb" }));
 
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+app.use((req, res, next) => {
+  const originalJson = res.json.bind(res);
+  res.json = ((body?: any) => {
+    if (body && typeof body === "object" && !Array.isArray(body)) {
+      body = { ...body, requestId: req.requestId };
+    }
+    return originalJson(body);
+  }) as typeof res.json;
+  next();
+});
+
+// request logger with requestId context
+app.use((req, res, next) => {
+  const start = Date.now();
+  console.log(`[app] ${req.method} ${req.url} reqId=${req.requestId}`);
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    console.log(
+      `[app] ${req.method} ${req.url} reqId=${req.requestId} status=${res.statusCode} duration=${duration}ms`
+    );
+  });
+  next();
+});
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.get("/healthz", async (req, res) => {
+  const report = await gatherHealth();
+  const status = report.ok ? 200 : 503;
+  res.status(status).json({ ...report, requestId: req.requestId });
+});
+
+app.get("/metrics", async (_req, res) => {
+  res.setHeader("Content-Type", registry.contentType);
+  res.send(await registry.metrics());
+});
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);
@@ -32,7 +70,24 @@ app.use("/api", paymentsApi);
 app.use("/api", api);
 
 // 404 fallback (must be last)
-app.use((_req, res) => res.status(404).send("Not found"));
+app.use((req, res) => res.status(404).json({ error: "Not found", requestId: req.requestId }));
+
+const errorHandler: ErrorRequestHandler = (err, req, res, next) => {
+  const status = err?.status || 500;
+  console.error("[app] request failed", { requestId: req.requestId, error: err });
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const payload = {
+    error: status === 500 ? "Internal Server Error" : err?.message || "Error",
+    requestId: req.requestId,
+  };
+
+  res.status(status).json(payload);
+};
+
+app.use(errorHandler);
 
 const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => console.log("APGMS server listening on", port));

--- a/src/middleware/requestId.ts
+++ b/src/middleware/requestId.ts
@@ -1,0 +1,18 @@
+import { RequestHandler } from "express";
+import { randomUUID } from "node:crypto";
+
+declare module "express-serve-static-core" {
+  interface Request {
+    requestId: string;
+  }
+}
+
+export const requestIdMiddleware: RequestHandler = (req, res, next) => {
+  const headerId = req.header("x-request-id");
+  const requestId = headerId && headerId.trim().length > 0 ? headerId : randomUUID();
+
+  req.requestId = requestId;
+  res.setHeader("x-request-id", requestId);
+
+  next();
+};

--- a/src/observability/health.ts
+++ b/src/observability/health.ts
@@ -1,0 +1,55 @@
+import { Pool } from "pg";
+
+export type DependencyStatus = {
+  name: string;
+  ok: boolean;
+  error?: string;
+};
+
+const pool = new Pool();
+
+async function checkDb(): Promise<DependencyStatus> {
+  try {
+    const client = await pool.connect();
+    try {
+      await client.query("select 1");
+      return { name: "db", ok: true };
+    } finally {
+      client.release();
+    }
+  } catch (error: any) {
+    return { name: "db", ok: false, error: error?.message ?? "unknown" };
+  }
+}
+
+async function checkHttpDependency(name: string, url: string): Promise<DependencyStatus> {
+  try {
+    const response = await fetch(url, { method: "GET" });
+    const ok = response.ok;
+    return {
+      name,
+      ok,
+      error: ok ? undefined : `${response.status} ${response.statusText}`,
+    };
+  } catch (error: any) {
+    return { name, ok: false, error: error?.message ?? "unknown" };
+  }
+}
+
+export async function gatherHealth(): Promise<{ ok: boolean; deps: DependencyStatus[] }> {
+  const checks: Promise<DependencyStatus>[] = [checkDb()];
+
+  const natsUrl = process.env.NATS_HEALTH_URL;
+  if (natsUrl) {
+    checks.push(checkHttpDependency("nats", natsUrl));
+  }
+
+  const taxEngineUrl = process.env.TAX_ENGINE_HEALTH_URL;
+  if (taxEngineUrl) {
+    checks.push(checkHttpDependency("tax_engine", taxEngineUrl));
+  }
+
+  const deps = await Promise.all(checks);
+  const ok = deps.every((dep) => dep.ok);
+  return { ok, deps };
+}

--- a/src/observability/metrics.ts
+++ b/src/observability/metrics.ts
@@ -1,0 +1,28 @@
+import { Counter, Registry, collectDefaultMetrics } from "prom-client";
+
+export const registry = new Registry();
+collectDefaultMetrics({ register: registry, prefix: "apgms_" });
+
+export const releaseAttemptsCounter = new Counter({
+  name: "apgms_release_attempts_total",
+  help: "Number of attempts to release payments",
+  registers: [registry],
+});
+
+export const releaseSuccessCounter = new Counter({
+  name: "apgms_release_success_total",
+  help: "Number of successful payment releases",
+  registers: [registry],
+});
+
+export const releaseFailureCounter = new Counter({
+  name: "apgms_release_failure_total",
+  help: "Number of failed payment releases",
+  registers: [registry],
+});
+
+export const reconciliationImportsCounter = new Counter({
+  name: "apgms_reconciliation_import_total",
+  help: "Number of reconciliation import requests processed",
+  registers: [registry],
+});

--- a/src/observability/tracing.ts
+++ b/src/observability/tracing.ts
@@ -1,0 +1,53 @@
+let sdk: any;
+
+function isEnabled(value: string | undefined) {
+  return value !== undefined && ["1", "true", "TRUE"].includes(value);
+}
+
+export async function initTracing() {
+  const enabled = process.env.OTEL_ENABLED;
+  if (!isEnabled(enabled)) {
+    return;
+  }
+
+  const url = process.env.OTEL_EXPORTER_OTLP_ENDPOINT;
+  if (!url) {
+    console.warn("OTEL_ENABLED set but OTEL_EXPORTER_OTLP_ENDPOINT missing");
+    return;
+  }
+
+  try {
+    const [{ NodeSDK }, { OTLPTraceExporter }, api] = await Promise.all([
+      import("@opentelemetry/sdk-node"),
+      import("@opentelemetry/exporter-trace-otlp-http"),
+      import("@opentelemetry/api"),
+    ]);
+
+    const { diag, DiagConsoleLogger, DiagLogLevel } = api as any;
+    if (!process.env.OTEL_LOG_LEVEL || process.env.OTEL_LOG_LEVEL === "debug") {
+      diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.DEBUG);
+    }
+
+    sdk = new NodeSDK({
+      traceExporter: new OTLPTraceExporter({ url }),
+    });
+
+    await sdk.start();
+    console.log("OpenTelemetry tracing initialized");
+
+    const shutdown = async () => {
+      if (!sdk) return;
+      try {
+        await sdk.shutdown();
+        console.log("OpenTelemetry tracing terminated");
+      } catch (err) {
+        console.error("Error terminating OpenTelemetry", err);
+      }
+    };
+
+    process.on("SIGTERM", shutdown);
+    process.on("SIGINT", shutdown);
+  } catch (err) {
+    console.error("Failed to initialize OpenTelemetry", err);
+  }
+}

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -4,6 +4,12 @@ import { releasePayment, resolveDestination } from "../rails/adapter";
 import { debit as paytoDebit } from "../payto/adapter";
 import { parseSettlementCSV } from "../settlement/splitParser";
 import { Pool } from "pg";
+import {
+  releaseAttemptsCounter,
+  releaseFailureCounter,
+  releaseSuccessCounter,
+  reconciliationImportsCounter,
+} from "../observability/metrics";
 const pool = new Pool();
 
 export async function closeAndIssue(req:any, res:any) {
@@ -14,22 +20,28 @@ export async function closeAndIssue(req:any, res:any) {
     const rpt = await issueRPT(abn, taxType, periodId, thr);
     return res.json(rpt);
   } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+    return res.status(400).json({ error: e.message, requestId: req.requestId });
   }
 }
 
 export async function payAto(req:any, res:any) {
   const { abn, taxType, periodId, rail } = req.body; // EFT|BPAY
   const pr = await pool.query("select * from rpt_tokens where abn= and tax_type= and period_id= order by id desc limit 1", [abn, taxType, periodId]);
-  if (pr.rowCount === 0) return res.status(400).json({error:"NO_RPT"});
+  releaseAttemptsCounter.inc();
+  if (pr.rowCount === 0) {
+    releaseFailureCounter.inc();
+    return res.status(400).json({ error: "NO_RPT", requestId: req.requestId });
+  }
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
     const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
+    releaseSuccessCounter.inc();
     return res.json(r);
   } catch (e:any) {
-    return res.status(400).json({ error: e.message });
+    releaseFailureCounter.inc();
+    return res.status(400).json({ error: e.message, requestId: req.requestId });
   }
 }
 
@@ -43,6 +55,7 @@ export async function settlementWebhook(req:any, res:any) {
   const csvText = req.body?.csv || "";
   const rows = parseSettlementCSV(csvText);
   // TODO: For each row, post GST and NET into your ledgers, maintain txn_id reversal map
+  reconciliationImportsCounter.inc();
   return res.json({ ingested: rows.length });
 }
 

--- a/src/types/opentelemetry.d.ts
+++ b/src/types/opentelemetry.d.ts
@@ -1,0 +1,3 @@
+declare module "@opentelemetry/sdk-node";
+declare module "@opentelemetry/exporter-trace-otlp-http";
+declare module "@opentelemetry/api";


### PR DESCRIPTION
## Summary
- add request ID middleware to propagate x-request-id through logs and API responses and centralize error handling
- expose /healthz and /metrics endpoints with dependency checks and Prometheus counters for releases and reconciliation imports
- bootstrap optional OpenTelemetry tracing via OTLP when enabled by environment variables

## Testing
- not run (npm install failed: npm error 403 installing @opentelemetry/api)


------
https://chatgpt.com/codex/tasks/task_e_68e3ba2f0cd48327b6ba8f908c7de6c2