### PR TITLE
Add in-app help drawer with docs coverage checks

### DIFF
--- a/docs/errors.mdx
+++ b/docs/errors.mdx
@@ -1,0 +1,28 @@
+---
+title: Errors
+slug: errors
+summary: Manage exceptions when automation encounters missing data, rejected payments or compliance risks.
+---
+
+# Errors
+
+Errors capture issues that require human intervention so APGMS stays compliant even when external
+systems fail.
+
+## When to raise an error
+
+* Transfers rejected by the bank or payments that exceed account balances.
+* Missing payroll submissions, late sales uploads or API outages from source systems.
+* Variances discovered during reconciliation that cannot be auto-resolved.
+
+## Workflow
+
+1. Create an error record with context, impacted obligation and severity.
+2. Assign an owner and due date. Attach screenshots or exports that assist in remediation.
+3. Monitor resolution progress on the **Fraud & Errors** page and capture final outcome notes.
+
+## Links to other modules
+
+* From **Reconciliation**, convert a variance directly into an error for tracking.
+* **Releases** must reference any open errors before deployment proceeds.
+* Evidence exports automatically include the audit history of related errors.

--- a/docs/evidence.mdx
+++ b/docs/evidence.mdx
@@ -1,0 +1,31 @@
+---
+title: Evidence
+slug: evidence
+summary: Capture artefacts that substantiate PAYGW and GST positions for audit and dispute handling.
+---
+
+# Evidence
+
+APGMS aggregates records from payroll, sales and banking systems so you can evidence compliance
+quickly. Use this guide to understand what is stored and how to access it.
+
+## Evidence sources
+
+1. **Payroll events** – Gross wages, PAYGW withheld, superannuation contributions and submission
+   timestamps.
+2. **Sales events** – GST collected per channel, exemptions applied and adjustments.
+3. **Bank transfers** – Automated movements between operating, PAYGW and GST accounts.
+4. **User actions** – Configuration changes, approvals and overrides captured in the audit log.
+
+## Retrieving evidence
+
+* Navigate to **Audit → Evidence register** in-product to filter by period or obligation type.
+* Export CSV packages for auditors; each bundle includes human readable summaries plus raw machine
+  data.
+* The Help drawer surfaces relevant evidence tips when opened from the Audit page.
+
+## Best practices
+
+* Store downloads in your DMS with retention aligned to ATO requirements (generally five years).
+* Use the **Errors** workflow when data is incomplete so exceptions are tracked and resolved.
+* Pair exports with the Releases process to capture sign-off before obligations are lodged.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,0 +1,44 @@
+---
+title: Getting Started
+slug: getting-started
+summary: Understand how APGMS guides you through setup and daily compliance tasks.
+---
+
+# Getting Started
+
+Automated PAYGW & GST Management System (APGMS) keeps payment obligations visible while reducing
+manual reconciliation. Use this guide to stand up a workspace and link the systems that provide
+source data.
+
+## 1. Create your workspace foundation
+
+1. Configure legal identifiers such as ABN, trading name and contact channels in **Settings → Business Profile**.
+2. Link the operating account, PAYGW saver and GST saver accounts so that automated transfers can
+   draw from and return funds to the correct destinations.
+3. Invite finance approvers and payroll operators if the workspace requires multi-person controls.
+
+## 2. Connect revenue and payroll sources
+
+* Link payroll systems (for example MYOB or QuickBooks) to feed withholding events.
+* Connect sales channels so GST calculations stay accurate as revenue streams change.
+* Map each source to a reporting mode so that the wizard applies the right collection rules.
+
+## 3. Run the setup wizard
+
+The wizard validates banking details, prompts for transfer frequencies, and checks for
+ATO-mandated data points. Completing every step ensures automated tasks run without manual
+intervention.
+
+## 4. Review the dashboard
+
+After setup the dashboard highlights:
+
+* lodgment status for BAS and payroll submissions,
+* cash required for upcoming obligations,
+* alerts for overdue actions.
+
+## 5. Next steps
+
+* Review the other help topics for deeper workflows.
+* Bookmark the in-product help drawer (⇧+/) for contextual answers.
+* Visit the **Releases** article when promoting changes between environments.

--- a/docs/modes.mdx
+++ b/docs/modes.mdx
@@ -1,0 +1,32 @@
+---
+title: Modes
+slug: modes
+summary: Configure PAYGW and GST collection modes to reflect how revenue and payroll data arrive.
+---
+
+# Modes
+
+Modes describe how APGMS should interpret incoming transactions and obligations. They keep
+automation predictable when business processes vary by channel or employee type.
+
+## Operating modes
+
+| Mode | Primary use | Notes |
+| ---- | ------------ | ----- |
+| Real-time | Stream data from integrated payroll or POS tools for immediate withholding. | Ideal when APIs push events as they happen. |
+| Batch | Upload CSV or manual journals on a schedule. | Use for legacy systems without live integrations. |
+| Advisory | Track obligations without triggering transfers. | Great for modelling new business units or sandboxes. |
+
+## Selecting a mode
+
+* **Wizard** steps prompt for a mode per revenue stream.
+* **Settings → Payroll & Sales** lets you adjust assignments after onboarding.
+* Switching from Advisory to Real-time recalculates standing transfer schedules so no obligation is
+  missed.
+
+## Governance tips
+
+* Keep sandbox or UAT workspaces in Advisory to prevent unintended banking activity.
+* Document who can promote a workspace to Real-time in the Releases process.
+* Pair modes with alerts in **Settings → Notifications** so stakeholders know when automation
+  changes.

--- a/docs/reconciliation.mdx
+++ b/docs/reconciliation.mdx
@@ -1,0 +1,29 @@
+---
+title: Reconciliation
+slug: reconciliation
+summary: Match PAYGW and GST obligations with source data and banking activity.
+---
+
+# Reconciliation
+
+Reconciliation ensures PAYGW and GST figures align across payroll, sales and banking. APGMS automates
+much of the heavy lifting but finance teams retain control over approvals.
+
+## Daily process
+
+1. Review the **Dashboard** summary for outstanding balances and overdue tasks.
+2. Visit **BAS → Reconciliation** to compare calculated obligations with actual transfers.
+3. Use the drill-down tables to investigate mismatches by employee, channel or tax code.
+4. Approve or reject system-generated adjustments so the ledger stays accurate.
+
+## Exception handling
+
+* Raise an item in **Errors** when the variance exceeds tolerance or data is missing.
+* Attach screenshots, CSV extracts or commentary so auditors can follow the decision trail.
+* Link the exception to a release if remediation requires configuration changes.
+
+## Period close
+
+* Lock the period once balances agree and evidence exports are saved.
+* Trigger the BAS lodgment workflow with approvals from finance leadership.
+* Store the reconciliation report with the official BAS submission package.

--- a/docs/releases.mdx
+++ b/docs/releases.mdx
@@ -1,0 +1,33 @@
+---
+title: Releases
+slug: releases
+summary: Promote configuration changes safely across sandboxes, UAT and production workspaces.
+---
+
+# Releases
+
+Releases coordinate how configuration, integrations and automation changes move between
+non-production and production environments.
+
+## Release stages
+
+1. **Draft** – Capture the intent of the change, impacted obligations and stakeholders who must
+   approve.
+2. **UAT** – Validate behaviour in an Advisory-mode workspace before automation triggers real-world
+   transfers.
+3. **Ready for production** – Secure approvals, attach evidence exports and schedule the change.
+4. **Production** – Monitor the first automated cycle after deployment and roll back if needed.
+
+## Managing releases in APGMS
+
+* Use **Settings → Customisation** to prepare configuration changes, then attach screenshots to the
+  release record.
+* Integrations updated via **Integrations → Connections** inherit the release identifier so you can
+  trace which version is active.
+* Link evidence exports to releases so auditors understand the decision trail.
+
+## Controls checklist
+
+* Segregate duties: preparer, approver and deployer roles must remain distinct.
+* Capture test results within the release card before promoting to production.
+* If automation fails post-release, open the **Errors** workflow to coordinate remediation.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "check:help": "node scripts/check-help-coverage.mjs"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/scripts/check-help-coverage.mjs
+++ b/scripts/check-help-coverage.mjs
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+
+const root = path.resolve(new URL('.', import.meta.url).pathname, '..');
+const appFile = path.join(root, 'src', 'App.tsx');
+const pagesDir = path.join(root, 'src', 'pages');
+const docsDir = path.join(root, 'docs');
+
+function readFile(filePath) {
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+const appSource = readFile(appFile);
+const routeRegex = /<Route\s+path="([^"]+)"\s+element={<([A-Za-z0-9_]+)\s*\/>}/g;
+const routes = [];
+let match;
+while ((match = routeRegex.exec(appSource)) !== null) {
+  routes.push({ path: match[1], component: match[2] });
+}
+
+const errors = [];
+const seenSlugs = new Set();
+
+routes.forEach(({ path: routePath, component }) => {
+  const pageFile = path.join(pagesDir, `${component}.tsx`);
+  if (!fs.existsSync(pageFile)) {
+    errors.push(`Route ${routePath} points to missing page file ${pageFile}`);
+    return;
+  }
+  const source = readFile(pageFile);
+  const metaMatch = source.match(/export const meta:[^=]*=\s*({[\s\S]*?});/);
+  if (!metaMatch) {
+    errors.push(`Page ${component} is missing an exported meta constant.`);
+    return;
+  }
+  const metaBlock = metaMatch[1];
+  const helpMatch = metaBlock.match(/helpSlug:\s*['"]([^'"\n]+)['"]/);
+  if (!helpMatch) {
+    errors.push(`Page ${component} meta does not include helpSlug.`);
+    return;
+  }
+  const slug = helpMatch[1];
+  seenSlugs.add(slug);
+  const docPath = path.join(docsDir, `${slug}.mdx`);
+  if (!fs.existsSync(docPath)) {
+    errors.push(`Help slug "${slug}" for page ${component} does not have a docs/${slug}.mdx file.`);
+  }
+});
+
+if (routes.length === 0) {
+  errors.push('No routes discovered in src/App.tsx');
+}
+
+if (errors.length > 0) {
+  console.error('Help coverage check failed:\n' + errors.map((err) => ` - ${err}`).join('\n'));
+  process.exit(1);
+}
+
+console.log(`Help coverage check passed for ${routes.length} routes. Slugs covered: ${Array.from(seenSlugs).join(', ')}.`);

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -1,6 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { NavLink, Outlet } from "react-router-dom";
 import atoLogo from "../assets/ato-logo.svg";
+import HelpCenter from "../help/HelpCenter";
+import { HelpContextProvider } from "../help/HelpContext";
 
 const navLinks = [
   { to: "/", label: "Dashboard" },
@@ -13,14 +15,42 @@ const navLinks = [
   { to: "/help", label: "Help" },
 ];
 
-export default function AppLayout() {
+function AppLayoutShell() {
+  const [helpOpen, setHelpOpen] = useState(false);
+
+  useEffect(() => {
+    const handleHotkey = (event: KeyboardEvent) => {
+      const isShiftSlash = event.shiftKey && event.code === "Slash";
+      if (event.key === "?" || isShiftSlash) {
+        const tagName = (event.target as HTMLElement)?.tagName;
+        if (tagName && ["INPUT", "TEXTAREA"].includes(tagName)) {
+          return;
+        }
+        event.preventDefault();
+        setHelpOpen(true);
+      }
+    };
+
+    window.addEventListener("keydown", handleHotkey);
+    return () => window.removeEventListener("keydown", handleHotkey);
+  }, []);
+
   return (
     <div>
       <header className="app-header">
         <img src={atoLogo} alt="ATO Logo" />
         <h1>APGMS - Automated PAYGW & GST Management</h1>
         <p>ATO-Compliant Tax Management System</p>
-        <nav style={{ marginTop: 16 }}>
+        <nav
+          style={{
+            marginTop: 16,
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
+            flexWrap: "wrap",
+            gap: 12,
+          }}
+        >
           {navLinks.map((link) => (
             <NavLink
               key={link.to}
@@ -29,7 +59,7 @@ export default function AppLayout() {
                 isActive ? "nav-link active" : "nav-link"
               }
               style={{
-                margin: "0 18px",
+                margin: "0 12px",
                 textDecoration: "none",
                 color: "#fff",
                 fontWeight: 500,
@@ -41,10 +71,38 @@ export default function AppLayout() {
               {link.label}
             </NavLink>
           ))}
+          <button
+            type="button"
+            onClick={() => setHelpOpen(true)}
+            style={{
+              background: "rgba(255,255,255,0.12)",
+              color: "#fff",
+              border: "1px solid rgba(255,255,255,0.35)",
+              borderRadius: 8,
+              padding: "8px 14px",
+              cursor: "pointer",
+              fontWeight: 600,
+              fontSize: 15,
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+            }}
+          >
+            Help
+            <span
+              style={{
+                background: "rgba(255,255,255,0.18)",
+                borderRadius: 6,
+                padding: "2px 8px",
+                fontSize: 12,
+              }}
+            >
+              ⇧ + /
+            </span>
+          </button>
         </nav>
       </header>
 
-      {/* 👇 This tells React Router where to render the child pages */}
       <main style={{ padding: 20 }}>
         <Outlet />
       </main>
@@ -52,6 +110,16 @@ export default function AppLayout() {
       <footer className="app-footer">
         <p>© 2025 APGMS | Compliant with Income Tax Assessment Act 1997 & GST Act 1999</p>
       </footer>
+
+      <HelpCenter isOpen={helpOpen} onClose={() => setHelpOpen(false)} />
     </div>
+  );
+}
+
+export default function AppLayout() {
+  return (
+    <HelpContextProvider>
+      <AppLayoutShell />
+    </HelpContextProvider>
   );
 }

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,0 +1,21 @@
+import React, { useEffect } from "react";
+import { PageMeta, useHelpContext } from "../help/HelpContext";
+
+type PageProps = {
+  meta: PageMeta;
+  children: React.ReactNode;
+};
+
+export default function Page({ meta, children }: PageProps) {
+  const { setPageMeta } = useHelpContext();
+
+  useEffect(() => {
+    setPageMeta(meta);
+    if (typeof document !== "undefined" && meta.title) {
+      document.title = `APGMS – ${meta.title}`;
+    }
+    return () => setPageMeta(undefined);
+  }, [meta, setPageMeta]);
+
+  return <>{children}</>;
+}

--- a/src/help/HelpCenter.tsx
+++ b/src/help/HelpCenter.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { useHelpContext } from "./HelpContext";
+import { helpArticles } from "./helpArticles";
+
+type HelpCenterProps = {
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export default function HelpCenter({ isOpen, onClose }: HelpCenterProps) {
+  const { pageMeta } = useHelpContext();
+  const [query, setQuery] = useState("");
+  const [activeSlug, setActiveSlug] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setQuery("");
+      return;
+    }
+    const defaultSlug = pageMeta?.helpSlug ?? helpArticles[0]?.slug;
+    setActiveSlug(defaultSlug);
+  }, [isOpen, pageMeta]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [isOpen, onClose]);
+
+  const filteredArticles = useMemo(() => {
+    const search = query.trim().toLowerCase();
+    if (!search) {
+      return helpArticles;
+    }
+    return helpArticles.filter((article) => {
+      return (
+        article.title.toLowerCase().includes(search) ||
+        article.body.toLowerCase().includes(search) ||
+        article.summary.toLowerCase().includes(search)
+      );
+    });
+  }, [query]);
+
+  useEffect(() => {
+    if (!filteredArticles.length) {
+      return;
+    }
+    if (!activeSlug || !filteredArticles.some((article) => article.slug === activeSlug)) {
+      setActiveSlug(filteredArticles[0].slug);
+    }
+  }, [filteredArticles, activeSlug]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const activeArticle = filteredArticles.find((article) => article.slug === activeSlug) ?? filteredArticles[0];
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="help-center-overlay"
+      onClick={(event) => {
+        if (event.target === event.currentTarget) {
+          onClose();
+        }
+      }}
+    >
+      <div className="help-center">
+        <header className="help-center__header">
+          <div>
+            <h2>Help Center</h2>
+            {pageMeta?.title && (
+              <p className="help-center__context">Context: {pageMeta.title}</p>
+            )}
+          </div>
+          <button className="help-center__close" onClick={onClose} aria-label="Close help">
+            ×
+          </button>
+        </header>
+
+        <div className="help-center__search">
+          <input
+            autoFocus
+            type="search"
+            placeholder="Search help articles"
+            value={query}
+            onChange={(event) => setQuery(event.target.value)}
+          />
+          <span className="help-center__shortcut">⇧ + /</span>
+        </div>
+
+        {filteredArticles.length === 0 ? (
+          <div className="help-center__empty">No articles match "{query}".</div>
+        ) : (
+          <div className="help-center__content">
+            <aside>
+              <ul>
+                {filteredArticles.map((article) => (
+                  <li key={article.slug}>
+                    <button
+                      className={article.slug === activeArticle.slug ? "active" : ""}
+                      onClick={() => setActiveSlug(article.slug)}
+                    >
+                      <span className="title">{article.title}</span>
+                      <span className="summary">{article.summary}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </aside>
+            <article>
+              <h3>{activeArticle.title}</h3>
+              <p className="help-center__summary">{activeArticle.summary}</p>
+              {activeArticle.body.split("\n\n").map((paragraph, index) => (
+                <p key={index}>{paragraph}</p>
+              ))}
+              <a
+                className="help-center__link"
+                href={activeArticle.docsUrl}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Open in docs ↗
+              </a>
+            </article>
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/src/help/HelpContext.tsx
+++ b/src/help/HelpContext.tsx
@@ -1,0 +1,37 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+export type PageMeta = {
+  title: string;
+  description?: string;
+  helpSlug: string;
+  route: string;
+};
+
+type HelpContextValue = {
+  pageMeta?: PageMeta;
+  setPageMeta: (meta?: PageMeta) => void;
+};
+
+const HelpContext = createContext<HelpContextValue | undefined>(undefined);
+
+export function HelpContextProvider({ children }: { children: React.ReactNode }) {
+  const [pageMeta, setPageMeta] = useState<PageMeta | undefined>(undefined);
+
+  const value = useMemo(
+    () => ({
+      pageMeta,
+      setPageMeta,
+    }),
+    [pageMeta]
+  );
+
+  return <HelpContext.Provider value={value}>{children}</HelpContext.Provider>;
+}
+
+export function useHelpContext() {
+  const context = useContext(HelpContext);
+  if (!context) {
+    throw new Error("useHelpContext must be used within a HelpContextProvider");
+  }
+  return context;
+}

--- a/src/help/helpArticles.ts
+++ b/src/help/helpArticles.ts
@@ -1,0 +1,75 @@
+export type HelpArticle = {
+  slug: string;
+  title: string;
+  summary: string;
+  body: string;
+  docsUrl: string;
+};
+
+const DOCS_BASE_URL = "https://docs.apgms.io";
+
+export const helpArticles: HelpArticle[] = [
+  {
+    slug: "getting-started",
+    title: "Getting Started",
+    summary:
+      "Stand up a workspace, connect data sources and understand the dashboard before automation begins.",
+    body: [
+      "Configure legal identifiers in Settings, link your PAYGW and GST accounts, and complete the onboarding wizard so APGMS can track obligations from day one.",
+      "The dashboard surfaces lodgment status, required cash and overdue actions so you always know what needs attention."
+    ].join("\n\n"),
+    docsUrl: `${DOCS_BASE_URL}/getting-started`,
+  },
+  {
+    slug: "modes",
+    title: "Modes",
+    summary:
+      "Choose how automation should interpret data feeds – Real-time, Batch or Advisory – and switch safely when business processes evolve.",
+    body: [
+      "Assign a mode to each revenue and payroll source during the wizard or from Settings. Real-time triggers standing transfers automatically, Batch expects scheduled uploads, and Advisory lets you model changes without moving cash.",
+      "Pair mode changes with notifications so stakeholders know when automation settings shift."
+    ].join("\n\n"),
+    docsUrl: `${DOCS_BASE_URL}/modes`,
+  },
+  {
+    slug: "evidence",
+    title: "Evidence",
+    summary: "Capture artefacts from payroll, sales and banking so audit trails are ready when regulators ask.",
+    body: [
+      "Use the Audit area to export CSV packages that combine payroll events, GST collections, automated transfers and user actions.",
+      "Link the exports to releases or reconciliation sign-offs to keep a clean compliance story."
+    ].join("\n\n"),
+    docsUrl: `${DOCS_BASE_URL}/evidence`,
+  },
+  {
+    slug: "releases",
+    title: "Releases",
+    summary:
+      "Promote configuration and integration updates from sandbox to production with clear approvals and rollback plans.",
+    body: [
+      "Track release stages from Draft to Production, attach testing evidence, and ensure duties stay segregated.",
+      "Integrations inherit release identifiers so you always know which version is live and who approved it."
+    ].join("\n\n"),
+    docsUrl: `${DOCS_BASE_URL}/releases`,
+  },
+  {
+    slug: "reconciliation",
+    title: "Reconciliation",
+    summary: "Match obligations with actual payments, investigate variances and lock the period before lodging BAS.",
+    body: [
+      "Review the BAS reconciliation tables daily, investigate mismatches by employee or channel, and escalate exceptions into the Errors workflow.",
+      "Close the period once balances align and evidence exports are complete."
+    ].join("\n\n"),
+    docsUrl: `${DOCS_BASE_URL}/reconciliation`,
+  },
+  {
+    slug: "errors",
+    title: "Errors",
+    summary: "Coordinate remediation when automation cannot complete a task or data is missing.",
+    body: [
+      "Raise an error when transfers fail, data is incomplete or variances exceed tolerance.",
+      "Assign owners, capture resolution notes and link the record back to reconciliation items or releases for full traceability."
+    ].join("\n\n"),
+    docsUrl: `${DOCS_BASE_URL}/errors`,
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -197,3 +197,179 @@ th {
   font-weight: 600;
   color: #00205b;
 }
+
+/* Help Center */
+.help-center-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 60px 24px 24px;
+  z-index: 999;
+}
+
+.help-center {
+  background: #ffffff;
+  border-radius: 16px;
+  box-shadow: 0 18px 45px rgba(0, 32, 91, 0.2);
+  max-width: 960px;
+  width: 100%;
+  max-height: calc(100vh - 120px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.help-center__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  padding: 24px 28px 0;
+}
+
+.help-center__header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+  color: #00205b;
+}
+
+.help-center__context {
+  margin: 6px 0 0 0;
+  color: #4b5d7a;
+  font-size: 0.9rem;
+}
+
+.help-center__close {
+  background: none;
+  border: none;
+  font-size: 1.8rem;
+  line-height: 1;
+  cursor: pointer;
+  color: #4b5d7a;
+}
+
+.help-center__search {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 28px 16px;
+  border-bottom: 1px solid #e1e6ef;
+}
+
+.help-center__search input {
+  flex: 1;
+  padding: 10px 14px;
+  border-radius: 8px;
+  border: 1px solid #c7d0e2;
+  font-size: 0.95rem;
+}
+
+.help-center__shortcut {
+  font-size: 0.85rem;
+  color: #4b5d7a;
+  background: #eef2fb;
+  border-radius: 6px;
+  padding: 4px 8px;
+}
+
+.help-center__content {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 0;
+  overflow: hidden;
+  flex: 1;
+}
+
+.help-center__content aside {
+  border-right: 1px solid #e1e6ef;
+  background: #f8f9fb;
+  overflow-y: auto;
+}
+
+.help-center__content aside ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.help-center__content aside li + li {
+  border-top: 1px solid #e1e6ef;
+}
+
+.help-center__content aside button {
+  display: block;
+  width: 100%;
+  padding: 16px 20px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.help-center__content aside button .title {
+  display: block;
+  font-weight: 600;
+  color: #00205b;
+}
+
+.help-center__content aside button .summary {
+  display: block;
+  font-size: 0.85rem;
+  color: #4b5d7a;
+  margin-top: 4px;
+}
+
+.help-center__content aside button.active,
+.help-center__content aside button:hover {
+  background: rgba(0, 113, 107, 0.1);
+}
+
+.help-center__content article {
+  padding: 24px 28px 32px;
+  overflow-y: auto;
+}
+
+.help-center__content article h3 {
+  margin-top: 0;
+  color: #00205b;
+}
+
+.help-center__summary {
+  color: #4b5d7a;
+  font-size: 0.95rem;
+  margin-top: 4px;
+  margin-bottom: 18px;
+}
+
+.help-center__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin-top: 18px;
+  color: #00716b;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.help-center__link:hover {
+  text-decoration: underline;
+}
+
+.help-center__empty {
+  padding: 48px;
+  text-align: center;
+  color: #4b5d7a;
+}
+
+@media (max-width: 900px) {
+  .help-center__content {
+    grid-template-columns: 1fr;
+  }
+
+  .help-center__content aside {
+    border-right: none;
+    border-bottom: 1px solid #e1e6ef;
+  }
+}

--- a/src/pages/Audit.tsx
+++ b/src/pages/Audit.tsx
@@ -1,4 +1,13 @@
 import React, { useState } from 'react';
+import Page from '../components/Page';
+import type { PageMeta } from '../help/HelpContext';
+
+export const meta: PageMeta = {
+  title: 'Audit',
+  description: 'Review evidence packages and compliance activity for PAYGW and GST.',
+  helpSlug: 'evidence',
+  route: '/audit',
+};
 
 export default function Audit() {
   const [logs] = useState([
@@ -12,30 +21,32 @@ export default function Audit() {
   ]);
 
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Compliance & Audit</h1>
-      <p className="text-sm text-muted-foreground">
-        Track every action in your PAYGW and GST account for compliance.
-      </p>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border border-gray-300 rounded-lg">
-          <thead className="bg-gray-100">
-            <tr>
-              <th className="px-4 py-2 text-left border-b">Date</th>
-              <th className="px-4 py-2 text-left border-b">Action</th>
-            </tr>
-          </thead>
-          <tbody>
-            {logs.map((log, i) => (
-              <tr key={i} className="border-t">
-                <td className="px-4 py-2">{log.date}</td>
-                <td className="px-4 py-2">{log.action}</td>
+    <Page meta={meta}>
+      <div className="p-6 space-y-4">
+        <h1 className="text-2xl font-bold">Compliance & Audit</h1>
+        <p className="text-sm text-muted-foreground">
+          Track every action in your PAYGW and GST account for compliance.
+        </p>
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm border border-gray-300 rounded-lg">
+            <thead className="bg-gray-100">
+              <tr>
+                <th className="px-4 py-2 text-left border-b">Date</th>
+                <th className="px-4 py-2 text-left border-b">Action</th>
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {logs.map((log, i) => (
+                <tr key={i} className="border-t">
+                  <td className="px-4 py-2">{log.date}</td>
+                  <td className="px-4 py-2">{log.action}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <button className="mt-4 bg-primary text-white p-2 rounded-md">Download Full Log</button>
       </div>
-      <button className="mt-4 bg-primary text-white p-2 rounded-md">Download Full Log</button>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/BAS.tsx
+++ b/src/pages/BAS.tsx
@@ -1,4 +1,13 @@
 import React from 'react';
+import Page from '../components/Page';
+import type { PageMeta } from '../help/HelpContext';
+
+export const meta: PageMeta = {
+  title: 'BAS',
+  description: 'Reconcile PAYGW and GST before lodging Business Activity Statements.',
+  helpSlug: 'reconciliation',
+  route: '/bas',
+};
 
 export default function BAS() {
   const complianceStatus = {
@@ -12,11 +21,12 @@ export default function BAS() {
   };
 
   return (
-    <div className="main-card">
-      <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
-      <p className="text-sm text-muted-foreground mb-4">
-        Lodge your BAS on time and accurately. Below is a summary of your current obligations.
-      </p>
+    <Page meta={meta}>
+      <div className="main-card">
+        <h1 className="text-2xl font-bold">Business Activity Statement (BAS)</h1>
+        <p className="text-sm text-muted-foreground mb-4">
+          Lodge your BAS on time and accurately. Below is a summary of your current obligations.
+        </p>
 
       {!complianceStatus.lodgmentsUpToDate || !complianceStatus.paymentsUpToDate ? (
         <div className="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-800 p-4 rounded">
@@ -111,6 +121,6 @@ export default function BAS() {
           Staying highly compliant may help avoid audits, reduce penalties, and support eligibility for ATO support programs.
         </p>
       </div>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,15 @@
 // src/pages/Dashboard.tsx
 import React from 'react';
 import { Link } from 'react-router-dom';
+import Page from '../components/Page';
+import type { PageMeta } from '../help/HelpContext';
+
+export const meta: PageMeta = {
+  title: 'Dashboard',
+  description: 'Compliance overview with current PAYGW and GST obligations.',
+  helpSlug: 'getting-started',
+  route: '/',
+};
 
 export default function Dashboard() {
   const complianceStatus = {
@@ -14,87 +23,101 @@ export default function Dashboard() {
   };
 
   return (
-    <div className="main-card">
-      <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
-        <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
-        <p className="text-sm opacity-90">
-          Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
-        </p>
-        <div className="mt-4">
-          <Link to="/wizard" className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100">
-            Get Started
-          </Link>
-        </div>
-      </div>
-
-      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-        <div className="bg-white p-4 rounded-xl shadow space-y-2">
-          <h2 className="text-lg font-semibold">Lodgments</h2>
-          <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
+    <Page meta={meta}>
+      <div className="main-card">
+        <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
+          <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
+          <p className="text-sm opacity-90">
+            Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
           </p>
-          <Link to="/bas" className="text-blue-600 text-sm underline">View BAS</Link>
-        </div>
-
-        <div className="bg-white p-4 rounded-xl shadow space-y-2">
-          <h2 className="text-lg font-semibold">Payments</h2>
-          <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
-          </p>
-          <Link to="/audit" className="text-blue-600 text-sm underline">View Audit</Link>
-        </div>
-
-        <div className="bg-white p-4 rounded-xl shadow text-center">
-          <h2 className="text-lg font-semibold mb-2">Compliance Score</h2>
-          <div className="relative w-16 h-16 mx-auto">
-            <svg viewBox="0 0 36 36" className="w-full h-full">
-              <path
-                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
-                fill="none"
-                stroke="#eee"
-                strokeWidth="2"
-              />
-              <path
-                d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831"
-                fill="none"
-                stroke="url(#grad)"
-                strokeWidth="2"
-                strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
-              />
-              <defs>
-                <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
-                  <stop offset="0%" stopColor="red" />
-                  <stop offset="50%" stopColor="yellow" />
-                  <stop offset="100%" stopColor="green" />
-                </linearGradient>
-              </defs>
-              <text x="18" y="20.35" textAnchor="middle" fontSize="5">{complianceStatus.overallCompliance}%</text>
-            </svg>
+          <div className="mt-4">
+            <Link
+              to="/wizard"
+              className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100"
+            >
+              Get Started
+            </Link>
           </div>
-          <p className="text-sm mt-2 text-gray-600">
-            {complianceStatus.overallCompliance >= 90
-              ? 'Excellent'
-              : complianceStatus.overallCompliance >= 70
-              ? 'Good'
-              : 'Needs attention'}
+        </div>
+
+        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div className="bg-white p-4 rounded-xl shadow space-y-2">
+            <h2 className="text-lg font-semibold">Lodgments</h2>
+            <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
+              {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
+            </p>
+            <Link to="/bas" className="text-blue-600 text-sm underline">View BAS</Link>
+          </div>
+
+          <div className="bg-white p-4 rounded-xl shadow space-y-2">
+            <h2 className="text-lg font-semibold">Payments</h2>
+            <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
+              {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
+            </p>
+            <Link to="/audit" className="text-blue-600 text-sm underline">View Audit</Link>
+          </div>
+
+          <div className="bg-white p-4 rounded-xl shadow text-center">
+            <h2 className="text-lg font-semibold mb-2">Compliance Score</h2>
+            <div className="relative w-16 h-16 mx-auto">
+              <svg viewBox="0 0 36 36" className="w-full h-full">
+                <path
+                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
+                  fill="none"
+                  stroke="#eee"
+                  strokeWidth="2"
+                />
+                <path
+                  d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831"
+                  fill="none"
+                  stroke="url(#grad)"
+                  strokeWidth="2"
+                  strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
+                />
+                <defs>
+                  <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
+                    <stop offset="0%" stopColor="red" />
+                    <stop offset="50%" stopColor="yellow" />
+                    <stop offset="100%" stopColor="green" />
+                  </linearGradient>
+                </defs>
+                <text x="18" y="20.35" textAnchor="middle" fontSize="5">{complianceStatus.overallCompliance}%</text>
+              </svg>
+            </div>
+            <p className="text-sm mt-2 text-gray-600">
+              {complianceStatus.overallCompliance >= 90
+                ? 'Excellent'
+                : complianceStatus.overallCompliance >= 70
+                ? 'Good'
+                : 'Needs attention'}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 text-sm text-gray-700">
+          <p>
+            Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>.{' '}
+            <Link to="/bas" className="text-blue-600 underline">
+              Go to BAS
+            </Link>
           </p>
+          <p>Next BAS due by <strong>{complianceStatus.nextDue}</strong>.</p>
+          {complianceStatus.outstandingLodgments.length > 0 && (
+            <p className="text-red-600">
+              Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}
+            </p>
+          )}
+          {complianceStatus.outstandingAmounts.length > 0 && (
+            <p className="text-red-600">
+              Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}
+            </p>
+          )}
+        </div>
+
+        <div className="mt-4 text-xs text-gray-500 italic">
+          Staying compliant helps avoid audits, reduce penalties, and increase access to ATO support programs.
         </div>
       </div>
-
-      <div className="mt-6 text-sm text-gray-700">
-        <p>Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>. <Link to="/bas" className="text-blue-600 underline">Go to BAS</Link></p>
-        <p>Next BAS due by <strong>{complianceStatus.nextDue}</strong>.</p>
-        {complianceStatus.outstandingLodgments.length > 0 && (
-          <p className="text-red-600">Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
-        )}
-        {complianceStatus.outstandingAmounts.length > 0 && (
-          <p className="text-red-600">Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
-        )}
-      </div>
-
-      <div className="mt-4 text-xs text-gray-500 italic">
-        Staying compliant helps avoid audits, reduce penalties, and increase access to ATO support programs.
-      </div>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Fraud.tsx
+++ b/src/pages/Fraud.tsx
@@ -1,24 +1,36 @@
 import React, { useState } from "react";
+import Page from "../components/Page";
+import type { PageMeta } from "../help/HelpContext";
+
+export const meta: PageMeta = {
+  title: "Fraud & Errors",
+  description: "Monitor exception alerts and manage remediation for automation issues.",
+  helpSlug: "errors",
+  route: "/fraud",
+};
 
 export default function Fraud() {
   const [alerts] = useState([
     { date: "02/06/2025", detail: "PAYGW payment skipped (flagged)" },
     { date: "16/05/2025", detail: "GST transfer lower than usual" }
   ]);
+
   return (
-    <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
-      <h3>Alerts</h3>
-      <ul>
-        {alerts.map((row, i) => (
-          <li key={i} style={{ color: "#e67c00", fontWeight: 500, marginBottom: 7 }}>
-            {row.date}: {row.detail}
-          </li>
-        ))}
-      </ul>
-      <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
-        (Machine learning analysis coming soon.)
+    <Page meta={meta}>
+      <div className="main-card">
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Fraud Detection</h1>
+        <h3>Alerts</h3>
+        <ul>
+          {alerts.map((row, i) => (
+            <li key={i} style={{ color: "#e67c00", fontWeight: 500, marginBottom: 7 }}>
+              {row.date}: {row.detail}
+            </li>
+          ))}
+        </ul>
+        <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
+          (Machine learning analysis coming soon.)
+        </div>
       </div>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -1,39 +1,46 @@
 import React from 'react';
+import Page from '../components/Page';
+import type { PageMeta } from '../help/HelpContext';
+import { helpArticles } from '../help/helpArticles';
+
+export const meta: PageMeta = {
+  title: 'Help Center',
+  description: 'Browse help topics and open the in-app help drawer.',
+  helpSlug: 'getting-started',
+  route: '/help',
+};
 
 export default function Help() {
   return (
-    <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Help & Guidance</h1>
-      <p className="text-sm text-muted-foreground">
-        Access support for PAYGW, GST, BAS and using this system.
-      </p>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Getting Started</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Set up your buffer accounts and payment schedule in <strong>Settings</strong>.</li>
-          <li>Use the <strong>Wizard</strong> to define PAYGW and GST split rules.</li>
-          <li>Review <strong>Dashboard</strong> for current obligations and payment alerts.</li>
-          <li>Go to <strong>BAS</strong> to lodge your Business Activity Statement each quarter.</li>
-        </ul>
+    <Page meta={meta}>
+      <div className="p-6 space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold">Help & Guidance</h1>
+          <p className="text-sm text-muted-foreground">
+            Use <strong>Shift + /</strong> anywhere in the app to open the help drawer. Search articles below
+            or jump straight to the documentation site.
+          </p>
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          {helpArticles.map((article) => (
+            <div key={article.slug} className="bg-card p-4 rounded-xl shadow space-y-2">
+              <h2 className="text-lg font-semibold">{article.title}</h2>
+              <p className="text-sm text-muted-foreground">{article.summary}</p>
+              <div className="flex items-center justify-between text-sm">
+                <span className="font-medium text-[#00716b]">Help drawer search: "{article.title}"</span>
+                <a
+                  className="text-blue-600 hover:underline"
+                  href={article.docsUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Open in docs ↗
+                </a>
+              </div>
+            </div>
+          ))}
+        </div>
       </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">ATO Compliance</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li>Use one-way tax accounts to prevent accidental use of withheld/collected funds.</li>
-          <li>Audit trail with timestamped actions supports legal protection and evidence.</li>
-          <li>Helps avoid wind-up notices, director penalties, and late lodgment fines.</li>
-        </ul>
-      </div>
-      <div className="bg-card p-4 rounded-xl shadow space-y-2">
-        <h2 className="text-lg font-semibold">Support Links</h2>
-        <ul className="list-disc pl-5 text-sm">
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/payg-withholding/">ATO PAYGW Guide</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/gst/">ATO GST Information</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/business-activity-statements-(bas)/">ATO BAS Portal</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/business/super-for-employers/">ATO Super Obligations</a></li>
-          <li><a className="text-blue-600" href="https://www.ato.gov.au/General/Online-services/">ATO Online Services</a></li>
-        </ul>
-      </div>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -1,19 +1,38 @@
 import React from "react";
+import Page from "../components/Page";
+import type { PageMeta } from "../help/HelpContext";
+
+export const meta: PageMeta = {
+  title: "Integrations",
+  description: "Connect payroll and sales systems and track deployment readiness.",
+  helpSlug: "releases",
+  route: "/integrations",
+};
 
 export default function Integrations() {
   return (
-    <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
-      <h3>Connect to Providers</h3>
-      <ul>
-        <li>MYOB (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-        <li>QuickBooks (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-        <li>Square (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-        <li>Vend (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-      </ul>
-      <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
-        (More integrations coming soon.)
+    <Page meta={meta}>
+      <div className="main-card">
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
+        <h3>Connect to Providers</h3>
+        <ul>
+          <li>
+            MYOB (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button>
+          </li>
+          <li>
+            QuickBooks (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button>
+          </li>
+          <li>
+            Square (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button>
+          </li>
+          <li>
+            Vend (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button>
+          </li>
+        </ul>
+        <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
+          (More integrations coming soon.)
+        </div>
       </div>
-    </div>
+    </Page>
   );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import Page from "../components/Page";
+import type { PageMeta } from "../help/HelpContext";
 
 const tabs = [
   "Business Profile",
@@ -12,6 +14,13 @@ const tabs = [
   "Advanced"
 ];
 
+export const meta: PageMeta = {
+  title: "Settings",
+  description: "Configure accounts, automation modes and notifications for your workspace.",
+  helpSlug: "modes",
+  route: "/settings",
+};
+
 export default function Settings() {
   const [activeTab, setActiveTab] = useState(tabs[0]);
   // Mock business profile state
@@ -23,21 +32,22 @@ export default function Settings() {
   });
 
   return (
-    <div className="settings-card">
-      <div className="tabs-row">
-        {tabs.map(tab => (
-          <div
-            key={tab}
-            className={`tab-item${activeTab === tab ? " active" : ""}`}
-            onClick={() => setActiveTab(tab)}
-            tabIndex={0}
-          >
-            {tab}
-          </div>
-        ))}
-      </div>
+    <Page meta={meta}>
+      <div className="settings-card">
+        <div className="tabs-row">
+          {tabs.map(tab => (
+            <div
+              key={tab}
+              className={`tab-item${activeTab === tab ? " active" : ""}`}
+              onClick={() => setActiveTab(tab)}
+              tabIndex={0}
+            >
+              {tab}
+            </div>
+          ))}
+        </div>
 
-      <div style={{ marginTop: 30 }}>
+        <div style={{ marginTop: 30 }}>
         {activeTab === "Business Profile" && (
           <form
             style={{
@@ -211,6 +221,7 @@ export default function Settings() {
           </div>
         )}
       </div>
-    </div>
+      </div>
+    </Page>
   );
 }

--- a/src/pages/Wizard.tsx
+++ b/src/pages/Wizard.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from "react";
+import Page from "../components/Page";
+import type { PageMeta } from "../help/HelpContext";
 
 const steps = [
   "Business Details",
@@ -8,70 +10,81 @@ const steps = [
   "Review & Complete"
 ];
 
+export const meta: PageMeta = {
+  title: "Setup Wizard",
+  description: "Guide administrators through onboarding and automation configuration.",
+  helpSlug: "modes",
+  route: "/wizard",
+};
+
 export default function Wizard() {
   const [step, setStep] = useState(0);
 
   return (
-    <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Setup Wizard</h1>
-      <div style={{ marginBottom: 20 }}>
-        <b>Step {step + 1} of {steps.length}: {steps[step]}</b>
+    <Page meta={meta}>
+      <div className="main-card">
+        <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Setup Wizard</h1>
+        <div style={{ marginBottom: 20 }}>
+          <b>
+            Step {step + 1} of {steps.length}: {steps[step]}
+          </b>
+        </div>
+        <div style={{ background: "#f9f9f9", borderRadius: 10, padding: 24, minHeight: 120 }}>
+          {step === 0 && (
+            <div>
+              <label>Business ABN:</label>
+              <input className="settings-input" style={{ width: 220 }} defaultValue="12 345 678 901" />
+              <br />
+              <label>Legal Name:</label>
+              <input className="settings-input" style={{ width: 220 }} defaultValue="Example Pty Ltd" />
+            </div>
+          )}
+          {step === 1 && (
+            <div>
+              <label>BSB:</label>
+              <input className="settings-input" style={{ width: 140 }} defaultValue="123-456" />
+              <br />
+              <label>Account #:</label>
+              <input className="settings-input" style={{ width: 140 }} defaultValue="11111111" />
+            </div>
+          )}
+          {step === 2 && (
+            <div>
+              <label>Payroll Provider:</label>
+              <select className="settings-input" style={{ width: 220 }}>
+                <option>MYOB</option>
+                <option>QuickBooks</option>
+              </select>
+            </div>
+          )}
+          {step === 3 && (
+            <div>
+              <label>Automated PAYGW transfer?</label>
+              <input type="checkbox" defaultChecked /> Yes
+            </div>
+          )}
+          {step === 4 && (
+            <div style={{ color: "#00716b", fontWeight: 600 }}>
+              All done! Click "Finish" to save your setup.
+            </div>
+          )}
+        </div>
+        <div style={{ marginTop: 20 }}>
+          {step > 0 && (
+            <button className="button" onClick={() => setStep(step - 1)} style={{ marginRight: 14 }}>
+              Back
+            </button>
+          )}
+          {step < steps.length - 1 && (
+            <button className="button" onClick={() => setStep(step + 1)}>
+              Next
+            </button>
+          )}
+          {step === steps.length - 1 && (
+            <button className="button" style={{ background: "#4CAF50" }}>Finish</button>
+          )}
+        </div>
       </div>
-      <div style={{ background: "#f9f9f9", borderRadius: 10, padding: 24, minHeight: 120 }}>
-        {step === 0 && (
-          <div>
-            <label>Business ABN:</label>
-            <input className="settings-input" style={{ width: 220 }} defaultValue="12 345 678 901" />
-            <br />
-            <label>Legal Name:</label>
-            <input className="settings-input" style={{ width: 220 }} defaultValue="Example Pty Ltd" />
-          </div>
-        )}
-        {step === 1 && (
-          <div>
-            <label>BSB:</label>
-            <input className="settings-input" style={{ width: 140 }} defaultValue="123-456" />
-            <br />
-            <label>Account #:</label>
-            <input className="settings-input" style={{ width: 140 }} defaultValue="11111111" />
-          </div>
-        )}
-        {step === 2 && (
-          <div>
-            <label>Payroll Provider:</label>
-            <select className="settings-input" style={{ width: 220 }}>
-              <option>MYOB</option>
-              <option>QuickBooks</option>
-            </select>
-          </div>
-        )}
-        {step === 3 && (
-          <div>
-            <label>Automated PAYGW transfer?</label>
-            <input type="checkbox" defaultChecked /> Yes
-          </div>
-        )}
-        {step === 4 && (
-          <div style={{ color: "#00716b", fontWeight: 600 }}>
-            All done! Click "Finish" to save your setup.
-          </div>
-        )}
-      </div>
-      <div style={{ marginTop: 20 }}>
-        {step > 0 && (
-          <button className="button" onClick={() => setStep(step - 1)} style={{ marginRight: 14 }}>
-            Back
-          </button>
-        )}
-        {step < steps.length - 1 && (
-          <button className="button" onClick={() => setStep(step + 1)}>
-            Next
-          </button>
-        )}
-        {step === steps.length - 1 && (
-          <button className="button" style={{ background: "#4CAF50" }}>Finish</button>
-        )}
-      </div>
-    </div>
+    </Page>
   );
 }


### PR DESCRIPTION
## Summary
- add Shift+/ activated help drawer with contextual article search and external doc links
- create MDX help topics for getting started, modes, evidence, releases, reconciliation, and errors
- attach help metadata to each page and add a coverage script to ensure every route references a docs page

## Testing
- npm run check:help

------
https://chatgpt.com/codex/tasks/task_e_68e3ba4694708327945ef4f68119a69d