### PR TITLE
Add JWT auth, MFA, and dual approval protections

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,10 +18,15 @@
         "typescript": "^5.9.3"
     },
     "dependencies": {
+        "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.4.0",
+        "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.2",
         "pg": "^8.16.3",
+        "speakeasy": "^2.0.0",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
     }

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -1,6 +1,10 @@
 // src/api/payments.ts
 import express from "express";
 import { Payments } from "../../libs/paymentsClient"; // adjust if your libs path differs
+import { AuthenticatedRequest, authenticate, requireRole } from "../http/auth";
+import { getAppMode } from "../state/settings";
+import { isMfaVerified } from "../security/mfa";
+import { dualApprovals } from "../approvals/dual";
 
 export const paymentsApi = express.Router();
 
@@ -50,15 +54,40 @@ paymentsApi.post("/deposit", async (req, res) => {
 });
 
 // POST /api/release  (calls payAto)
-paymentsApi.post("/release", async (req, res) => {
+paymentsApi.post("/release", authenticate, requireRole("admin", "accountant"), async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body || {};
     if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
       return res.status(400).json({ error: "Missing fields" });
     }
+    if (!Number.isFinite(amountCents)) {
+      return res.status(400).json({ error: "Invalid amount" });
+    }
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
     }
+
+    const authReq = req as AuthenticatedRequest;
+    const user = authReq.user;
+    if (!user) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+
+    if (getAppMode() === "real" && (!user.mfa || !isMfaVerified(user.id))) {
+      return res.status(403).json({ error: "MFA_REQUIRED" });
+    }
+
+    const approvalKey = [abn, taxType, periodId, Math.abs(amountCents)].join(":");
+    const approval = dualApprovals.request(approvalKey, user.id, amountCents);
+    if (!approval.granted) {
+      return res.status(202).json({
+        pending: true,
+        approvals: approval.approvals,
+        required: approval.required,
+        message: approval.message,
+      });
+    }
+
     const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
     res.json(data);
   } catch (err: any) {

--- a/src/approvals/dual.ts
+++ b/src/approvals/dual.ts
@@ -1,0 +1,93 @@
+export interface ApprovalResult {
+  granted: boolean;
+  approvals: string[];
+  required: number;
+  message?: string;
+}
+
+interface ApprovalRecord {
+  amount: number;
+  approvers: Map<string, number>;
+  createdAt: number;
+}
+
+export class DualApprovalTable {
+  private readonly approvals = new Map<string, ApprovalRecord>();
+
+  constructor(private thresholdCents: number, private readonly ttlMs = 15 * 60 * 1000) {}
+
+  needsApproval(amountCents: number): boolean {
+    return Math.abs(amountCents) > this.thresholdCents;
+  }
+
+  getThreshold(): number {
+    return this.thresholdCents;
+  }
+
+  setThreshold(value: number) {
+    this.thresholdCents = Math.max(0, Math.floor(value));
+  }
+
+  request(key: string, userId: string, amountCents: number): ApprovalResult {
+    const now = Date.now();
+    this.cleanup(now);
+
+    if (!this.needsApproval(amountCents)) {
+      return { granted: true, approvals: [], required: 0 };
+    }
+
+    let record = this.approvals.get(key);
+    if (!record) {
+      record = {
+        amount: Math.abs(amountCents),
+        approvers: new Map(),
+        createdAt: now,
+      };
+      this.approvals.set(key, record);
+    }
+
+    record.approvers.set(userId, now);
+
+    if (record.approvers.size >= 2) {
+      const approvers = Array.from(record.approvers.keys());
+      this.approvals.delete(key);
+      return { granted: true, approvals: approvers, required: 2 };
+    }
+
+    const approvers = Array.from(record.approvers.keys());
+    const awaitingSecond = approvers.length === 1 && approvers.includes(userId);
+    return {
+      granted: false,
+      approvals: approvers,
+      required: 2,
+      message: awaitingSecond ? "Awaiting second approver." : "Awaiting additional approver.",
+    };
+  }
+
+  listPending() {
+    this.cleanup();
+    return Array.from(this.approvals.entries()).map(([key, record]) => ({
+      key,
+      amount: record.amount,
+      approvers: Array.from(record.approvers.keys()),
+      expiresAt: this.computeExpiry(record),
+    }));
+  }
+
+  private cleanup(now: number = Date.now()) {
+    for (const [key, record] of this.approvals.entries()) {
+      if (now > this.computeExpiry(record)) {
+        this.approvals.delete(key);
+      }
+    }
+  }
+
+  private computeExpiry(record: ApprovalRecord): number {
+    const newestApproval = Math.max(record.createdAt, ...record.approvers.values());
+    return newestApproval + this.ttlMs;
+  }
+}
+
+const defaultThreshold = Number(process.env.DUAL_APPROVAL_THRESHOLD || 250_000);
+
+export const dualApprovals = new DualApprovalTable(defaultThreshold);

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,100 @@
+import { NextFunction, Request, Response } from "express";
+import jwt, { JwtPayload } from "jsonwebtoken";
+
+export type Role = "admin" | "accountant" | "auditor";
+
+export interface TokenClaims extends JwtPayload {
+  sub: string;
+  role: Role;
+  mfa?: boolean;
+}
+
+export interface AuthenticatedRequest extends Request {
+  user?: {
+    id: string;
+    role: Role;
+    mfa: boolean;
+  };
+}
+
+declare global {
+  namespace Express {
+    // eslint-disable-next-line @typescript-eslint/no-empty-interface
+    interface User {}
+    interface Request {
+      user?: {
+        id: string;
+        role: Role;
+        mfa: boolean;
+      };
+    }
+  }
+}
+
+const roles = new Set<Role>(["admin", "accountant", "auditor"]);
+
+const DEFAULT_SECRET = "change-me-dev-secret";
+const secret = process.env.AUTH_SECRET || DEFAULT_SECRET;
+
+if (!process.env.AUTH_SECRET) {
+  console.warn("[auth] AUTH_SECRET not set; using development secret. Set AUTH_SECRET for real mode.");
+}
+
+export function issueToken(user: { id: string; role: Role; mfa?: boolean }, expiresIn = "8h") {
+  if (!roles.has(user.role)) {
+    throw new Error(`Unsupported role: ${user.role}`);
+  }
+  const payload: TokenClaims = {
+    sub: user.id,
+    role: user.role,
+    mfa: Boolean(user.mfa),
+  };
+  return jwt.sign(payload, secret, { algorithm: "HS256", expiresIn });
+}
+
+function extractBearerToken(header?: string | string[]): string | null {
+  if (!header) return null;
+  const value = Array.isArray(header) ? header[0] : header;
+  if (!value) return null;
+  const [scheme, token] = value.split(" ");
+  if (!scheme || scheme.toLowerCase() !== "bearer" || !token) {
+    return null;
+  }
+  return token.trim();
+}
+
+export function authenticate(req: Request, res: Response, next: NextFunction) {
+  const token = extractBearerToken(req.headers.authorization);
+  if (!token) {
+    return res.status(401).json({ error: "AUTH_REQUIRED" });
+  }
+
+  try {
+    const decoded = jwt.verify(token, secret, { algorithms: ["HS256"] }) as TokenClaims;
+    if (!decoded.sub || !decoded.role || !roles.has(decoded.role)) {
+      return res.status(403).json({ error: "INVALID_TOKEN" });
+    }
+    (req as AuthenticatedRequest).user = {
+      id: decoded.sub,
+      role: decoded.role,
+      mfa: Boolean(decoded.mfa),
+    };
+    return next();
+  } catch (err) {
+    return res.status(401).json({ error: "AUTH_INVALID", detail: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+export function requireRole(...allowed: Role[]) {
+  const allowedSet = new Set(allowed);
+  return (req: Request, res: Response, next: NextFunction) => {
+    const user = (req as AuthenticatedRequest).user;
+    if (!user) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+    if (!allowedSet.has(user.role)) {
+      return res.status(403).json({ error: "INSUFFICIENT_ROLE", role: user.role });
+    }
+    return next();
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,15 +5,53 @@ import dotenv from "dotenv";
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
-import { api } from "./api";                  // your existing API router(s)
+import { api } from "./api"; // your existing API router(s)
+import { applySecurityHeaders, getCorsAllowList, setCorsAllowList } from "./ops/headers";
+import { authenticate, requireRole } from "./http/auth";
+import { createMfaRouter } from "./security/mfa";
+import { dualApprovals } from "./approvals/dual";
+import { getAppMode, setAppMode } from "./state/settings";
 
 dotenv.config();
 
 const app = express();
 app.use(express.json({ limit: "2mb" }));
+applySecurityHeaders(app);
 
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+
+app.use("/auth/mfa", authenticate, createMfaRouter());
+
+app.get("/ops/mode", authenticate, requireRole("admin", "accountant", "auditor"), (_req, res) => {
+  res.json({ mode: getAppMode() });
+});
+
+app.post("/ops/mode", authenticate, requireRole("admin"), (req, res) => {
+  const { mode } = req.body || {};
+  if (mode !== "demo" && mode !== "real") {
+    return res.status(400).json({ error: "INVALID_MODE" });
+  }
+  setAppMode(mode);
+  res.json({ ok: true, mode });
+});
+
+app.get("/ops/allowlist", authenticate, requireRole("admin", "accountant"), (_req, res) => {
+  res.json({ origins: getCorsAllowList() });
+});
+
+app.put("/ops/allowlist", authenticate, requireRole("admin"), (req, res) => {
+  const { origins } = req.body || {};
+  if (!Array.isArray(origins)) {
+    return res.status(400).json({ error: "INVALID_ALLOWLIST" });
+  }
+  setCorsAllowList(origins.map((origin: unknown) => String(origin)));
+  res.json({ ok: true, origins: getCorsAllowList() });
+});
+
+app.get("/ops/approvals", authenticate, requireRole("admin", "accountant", "auditor"), (_req, res) => {
+  res.json({ pending: dualApprovals.listPending() });
+});
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
@@ -30,6 +68,13 @@ app.use("/api", paymentsApi);
 
 // Existing API router(s) after
 app.use("/api", api);
+
+app.use((err: any, _req, res, next) => {
+  if (err?.message === "Origin not allowed by CORS") {
+    return res.status(403).json({ error: "CORS_NOT_ALLOWED" });
+  }
+  return next(err);
+});
 
 // 404 fallback (must be last)
 app.use((_req, res) => res.status(404).send("Not found"));

--- a/src/ops/headers.ts
+++ b/src/ops/headers.ts
@@ -1,0 +1,74 @@
+import cors from "cors";
+import { Express } from "express";
+import helmet from "helmet";
+import rateLimit from "express-rate-limit";
+
+const defaultAllowList = (process.env.CORS_ALLOWLIST || "http://localhost:3000")
+  .split(",")
+  .map((origin) => origin.trim())
+  .filter((origin) => origin.length > 0);
+
+const allowList = new Set<string>(defaultAllowList);
+
+export function applySecurityHeaders(app: Express) {
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          "default-src": ["'self'"],
+          "img-src": ["'self'", "data:"],
+          "style-src": ["'self'", "'unsafe-inline'"],
+          "script-src": ["'self'"],
+        },
+      },
+      hsts: { maxAge: 31536000, includeSubDomains: true, preload: true },
+    })
+  );
+
+  app.use(
+    cors({
+      origin(origin, callback) {
+        if (!origin || allowList.has(origin)) {
+          return callback(null, true);
+        }
+        return callback(new Error("Origin not allowed by CORS"));
+      },
+      credentials: true,
+    })
+  );
+
+  app.use(
+    rateLimit({
+      windowMs: 60 * 1000,
+      max: 120,
+      standardHeaders: true,
+      legacyHeaders: false,
+      handler: (_req, res) => {
+        res.status(429).json({ error: "RATE_LIMIT", message: "Too many requests, slow down." });
+      },
+    })
+  );
+}
+
+export function getCorsAllowList(): string[] {
+  return Array.from(allowList);
+}
+
+export function setCorsAllowList(origins: string[]) {
+  allowList.clear();
+  origins
+    .map((origin) => origin.trim())
+    .filter((origin) => origin.length > 0)
+    .forEach((origin) => allowList.add(origin));
+}
+
+export function addCorsOrigin(origin: string) {
+  if (origin && origin.trim().length > 0) {
+    allowList.add(origin.trim());
+  }
+}
+
+export function removeCorsOrigin(origin: string) {
+  allowList.delete(origin.trim());
+}

--- a/src/security/mfa.ts
+++ b/src/security/mfa.ts
@@ -1,0 +1,85 @@
+import { Router } from "express";
+import speakeasy from "speakeasy";
+
+import { AuthenticatedRequest, issueToken } from "../http/auth";
+
+type SecretRecord = {
+  secret: string;
+  verified: boolean;
+  updatedAt: number;
+};
+
+const userSecrets = new Map<string, SecretRecord>();
+
+export function isMfaVerified(userId: string): boolean {
+  const record = userSecrets.get(userId);
+  return Boolean(record?.verified);
+}
+
+function upsertSecret(userId: string, secret: string, verified: boolean) {
+  userSecrets.set(userId, { secret, verified, updatedAt: Date.now() });
+}
+
+export function createMfaRouter() {
+  const router = Router();
+
+  router.post("/setup", (req, res) => {
+    const { user } = req as AuthenticatedRequest;
+    if (!user) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+
+    const secret = speakeasy.generateSecret({ length: 20, name: `APGMS (${user.id})` });
+    upsertSecret(user.id, secret.base32, false);
+
+    return res.json({
+      secret: secret.base32,
+      otpauthUrl: secret.otpauth_url,
+    });
+  });
+
+  router.post("/verify", (req, res) => {
+    const { user } = req as AuthenticatedRequest;
+    if (!user) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+
+    const { token } = req.body || {};
+    if (typeof token !== "string" || token.trim().length === 0) {
+      return res.status(400).json({ error: "TOKEN_REQUIRED" });
+    }
+
+    const record = userSecrets.get(user.id);
+    if (!record) {
+      return res.status(400).json({ error: "SETUP_REQUIRED" });
+    }
+
+    const ok = speakeasy.totp.verify({
+      secret: record.secret,
+      encoding: "base32",
+      token,
+      window: 1,
+    });
+
+    if (!ok) {
+      return res.status(400).json({ error: "INVALID_TOKEN" });
+    }
+
+    upsertSecret(user.id, record.secret, true);
+    user.mfa = true;
+    const refreshedToken = issueToken({ id: user.id, role: user.role, mfa: true });
+
+    return res.json({ ok: true, token: refreshedToken });
+  });
+
+  router.get("/status", (req, res) => {
+    const { user } = req as AuthenticatedRequest;
+    if (!user) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+
+    return res.json({ enabled: isMfaVerified(user.id) });
+  });
+
+  return router;
+}

--- a/src/state/settings.ts
+++ b/src/state/settings.ts
@@ -1,0 +1,11 @@
+export type AppMode = "demo" | "real";
+
+let appMode: AppMode = process.env.APP_MODE === "real" ? "real" : "demo";
+
+export function getAppMode(): AppMode {
+  return appMode;
+}
+
+export function setAppMode(next: AppMode) {
+  appMode = next;
+}


### PR DESCRIPTION
## Summary
- add bearer JWT authentication middleware with MFA setup/verify endpoints and shared app mode state
- harden the express server with helmet, rate limiting, and a configurable CORS allow list alongside operational toggles
- require signed JWTs, MFA in real mode, and dual approval for large releases before delegating to the payments service

## Testing
- not run (node tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e3ba20ce2883278589ae77b295852c