### PR TITLE
Add readiness scorecard endpoint and banner

### DIFF
--- a/scripts/scorecard/checks.ts
+++ b/scripts/scorecard/checks.ts
@@ -1,0 +1,422 @@
+import { promises as fs } from "fs";
+import path from "path";
+
+export type ReadinessMode = "prototype" | "real";
+
+export interface ReadinessCheckResult {
+  key: string;
+  label: string;
+  mode: ReadinessMode;
+  ok: boolean;
+  details: string;
+  helpUrl?: string;
+}
+
+export interface ReadinessScorecard {
+  score: number;
+  max: number;
+  checks: ReadinessCheckResult[];
+}
+
+interface CheckDefinition {
+  key: string;
+  label: string;
+  mode: ReadinessMode;
+  helpUrl?: string;
+  run: (context: { lite: boolean }) => Promise<{ ok: boolean; details: string }>;
+}
+
+const REPO_ROOT = process.env.APGMS_REPO_ROOT || process.cwd();
+
+async function pathExists(relativePath: string): Promise<boolean> {
+  try {
+    await fs.access(path.resolve(REPO_ROOT, relativePath));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function envFlagTrue(name: string): boolean {
+  const raw = process.env[name];
+  if (!raw) return false;
+  return raw.trim().toLowerCase() === "true";
+}
+
+const prototypeChecks: CheckDefinition[] = [
+  {
+    key: "prototype-event-normalizer",
+    label: "Event normalizer service available",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/runbooks/event-normalizer",
+    run: async () => {
+      const exists = await pathExists("apps/services/event-normalizer");
+      return {
+        ok: exists,
+        details: exists
+          ? "Service folder present in repository"
+          : "Missing event-normalizer service directory",
+      };
+    },
+  },
+  {
+    key: "prototype-payments-build",
+    label: "Payments service source tracked",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/runbooks/payments-prototype",
+    run: async () => {
+      const exists = await pathExists("apps/services/payments/package.json");
+      return {
+        ok: exists,
+        details: exists
+          ? "package.json found for payments service"
+          : "Payments package.json missing",
+      };
+    },
+  },
+  {
+    key: "prototype-recon-job",
+    label: "Reconciliation job defined",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/runbooks/recon-prototype",
+    run: async () => {
+      const exists = await pathExists("apps/services/recon");
+      return {
+        ok: exists,
+        details: exists
+          ? "Recon service sources present"
+          : "Recon service directory missing",
+      };
+    },
+  },
+  {
+    key: "prototype-rpt-verify",
+    label: "Reporting verification scripts available",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/runbooks/rpt-verify",
+    run: async () => {
+      const exists = await pathExists("apps/services/rpt-verify");
+      return {
+        ok: exists,
+        details: exists
+          ? "rpt-verify service folder present"
+          : "rpt-verify service missing",
+      };
+    },
+  },
+  {
+    key: "prototype-bank-egress",
+    label: "Bank egress integration committed",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/runbooks/bank-egress",
+    run: async () => {
+      const exists = await pathExists("apps/services/bank-egress");
+      return {
+        ok: exists,
+        details: exists
+          ? "bank-egress service present"
+          : "bank-egress service missing",
+      };
+    },
+  },
+  {
+    key: "prototype-grafana-dashboards",
+    label: "Grafana dashboards checked in",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/observability/grafana",
+    run: async () => {
+      const exists = await pathExists("ops/grafana/dashboards");
+      return {
+        ok: exists,
+        details: exists
+          ? "Grafana dashboards directory present"
+          : "Grafana dashboards directory missing",
+      };
+    },
+  },
+  {
+    key: "prototype-prometheus-rules",
+    label: "Prometheus config versioned",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/observability/prometheus",
+    run: async () => {
+      const exists = await pathExists("ops/prometheus.yml");
+      return {
+        ok: exists,
+        details: exists
+          ? "ops/prometheus.yml found"
+          : "Prometheus config missing",
+      };
+    },
+  },
+  {
+    key: "prototype-otel-config",
+    label: "OTel collector config committed",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/observability/otel",
+    run: async () => {
+      const exists = await pathExists("ops/otel-config.yaml");
+      return {
+        ok: exists,
+        details: exists
+          ? "ops/otel-config.yaml available"
+          : "OTel collector config missing",
+      };
+    },
+  },
+  {
+    key: "prototype-bcp-drill",
+    label: "BCP drill completed",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/bcp/runbook",
+    run: async () => {
+      const ok = envFlagTrue("PROTOTYPE_BCP_DRILL_COMPLETE");
+      return {
+        ok,
+        details: ok
+          ? "PROTOTYPE_BCP_DRILL_COMPLETE flag set"
+          : "Awaiting BCP drill completion (set PROTOTYPE_BCP_DRILL_COMPLETE=true)",
+      };
+    },
+  },
+  {
+    key: "prototype-security-review",
+    label: "Security review accepted",
+    mode: "prototype",
+    helpUrl: "https://intranet.apgms.example/security/reviews",
+    run: async () => {
+      const ok = envFlagTrue("PROTOTYPE_SECURITY_REVIEW_APPROVED");
+      return {
+        ok,
+        details: ok
+          ? "Prototype security review approved"
+          : "Security review approval missing (set PROTOTYPE_SECURITY_REVIEW_APPROVED=true)",
+      };
+    },
+  },
+];
+
+function formatPenTestDetails(raw: string | undefined): { ok: boolean; details: string } {
+  if (!raw) {
+    return {
+      ok: false,
+      details: "Pen test date missing (set REAL_LAST_PEN_TEST_AT=YYYY-MM-DD)",
+    };
+  }
+
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    return {
+      ok: false,
+      details: `Invalid pen test date '${raw}' (expected YYYY-MM-DD)`,
+    };
+  }
+
+  const ageMs = Date.now() - parsed.getTime();
+  const maxAgeMs = 1000 * 60 * 60 * 24 * 180; // 180 days
+  const ok = ageMs <= maxAgeMs;
+  if (ok) {
+    return {
+      ok,
+      details: `Pen test completed on ${raw}`,
+    };
+  }
+
+  return {
+    ok,
+    details: `Last pen test on ${raw} exceeds 180 day threshold`,
+  };
+}
+
+const realChecks: CheckDefinition[] = [
+  {
+    key: "real-tax-engine",
+    label: "Tax engine deployed",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/runbooks/tax-engine",
+    run: async () => {
+      const exists = await pathExists("apps/services/tax-engine");
+      return {
+        ok: exists,
+        details: exists
+          ? "tax-engine service folder present"
+          : "tax-engine service missing",
+      };
+    },
+  },
+  {
+    key: "real-audit-pipeline",
+    label: "Audit pipeline ready",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/runbooks/audit",
+    run: async () => {
+      const exists = await pathExists("apps/services/audit");
+      return {
+        ok: exists,
+        details: exists
+          ? "audit service folder present"
+          : "audit service missing",
+      };
+    },
+  },
+  {
+    key: "real-bas-gate",
+    label: "BAS gate service packaged",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/runbooks/bas-gate",
+    run: async () => {
+      const exists = await pathExists("apps/services/bas-gate");
+      return {
+        ok: exists,
+        details: exists
+          ? "bas-gate service folder present"
+          : "bas-gate service missing",
+      };
+    },
+  },
+  {
+    key: "real-nginx-config",
+    label: "Ingress configuration committed",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/operations/nginx",
+    run: async () => {
+      const exists = await pathExists("ops/nginx.main.conf");
+      return {
+        ok: exists,
+        details: exists
+          ? "ops/nginx.main.conf found"
+          : "NGINX config missing",
+      };
+    },
+  },
+  {
+    key: "real-prometheus",
+    label: "Production Prometheus config ready",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/observability/prometheus",
+    run: async () => {
+      const exists = await pathExists("ops/prometheus.yml");
+      return {
+        ok: exists,
+        details: exists
+          ? "ops/prometheus.yml found"
+          : "Prometheus config missing",
+      };
+    },
+  },
+  {
+    key: "real-runbooks",
+    label: "Runbooks in repository",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/runbooks",
+    run: async () => {
+      const exists = await pathExists("ops/runbooks/README.md");
+      return {
+        ok: exists,
+        details: exists
+          ? "Runbook index present"
+          : "Runbook README missing",
+      };
+    },
+  },
+  {
+    key: "real-production-credentials",
+    label: "Production credential rotation",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/security/credentials",
+    run: async () => {
+      const ok = envFlagTrue("REAL_PROD_CREDENTIALS_READY");
+      return {
+        ok,
+        details: ok
+          ? "Production credentials rotated"
+          : "Rotate credentials and set REAL_PROD_CREDENTIALS_READY=true",
+      };
+    },
+  },
+  {
+    key: "real-penetration-test",
+    label: "Recent penetration testing",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/security/pen-tests",
+    run: async () => formatPenTestDetails(process.env.REAL_LAST_PEN_TEST_AT),
+  },
+  {
+    key: "real-regulator-signoff",
+    label: "Regulator sign-off recorded",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/compliance/regulator",
+    run: async () => {
+      const ok = envFlagTrue("REAL_REGULATOR_SIGNOFF");
+      return {
+        ok,
+        details: ok
+          ? "Regulator sign-off confirmed"
+          : "Awaiting regulator sign-off (set REAL_REGULATOR_SIGNOFF=true)",
+      };
+    },
+  },
+  {
+    key: "real-dr-exercise",
+    label: "Disaster recovery exercise",
+    mode: "real",
+    helpUrl: "https://intranet.apgms.example/bcp/dr-plan",
+    run: async () => {
+      const ok = envFlagTrue("REAL_DR_EXERCISE_COMPLETE");
+      return {
+        ok,
+        details: ok
+          ? "REAL_DR_EXERCISE_COMPLETE flag set"
+          : "Schedule DR exercise and set REAL_DR_EXERCISE_COMPLETE=true",
+      };
+    },
+  },
+];
+
+const allChecks = [...prototypeChecks, ...realChecks];
+
+export async function runScorecard(
+  mode: ReadinessMode,
+  options: { lite?: boolean } = {},
+): Promise<ReadinessScorecard> {
+  const relevant = allChecks.filter((check) => check.mode === mode);
+  const lite = options.lite ?? false;
+  const results: ReadinessCheckResult[] = [];
+
+  for (const check of relevant) {
+    try {
+      const outcome = await check.run({ lite });
+      results.push({
+        key: check.key,
+        label: check.label,
+        mode: check.mode,
+        ok: outcome.ok,
+        details: outcome.details,
+        helpUrl: check.helpUrl,
+      });
+    } catch (error) {
+      const details =
+        error instanceof Error ? error.message : "Unexpected error running check";
+      results.push({
+        key: check.key,
+        label: check.label,
+        mode: check.mode,
+        ok: false,
+        details,
+        helpUrl: check.helpUrl,
+      });
+    }
+  }
+
+  const score = results.filter((result) => result.ok).length;
+  return { score, max: results.length, checks: results };
+}
+
+export async function runAllScorecards(options: { lite?: boolean } = {}) {
+  const [prototype, real] = await Promise.all([
+    runScorecard("prototype", options),
+    runScorecard("real", options),
+  ]);
+
+  return { prototype, real };
+}

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import ModeBanner from "./ModeBanner";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -16,6 +17,7 @@ const navLinks = [
 export default function AppLayout() {
   return (
     <div>
+      <ModeBanner />
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>

--- a/src/components/ModeBanner.tsx
+++ b/src/components/ModeBanner.tsx
@@ -1,0 +1,167 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+type ReadinessMode = "prototype" | "real";
+
+interface ReadinessCheck {
+  key: string;
+  label: string;
+  mode: ReadinessMode;
+  ok: boolean;
+  details: string;
+  helpUrl?: string;
+}
+
+interface Scorecard {
+  score: number;
+  max: number;
+  checks: ReadinessCheck[];
+}
+
+interface ReadinessResponse {
+  rubric: { version: string };
+  prototype: Scorecard;
+  real: Scorecard;
+  timestamp: string;
+  appMode: string;
+}
+
+const ModeBanner: React.FC = () => {
+  const [readiness, setReadiness] = useState<ReadinessResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function load() {
+      try {
+        const response = await fetch("/ops/readiness");
+        if (!response.ok) {
+          throw new Error(`Readiness request failed (${response.status})`);
+        }
+        const payload: ReadinessResponse = await response.json();
+        if (!isMounted) return;
+        setReadiness(payload);
+        setError(null);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(err instanceof Error ? err.message : "Unable to load readiness");
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    }
+
+    load();
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const failingChecks = useMemo(() => {
+    if (!readiness) return [] as ReadinessCheck[];
+    return [...readiness.prototype.checks, ...readiness.real.checks].filter(
+      (check) => !check.ok,
+    );
+  }, [readiness]);
+
+  const bannerText = useMemo(() => {
+    if (loading) return "Loading readiness…";
+    if (error || !readiness)
+      return "Readiness unavailable";
+    return `Prototype readiness: ${readiness.prototype.score}/${readiness.prototype.max} • Real readiness: ${readiness.real.score}/${readiness.real.max} • Rubric v${readiness.rubric.version}`;
+  }, [loading, error, readiness]);
+
+  const timestampText = readiness
+    ? new Date(readiness.timestamp).toLocaleString()
+    : "";
+
+  const handleToggleDrawer = () => {
+    if (loading || error) return;
+    setDrawerOpen((open) => !open);
+  };
+
+  const closeDrawer = () => setDrawerOpen(false);
+
+  return (
+    <>
+      <div className="mode-banner" role="status" aria-live="polite">
+        <span className="mode-banner__text">{bannerText}</span>
+        <button
+          type="button"
+          className="mode-banner__button"
+          onClick={handleToggleDrawer}
+          disabled={loading || !!error}
+        >
+          See details
+        </button>
+      </div>
+
+      <div className={`readiness-drawer${drawerOpen ? " open" : ""}`}>
+        <div className="readiness-drawer__header">
+          <div>
+            <h2>Readiness details</h2>
+            {readiness && (
+              <p>
+                Mode: <strong>{readiness.appMode}</strong> • Updated: {timestampText}
+              </p>
+            )}
+          </div>
+          <button
+            type="button"
+            className="readiness-drawer__close"
+            onClick={closeDrawer}
+            aria-label="Close readiness details"
+          >
+            ×
+          </button>
+        </div>
+
+        <div className="readiness-drawer__body">
+          {loading && <p>Loading readiness…</p>}
+          {error && !loading && <p className="readiness-error">{error}</p>}
+          {!loading && !error && readiness && failingChecks.length === 0 && (
+            <p>All readiness checks are passing.</p>
+          )}
+          {!loading && !error && readiness && failingChecks.length > 0 && (
+            <ul className="readiness-check-list">
+              {failingChecks.map((check) => (
+                <li key={check.key} className="readiness-check">
+                  <div className="readiness-check__title">
+                    <span className={`readiness-badge readiness-badge--${check.mode}`}>
+                      {check.mode === "prototype" ? "Prototype" : "Real"}
+                    </span>
+                    <span className="readiness-check__label">{check.label}</span>
+                  </div>
+                  <p className="readiness-check__details">{check.details}</p>
+                  {check.helpUrl && (
+                    <a
+                      href={check.helpUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="readiness-check__link"
+                    >
+                      View runbook
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      {drawerOpen && (
+        <div
+          className="readiness-drawer__overlay"
+          onClick={closeDrawer}
+          aria-hidden="true"
+        />
+      )}
+    </>
+  );
+};
+
+export default ModeBanner;

--- a/src/index.css
+++ b/src/index.css
@@ -159,6 +159,183 @@ label {
   .tabs-row {
     gap: 18px;
     font-size: 15px;
+}
+}
+
+.mode-banner {
+  background: #0b2f6b;
+  color: #fff;
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  font-size: 0.95rem;
+}
+
+.mode-banner__text {
+  flex: 1;
+}
+
+.mode-banner__button {
+  background: #fff;
+  color: #0b2f6b;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.mode-banner__button:hover {
+  background: #dbe4ff;
+}
+
+.mode-banner__button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  background: #f0f3fa;
+  color: #566280;
+}
+
+.readiness-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  width: 380px;
+  max-width: 90vw;
+  height: 100%;
+  background: #fff;
+  box-shadow: -2px 0 16px rgba(15, 23, 42, 0.18);
+  transform: translateX(100%);
+  transition: transform 0.3s ease;
+  z-index: 2000;
+  display: flex;
+  flex-direction: column;
+}
+
+.readiness-drawer.open {
+  transform: translateX(0);
+}
+
+.readiness-drawer__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 20px;
+  border-bottom: 1px solid #e5e8f0;
+  gap: 12px;
+}
+
+.readiness-drawer__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.readiness-drawer__header p {
+  margin: 6px 0 0 0;
+  color: #4a5568;
+  font-size: 0.9rem;
+}
+
+.readiness-drawer__close {
+  border: none;
+  background: transparent;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #334155;
+}
+
+.readiness-drawer__body {
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
+}
+
+.readiness-check-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.readiness-check {
+  border-bottom: 1px solid #e5e8f0;
+  padding: 14px 0;
+}
+
+.readiness-check:last-child {
+  border-bottom: none;
+}
+
+.readiness-check__title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.readiness-badge {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  font-weight: 700;
+  padding: 2px 10px;
+  border-radius: 999px;
+}
+
+.readiness-badge--prototype {
+  background: rgba(0, 32, 91, 0.16);
+  color: #00205b;
+}
+
+.readiness-badge--real {
+  background: rgba(0, 113, 107, 0.16);
+  color: #00716b;
+}
+
+.readiness-check__label {
+  font-weight: 600;
+  color: #1f2937;
+}
+
+.readiness-check__details {
+  margin: 0 0 6px 0;
+  color: #4a5568;
+  font-size: 0.9rem;
+}
+
+.readiness-check__link {
+  color: #00716b;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.readiness-check__link:hover {
+  text-decoration: underline;
+}
+
+.readiness-error {
+  color: #b00020;
+  font-weight: 600;
+}
+
+.readiness-drawer__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  z-index: 1990;
+}
+
+@media (max-width: 600px) {
+  .mode-banner {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .mode-banner__button {
+    width: 100%;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { getReadinessSnapshot } from "./ops/readiness";
 
 dotenv.config();
 
@@ -17,6 +18,15 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.get("/ops/readiness", async (_req, res, next) => {
+  try {
+    const readiness = await getReadinessSnapshot();
+    res.json(readiness);
+  } catch (error) {
+    next(error);
+  }
+});
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);

--- a/src/ops/readiness.ts
+++ b/src/ops/readiness.ts
@@ -1,0 +1,21 @@
+import { runAllScorecards } from "../../scripts/scorecard/checks";
+
+export interface ReadinessSnapshot {
+  rubric: { version: string };
+  prototype: Awaited<ReturnType<typeof runAllScorecards>>["prototype"];
+  real: Awaited<ReturnType<typeof runAllScorecards>>["real"];
+  timestamp: string;
+  appMode: string;
+}
+
+export async function getReadinessSnapshot(): Promise<ReadinessSnapshot> {
+  const { prototype, real } = await runAllScorecards({ lite: true });
+
+  return {
+    rubric: { version: "1.0" },
+    prototype,
+    real,
+    timestamp: new Date().toISOString(),
+    appMode: process.env.APP_MODE || "prototype",
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,5 @@
     "isolatedModules": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"]
+  "include": ["src", "scripts/scorecard/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add shared readiness scorecard logic with prototype and real checks in scripts/scorecard/checks.ts
- expose a new /ops/readiness endpoint that serves the lite scorecard snapshot with rubric metadata
- surface readiness scores in the app via a mode banner and drawer showing failing checks and runbooks

## Testing
- npx tsx -e "import('./scripts/scorecard/checks.ts').then(async (mod) => { const data = await mod.runAllScorecards({ lite: true }); console.log(JSON.stringify(data, null, 2)); })"
- npx tsx -e "import('./src/ops/readiness.ts').then(async (mod) => { const data = await mod.getReadinessSnapshot(); console.log(JSON.stringify(data, null, 2)); process.exit(0); })"

------
https://chatgpt.com/codex/tasks/task_e_68e3bba090f88327ac4b63ba02c71cc2