### PR TITLE
Add simulated bank rail provider and settlement import flow

### DIFF
--- a/apps/services/payments/src/bank/simRailAdapter.ts
+++ b/apps/services/payments/src/bank/simRailAdapter.ts
@@ -1,0 +1,44 @@
+const DEFAULT_BASE = "http://localhost:3000/sim/rail";
+
+type SimParams = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amount_cents: number;
+  rail: "EFT" | "BPAY";
+  reference?: string;
+  idempotencyKey: string;
+};
+
+type SimResult = {
+  provider_receipt_id: string;
+  paid_at: string;
+};
+
+export async function sendViaSimRail(params: SimParams): Promise<SimResult> {
+  const base = (process.env.SIM_RAIL_BASE_URL || DEFAULT_BASE).replace(/\/$/, "");
+  const url = `${base}/${params.rail.toLowerCase()}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": params.idempotencyKey,
+    },
+    body: JSON.stringify({
+      amount_cents: params.amount_cents,
+      abn: params.abn,
+      taxType: params.taxType,
+      periodId: params.periodId,
+      reference: params.reference,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Sim rail error: ${text || res.status}`);
+  }
+  const data = await res.json();
+  const provider_ref = String(data.provider_ref || "");
+  const paid_at = String(data.paid_at || new Date().toISOString());
+  if (!provider_ref) throw new Error("Sim rail missing provider_ref");
+  return { provider_receipt_id: provider_ref, paid_at };
+}

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -1,18 +1,65 @@
 ﻿// apps/services/payments/src/routes/payAto.ts
 import { Request, Response } from 'express';
 import crypto from 'crypto';
-import pg from 'pg'; const { Pool } = pg;
+import { PoolClient } from 'pg';
 import { pool } from '../index.js';
+import { sendEftOrBpay } from '../bank/eftBpayAdapter.js';
+import { sendViaSimRail } from '../bank/simRailAdapter.js';
+
+let ensuredTables = false;
+async function ensureSettlementTable() {
+  if (ensuredTables) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS settlements (
+      id              BIGSERIAL PRIMARY KEY,
+      provider_ref    TEXT UNIQUE NOT NULL,
+      rail            TEXT NOT NULL,
+      amount_cents    BIGINT NOT NULL,
+      paid_at         TIMESTAMPTZ,
+      abn             TEXT,
+      tax_type        TEXT,
+      period_id       TEXT,
+      idempotency_key TEXT,
+      transfer_uuid   UUID,
+      recon_payload   JSONB DEFAULT '{}'::jsonb,
+      evidence_uri    TEXT,
+      evidence_bundle BIGINT,
+      created_at      TIMESTAMPTZ DEFAULT NOW(),
+      updated_at      TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ux_settlements_idem_key
+      ON settlements(idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+  `);
+  ensuredTables = true;
+}
+
+function envTrue(v?: string | null) {
+  return !!v && /^(1|true|yes)$/i.test(v);
+}
 
 function genUUID() {
   return crypto.randomUUID();
 }
 
+async function selectDestination(client: PoolClient, abn: string) {
+  const { rows } = await client.query(
+    `SELECT rail, reference, account_bsb, account_number
+       FROM remittance_destinations
+      WHERE abn=$1 AND rail IN ('EFT','BPAY')
+      ORDER BY CASE WHEN rail='EFT' THEN 0 ELSE 1 END
+      LIMIT 1`,
+    [abn]
+  );
+  if (!rows.length) throw new Error('DEST_NOT_ALLOW_LISTED');
+  return rows[0];
+}
+
 /**
- * Minimal release path:
- * - Requires rptGate to have attached req.rpt
- * - Inserts a single negative ledger entry for the given period
- * - Sets rpt_verified=true and a unique release_uuid to satisfy constraints
+ * Minimal release path with bank rail hand-off.
+ * Ensures idempotency via settlements table and provider responses.
  */
 export async function payAtoRelease(req: Request, res: Response) {
   const { abn, taxType, periodId, amountCents } = req.body || {};
@@ -20,49 +67,90 @@ export async function payAtoRelease(req: Request, res: Response) {
     return res.status(400).json({ error: 'Missing abn/taxType/periodId' });
   }
 
-  // default a tiny test debit if not provided
   const amt = Number.isFinite(Number(amountCents)) ? Number(amountCents) : -100;
-
-  // must be negative for a release
   if (amt >= 0) {
     return res.status(400).json({ error: 'amountCents must be negative for a release' });
   }
 
-  // rptGate attaches req.rpt when verification succeeds
   const rpt = (req as any).rpt;
   if (!rpt) {
     return res.status(403).json({ error: 'RPT not verified' });
   }
 
+  const idempotencyKey = req.header('Idempotency-Key') || genUUID();
+  const useSim = envTrue(process.env.FEATURE_SIM_OUTBOUND);
+
+  await ensureSettlementTable();
+
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
 
-    // compute running balance AFTER this entry:
-    // fetch last balance in this period (by id order), default 0
-    const { rows: lastRows } = await client.query<{
-      balance_after_cents: string | number;
-    }>(
+    const existing = await client.query(
+      `SELECT provider_ref, paid_at FROM settlements WHERE idempotency_key=$1`,
+      [idempotencyKey]
+    );
+    if (existing.rowCount) {
+      await client.query('COMMIT');
+      const row = existing.rows[0];
+      return res.json({
+        ok: true,
+        idempotent: true,
+        provider_ref: row.provider_ref,
+        paid_at: row.paid_at ? new Date(row.paid_at).toISOString() : null,
+      });
+    }
+
+    const dest = await selectDestination(client, abn);
+    const rail = (dest.rail || 'EFT') as 'EFT' | 'BPAY';
+
+    const { rows: lastRows } = await client.query<{ balance_after_cents: string | number }>(
       `SELECT balance_after_cents
-       FROM owa_ledger
-       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-       ORDER BY id DESC
-       LIMIT 1`,
+         FROM owa_ledger
+        WHERE abn=$1 AND tax_type=$2 AND period_id=$3
+        ORDER BY id DESC
+        LIMIT 1`,
       [abn, taxType, periodId]
     );
     const lastBal = lastRows.length ? Number(lastRows[0].balance_after_cents) : 0;
     const newBal = lastBal + amt;
 
-    const release_uuid = genUUID();
+    const sendResult = useSim
+      ? await sendViaSimRail({
+          abn,
+          taxType,
+          periodId,
+          amount_cents: Math.abs(amt),
+          rail,
+          reference: dest.reference,
+          idempotencyKey,
+        })
+      : await sendEftOrBpay({
+          abn,
+          taxType,
+          periodId,
+          amount_cents: Math.abs(amt),
+          destination:
+            rail === 'BPAY'
+              ? { bpay_biller: dest.reference, crn: dest.reference }
+              : { bsb: dest.account_bsb, acct: dest.account_number },
+          idempotencyKey,
+        });
 
+    const providerRef = sendResult.provider_receipt_id;
+    const paidAt = 'paid_at' in sendResult ? (sendResult as any).paid_at : new Date().toISOString();
+    const transfer_uuid = 'transfer_uuid' in sendResult && (sendResult as any).transfer_uuid
+      ? (sendResult as any).transfer_uuid
+      : genUUID();
+    const release_uuid = genUUID();
     const insert = `
       INSERT INTO owa_ledger
         (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents,
-         rpt_verified, release_uuid, created_at)
-      VALUES ($1,$2,$3,$4,$5,$6, TRUE, $7, now())
+         rpt_verified, release_uuid, bank_receipt_id, created_at)
+      VALUES ($1,$2,$3,$4,$5,$6, TRUE, $7, $8, now())
       RETURNING id, transfer_uuid, balance_after_cents
     `;
-    const transfer_uuid = genUUID();
+
     const { rows: ins } = await client.query(insert, [
       abn,
       taxType,
@@ -71,21 +159,46 @@ export async function payAtoRelease(req: Request, res: Response) {
       amt,
       newBal,
       release_uuid,
+      providerRef,
     ]);
+
+    await client.query(
+      `INSERT INTO settlements
+         (provider_ref, rail, amount_cents, paid_at, abn, tax_type, period_id, idempotency_key, transfer_uuid)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+       ON CONFLICT (provider_ref) DO UPDATE SET
+         paid_at = EXCLUDED.paid_at,
+         amount_cents = EXCLUDED.amount_cents,
+         rail = EXCLUDED.rail,
+         updated_at = NOW()
+      `,
+      [
+        providerRef,
+        rail,
+        Math.abs(amt),
+        new Date(paidAt),
+        abn,
+        taxType,
+        periodId,
+        idempotencyKey,
+        transfer_uuid,
+      ]
+    );
 
     await client.query('COMMIT');
 
     return res.json({
       ok: true,
+      provider_ref: providerRef,
+      paid_at: paidAt,
       ledger_id: ins[0].id,
-      transfer_uuid,
+      transfer_uuid: ins[0].transfer_uuid,
       release_uuid,
       balance_after_cents: ins[0].balance_after_cents,
       rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
     });
   } catch (e: any) {
     await client.query('ROLLBACK');
-    // common failures: unique single-release-per-period, allow-list, etc.
     return res.status(400).json({ error: 'Release failed', detail: String(e?.message || e) });
   } finally {
     client.release();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,20 @@
 ﻿// src/index.ts
 import express from "express";
+import { text } from "express";
 import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { simRailRouter } from "./sim/rail/Provider";
+import { simReconRouter } from "./sim/rail/recon";
+import { settlementImport } from "./routes/settlementImport";
 
 dotenv.config();
 
 const app = express();
+app.use(text({ type: ["text/csv", "application/csv"] }));
 app.use(express.json({ limit: "2mb" }));
 
 // (optional) quick request logger
@@ -23,10 +28,15 @@ app.post("/api/pay", idempotency(), payAto);
 app.post("/api/close-issue", closeAndIssue);
 app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
+app.post("/settlement/import", settlementImport);
 app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+
+// Simulated rail endpoints (used when FEATURE_SIM_OUTBOUND is enabled)
+app.use("/sim/rail", simRailRouter);
+app.use("/sim/rail", simReconRouter);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/rails/adapter.ts
+++ b/src/rails/adapter.ts
@@ -1,11 +1,52 @@
-﻿import { Pool } from "pg";
+import { Pool } from "pg";
 import { v4 as uuidv4 } from "uuid";
 import { appendAudit } from "../audit/appendOnly";
 import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
+function envTrue(v?: string | null) {
+  return !!v && /^(1|true|yes)$/i.test(v);
+}
+
+async function callSimRail(params: {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  rail: "EFT" | "BPAY";
+  reference: string;
+  amountCents: number;
+  idempotencyKey: string;
+}) {
+  const base = (process.env.SIM_RAIL_BASE_URL || "http://localhost:3000/sim/rail").replace(/\/$/, "");
+  const url = `${base}/${params.rail.toLowerCase()}`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "Idempotency-Key": params.idempotencyKey,
+    },
+    body: JSON.stringify({
+      amount_cents: params.amountCents,
+      abn: params.abn,
+      taxType: params.taxType,
+      periodId: params.periodId,
+      reference: params.reference,
+    }),
+  });
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text || `Sim rail error ${res.status}`);
+  }
+  const data = await res.json();
+  return {
+    provider_ref: String(data.provider_ref || ""),
+    paid_at: String(data.paid_at || new Date().toISOString()),
+  };
+}
+
 /** Allow-list enforcement and PRN/CRN lookup */
-export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", reference: string) {
+export async function resolveDestination(abn: string, rail: "EFT" | "BPAY", reference: string) {
   const { rows } = await pool.query(
     "select * from remittance_destinations where abn= and rail= and reference=",
     [abn, rail, reference]
@@ -15,28 +56,81 @@ export async function resolveDestination(abn: string, rail: "EFT"|"BPAY", refere
 }
 
 /** Idempotent release with a stable transfer_uuid (simulate bank release) */
-export async function releasePayment(abn: string, taxType: string, periodId: string, amountCents: number, rail: "EFT"|"BPAY", reference: string) {
+export async function releasePayment(
+  abn: string,
+  taxType: string,
+  periodId: string,
+  amountCents: number,
+  rail: "EFT" | "BPAY",
+  reference: string,
+  idempotencyKey?: string
+) {
   const transfer_uuid = uuidv4();
+  const idemKey = idempotencyKey || transfer_uuid;
+  const useSim = envTrue(process.env.FEATURE_SIM_OUTBOUND);
   try {
-    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [transfer_uuid, "INIT"]);
+    await pool.query("insert into idempotency_keys(key,last_status) values(,)", [idemKey, "INIT"]);
   } catch {
+    if (useSim && idempotencyKey) {
+      const existing = await pool.query(
+        "select provider_ref, paid_at from sim_settlements where idem_key= and rail= limit 1",
+        [idempotencyKey, rail]
+      );
+      if (existing.rowCount) {
+        const row = existing.rows[0];
+        return {
+          transfer_uuid,
+          bank_receipt_id: row.provider_ref,
+          provider_ref: row.provider_ref,
+          paid_at: new Date(row.paid_at).toISOString(),
+          status: "DUPLICATE",
+        };
+      }
+    }
     return { transfer_uuid, status: "DUPLICATE" };
   }
-  const bank_receipt_hash = "bank:" + transfer_uuid.slice(0,12);
+
+  let providerRef = "";
+  let paidAt = new Date().toISOString();
+  if (useSim) {
+    const sim = await callSimRail({
+      abn,
+      taxType,
+      periodId,
+      rail,
+      reference,
+      amountCents,
+      idempotencyKey: idemKey,
+    });
+    providerRef = sim.provider_ref;
+    paidAt = sim.paid_at;
+  }
+  const bank_receipt_id = providerRef || "bank:" + transfer_uuid.slice(0, 12);
 
   const { rows } = await pool.query(
     "select balance_after_cents, hash_after from owa_ledger where abn= and tax_type= and period_id= order by id desc limit 1",
-    [abn, taxType, periodId]);
+    [abn, taxType, periodId]
+  );
   const prevBal = rows[0]?.balance_after_cents ?? 0;
   const prevHash = rows[0]?.hash_after ?? "";
   const newBal = prevBal - amountCents;
-  const hashAfter = sha256Hex(prevHash + bank_receipt_hash + String(newBal));
+  const hashAfter = sha256Hex(prevHash + bank_receipt_id + String(newBal));
 
   await pool.query(
-    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_hash,prev_hash,hash_after) values (,,,,,,,,)",
-    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_hash, prevHash, hashAfter]
+    "insert into owa_ledger(abn,tax_type,period_id,transfer_uuid,amount_cents,balance_after_cents,bank_receipt_id,prev_hash,hash_after) values (,,,,,,,,)",
+    [abn, taxType, periodId, transfer_uuid, -amountCents, newBal, bank_receipt_id, prevHash, hashAfter]
   );
-  await appendAudit("rails", "release", { abn, taxType, periodId, amountCents, rail, reference, bank_receipt_hash });
-  await pool.query("update idempotency_keys set last_status= where key=", [transfer_uuid, "DONE"]);
-  return { transfer_uuid, bank_receipt_hash };
+  await appendAudit("rails", "release", {
+    abn,
+    taxType,
+    periodId,
+    amountCents,
+    rail,
+    reference,
+    bank_receipt_id,
+    providerRef,
+    paidAt,
+  });
+  await pool.query("update idempotency_keys set last_status= where key=", [idemKey, "DONE"]);
+  return { transfer_uuid, bank_receipt_id, provider_ref: providerRef || null, paid_at: paidAt };
 }

--- a/src/routes/reconcile.ts
+++ b/src/routes/reconcile.ts
@@ -25,7 +25,8 @@ export async function payAto(req:any, res:any) {
   const payload = pr.rows[0].payload;
   try {
     await resolveDestination(abn, rail, payload.reference);
-    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference);
+    const idemKey = req.header("Idempotency-Key") || undefined;
+    const r = await releasePayment(abn, taxType, periodId, payload.amount_cents, rail, payload.reference, idemKey);
     await pool.query("update periods set state='RELEASED' where abn= and tax_type= and period_id=", [abn, taxType, periodId]);
     return res.json(r);
   } catch (e:any) {

--- a/src/routes/settlementImport.ts
+++ b/src/routes/settlementImport.ts
@@ -1,0 +1,144 @@
+import { Request, Response } from "express";
+import { parse } from "csv-parse/sync";
+import { Pool } from "pg";
+
+const pool = new Pool();
+
+let ensured = false;
+async function ensureSettlementTable() {
+  if (ensured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS settlements (
+      id              BIGSERIAL PRIMARY KEY,
+      provider_ref    TEXT UNIQUE NOT NULL,
+      rail            TEXT NOT NULL,
+      amount_cents    BIGINT NOT NULL,
+      paid_at         TIMESTAMPTZ,
+      abn             TEXT,
+      tax_type        TEXT,
+      period_id       TEXT,
+      idempotency_key TEXT,
+      transfer_uuid   UUID,
+      recon_payload   JSONB DEFAULT '{}'::jsonb,
+      evidence_uri    TEXT,
+      evidence_bundle BIGINT,
+      created_at      TIMESTAMPTZ DEFAULT NOW(),
+      updated_at      TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ux_settlements_idem_key
+      ON settlements(idempotency_key)
+      WHERE idempotency_key IS NOT NULL;
+  `);
+  ensured = true;
+}
+
+type SettlementImportRow = {
+  provider_ref: string;
+  amount_cents: number;
+  paid_at: string;
+  rail?: string;
+  evidence_uri?: string;
+};
+
+function parseCsv(text: string): SettlementImportRow[] {
+  const rows = parse(text, { columns: true, skip_empty_lines: true });
+  return rows.map((row: any) => ({
+    provider_ref: String(row.provider_ref ?? row.providerRef ?? "").trim(),
+    amount_cents: Number(row.amount_cents ?? row.amountCents ?? 0),
+    paid_at: String(row.paid_at ?? row.paidAt ?? ""),
+    rail: row.rail ? String(row.rail).toUpperCase() : undefined,
+    evidence_uri: row.evidence_uri ?? row.evidenceUri ?? undefined,
+  }));
+}
+
+function parseJson(body: any): SettlementImportRow[] {
+  if (!body) return [];
+  const rows = Array.isArray(body) ? body : body.rows ?? body.settlements ?? [];
+  return rows.map((row: any) => ({
+    provider_ref: String(row.provider_ref ?? row.providerRef ?? "").trim(),
+    amount_cents: Number(row.amount_cents ?? row.amountCents ?? 0),
+    paid_at: String(row.paid_at ?? row.paidAt ?? ""),
+    rail: row.rail ? String(row.rail).toUpperCase() : undefined,
+    evidence_uri: row.evidence_uri ?? row.evidenceUri ?? undefined,
+  }));
+}
+
+function validateRow(row: SettlementImportRow) {
+  if (!row.provider_ref) throw new Error("provider_ref required");
+  if (!Number.isFinite(row.amount_cents)) throw new Error("amount_cents must be numeric");
+  if (!row.paid_at) throw new Error("paid_at required");
+  const ts = new Date(row.paid_at);
+  if (Number.isNaN(ts.getTime())) throw new Error("paid_at invalid");
+}
+
+export async function settlementImport(req: Request, res: Response) {
+  try {
+    await ensureSettlementTable();
+
+    const contentType = String(req.headers["content-type"] || "").split(";")[0];
+    let rows: SettlementImportRow[];
+    if (contentType === "text/csv" || contentType === "application/csv") {
+      const body = typeof req.body === "string" ? req.body : "";
+      rows = parseCsv(body);
+    } else if (contentType === "application/json") {
+      rows = parseJson(req.body);
+    } else if (typeof req.body === "string" && req.body.includes(",")) {
+      rows = parseCsv(req.body);
+    } else {
+      rows = parseJson(req.body);
+    }
+
+    if (!rows.length) {
+      return res.status(400).json({ error: "No settlement rows provided" });
+    }
+
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
+      const updated: string[] = [];
+      for (const row of rows) {
+        validateRow(row);
+        const paidAt = new Date(row.paid_at);
+        const { rows: existing } = await client.query(
+          `SELECT id, abn, tax_type, period_id, amount_cents FROM settlements WHERE provider_ref=$1`,
+          [row.provider_ref]
+        );
+        if (!existing.length) {
+          // nothing to reconcile yet; skip but record for visibility
+          continue;
+        }
+        const current = existing[0];
+        await client.query(
+          `UPDATE settlements
+             SET paid_at = $2,
+                 amount_cents = COALESCE($3, amount_cents),
+                 rail = COALESCE($4, rail),
+                 recon_payload = $5::jsonb,
+                 evidence_uri = COALESCE($6, evidence_uri),
+                 updated_at = NOW()
+           WHERE provider_ref = $1`,
+          [
+            row.provider_ref,
+            paidAt,
+            Number.isFinite(row.amount_cents) ? row.amount_cents : current.amount_cents,
+            row.rail ?? current.rail,
+            JSON.stringify({ provider_ref: row.provider_ref, paid_at: paidAt.toISOString(), amount_cents: row.amount_cents, rail: row.rail ?? current.rail }),
+            row.evidence_uri ?? null,
+          ]
+        );
+        updated.push(row.provider_ref);
+      }
+      await client.query("COMMIT");
+      return res.json({ ingested: updated.length, provider_refs: updated });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      throw err;
+    } finally {
+      client.release();
+    }
+  } catch (e: any) {
+    return res.status(400).json({ error: String(e?.message || e) });
+  }
+}

--- a/src/sim/rail/Provider.ts
+++ b/src/sim/rail/Provider.ts
@@ -1,0 +1,173 @@
+import { Router } from "express";
+import { Pool } from "pg";
+import { randomUUID } from "crypto";
+
+export type SimSettlementRow = {
+  provider_ref: string;
+  amount_cents: number;
+  paid_at: string;
+  rail: "EFT" | "BPAY";
+  idem_key: string | null;
+  abn?: string;
+  tax_type?: string;
+  period_id?: string;
+  reference?: string;
+};
+
+const pool = new Pool();
+
+let ensured = false;
+async function ensureSimTable() {
+  if (ensured) return;
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS sim_settlements (
+      id           BIGSERIAL PRIMARY KEY,
+      provider_ref TEXT NOT NULL UNIQUE,
+      amount_cents BIGINT NOT NULL,
+      paid_at      TIMESTAMPTZ NOT NULL,
+      rail         TEXT NOT NULL,
+      idem_key     TEXT,
+      abn          TEXT,
+      tax_type     TEXT,
+      period_id    TEXT,
+      reference    TEXT,
+      created_at   TIMESTAMPTZ DEFAULT NOW(),
+      updated_at   TIMESTAMPTZ DEFAULT NOW()
+    );
+  `);
+  await pool.query(`
+    CREATE UNIQUE INDEX IF NOT EXISTS ux_sim_settlements_idem_key
+      ON sim_settlements(idem_key, rail)
+      WHERE idem_key IS NOT NULL;
+  `);
+  ensured = true;
+}
+
+function normaliseRail(railParam: string): "EFT" | "BPAY" {
+  const upper = railParam.toUpperCase();
+  if (upper !== "EFT" && upper !== "BPAY") {
+    throw new Error("Unsupported rail");
+  }
+  return upper;
+}
+
+export async function recordSimSettlement(row: Omit<SimSettlementRow, "paid_at"> & { paid_at: Date }) {
+  await ensureSimTable();
+  await pool.query(
+    `INSERT INTO sim_settlements
+       (provider_ref, amount_cents, paid_at, rail, idem_key, abn, tax_type, period_id, reference)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+     ON CONFLICT (provider_ref) DO UPDATE SET
+       amount_cents = EXCLUDED.amount_cents,
+       paid_at = EXCLUDED.paid_at,
+       rail = EXCLUDED.rail,
+       idem_key = EXCLUDED.idem_key,
+       abn = EXCLUDED.abn,
+       tax_type = EXCLUDED.tax_type,
+       period_id = EXCLUDED.period_id,
+       reference = EXCLUDED.reference,
+       updated_at = NOW()
+    `,
+    [
+      row.provider_ref,
+      row.amount_cents,
+      row.paid_at,
+      row.rail,
+      row.idem_key,
+      row.abn ?? null,
+      row.tax_type ?? null,
+      row.period_id ?? null,
+      row.reference ?? null,
+    ]
+  );
+}
+
+export const simRailRouter = Router();
+
+simRailRouter.post("/:rail(eft|bpay)", async (req, res) => {
+  try {
+    const rail = normaliseRail(req.params.rail);
+    const idemKey = req.header("Idempotency-Key") || null;
+    const amount = Number(req.body?.amount_cents ?? req.body?.amountCents);
+    if (!Number.isFinite(amount) || amount <= 0) {
+      return res.status(400).json({ error: "amount_cents must be > 0" });
+    }
+    await ensureSimTable();
+
+    if (idemKey) {
+      const existing = await pool.query(
+        `SELECT provider_ref, paid_at FROM sim_settlements WHERE idem_key=$1 AND rail=$2 LIMIT 1`,
+        [idemKey, rail]
+      );
+      if (existing.rowCount) {
+        const row = existing.rows[0];
+        return res.json({
+          provider_ref: row.provider_ref,
+          paid_at: new Date(row.paid_at).toISOString(),
+        });
+      }
+    }
+
+    const paidAt = new Date();
+    const providerRef = `SIM-${randomUUID()}`;
+
+    try {
+      await recordSimSettlement({
+        provider_ref: providerRef,
+        amount_cents: amount,
+        paid_at: paidAt,
+        rail,
+        idem_key: idemKey,
+        abn: req.body?.abn,
+        tax_type: req.body?.taxType,
+        period_id: req.body?.periodId,
+        reference: req.body?.reference,
+      });
+    } catch (err: any) {
+      // handle race on idempotency key
+      if (err?.code === "23505" && idemKey) {
+        const existing = await pool.query(
+          `SELECT provider_ref, paid_at FROM sim_settlements WHERE idem_key=$1 AND rail=$2 LIMIT 1`,
+          [idemKey, rail]
+        );
+        if (existing.rowCount) {
+          const row = existing.rows[0];
+          return res.json({
+            provider_ref: row.provider_ref,
+            paid_at: new Date(row.paid_at).toISOString(),
+          });
+        }
+      }
+      throw err;
+    }
+
+    return res.json({ provider_ref: providerRef, paid_at: paidAt.toISOString() });
+  } catch (e: any) {
+    return res.status(400).json({ error: String(e?.message || e) });
+  }
+});
+
+export async function listSimSettlements(since?: Date) {
+  await ensureSimTable();
+  const params: any[] = [];
+  const where = since ? (params.push(since), "WHERE paid_at >= $1") : "";
+  const { rows } = await pool.query(
+    `SELECT provider_ref, amount_cents, paid_at, rail, idem_key, abn, tax_type, period_id, reference
+     FROM sim_settlements
+     ${where}
+     ORDER BY paid_at ASC, id ASC`
+  , params);
+  return rows.map((row) => ({
+    provider_ref: row.provider_ref,
+    amount_cents: Number(row.amount_cents),
+    paid_at: new Date(row.paid_at).toISOString(),
+    rail: row.rail as "EFT" | "BPAY",
+    idem_key: row.idem_key as string | null,
+    abn: row.abn ?? undefined,
+    tax_type: row.tax_type ?? undefined,
+    period_id: row.period_id ?? undefined,
+    reference: row.reference ?? undefined,
+  }));
+}
+
+export { ensureSimTable };

--- a/src/sim/rail/recon.ts
+++ b/src/sim/rail/recon.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { listSimSettlements } from "./Provider";
+
+function wantsCsv(req: any): boolean {
+  const format = (req.query.format || "").toString().toLowerCase();
+  if (format === "csv") return true;
+  const accept = String(req.headers["accept"] || "");
+  return accept.includes("text/csv");
+}
+
+function toCsv(rows: Awaited<ReturnType<typeof listSimSettlements>>) {
+  const header = "provider_ref,amount_cents,paid_at,rail";
+  const body = rows
+    .map((r) =>
+      [r.provider_ref, r.amount_cents, r.paid_at, r.rail]
+        .map((val) => `"${String(val).replace(/"/g, '""')}"`)
+        .join(",")
+    )
+    .join("\n");
+  return `${header}\n${body}`;
+}
+
+export const simReconRouter = Router();
+
+simReconRouter.get("/recon-file", async (req, res) => {
+  try {
+    const sinceParam = req.query.since ? new Date(String(req.query.since)) : undefined;
+    if (sinceParam && Number.isNaN(sinceParam.getTime())) {
+      return res.status(400).json({ error: "Invalid since timestamp" });
+    }
+    const rows = await listSimSettlements(sinceParam);
+    if (wantsCsv(req)) {
+      res.type("text/csv");
+      return res.send(toCsv(rows));
+    }
+    return res.json({ settlements: rows });
+  } catch (e: any) {
+    return res.status(500).json({ error: String(e?.message || e) });
+  }
+});


### PR DESCRIPTION
## Summary
- add simulated rail provider endpoints that record settlements with idempotent Idempotency-Key handling and recon file export
- route payments release flow through the simulated rail when FEATURE_SIM_OUTBOUND is enabled, persisting provider references for later reconciliation
- expose a settlement import endpoint that accepts CSV or JSON recon files to update stored settlements and evidence metadata

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3ba0ca8948327a5baf7037bdf2792