### PR TITLE
Add parity regression test and enforce safe feature toggles

### DIFF
--- a/apps/services/payments/src/config/features.ts
+++ b/apps/services/payments/src/config/features.ts
@@ -1,0 +1,41 @@
+import type { Console } from "node:console";
+
+function parseBool(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on";
+}
+
+export interface FeatureToggles {
+  simOutbound: boolean;
+  allowUnsafe: boolean;
+}
+
+function readToggles(): FeatureToggles {
+  return {
+    simOutbound: parseBool(process.env.FEATURE_SIM_OUTBOUND),
+    allowUnsafe: parseBool(process.env.ALLOW_UNSAFE),
+  };
+}
+
+export function getFeatureToggles(): FeatureToggles {
+  return readToggles();
+}
+
+export function assertSafeCombo(): void {
+  const toggles = readToggles();
+  const appMode = (process.env.APP_MODE || "sim").toLowerCase();
+  if (appMode === "real" && toggles.simOutbound && !toggles.allowUnsafe) {
+    throw new Error("Unsafe feature combination: FEATURE_SIM_OUTBOUND cannot run in APP_MODE=real without ALLOW_UNSAFE=true");
+  }
+}
+
+export function logFeatureToggles(logger: Pick<Console, "log"> = console): void {
+  const toggles = readToggles();
+  const parts = [
+    `APP_MODE=${process.env.APP_MODE ?? ""}`.trim(),
+    `FEATURE_SIM_OUTBOUND=${toggles.simOutbound}`,
+    `ALLOW_UNSAFE=${toggles.allowUnsafe}`,
+  ];
+  logger.log(`[features] ${parts.filter(Boolean).join(" ")}`.trim());
+}

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -2,6 +2,8 @@
 import 'dotenv/config';
 import './loadEnv.js'; // ensures .env.local is loaded when running with tsx
 
+import { assertSafeCombo, logFeatureToggles } from './config/features.js';
+
 import express from 'express';
 import pg from 'pg'; const { Pool } = pg;
 
@@ -23,6 +25,10 @@ const connectionString =
 // Export pool for other modules
 export const pool = new Pool({ connectionString });
 
+// Validate feature toggles as early as possible
+assertSafeCombo();
+logFeatureToggles();
+
 const app = express();
 app.use(express.json());
 
@@ -38,7 +44,9 @@ app.get('/ledger', ledger);
 // 404 fallback
 app.use((_req, res) => res.status(404).send('Not found'));
 
-// Start server
-app.listen(PORT, () => {
-  console.log(`[payments] listening on http://localhost:${PORT}`);
-});
+// Start server unless running under tests
+if (process.env.NODE_ENV !== 'test') {
+  app.listen(PORT, () => {
+    console.log(`[payments] listening on http://localhost:${PORT}`);
+  });
+}

--- a/apps/services/payments/src/middleware/rptGate.ts
+++ b/apps/services/payments/src/middleware/rptGate.ts
@@ -16,7 +16,7 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
 
     // Accept pending/active. Order by created_at so newest wins.
     const q = `
-      SELECT id as rpt_id, payload_c14n, payload_sha256, signature, expires_at, status, nonce
+      SELECT rpt_id, kid, payload_c14n, payload_sha256, signature, expires_at, status, nonce
       FROM rpt_tokens
       WHERE abn = $1 AND tax_type = $2 AND period_id = $3
         AND status IN ('pending','active')
@@ -43,7 +43,7 @@ export async function rptGate(req: Request, res: Response, next: NextFunction) {
     const ok = await kms.verify(payload, sig);
     if (!ok) return res.status(403).json({ error: "RPT signature invalid" });
 
-    (req as any).rpt = { rpt_id: r.rpt_id, nonce: r.nonce, payload_sha256: r.payload_sha256 };
+    (req as any).rpt = { rpt_id: r.rpt_id, nonce: r.nonce, payload_sha256: r.payload_sha256, kid: r.kid };
     return next();
   } catch (e: any) {
     return res.status(500).json({ error: "RPT verification error", detail: String(e?.message || e) });

--- a/apps/services/payments/src/recon/importer.ts
+++ b/apps/services/payments/src/recon/importer.ts
@@ -1,0 +1,30 @@
+import type { PoolClient } from 'pg';
+
+export interface ReconImportParams {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  manifestSha256: string;
+  gateState: string;
+}
+
+export async function recordReconImport(client: PoolClient, params: ReconImportParams) {
+  const sql = `
+    INSERT INTO recon_imports (abn, tax_type, period_id, manifest_sha256, gate_state, imported_at)
+    VALUES ($1,$2,$3,$4,$5, now())
+    ON CONFLICT (abn, tax_type, period_id)
+    DO UPDATE SET
+      manifest_sha256 = EXCLUDED.manifest_sha256,
+      gate_state = EXCLUDED.gate_state,
+      imported_at = now()
+    RETURNING manifest_sha256, gate_state
+  `;
+  const { rows } = await client.query(sql, [
+    params.abn,
+    params.taxType,
+    params.periodId,
+    params.manifestSha256,
+    params.gateState,
+  ]);
+  return rows[0];
+}

--- a/apps/services/payments/src/routes/payAto.ts
+++ b/apps/services/payments/src/routes/payAto.ts
@@ -1,35 +1,168 @@
-﻿// apps/services/payments/src/routes/payAto.ts
-import { Request, Response } from 'express';
-import crypto from 'crypto';
-import pg from 'pg'; const { Pool } = pg;
-import { pool } from '../index.js';
+// apps/services/payments/src/routes/payAto.ts
+import type { Request, Response } from 'express';
+import { randomUUID } from 'node:crypto';
+import type { PoolClient } from 'pg';
 
-function genUUID() {
-  return crypto.randomUUID();
+import { pool } from '../index.js';
+import { isAllowlisted, type Dest as Destination } from '../utils/allowlist.js';
+import { buildEvidenceBundle } from '../evidence/evidenceBundle.js';
+import { getFeatureToggles } from '../config/features.js';
+import { sha256Hex } from '../utils/crypto.js';
+import { sendEftOrBpay } from '../bank/eftBpayAdapter.js';
+
+type RptContext = { rpt_id: number; kid?: string; payload_sha256: string };
+
+type ReleaseRequest = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: number;
+  destination: Destination;
+  rpt: RptContext;
+};
+
+export type ReleaseResult = {
+  provider_ref: string;
+  bank_receipt_hash: string;
+  release_uuid: string;
+  amount_cents: number;
+  rpt_ref: { rpt_id: number; kid?: string; payload_sha256: string };
+};
+
+function defaultIdempotencyKey(p: ReleaseRequest) {
+  return `payato:${p.abn}:${p.taxType}:${p.periodId}`;
 }
 
-/**
- * Minimal release path:
- * - Requires rptGate to have attached req.rpt
- * - Inserts a single negative ledger entry for the given period
- * - Sets rpt_verified=true and a unique release_uuid to satisfy constraints
- */
+function uuidFromHash(hex: string): string {
+  const clean = hex.padEnd(32, '0');
+  return `${clean.slice(0, 8)}-${clean.slice(8, 12)}-${clean.slice(12, 16)}-${clean.slice(16, 20)}-${clean.slice(20, 32)}`;
+}
+
+function simulateOutbound(idempotencyKey: string, amountCents: number) {
+  const base = sha256Hex(`${idempotencyKey}|${amountCents}`);
+  const provider_ref = `SIM-${base.slice(0, 16)}`;
+  return {
+    provider_ref,
+    release_uuid: uuidFromHash(base),
+    bank_receipt_hash: sha256Hex(provider_ref),
+  };
+}
+
+export async function processRelease(
+  client: PoolClient,
+  request: ReleaseRequest,
+  options: { idempotencyKey?: string } = {}
+): Promise<ReleaseResult> {
+  const { abn, taxType, periodId, destination, rpt } = request;
+  const amt = Number(request.amountCents);
+  if (!Number.isFinite(amt) || amt >= 0) {
+    throw new Error('amountCents must be negative for a release');
+  }
+  if (!isAllowlisted(abn, destination)) {
+    throw new Error('Destination not allowlisted');
+  }
+
+  const toggles = getFeatureToggles();
+  const idempotencyKey = options.idempotencyKey || defaultIdempotencyKey(request);
+
+  const existing = await client.query(
+    'SELECT last_status, response_hash FROM idempotency_keys WHERE key=$1 FOR UPDATE',
+    [idempotencyKey]
+  );
+  if (existing.rowCount) {
+    const row = existing.rows[0];
+    if (row.last_status === 'DONE' && row.response_hash) {
+      try {
+        return JSON.parse(row.response_hash) as ReleaseResult;
+      } catch {
+        // fall through if payload corrupted
+      }
+    }
+  } else {
+    await client.query('INSERT INTO idempotency_keys(key,last_status) VALUES ($1,$2)', [idempotencyKey, 'INIT']);
+  }
+
+  const balQ = await client.query(
+    'SELECT COALESCE(SUM(amount_cents),0) AS bal FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3',
+    [abn, taxType, periodId]
+  );
+  const balance = Number(balQ.rows[0]?.bal || 0);
+  if (Math.abs(amt) > balance) {
+    throw new Error('Insufficient OWA balance');
+  }
+
+  const prev = await client.query(
+    'SELECT entry_id, hash_after FROM owa_ledger WHERE abn=$1 AND tax_type=$2 AND period_id=$3 ORDER BY entry_id DESC LIMIT 1',
+    [abn, taxType, periodId]
+  );
+  const prevHash = prev.rows[0]?.hash_after || ''.padEnd(64, '0');
+
+  let provider_ref: string;
+  let release_uuid: string;
+  let bank_receipt_hash: string;
+
+  if (toggles.simOutbound) {
+    const sim = simulateOutbound(idempotencyKey, amt);
+    provider_ref = sim.provider_ref;
+    release_uuid = sim.release_uuid;
+    bank_receipt_hash = sim.bank_receipt_hash;
+  } else {
+    const bank = await sendEftOrBpay({
+      abn,
+      taxType,
+      periodId,
+      amount_cents: Math.abs(amt),
+      destination,
+      idempotencyKey,
+    });
+    provider_ref = bank.provider_receipt_id;
+    release_uuid = bank.transfer_uuid || randomUUID();
+    bank_receipt_hash = bank.bank_receipt_hash;
+  }
+
+  const hash_after = sha256Hex(`${prevHash}|${abn}|${taxType}|${periodId}|${amt}|${provider_ref}|${release_uuid}`);
+
+  const insert = `
+    INSERT INTO owa_ledger
+      (abn, tax_type, period_id, amount_cents, rpt_verified, release_uuid, bank_receipt_id, hash_before, hash_after, created_at)
+    VALUES ($1,$2,$3,$4,true,$5,$6,$7,$8,now())
+    RETURNING entry_id
+  `;
+  await client.query(insert, [abn, taxType, periodId, amt, release_uuid, provider_ref, prevHash, hash_after]);
+
+  await buildEvidenceBundle(client, {
+    abn,
+    taxType,
+    periodId,
+    bankReceipts: [{ provider: toggles.simOutbound ? 'SIM' : 'EFT/BPAY', receipt_id: provider_ref }],
+    atoReceipts: [],
+    operatorOverrides: [],
+    owaAfterHash: hash_after,
+  });
+
+  const result: ReleaseResult = {
+    provider_ref,
+    bank_receipt_hash,
+    release_uuid,
+    amount_cents: Math.abs(amt),
+    rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
+  };
+
+  await client.query(
+    'UPDATE idempotency_keys SET last_status=$2, response_hash=$3 WHERE key=$1',
+    [idempotencyKey, 'DONE', JSON.stringify(result)]
+  );
+
+  return result;
+}
+
 export async function payAtoRelease(req: Request, res: Response) {
-  const { abn, taxType, periodId, amountCents } = req.body || {};
+  const { abn, taxType, periodId, amountCents, destination } = req.body || {};
   if (!abn || !taxType || !periodId) {
     return res.status(400).json({ error: 'Missing abn/taxType/periodId' });
   }
 
-  // default a tiny test debit if not provided
-  const amt = Number.isFinite(Number(amountCents)) ? Number(amountCents) : -100;
-
-  // must be negative for a release
-  if (amt >= 0) {
-    return res.status(400).json({ error: 'amountCents must be negative for a release' });
-  }
-
-  // rptGate attaches req.rpt when verification succeeds
-  const rpt = (req as any).rpt;
+  const rpt = (req as any).rpt as RptContext | undefined;
   if (!rpt) {
     return res.status(403).json({ error: 'RPT not verified' });
   }
@@ -37,55 +170,22 @@ export async function payAtoRelease(req: Request, res: Response) {
   const client = await pool.connect();
   try {
     await client.query('BEGIN');
-
-    // compute running balance AFTER this entry:
-    // fetch last balance in this period (by id order), default 0
-    const { rows: lastRows } = await client.query<{
-      balance_after_cents: string | number;
-    }>(
-      `SELECT balance_after_cents
-       FROM owa_ledger
-       WHERE abn=$1 AND tax_type=$2 AND period_id=$3
-       ORDER BY id DESC
-       LIMIT 1`,
-      [abn, taxType, periodId]
+    const result = await processRelease(
+      client,
+      {
+        abn,
+        taxType,
+        periodId,
+        amountCents: Number.isFinite(Number(amountCents)) ? Number(amountCents) : -100,
+        destination: destination || {},
+        rpt,
+      },
+      { idempotencyKey: req.header('Idempotency-Key') || undefined }
     );
-    const lastBal = lastRows.length ? Number(lastRows[0].balance_after_cents) : 0;
-    const newBal = lastBal + amt;
-
-    const release_uuid = genUUID();
-
-    const insert = `
-      INSERT INTO owa_ledger
-        (abn, tax_type, period_id, transfer_uuid, amount_cents, balance_after_cents,
-         rpt_verified, release_uuid, created_at)
-      VALUES ($1,$2,$3,$4,$5,$6, TRUE, $7, now())
-      RETURNING id, transfer_uuid, balance_after_cents
-    `;
-    const transfer_uuid = genUUID();
-    const { rows: ins } = await client.query(insert, [
-      abn,
-      taxType,
-      periodId,
-      transfer_uuid,
-      amt,
-      newBal,
-      release_uuid,
-    ]);
-
     await client.query('COMMIT');
-
-    return res.json({
-      ok: true,
-      ledger_id: ins[0].id,
-      transfer_uuid,
-      release_uuid,
-      balance_after_cents: ins[0].balance_after_cents,
-      rpt_ref: { rpt_id: rpt.rpt_id, kid: rpt.kid, payload_sha256: rpt.payload_sha256 },
-    });
+    return res.json(result);
   } catch (e: any) {
     await client.query('ROLLBACK');
-    // common failures: unique single-release-per-period, allow-list, etc.
     return res.status(400).json({ error: 'Release failed', detail: String(e?.message || e) });
   } finally {
     client.release();

--- a/package.json
+++ b/package.json
@@ -4,12 +4,13 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "prototype:parity": "tsx tests/sim/parity.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.0.0",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",

--- a/tests/sim/parity.test.ts
+++ b/tests/sim/parity.test.ts
@@ -1,0 +1,355 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+process.env.APP_MODE = 'sim';
+process.env.FEATURE_SIM_OUTBOUND = 'true';
+delete process.env.ALLOW_UNSAFE;
+process.env.ED25519_PUBLIC_KEY_BASE64 = Buffer.alloc(32, 1).toString('base64');
+process.env.NODE_ENV = 'test';
+
+const Module = require('module');
+const originalLoad = Module._load;
+Module._load = function(request: string, parent: any, isMain: boolean) {
+  if (request === 'axios') {
+    return {
+      create: () => ({
+        post: async () => ({ data: { receipt_id: 'SIM-RECEIPT' } }),
+      }),
+    };
+  }
+  return originalLoad.call(this, request, parent, isMain);
+};
+
+const { canonicalJson, sha256Hex } = require('../../apps/services/payments/src/utils/crypto.js') as typeof import('../../apps/services/payments/src/utils/crypto.js');
+const { processRelease } = require('../../apps/services/payments/src/routes/payAto.js') as typeof import('../../apps/services/payments/src/routes/payAto.js');
+const { recordReconImport } = require('../../apps/services/payments/src/recon/importer.js') as typeof import('../../apps/services/payments/src/recon/importer.js');
+const { buildEvidenceBundle } = require('../../apps/services/payments/src/evidence/evidenceBundle.js') as typeof import('../../apps/services/payments/src/evidence/evidenceBundle.js');
+
+type QueryResult = { rows: any[] };
+
+type IdempotencyRow = { last_status?: string | null; response_hash?: string | null };
+type LedgerRow = {
+  entry_id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  amount_cents: number;
+  rpt_verified: boolean;
+  release_uuid?: string | null;
+  bank_receipt_id?: string | null;
+  hash_before: string;
+  hash_after: string;
+  created_at: Date;
+};
+type RptRow = {
+  rpt_id: number;
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  kid: string;
+  payload_c14n: string;
+  payload_sha256: string;
+  signature: string;
+  status: string;
+  created_at: Date;
+  expires_at: Date;
+  nonce: string;
+};
+type ReconRow = { manifest_sha256: string; gate_state: string; imported_at: Date };
+
+type EvidenceRow = { bundle_id: number };
+
+class FakeDatabase {
+  idempotency = new Map<string, IdempotencyRow>();
+  ledger: LedgerRow[] = [];
+  rptTokens: RptRow[] = [];
+  evidence = new Map<string, EvidenceRow>();
+  recon = new Map<string, ReconRow>();
+  nextEntryId = 1;
+  nextRptId = 1;
+  nextBundleId = 1;
+}
+
+class FakeClient {
+  constructor(private db: FakeDatabase) {}
+
+  async query(sql: string, params: any[] = []): Promise<QueryResult> {
+    const norm = sql.replace(/\s+/g, ' ').trim();
+    const upper = norm.toUpperCase();
+
+    if (upper === 'BEGIN' || upper === 'COMMIT' || upper === 'ROLLBACK') {
+      return { rows: [] };
+    }
+
+    if (upper.startsWith('SELECT LAST_STATUS, RESPONSE_HASH FROM IDEMPOTENCY_KEYS')) {
+      const key = params[0];
+      const row = this.db.idempotency.get(key);
+      if (!row) return { rows: [] };
+      return { rows: [{ last_status: row.last_status ?? null, response_hash: row.response_hash ?? null }] };
+    }
+
+    if (upper.startsWith('INSERT INTO IDEMPOTENCY_KEYS')) {
+      const [key, status] = params;
+      this.db.idempotency.set(key, { last_status: status, response_hash: null });
+      return { rows: [] };
+    }
+
+    if (upper.startsWith('UPDATE IDEMPOTENCY_KEYS SET LAST_STATUS')) {
+      const [key, status, hash] = params;
+      const row = this.db.idempotency.get(key);
+      if (row) {
+        row.last_status = status;
+        row.response_hash = hash;
+      }
+      return { rows: [] };
+    }
+
+    if (upper.startsWith('SELECT COALESCE(SUM(AMOUNT_CENTS),0) BAL FROM OWA_LEDGER WHERE') && upper.includes('ENTRY_ID <')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.db.ledger.filter((row) => row.abn === abn && row.tax_type === taxType && row.period_id === periodId);
+      const maxEntry = rows.reduce((m, row) => Math.max(m, row.entry_id), 0);
+      const sum = rows.filter((row) => row.entry_id < maxEntry).reduce((acc, row) => acc + row.amount_cents, 0);
+      return { rows: [{ bal: sum }] };
+    }
+
+    if (upper.startsWith('SELECT COALESCE(SUM(AMOUNT_CENTS),0) AS BAL FROM OWA_LEDGER WHERE') ||
+        (upper.startsWith('SELECT COALESCE(SUM(AMOUNT_CENTS),0) BAL FROM OWA_LEDGER WHERE') && !upper.includes('ENTRY_ID <'))) {
+      const [abn, taxType, periodId] = params;
+      const sum = this.db.ledger
+        .filter((row) => row.abn === abn && row.tax_type === taxType && row.period_id === periodId)
+        .reduce((acc, row) => acc + row.amount_cents, 0);
+      return { rows: [{ bal: sum }] };
+    }
+
+    if (upper.startsWith('SELECT ENTRY_ID, HASH_AFTER FROM OWA_LEDGER WHERE')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.db.ledger
+        .filter((row) => row.abn === abn && row.tax_type === taxType && row.period_id === periodId)
+        .sort((a, b) => b.entry_id - a.entry_id);
+      if (!rows.length) return { rows: [] };
+      const latest = rows[0];
+      return { rows: [{ entry_id: latest.entry_id, hash_after: latest.hash_after }] };
+    }
+
+    if (upper.startsWith('INSERT INTO OWA_LEDGER (ABN,TAX_TYPE,PERIOD_ID,AMOUNT_CENTS,RPT_VERIFIED,HASH_BEFORE,HASH_AFTER)')) {
+      const [abn, taxType, periodId, amount, hashBefore, hashAfter] = params;
+      const row: LedgerRow = {
+        entry_id: this.db.nextEntryId++,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        amount_cents: Number(amount),
+        rpt_verified: false,
+        release_uuid: null,
+        bank_receipt_id: null,
+        hash_before: hashBefore,
+        hash_after: hashAfter,
+        created_at: new Date(),
+      };
+      this.db.ledger.push(row);
+      return { rows: [] };
+    }
+
+    if (upper.startsWith('INSERT INTO OWA_LEDGER') && upper.includes('RPT_VERIFIED, RELEASE_UUID, BANK_RECEIPT_ID')) {
+      const [abn, taxType, periodId, amount, releaseUuid, receiptId, hashBefore, hashAfter] = params;
+      const row: LedgerRow = {
+        entry_id: this.db.nextEntryId++,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        amount_cents: Number(amount),
+        rpt_verified: true,
+        release_uuid: releaseUuid,
+        bank_receipt_id: receiptId,
+        hash_before: hashBefore,
+        hash_after: hashAfter,
+        created_at: new Date(),
+      };
+      this.db.ledger.push(row);
+      return { rows: [{ entry_id: row.entry_id }] };
+    }
+
+    if (upper.startsWith('SELECT RPT_ID, KID, PAYLOAD_C14N, PAYLOAD_SHA256, SIGNATURE FROM RPT_TOKENS WHERE')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.db.rptTokens
+        .filter((row) => row.abn === abn && row.tax_type === taxType && row.period_id === periodId && row.status === 'ISSUED')
+        .sort((a, b) => b.created_at.getTime() - a.created_at.getTime());
+      if (!rows.length) return { rows: [] };
+      const latest = rows[0];
+      return {
+        rows: [
+          {
+            rpt_id: latest.rpt_id,
+            kid: latest.kid,
+            payload_c14n: latest.payload_c14n,
+            payload_sha256: latest.payload_sha256,
+            signature: latest.signature,
+          },
+        ],
+      };
+    }
+
+    if (upper.startsWith('INSERT INTO RPT_TOKENS')) {
+      const [abn, taxType, periodId, kid, payload, payloadSha, signature, nonce] = params;
+      const row: RptRow = {
+        rpt_id: this.db.nextRptId++,
+        abn,
+        tax_type: taxType,
+        period_id: periodId,
+        kid,
+        payload_c14n: payload,
+        payload_sha256: payloadSha,
+        signature,
+        status: 'ISSUED',
+        created_at: new Date(),
+        expires_at: new Date(Date.now() + 86_400_000),
+        nonce,
+      };
+      this.db.rptTokens.push(row);
+      return { rows: [{ rpt_id: row.rpt_id }] };
+    }
+
+    if (upper.startsWith('SELECT MANIFEST_SHA256, GATE_STATE FROM RECON_IMPORTS WHERE')) {
+      const [abn, taxType, periodId] = params;
+      const key = `${abn}|${taxType}|${periodId}`;
+      const row = this.db.recon.get(key);
+      return row ? { rows: [{ manifest_sha256: row.manifest_sha256, gate_state: row.gate_state }] } : { rows: [] };
+    }
+
+    if (upper.startsWith('INSERT INTO RECON_IMPORTS')) {
+      const [abn, taxType, periodId, manifest, gate] = params;
+      const key = `${abn}|${taxType}|${periodId}`;
+      this.db.recon.set(key, { manifest_sha256: manifest, gate_state: gate, imported_at: new Date() });
+      return { rows: [{ manifest_sha256: manifest, gate_state: gate }] };
+    }
+
+    if (upper.startsWith('INSERT INTO EVIDENCE_BUNDLES')) {
+      const [abn, taxType, periodId] = params;
+      const key = `${abn}|${taxType}|${periodId}`;
+      let row = this.db.evidence.get(key);
+      if (!row) {
+        row = { bundle_id: this.db.nextBundleId++ };
+        this.db.evidence.set(key, row);
+      }
+      return { rows: [{ bundle_id: row.bundle_id }] };
+    }
+
+    if (upper.startsWith('SELECT AMOUNT_CENTS, BANK_RECEIPT_ID FROM OWA_LEDGER WHERE')) {
+      const [abn, taxType, periodId] = params;
+      const rows = this.db.ledger
+        .filter((row) => row.abn === abn && row.tax_type === taxType && row.period_id === periodId && row.amount_cents < 0)
+        .sort((a, b) => b.entry_id - a.entry_id);
+      if (!rows.length) return { rows: [] };
+      const latest = rows[0];
+      return { rows: [{ amount_cents: latest.amount_cents, bank_receipt_id: latest.bank_receipt_id }] };
+    }
+
+    throw new Error(`Unsupported query: ${norm}`);
+  }
+
+  release(): void {
+    // no-op
+  }
+}
+
+class FakePool {
+  constructor(private db: FakeDatabase) {}
+  async connect() {
+    return new FakeClient(this.db);
+  }
+}
+
+const database = new FakeDatabase();
+const pool = new FakePool(database);
+
+async function withClient<T>(fn: (client: FakeClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const out = await fn(client);
+    await client.query('COMMIT');
+    return out;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+test('sim release -> recon import -> evidence parity', async () => {
+  const abn = '53004085616';
+  const taxType = 'PAYGW';
+  const periodId = '2025-09';
+  const kid = 'dev-ed25519-kms-001';
+  const amountCents = -5_000;
+  const destination = { bpay_biller: '75556', crn: '12345678901' } as const;
+  const idempotencyKey = 'sim-release-key-001';
+
+  const payload = canonicalJson({ abn, taxType, periodId, kid });
+  const payloadSha = sha256Hex(payload);
+
+  let rptContext = { rpt_id: 0, kid, payload_sha256: payloadSha };
+
+  await withClient(async (client) => {
+    await client.query(
+      `INSERT INTO owa_ledger (abn,tax_type,period_id,amount_cents,rpt_verified,hash_before,hash_after)
+       VALUES ($1,$2,$3,$4,false,$5,$6)`,
+      [abn, taxType, periodId, 10_000, ''.padEnd(64, '0'), ''.padEnd(64, '1')]
+    );
+    const { rows } = await client.query(
+      `INSERT INTO rpt_tokens (abn,tax_type,period_id,kid,payload_c14n,payload_sha256,signature,expires_at,status,nonce)
+       VALUES ($1,$2,$3,$4,$5,$6,$7, now() + interval '1 day','ISSUED',$8)
+       RETURNING rpt_id`,
+      [abn, taxType, periodId, kid, payload, payloadSha, 'sig', 'nonce-001']
+    );
+    rptContext = { rpt_id: rows[0].rpt_id, kid, payload_sha256: payloadSha };
+  });
+
+  const releaseOne = await withClient((client) =>
+    processRelease(
+      client,
+      { abn, taxType, periodId, amountCents, destination: { ...destination }, rpt: rptContext },
+      { idempotencyKey }
+    )
+  );
+
+  const releaseTwo = await withClient((client) =>
+    processRelease(
+      client,
+      { abn, taxType, periodId, amountCents, destination: { ...destination }, rpt: rptContext },
+      { idempotencyKey }
+    )
+  );
+
+  assert.ok(releaseOne.provider_ref, 'provider_ref should be returned');
+  assert.equal(releaseOne.provider_ref, releaseTwo.provider_ref, 'provider_ref must be stable for same idempotency key');
+
+  await withClient((client) =>
+    recordReconImport(client, {
+      abn,
+      taxType,
+      periodId,
+      manifestSha256: 'rules-manifest-sha',
+      gateState: 'RPT-Issued',
+    })
+  );
+
+  const evidence = await withClient((client) =>
+    buildEvidenceBundle(client, {
+      abn,
+      taxType,
+      periodId,
+      bankReceipts: [{ provider: 'SIM', receipt_id: releaseOne.provider_ref }],
+      atoReceipts: [],
+      operatorOverrides: [],
+      owaAfterHash: '',
+    })
+  );
+
+  assert.ok(evidence.settlement, 'settlement should exist');
+  assert.equal(evidence.settlement?.amount_cents, Math.abs(amountCents), 'settlement amount should match release');
+  assert.ok(evidence.rules.manifest_sha256, 'rules.manifest_sha256 should be populated');
+  assert.ok(evidence.narrative.some((line) => line.includes('gate:RPT-Issued')));
+  assert.ok(evidence.narrative.some((line) => line.includes(`kid:${kid}`)));
+});


### PR DESCRIPTION
## Summary
- add a feature toggle helper that blocks unsafe APP_MODE and FEATURE_SIM_OUTBOUND combinations and logs active flags during startup
- harden the payments release flow with explicit idempotency handling, simulated outbound stubs, and richer evidence bundle metadata
- introduce a recon import helper and a regression test that drives a simulated release → recon → evidence loop via a fake database harness
- wire up the new parity test in package.json so CI can gate scorecard runs

## Testing
- `npx tsx tests/sim/parity.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e3bbaade748327a4b0e12519825b6d