### PR TITLE
Add tax schedules and secure release flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2025-10-06
+- Updated PAYG withholding schedules and GST label mappings for ATO 2024-25 guidance.
+- Published consolidated rules manifest and bumped application rates version.

--- a/apps/services/tax-engine/app/domains/payg_w.py
+++ b/apps/services/tax-engine/app/domains/payg_w.py
@@ -1,5 +1,8 @@
 ﻿from __future__ import annotations
+from decimal import Decimal
 from typing import Dict, Any, Tuple
+
+from ..schedules import payg_withholding
 
 def _round(amount: float, mode: str="HALF_UP") -> float:
     from decimal import Decimal, ROUND_HALF_UP, ROUND_HALF_EVEN, getcontext
@@ -7,51 +10,62 @@ def _round(amount: float, mode: str="HALF_UP") -> float:
     q = Decimal(str(amount)).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP if mode=="HALF_UP" else ROUND_HALF_EVEN)
     return float(q)
 
-def _bracket_withholding(gross: float, cfg: Dict[str, Any]) -> float:
-    """Generic progressive bracket formula: tax = a*gross - b + fixed (per period)."""
-    brs = cfg.get("brackets", [])
-    for br in brs:
-        if gross <= float(br.get("up_to", 9e9)):
-            a = float(br.get("a", 0.0)); b = float(br.get("b", 0.0)); fixed = float(br.get("fixed", 0.0))
-            return max(0.0, a * gross - b + fixed)
-    return 0.0
-
 def _percent_simple(gross: float, rate: float) -> float:
     return max(0.0, gross * rate)
 
 def _flat_plus_percent(gross: float, rate: float, extra: float) -> float:
     return max(0.0, gross * rate + extra)
 
-def _bonus_marginal(regular_gross: float, bonus: float, cfg: Dict[str, Any]) -> float:
-    base = _bracket_withholding(regular_gross + bonus, cfg)
-    only_base = _bracket_withholding(regular_gross, cfg)
-    return max(0.0, base - only_base)
+def _bonus_marginal(regular_gross: float, bonus: float, rules: Dict[str, Any], period: str, tax_free_threshold: bool, stsl: bool) -> float:
+    base = payg_withholding(regular_gross + bonus, period=period, tax_free_threshold=tax_free_threshold, stsl=stsl, rules=rules)
+    only_base = payg_withholding(regular_gross, period=period, tax_free_threshold=tax_free_threshold, stsl=stsl, rules=rules)
+    return max(0.0, float(base - only_base))
 
-def _solve_net_to_gross(target_net: float, method_cfg: Tuple[str, Dict[str, Any]]) -> Tuple[float,float]:
+def _solve_net_to_gross(target_net: float, method_cfg: Tuple[str, Dict[str, Any]], rules: Dict[str, Any]) -> Tuple[float,float]:
     mname, params = method_cfg
     lo, hi = 0.0, max(1.0, target_net * 3.0)
     for _ in range(60):
         mid = (lo+hi)/2
-        w = compute_withholding_for_gross(mid, mname, params)
+        w = compute_withholding_for_gross(mid, mname, params, rules)
         net = mid - w
         if net > target_net: hi = mid
         else: lo = mid
     gross = (lo+hi)/2
-    w = compute_withholding_for_gross(gross, mname, params)
+    w = compute_withholding_for_gross(gross, mname, params, rules)
     return gross, w
 
-def compute_withholding_for_gross(gross: float, method: str, params: Dict[str, Any]) -> float:
+def compute_withholding_for_gross(gross: float, method: str, params: Dict[str, Any], rules: Dict[str, Any]) -> float:
     if method == "formula_progressive":
-        return _bracket_withholding(gross, params.get("formula_progressive", {}))
+        result = payg_withholding(
+            gross,
+            period=params.get("period", "weekly"),
+            tax_free_threshold=params.get("tax_free_threshold", True),
+            stsl=params.get("stsl", False),
+            rules=rules,
+        )
+        return float(result)
     if method == "percent_simple":
         return _percent_simple(gross, float(params.get("percent", 0.0)))
     if method == "flat_plus_percent":
         return _flat_plus_percent(gross, float(params.get("percent", 0.0)), float(params.get("extra", 0.0)))
     if method == "bonus_marginal":
-        return _bonus_marginal(float(params.get("regular_gross", 0.0)), float(params.get("bonus", 0.0)), params.get("formula_progressive", {}))
+        return _bonus_marginal(
+            float(params.get("regular_gross", 0.0)),
+            float(params.get("bonus", 0.0)),
+            rules,
+            params.get("period", "weekly"),
+            params.get("tax_free_threshold", True),
+            params.get("stsl", False),
+        )
     if method == "table_ato":
-        # Placeholder: replace with exact ATO schedule logic per period & flags.
-        return _bracket_withholding(gross, params.get("formula_progressive", {}))
+        result = payg_withholding(
+            gross,
+            period=params.get("period", "weekly"),
+            tax_free_threshold=params.get("tax_free_threshold", True),
+            stsl=params.get("stsl", False),
+            rules=rules,
+        )
+        return float(result)
     return 0.0
 
 def compute(event: Dict[str, Any], rules: Dict[str, Any]) -> Dict[str, Any]:
@@ -66,17 +80,28 @@ def compute(event: Dict[str, Any], rules: Dict[str, Any]) -> Dict[str, Any]:
         "extra": float(pw.get("extra", 0.0)),
         "regular_gross": float(pw.get("regular_gross", 0.0)),
         "bonus": float(pw.get("bonus", 0.0)),
-        "formula_progressive": (rules.get("formula_progressive") or {})
     }
     explain = [f"method={method} period={period} TFT={params['tax_free_threshold']} STSL={params['stsl']}"]
     gross = float(pw.get("gross", 0.0) or 0.0)
     target_net = pw.get("target_net")
 
     if method == "net_to_gross" and target_net is not None:
-        gross, w = _solve_net_to_gross(float(target_net), ("formula_progressive", params))
+        gross, w = _solve_net_to_gross(float(target_net), ("formula_progressive", params), rules)
         net = gross - w
-        return {"method": method, "gross": _round(gross), "withholding": _round(w), "net": _round(net), "explain": explain + [f"solved net_to_gross target_net={target_net}"]}
+        return {
+            "method": method,
+            "gross": _round(gross),
+            "withholding": _round(w),
+            "net": _round(net),
+            "explain": explain + [f"solved net_to_gross target_net={target_net}"]
+        }
     else:
-        w = compute_withholding_for_gross(gross, method, params)
+        w = compute_withholding_for_gross(gross, method, params, rules)
         net = gross - w
-        return {"method": method, "gross": _round(gross), "withholding": _round(w), "net": _round(net), "explain": explain + [f"computed from gross={gross}"]}
+        return {
+            "method": method,
+            "gross": _round(gross),
+            "withholding": _round(w),
+            "net": _round(net),
+            "explain": explain + [f"computed from gross={gross}"]
+        }

--- a/apps/services/tax-engine/app/rules/gst_rates_2000_current.json
+++ b/apps/services/tax-engine/app/rules/gst_rates_2000_current.json
@@ -1,0 +1,26 @@
+{
+  "version": "2000-current",
+  "notes": "Australian GST baseline rates for BAS labelling across sales and purchases.",
+  "codes": {
+    "GST": { "rate": 0.10, "label": "Taxable supplies" },
+    "GST_FREE": { "rate": 0.0, "label": "GST-free supplies" },
+    "EXEMPT": { "rate": 0.0, "label": "Input-taxed supplies" },
+    "ZERO_RATED": { "rate": 0.0, "label": "Exports / zero-rated" }
+  },
+  "labels": {
+    "sales": {
+      "G1": { "description": "Total sales", "codes": ["GST", "GST_FREE", "EXEMPT", "ZERO_RATED"] },
+      "G2": { "description": "Exports (GST-free)", "codes": ["ZERO_RATED"] },
+      "G3": { "description": "Other GST-free sales", "codes": ["GST_FREE", "EXEMPT"] },
+      "1A": { "description": "GST on sales", "codes": ["GST"], "type": "tax" }
+    },
+    "purchases": {
+      "G10": { "description": "Capital purchases", "codes": ["GST"], "type": "capital" },
+      "G11": { "description": "Non-capital purchases", "codes": ["GST", "GST_FREE", "EXEMPT", "ZERO_RATED"] },
+      "1B": { "description": "GST on purchases", "codes": ["GST"], "type": "tax" }
+    }
+  },
+  "rounding": {
+    "mode": "NEAREST_DOLLAR"
+  }
+}

--- a/apps/services/tax-engine/app/rules/manifest.json
+++ b/apps/services/tax-engine/app/rules/manifest.json
@@ -1,0 +1,9 @@
+{
+  "version": "2024-25",
+  "generated_at": "2025-10-06T16:55:46Z",
+  "sha256": "fb8a8a965e64043f5239ef2d3e1e3e7c728266ef7168e3d22e7a642749f9d232",
+  "files": {
+    "gst_rates_2000_current.json": "6bf2c3e4cdaab111a79d3285553e624d17abacad09db9054a4d359ed189d666b",
+    "payg_w_2024_25.json": "6ddce5f194816239c5be60ccf7b32e36329e447913f4b597e72042762955dc72"
+  }
+}

--- a/apps/services/tax-engine/app/rules/payg_w_2024_25.json
+++ b/apps/services/tax-engine/app/rules/payg_w_2024_25.json
@@ -1,18 +1,49 @@
-﻿{
+{
   "version": "2024-25",
-  "notes": "Replace with ATO-published formulas/tables each 1 July before production.",
-  "methods_enabled": ["table_ato","formula_progressive","percent_simple","flat_plus_percent","bonus_marginal","net_to_gross"],
-  "formula_progressive": {
-    "period": "weekly",
-    "brackets": [
-      { "up_to": 359.00,   "a": 0.00,  "b":   0.0,  "fixed": 0.0 },
-      { "up_to": 438.00,   "a": 0.19,  "b":  68.0,  "fixed": 0.0 },
-      { "up_to": 548.00,   "a": 0.234, "b":  87.82, "fixed": 0.0 },
-      { "up_to": 721.00,   "a": 0.347, "b": 148.50, "fixed": 0.0 },
-      { "up_to": 865.00,   "a": 0.345, "b": 147.00, "fixed": 0.0 },
-      { "up_to": 999999.0, "a": 0.39,  "b": 183.0,  "fixed": 0.0 }
+  "notes": "PAYG withholding schedule derived from ATO stage 3 personal income tax rates effective 1 July 2024.",
+  "periods": {
+    "weekly":   { "per_year": 52, "rounding": "NEAREST_DOLLAR" },
+    "fortnightly": { "per_year": 26, "rounding": "NEAREST_DOLLAR" },
+    "monthly":  { "per_year": 12, "rounding": "NEAREST_DOLLAR" }
+  },
+  "scales": {
+    "tax_free_threshold": [
+      { "threshold": 0, "limit": 18200, "rate": 0.0 },
+      { "threshold": 18200, "limit": 45000, "rate": 0.16 },
+      { "threshold": 45000, "limit": 135000, "rate": 0.30 },
+      { "threshold": 135000, "limit": 190000, "rate": 0.37 },
+      { "threshold": 190000, "rate": 0.45 }
     ],
-    "tax_free_threshold": true,
-    "rounding": "HALF_UP"
+    "no_tax_free_threshold": [
+      { "threshold": 0, "limit": 45000, "rate": 0.16 },
+      { "threshold": 45000, "limit": 135000, "rate": 0.30 },
+      { "threshold": 135000, "limit": 190000, "rate": 0.37 },
+      { "threshold": 190000, "rate": 0.45 }
+    ]
+  },
+  "stsl": {
+    "description": "2024-25 HELP/TSL compulsory repayment thresholds",
+    "rates": [
+      { "threshold": 0, "rate": 0.0 },
+      { "threshold": 51550, "rate": 0.01 },
+      { "threshold": 59518, "rate": 0.02 },
+      { "threshold": 63089, "rate": 0.025 },
+      { "threshold": 66875, "rate": 0.03 },
+      { "threshold": 70888, "rate": 0.035 },
+      { "threshold": 75140, "rate": 0.04 },
+      { "threshold": 79649, "rate": 0.045 },
+      { "threshold": 84429, "rate": 0.05 },
+      { "threshold": 89494, "rate": 0.055 },
+      { "threshold": 94865, "rate": 0.06 },
+      { "threshold": 100557, "rate": 0.065 },
+      { "threshold": 106590, "rate": 0.07 },
+      { "threshold": 112985, "rate": 0.075 },
+      { "threshold": 119764, "rate": 0.08 },
+      { "threshold": 126950, "rate": 0.085 },
+      { "threshold": 134568, "rate": 0.09 },
+      { "threshold": 142642, "rate": 0.095 },
+      { "threshold": 151201, "rate": 0.10 }
+    ],
+    "cap_rate": 0.10
   }
 }

--- a/apps/services/tax-engine/app/schedules.py
+++ b/apps/services/tax-engine/app/schedules.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from decimal import Decimal, ROUND_HALF_UP
+from typing import Any, Dict, Iterable, Mapping
+
+AtoRoundingMode = str
+
+_PERIOD_KEY = "periods"
+_SCALE_KEY = "scales"
+_STSL_KEY = "stsl"
+
+
+def _ensure_decimal(value: Any) -> Decimal:
+    if isinstance(value, Decimal):
+        return value
+    return Decimal(str(value))
+
+
+def _ato_round(value: Decimal, mode: AtoRoundingMode) -> Decimal:
+    quantise = Decimal("1") if mode == "NEAREST_DOLLAR" else Decimal("0.01")
+    return value.quantize(quantise, rounding=ROUND_HALF_UP)
+
+
+def _annual_tax(income: Decimal, brackets: Iterable[Mapping[str, Any]]) -> Decimal:
+    if income <= 0:
+        return Decimal("0")
+    tax = Decimal("0")
+    for bracket in brackets:
+        lower = _ensure_decimal(bracket.get("threshold", 0))
+        upper = bracket.get("limit")
+        rate = _ensure_decimal(bracket.get("rate", 0))
+        if income <= lower:
+            break
+        effective_upper = _ensure_decimal(upper) if upper is not None else income
+        taxable = min(income, effective_upper) - lower
+        if taxable <= 0:
+            continue
+        tax += taxable * rate
+        if income <= effective_upper:
+            break
+    return tax
+
+
+def _stsl_rate(income: Decimal, stsl_cfg: Mapping[str, Any]) -> Decimal:
+    rates = stsl_cfg.get("rates", [])
+    applied = Decimal("0")
+    for row in sorted(rates, key=lambda r: r.get("threshold", 0)):
+        threshold = _ensure_decimal(row.get("threshold", 0))
+        if income >= threshold:
+            applied = _ensure_decimal(row.get("rate", 0))
+        else:
+            break
+    cap = stsl_cfg.get("cap_rate")
+    if cap is not None:
+        applied = min(applied, _ensure_decimal(cap))
+    return applied
+
+
+def payg_withholding(
+    gross: float | Decimal,
+    *,
+    period: str,
+    tax_free_threshold: bool,
+    stsl: bool,
+    rules: Mapping[str, Any],
+) -> Decimal:
+    """Compute PAYG withholding for a pay period using published schedules."""
+    gross_dec = _ensure_decimal(gross)
+    if gross_dec <= 0:
+        return Decimal("0")
+
+    periods_cfg = rules.get(_PERIOD_KEY, {})
+    if period not in periods_cfg:
+        raise ValueError(f"Unknown period '{period}'")
+    period_cfg = periods_cfg[period]
+    per_year = _ensure_decimal(period_cfg.get("per_year", 52))
+    rounding_mode: AtoRoundingMode = period_cfg.get("rounding") or rules.get("rounding", {}).get("mode", "NEAREST_DOLLAR")
+
+    scales = rules.get(_SCALE_KEY, {})
+    scale_key = "tax_free_threshold" if tax_free_threshold else "no_tax_free_threshold"
+    brackets = scales.get(scale_key)
+    if not brackets:
+        raise ValueError(f"Rules missing scale '{scale_key}'")
+
+    annual_income = gross_dec * per_year
+    annual_tax = _annual_tax(annual_income, brackets)
+
+    if stsl:
+        stsl_cfg = rules.get(_STSL_KEY, {})
+        rate = _stsl_rate(annual_income, stsl_cfg)
+        annual_tax += annual_income * rate
+
+    per_period = annual_tax / per_year
+    per_period = _ato_round(per_period, rounding_mode)
+    if per_period < 0:
+        return Decimal("0")
+    return per_period
+
+
+def _gst_round(value: Decimal, mode: AtoRoundingMode) -> Decimal:
+    return _ato_round(value, mode)
+
+
+def gst_labels(lines: Iterable[Mapping[str, Any]], rules: Mapping[str, Any]) -> Dict[str, Decimal]:
+    """Aggregate GST amounts into BAS labels using supplied rules."""
+    rounding_mode: AtoRoundingMode = rules.get("rounding", {}).get("mode", "NEAREST_DOLLAR")
+    codes = rules.get("codes", {})
+    sales_labels = rules.get("labels", {}).get("sales", {})
+    purchase_labels = rules.get("labels", {}).get("purchases", {})
+
+    totals: Dict[str, Decimal] = {
+        label: Decimal("0")
+        for label in set(list(sales_labels.keys()) + list(purchase_labels.keys()))
+    }
+
+    for line in lines:
+        amount = _ensure_decimal(line.get("amount", 0))
+        if amount == 0:
+            continue
+        tax_code = str(line.get("tax_code", "")).upper()
+        kind = (line.get("kind") or "sale").lower()
+        capital = bool(line.get("capital", False))
+        gst_rate = _ensure_decimal(codes.get(tax_code, {}).get("rate", 0))
+
+        if kind == "sale":
+            for label, cfg in sales_labels.items():
+                if cfg.get("type") == "tax":
+                    continue
+                if tax_code in cfg.get("codes", []):
+                    totals[label] = totals.get(label, Decimal("0")) + amount
+            tax_label = sales_labels.get("1A")
+            if gst_rate > 0 and tax_label and tax_code in tax_label.get("codes", []):
+                tax_amount = (amount * gst_rate) / (Decimal("1") + gst_rate)
+                totals["1A"] = totals.get("1A", Decimal("0")) + tax_amount
+        else:
+            if capital and "G10" in purchase_labels:
+                totals["G10"] = totals.get("G10", Decimal("0")) + amount
+            elif "G11" in purchase_labels:
+                totals["G11"] = totals.get("G11", Decimal("0")) + amount
+            tax_label = purchase_labels.get("1B")
+            if gst_rate > 0 and tax_label and tax_code in tax_label.get("codes", []):
+                tax_amount = (amount * gst_rate) / (Decimal("1") + gst_rate)
+                totals["1B"] = totals.get("1B", Decimal("0")) + tax_amount
+
+    for label in list(totals.keys()):
+        totals[label] = _gst_round(totals[label], rounding_mode)
+
+    return totals
+
+
+__all__ = ["payg_withholding", "gst_labels"]

--- a/package.json
+++ b/package.json
@@ -4,24 +4,37 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "vitest run"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
     "packageManager": "pnpm@9",
     "devDependencies": {
+        "@types/cors": "^2.8.17",
         "@types/express": "^5.0.3",
+        "@types/jsonwebtoken": "^9.0.5",
         "@types/node": "^24.6.2",
+        "@types/supertest": "^2.0.16",
         "ts-node": "^10.9.2",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^1.6.0"
     },
     "dependencies": {
+        "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
         "dotenv": "^17.2.3",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.3.1",
+        "helmet": "^7.1.0",
+        "jsonwebtoken": "^9.0.2",
+        "otplib": "^12.0.1",
         "pg": "^8.16.3",
+        "pino": "^9.2.0",
+        "pino-http": "^9.1.0",
+        "supertest": "^7.0.0",
         "tweetnacl": "^1.0.3",
         "uuid": "^13.0.0"
     }

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
 pythonpath = apps/services/tax-engine
+python_files = *.test.py test_*.py

--- a/scripts/ci/check_rules_drift.py
+++ b/scripts/ci/check_rules_drift.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Gate changes to tax rules to ensure manifest, version and changelog stay in sync."""
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import pathlib
+import re
+import subprocess
+import sys
+from typing import Iterable, List
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+RULES_DIR = REPO_ROOT / "apps/services/tax-engine/app/rules"
+MANIFEST_PATH = RULES_DIR / "manifest.json"
+TAX_CONSTANTS_PATH = REPO_ROOT / "src/constants/tax.ts"
+CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+
+
+class DriftError(RuntimeError):
+    pass
+
+
+def _git(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(["git", *args], check=True, capture_output=True, text=True)
+
+
+def _resolve_base_ref() -> str | None:
+    candidates: Iterable[str | None] = (
+        os.environ.get("RULES_DRIFT_BASE"),
+        "origin/main",
+        "origin/master",
+        "main",
+        "master",
+        "HEAD^",
+    )
+    for candidate in candidates:
+        if not candidate:
+            continue
+        try:
+            _git("rev-parse", candidate)
+            return candidate
+        except subprocess.CalledProcessError:
+            continue
+    return None
+
+
+def changed_files() -> List[str]:
+    base = _resolve_base_ref()
+    if base:
+        diff = _git("diff", "--name-only", f"{base}...HEAD").stdout
+    else:
+        diff = _git("status", "--porcelain").stdout
+        diff = "\n".join(line[3:] for line in diff.splitlines() if line)
+    return [line.strip() for line in diff.splitlines() if line.strip()]
+
+
+def compute_snapshot() -> dict:
+    files = sorted(p for p in RULES_DIR.glob("*.json") if p.name != "manifest.json")
+    per_file: dict[str, str] = {}
+    for file in files:
+        sha = hashlib.sha256(file.read_bytes()).hexdigest()
+        per_file[file.name] = sha
+    aggregate = "".join(f"{name}:{sha}\n" for name, sha in sorted(per_file.items()))
+    manifest_sha = hashlib.sha256(aggregate.encode("utf-8")).hexdigest()
+    return {"files": per_file, "sha256": manifest_sha}
+
+
+def load_manifest() -> dict:
+    if not MANIFEST_PATH.exists():
+        raise DriftError("rules manifest missing")
+    return json.loads(MANIFEST_PATH.read_text())
+
+
+def extract_rates_version() -> str:
+    if not TAX_CONSTANTS_PATH.exists():
+        raise DriftError("src/constants/tax.ts missing")
+    text = TAX_CONSTANTS_PATH.read_text()
+    match = re.search(r"RATES_VERSION\s*=\s*\"([^\"]+)\"", text)
+    if not match:
+        raise DriftError("RATES_VERSION constant not found in src/constants/tax.ts")
+    return match.group(1)
+
+
+def ensure_changelog_entry(changed: List[str]) -> None:
+    if "CHANGELOG.md" not in changed:
+        raise DriftError("rules changed but CHANGELOG.md was not updated")
+    if not CHANGELOG_PATH.exists():
+        raise DriftError("CHANGELOG.md missing")
+    text = CHANGELOG_PATH.read_text().strip()
+    if not text:
+        raise DriftError("CHANGELOG.md is empty")
+
+
+def main() -> int:
+    changed = changed_files()
+    rules_changed = [f for f in changed if f.startswith("apps/services/tax-engine/app/rules/") and f.endswith(".json") and pathlib.Path(f).name != "manifest.json"]
+    manifest_changed = "apps/services/tax-engine/app/rules/manifest.json" in changed
+    constants_changed = "src/constants/tax.ts" in changed
+
+    snapshot = compute_snapshot()
+    manifest = load_manifest()
+    version = extract_rates_version()
+
+    if rules_changed:
+        missing: List[str] = []
+        if not manifest_changed:
+            missing.append("rules manifest")
+        if not constants_changed:
+            missing.append("RATES_VERSION")
+        try:
+            ensure_changelog_entry(changed)
+        except DriftError as exc:
+            missing.append(str(exc))
+        if missing:
+            raise DriftError("Tax rules changed but required updates missing: " + ", ".join(missing))
+
+    if not rules_changed and manifest_changed:
+        raise DriftError("Rules manifest updated without changing underlying rules")
+
+    if manifest.get("sha256") != snapshot["sha256"] or manifest.get("files") != snapshot["files"]:
+        raise DriftError("Manifest sha256/files do not match current rules contents")
+
+    if manifest.get("version") != version:
+        raise DriftError(f"Manifest version {manifest.get('version')} does not match RATES_VERSION {version}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except DriftError as err:
+        print(f"rules drift check failed: {err}", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.CalledProcessError as err:
+        print(f"git command failed: {err}", file=sys.stderr)
+        sys.exit(1)

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -1,8 +1,29 @@
 // src/api/payments.ts
 import express from "express";
 import { Payments } from "../../libs/paymentsClient"; // adjust if your libs path differs
+import { authenticate } from "../http/auth";
+import { hasRecentVerification } from "../security/mfa";
+import { enforceDualApproval } from "../approvals/dual";
+import { getAppMode } from "../security/state";
 
 export const paymentsApi = express.Router();
+
+const RELEASE_THRESHOLD = Number(process.env.RELEASE_DUAL_APPROVAL_THRESHOLD_CENTS || 100_000);
+
+function ensureRealModeMfa(req: express.Request, res: express.Response, next: express.NextFunction) {
+  if (getAppMode() !== "real") {
+    return next();
+  }
+  const auth = res.locals.auth;
+  if (!auth) {
+    return res.status(401).json({ error: "AUTH_REQUIRED" });
+  }
+  if (!hasRecentVerification(auth.userId)) {
+    return res.status(403).json({ error: "MFA_REQUIRED" });
+  }
+  auth.mfaVerified = true;
+  return next();
+}
 
 // GET /api/balance?abn=&taxType=&periodId=
 paymentsApi.get("/balance", async (req, res) => {
@@ -50,7 +71,7 @@ paymentsApi.post("/deposit", async (req, res) => {
 });
 
 // POST /api/release  (calls payAto)
-paymentsApi.post("/release", async (req, res) => {
+paymentsApi.post("/release", authenticate({ roles: ["admin", "accountant"] }), ensureRealModeMfa, async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body || {};
     if (!abn || !taxType || !periodId || typeof amountCents !== "number") {
@@ -58,6 +79,20 @@ paymentsApi.post("/release", async (req, res) => {
     }
     if (amountCents >= 0) {
       return res.status(400).json({ error: "Release must be negative" });
+    }
+    const auth = res.locals.auth;
+    if (!auth) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+    const approvalKey = `${abn}:${taxType}:${periodId}:${Math.abs(amountCents)}`;
+    const approval = enforceDualApproval({
+      key: approvalKey,
+      userId: auth.userId,
+      amountCents: Math.abs(amountCents),
+      thresholdCents: RELEASE_THRESHOLD,
+    });
+    if (!approval.allowed) {
+      return res.status(403).json({ error: "SECOND_APPROVER_REQUIRED", approver: approval.firstApprover });
     }
     const data = await Payments.payAto({ abn, taxType, periodId, amountCents });
     res.json(data);

--- a/src/approvals/dual.ts
+++ b/src/approvals/dual.ts
@@ -1,0 +1,44 @@
+interface ApprovalRecord {
+  approver: string;
+  expiresAt: number;
+  amountCents: number;
+}
+
+const approvals = new Map<string, ApprovalRecord>();
+const DEFAULT_TTL_MS = Number(process.env.DUAL_APPROVAL_TTL_MS || 10 * 60 * 1000);
+
+export interface DualApprovalResult {
+  allowed: boolean;
+  pending: boolean;
+  firstApprover?: string;
+}
+
+export interface DualApprovalOptions {
+  key: string;
+  userId: string;
+  amountCents: number;
+  thresholdCents: number;
+  ttlMs?: number;
+  now?: number;
+}
+
+export function enforceDualApproval(options: DualApprovalOptions): DualApprovalResult {
+  const { key, userId, amountCents, thresholdCents, ttlMs = DEFAULT_TTL_MS, now = Date.now() } = options;
+  if (amountCents <= thresholdCents) {
+    return { allowed: true, pending: false };
+  }
+  const existing = approvals.get(key);
+  if (!existing || existing.expiresAt < now) {
+    approvals.set(key, { approver: userId, expiresAt: now + ttlMs, amountCents });
+    return { allowed: false, pending: true, firstApprover: userId };
+  }
+  if (existing.approver === userId) {
+    return { allowed: false, pending: true, firstApprover: existing.approver };
+  }
+  approvals.delete(key);
+  return { allowed: true, pending: false, firstApprover: existing.approver };
+}
+
+export function resetApprovals(): void {
+  approvals.clear();
+}

--- a/src/constants/tax.ts
+++ b/src/constants/tax.ts
@@ -1,0 +1,28 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type RatesManifest = {
+  version: string;
+  sha256: string;
+  generated_at?: string;
+  files?: Record<string, string>;
+};
+
+const PROJECT_ROOT = process.env.PROJECT_ROOT || path.resolve(__dirname, "..", "..");
+const MANIFEST_PATH = path.join(PROJECT_ROOT, "apps/services/tax-engine/app/rules/manifest.json");
+
+function loadManifest(): RatesManifest | undefined {
+  try {
+    const raw = fs.readFileSync(MANIFEST_PATH, "utf-8");
+    return JSON.parse(raw) as RatesManifest;
+  } catch (err) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn("[tax] unable to load rules manifest", err);
+    }
+    return undefined;
+  }
+}
+
+export const RATES_VERSION = "2024-25";
+export const RULES_MANIFEST: RatesManifest | undefined = loadManifest();
+export const RULES_MANIFEST_SHA256 = RULES_MANIFEST?.sha256 ?? "";

--- a/src/crypto/ed25519.ts
+++ b/src/crypto/ed25519.ts
@@ -5,6 +5,8 @@ export interface RptPayload {
   amount_cents: number; merkle_root: string; running_balance_hash: string;
   anomaly_vector: Record<string, number>; thresholds: Record<string, number>;
   rail_id: "EFT"|"BPAY"|"PayTo"; reference: string; expiry_ts: string; nonce: string;
+  rates_version?: string;
+  rules_manifest_sha256?: string;
 }
 
 export function signRpt(payload: RptPayload, secretKey: Uint8Array): string {

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,93 @@
+import { NextFunction, Request, Response } from "express";
+import jwt, { JwtPayload } from "jsonwebtoken";
+
+export type Role = "admin" | "accountant" | "auditor";
+
+export interface AuthClaims extends JwtPayload {
+  sub: string;
+  role: Role;
+  mfa?: boolean;
+  jti?: string;
+}
+
+export interface AuthContext {
+  userId: string;
+  role: Role;
+  mfaVerified: boolean;
+  tokenId?: string;
+  claims: AuthClaims;
+}
+
+declare global {
+  namespace Express {
+    interface Locals {
+      auth?: AuthContext;
+    }
+    interface Request {
+      auth?: AuthContext;
+    }
+  }
+}
+
+const HS_SECRET = process.env.APP_JWT_SECRET || process.env.JWT_SECRET || "dev-shared-secret";
+const PUBLIC_KEY = process.env.APP_JWT_PUBLIC_KEY;
+
+function verifyJwt(token: string): AuthClaims {
+  const errors: unknown[] = [];
+  if (PUBLIC_KEY) {
+    try {
+      return jwt.verify(token, PUBLIC_KEY, { algorithms: ["RS256"] }) as AuthClaims;
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+  if (HS_SECRET) {
+    try {
+      return jwt.verify(token, HS_SECRET, { algorithms: ["HS256"] }) as AuthClaims;
+    } catch (err) {
+      errors.push(err);
+    }
+  }
+  const message = errors.length ? String(errors[errors.length - 1]) : "No JWT verification strategy configured";
+  throw new Error(message);
+}
+
+export interface AuthOptions {
+  roles?: Role[];
+  required?: boolean;
+}
+
+export function authenticate(options: AuthOptions = {}) {
+  const { roles, required = true } = options;
+  return (req: Request, res: Response, next: NextFunction) => {
+    const header = req.headers.authorization || "";
+    const token = header.startsWith("Bearer ") ? header.slice(7) : undefined;
+    if (!token) {
+      if (required) {
+        return res.status(401).json({ error: "AUTH_REQUIRED" });
+      }
+      return next();
+    }
+    try {
+      const claims = verifyJwt(token);
+      if (!claims.sub || !claims.role) {
+        return res.status(401).json({ error: "INVALID_TOKEN" });
+      }
+      if (roles && !roles.includes(claims.role)) {
+        return res.status(403).json({ error: "FORBIDDEN_ROLE" });
+      }
+      const context: AuthContext = {
+        userId: claims.sub,
+        role: claims.role,
+        mfaVerified: Boolean(claims.mfa),
+        tokenId: claims.jti,
+        claims,
+      };
+      req.auth = context;
+      res.locals.auth = context;
+      return next();
+    } catch (err) {
+      return res.status(401).json({ error: "INVALID_TOKEN" });
+    }
+  };
+}

--- a/src/ops/headers.ts
+++ b/src/ops/headers.ts
@@ -1,0 +1,51 @@
+import { Express } from "express";
+import helmet from "helmet";
+import cors from "cors";
+import rateLimit from "express-rate-limit";
+
+const DEFAULT_RATE = Number(process.env.RATE_LIMIT_PER_MINUTE || 120);
+
+export function applySecurityHeaders(app: Express): void {
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        useDefaults: true,
+        directives: {
+          ...helmet.contentSecurityPolicy.getDefaultDirectives(),
+          "default-src": ["'self'"],
+        },
+      },
+      strictTransportSecurity: {
+        includeSubDomains: true,
+        maxAge: 15552000,
+      },
+    })
+  );
+
+  const rawOrigins = process.env.CORS_ALLOW_LIST || process.env.CORS_ORIGINS || "";
+  const allowList = rawOrigins
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+
+  const corsOptions: cors.CorsOptions = {
+    origin(origin, callback) {
+      if (!origin || allowList.length === 0 || allowList.includes(origin)) {
+        return callback(null, true);
+      }
+      return callback(new Error("Origin not allowed by CORS"));
+    },
+    credentials: true,
+  };
+
+  app.use(cors(corsOptions));
+
+  app.use(
+    rateLimit({
+      windowMs: 60 * 1000,
+      max: DEFAULT_RATE,
+      standardHeaders: true,
+      legacyHeaders: false,
+    })
+  );
+}

--- a/src/ops/logs.ts
+++ b/src/ops/logs.ts
@@ -1,0 +1,39 @@
+import { NextFunction, Request, Response } from "express";
+import pino from "pino";
+import pinoHttp from "pino-http";
+import { v4 as uuidv4 } from "uuid";
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL || "info",
+  redact: {
+    paths: [
+      "req.headers.authorization",
+      "req.body.password",
+      "req.body.secret",
+      "res.headers[set-cookie]",
+    ],
+    censor: "[redacted]",
+  },
+});
+
+export const httpLogger = pinoHttp({
+  logger,
+  genReqId: (req) => req.headers["x-request-id"]?.toString() || uuidv4(),
+  customSuccessMessage: (_req, res) => `${res.statusCode} handled`,
+  customErrorMessage: (_req, res) => `${res.statusCode} error`,
+  customProps: (req, res) => ({
+    userId: res.locals.auth?.userId,
+    role: res.locals.auth?.role,
+  }),
+});
+
+export function errorFormatter(err: any, req: Request, res: Response, _next: NextFunction): void {
+  const status = err.statusCode || err.status || 500;
+  const requestId = (req as any).id || req.headers["x-request-id"];
+  logger.error({ err, requestId, userId: res.locals.auth?.userId, role: res.locals.auth?.role }, err.message);
+  res.status(status).json({
+    title: err.title || "Request failed",
+    detail: err.message || "Unexpected error",
+    requestId,
+  });
+}

--- a/src/routes/security.ts
+++ b/src/routes/security.ts
@@ -1,0 +1,40 @@
+import { Router } from "express";
+import { authenticate } from "../http/auth";
+import { beginSetup, requireRecentMfa, verifyToken } from "../security/mfa";
+import { getAppMode, setAppMode } from "../security/state";
+
+export const securityRoutes = Router();
+
+securityRoutes.post("/auth/mfa/setup", authenticate(), (req, res) => {
+  const auth = res.locals.auth!;
+  const { secret, uri } = beginSetup(auth.userId);
+  res.json({ secret, uri });
+});
+
+securityRoutes.post("/auth/mfa/verify", authenticate(), (req, res) => {
+  const auth = res.locals.auth!;
+  const token = String(req.body?.token || "");
+  if (!token || !verifyToken(auth.userId, token)) {
+    return res.status(400).json({ error: "INVALID_TOTP" });
+  }
+  auth.mfaVerified = true;
+  res.json({ verified: true });
+});
+
+securityRoutes.get("/ops/mode", authenticate({ roles: ["admin", "accountant", "auditor"] }), (req, res) => {
+  res.json({ mode: getAppMode() });
+});
+
+securityRoutes.post(
+  "/ops/mode",
+  authenticate({ roles: ["admin"] }),
+  requireRecentMfa(),
+  (req, res) => {
+    const mode = String(req.body?.mode || "").toLowerCase();
+    if (!mode || !["demo", "real"].includes(mode)) {
+      return res.status(400).json({ error: "INVALID_MODE" });
+    }
+    const newMode = setAppMode(mode);
+    res.json({ mode: newMode });
+  }
+);

--- a/src/security/mfa.ts
+++ b/src/security/mfa.ts
@@ -1,0 +1,65 @@
+import { NextFunction, Request, Response } from "express";
+import { authenticator } from "otplib";
+
+interface MfaRecord {
+  secret: string;
+  verified: boolean;
+  lastVerifiedAt?: number;
+}
+
+const records = new Map<string, MfaRecord>();
+const DEFAULT_WINDOW_MS = Number(process.env.MFA_MAX_AGE_MS || 5 * 60 * 1000);
+
+export function beginSetup(userId: string, issuer = "APGMS", account?: string) {
+  const secret = authenticator.generateSecret();
+  const uri = authenticator.keyuri(account || userId, issuer, secret);
+  records.set(userId, { secret, verified: false });
+  return { secret, uri };
+}
+
+export function verifyToken(userId: string, token: string): boolean {
+  const rec = records.get(userId);
+  if (!rec) {
+    return false;
+  }
+  const ok = authenticator.check(token, rec.secret);
+  if (ok) {
+    rec.verified = true;
+    rec.lastVerifiedAt = Date.now();
+  }
+  return ok;
+}
+
+export function hasRecentVerification(userId: string, windowMs: number = DEFAULT_WINDOW_MS): boolean {
+  const rec = records.get(userId);
+  if (!rec || !rec.verified || !rec.lastVerifiedAt) {
+    return false;
+  }
+  return Date.now() - rec.lastVerifiedAt <= windowMs;
+}
+
+export function requireRecentMfa(windowMs: number = DEFAULT_WINDOW_MS) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const ctx = res.locals.auth;
+    if (!ctx) {
+      return res.status(401).json({ error: "AUTH_REQUIRED" });
+    }
+    if (!hasRecentVerification(ctx.userId, windowMs)) {
+      return res.status(403).json({ error: "MFA_REQUIRED" });
+    }
+    ctx.mfaVerified = true;
+    return next();
+  };
+}
+
+export function recordVerification(userId: string): void {
+  const rec = records.get(userId);
+  if (rec) {
+    rec.verified = true;
+    rec.lastVerifiedAt = Date.now();
+  }
+}
+
+export function resetMfa(): void {
+  records.clear();
+}

--- a/src/security/state.ts
+++ b/src/security/state.ts
@@ -1,0 +1,11 @@
+let currentMode = (process.env.APP_MODE || "demo").toLowerCase();
+
+export function getAppMode(): string {
+  return currentMode;
+}
+
+export function setAppMode(mode: string): string {
+  currentMode = mode.toLowerCase();
+  process.env.APP_MODE = currentMode;
+  return currentMode;
+}

--- a/tests/ops/headers.test.ts
+++ b/tests/ops/headers.test.ts
@@ -1,0 +1,35 @@
+import express from "express";
+import request from "supertest";
+import { describe, beforeEach, it, expect } from "vitest";
+
+import { applySecurityHeaders } from "../../src/ops/headers";
+
+function buildApp() {
+  const app = express();
+  applySecurityHeaders(app);
+  app.get("/test", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe("security headers", () => {
+  beforeEach(() => {
+    process.env.CORS_ALLOW_LIST = "https://client.test";
+    process.env.RATE_LIMIT_PER_MINUTE = "2";
+  });
+
+  it("sets expected headers", async () => {
+    const app = buildApp();
+    const res = await request(app).get("/test").set("Origin", "https://client.test");
+    expect(res.headers["content-security-policy"]).toBeDefined();
+    expect(res.headers["strict-transport-security"]).toContain("max-age");
+    expect(res.headers["access-control-allow-origin"]).toBe("https://client.test");
+  });
+
+  it("enforces rate limit", async () => {
+    const app = buildApp();
+    await request(app).get("/test").set("Origin", "https://client.test");
+    await request(app).get("/test").set("Origin", "https://client.test");
+    const limited = await request(app).get("/test").set("Origin", "https://client.test");
+    expect(limited.status).toBe(429);
+  });
+});

--- a/tests/security/release_guards.test.ts
+++ b/tests/security/release_guards.test.ts
@@ -1,0 +1,91 @@
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { describe, beforeAll, beforeEach, it, expect, vi } from "vitest";
+import { authenticator } from "otplib";
+
+import { paymentsApi } from "../../src/api/payments";
+import { Payments } from "../../libs/paymentsClient";
+import { resetApprovals } from "../../src/approvals/dual";
+import { beginSetup, resetMfa, verifyToken } from "../../src/security/mfa";
+import { setAppMode } from "../../src/security/state";
+
+const SECRET = "test-shared";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/api", paymentsApi);
+  return app;
+}
+
+describe("release guards", () => {
+  beforeAll(() => {
+    process.env.APP_JWT_SECRET = SECRET;
+    process.env.RELEASE_DUAL_APPROVAL_THRESHOLD_CENTS = "100000";
+  });
+
+  beforeEach(() => {
+    setAppMode("demo");
+    resetApprovals();
+    resetMfa();
+    vi.restoreAllMocks();
+    vi.spyOn(Payments, "payAto").mockResolvedValue({ ok: true });
+  });
+
+  function token(userId: string, role: "admin" | "accountant" | "auditor") {
+    return jwt.sign({ sub: userId, role }, SECRET, { algorithm: "HS256" });
+  }
+
+  it("rejects release without JWT", async () => {
+    const app = buildApp();
+    const res = await request(app).post("/api/release").send({
+      abn: "123", taxType: "PAYGW", periodId: "2024-09", amountCents: -200000,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("requires MFA when mode is real", async () => {
+    const app = buildApp();
+    setAppMode("real");
+    const res = await request(app)
+      .post("/api/release")
+      .set("Authorization", `Bearer ${token("user1", "admin")}`)
+      .send({ abn: "123", taxType: "PAYGW", periodId: "2024-09", amountCents: -200000 });
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("MFA_REQUIRED");
+  });
+
+  it("requires dual approval over threshold", async () => {
+    const app = buildApp();
+    setAppMode("real");
+
+    const setup1 = beginSetup("user1");
+    const setup2 = beginSetup("user2");
+    verifyToken("user1", authenticator.generate(setup1.secret));
+    verifyToken("user2", authenticator.generate(setup2.secret));
+
+    const payload = { abn: "123", taxType: "PAYGW", periodId: "2024-09", amountCents: -200000 };
+
+    const first = await request(app)
+      .post("/api/release")
+      .set("Authorization", `Bearer ${token("user1", "admin")}`)
+      .send(payload);
+    expect(first.status).toBe(403);
+    expect(first.body.error).toBe("SECOND_APPROVER_REQUIRED");
+
+    const second = await request(app)
+      .post("/api/release")
+      .set("Authorization", `Bearer ${token("user1", "admin")}`)
+      .send(payload);
+    expect(second.status).toBe(403);
+    expect(second.body.error).toBe("SECOND_APPROVER_REQUIRED");
+
+    const approved = await request(app)
+      .post("/api/release")
+      .set("Authorization", `Bearer ${token("user2", "accountant")}`)
+      .send(payload);
+    expect(approved.status).toBe(200);
+    expect(Payments.payAto).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/tax/test_gst_labels.py
+++ b/tests/tax/test_gst_labels.py
@@ -1,0 +1,25 @@
+import json
+from decimal import Decimal
+
+from app.schedules import gst_labels
+
+with open("apps/services/tax-engine/app/rules/gst_rates_2000_current.json", "r", encoding="utf-8") as f:
+    GST_RULES = json.load(f)
+
+
+def test_gst_label_aggregation():
+    lines = [
+        {"amount": Decimal("1100.00"), "tax_code": "GST", "kind": "sale"},
+        {"amount": Decimal("2000.00"), "tax_code": "GST_FREE", "kind": "sale"},
+        {"amount": Decimal("500.00"), "tax_code": "ZERO_RATED", "kind": "sale"},
+        {"amount": Decimal("550.00"), "tax_code": "GST", "kind": "purchase", "capital": True},
+        {"amount": Decimal("330.00"), "tax_code": "GST", "kind": "purchase", "capital": False},
+    ]
+    totals = gst_labels(lines, GST_RULES)
+    assert totals["G1"] == Decimal("3600")
+    assert totals["G2"] == Decimal("500")
+    assert totals["G3"] == Decimal("2000")
+    assert totals["1A"] == Decimal("100")
+    assert totals["G10"] == Decimal("550")
+    assert totals["G11"] == Decimal("330")
+    assert totals["1B"] == Decimal("80")

--- a/tests/tax/test_payg_golden.py
+++ b/tests/tax/test_payg_golden.py
@@ -1,0 +1,29 @@
+import json
+from decimal import Decimal
+
+from app.schedules import payg_withholding
+
+with open("apps/services/tax-engine/app/rules/payg_w_2024_25.json", "r", encoding="utf-8") as f:
+    PAYG_RULES = json.load(f)
+
+
+def test_weekly_threshold_brackets():
+    assert payg_withholding(Decimal("350"), period="weekly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES) == Decimal("0")
+    assert payg_withholding(Decimal("700"), period="weekly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES) == Decimal("56")
+    assert payg_withholding(Decimal("1200"), period="weekly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES) == Decimal("183")
+    assert payg_withholding(Decimal("2600"), period="weekly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES) == Decimal("603")
+
+
+def test_period_variants():
+    fortnight = payg_withholding(Decimal("1400"), period="fortnightly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES)
+    assert fortnight == Decimal("112")
+    no_tft = payg_withholding(Decimal("2400"), period="fortnightly", tax_free_threshold=False, stsl=False, rules=PAYG_RULES)
+    assert no_tft == Decimal("478")
+    monthly = payg_withholding(Decimal("6000"), period="monthly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES)
+    assert monthly == Decimal("1032")
+
+
+def test_stsl_addition():
+    base = payg_withholding(Decimal("6000"), period="monthly", tax_free_threshold=True, stsl=False, rules=PAYG_RULES)
+    with_stsl = payg_withholding(Decimal("6000"), period="monthly", tax_free_threshold=True, stsl=True, rules=PAYG_RULES)
+    assert with_stsl - base == Decimal("210")

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["tests/**/*.test.ts"],
+    environment: "node",
+    setupFiles: [],
+  },
+});


### PR DESCRIPTION
## Summary
- replace the PAYG withholding implementation with schedule-driven calculations and publish GST label rules with a manifest
- surface the active tax rates version/manifest in the platform and gate rule changes with a CI drift check
- harden release endpoints with JWT auth, MFA + dual approvals, and production security middleware with regression tests

## Testing
- pytest tests/tax
- scripts/ci/check_rules_drift.py
- npx vitest run tests/security/release_guards.test.ts tests/ops/headers.test.ts *(fails: npm registry 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f2682f4883279b69fd20a04e25f8