### PR TITLE
Add readiness scoring workflow and badges

### DIFF
--- a/.github/workflows/readiness.yml
+++ b/.github/workflows/readiness.yml
@@ -1,0 +1,158 @@
+name: Readiness
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+
+jobs:
+  readiness:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Run unit tests
+        run: npm test --if-present
+
+      - name: Generate readiness score
+        run: npm run readiness:score
+
+      - name: Generate readiness badges
+        run: npm run readiness:badge
+
+      - name: Upload readiness report
+        uses: actions/upload-artifact@v4
+        with:
+          name: readiness-report
+          path: artifacts/readiness/report.md
+
+      - name: Load readiness summary
+        id: readiness
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const summary = JSON.parse(fs.readFileSync('artifacts/readiness/summary.json', 'utf8'));
+          const lines = [
+            `prototype_score=${summary.prototype.score}`,
+            `prototype_delta=${summary.prototype.delta ?? 'null'}`,
+            `real_score=${summary.real.score}`,
+            `real_delta=${summary.real.delta ?? 'null'}`,
+            `prototype_pass=${summary.prototype.pass}`,
+            `real_pass=${summary.real.pass}`,
+            `report_path=artifacts/readiness/report.md`
+          ];
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, lines.join('\n') + '\n');
+          NODE
+
+      - name: Determine PR scope
+        id: scope
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            const realPatterns = [/infra\//i, /ops\//i, /server\.js$/i, /security/i, /kms/i, /rail/i, /crypto/i];
+            const prototypePatterns = [/src\//, /apps\//, /docs\//, /public\//, /tests\//];
+            let realRelated = false;
+            let prototypeRelated = false;
+            for (const file of files) {
+              if (realPatterns.some((re) => re.test(file.filename))) realRelated = true;
+              if (prototypePatterns.some((re) => re.test(file.filename))) prototypeRelated = true;
+            }
+            core.setOutput('prototype_only', String(prototypeRelated && !realRelated));
+            core.setOutput('real_related', String(realRelated));
+
+      - name: Post readiness comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        env:
+          PROTOTYPE_SCORE: ${{ steps.readiness.outputs.prototype_score }}
+          PROTOTYPE_DELTA: ${{ steps.readiness.outputs.prototype_delta }}
+          PROTOTYPE_PASS: ${{ steps.readiness.outputs.prototype_pass }}
+          REAL_SCORE: ${{ steps.readiness.outputs.real_score }}
+          REAL_DELTA: ${{ steps.readiness.outputs.real_delta }}
+          REAL_PASS: ${{ steps.readiness.outputs.real_pass }}
+          REPORT_PATH: ${{ steps.readiness.outputs.report_path }}
+        with:
+          script: |
+            const marker = '<!-- readiness-scorecard -->';
+            const prototypeScore = Number(process.env.PROTOTYPE_SCORE || '0').toFixed(2);
+            const protoDeltaRaw = process.env.PROTOTYPE_DELTA;
+            const protoDeltaNumber = protoDeltaRaw && protoDeltaRaw !== 'null' ? Number(protoDeltaRaw) : NaN;
+            const prototypeDelta = Number.isFinite(protoDeltaNumber) ? protoDeltaNumber.toFixed(2) : 'n/a';
+            const prototypePass = process.env.PROTOTYPE_PASS === 'true' ? '✅' : '❌';
+            const realScore = Number(process.env.REAL_SCORE || '0').toFixed(2);
+            const realDeltaRaw = process.env.REAL_DELTA;
+            const realDeltaNumber = realDeltaRaw && realDeltaRaw !== 'null' ? Number(realDeltaRaw) : NaN;
+            const realDelta = Number.isFinite(realDeltaNumber) ? realDeltaNumber.toFixed(2) : 'n/a';
+            const realPass = process.env.REAL_PASS === 'true' ? '✅' : '❌';
+            const repo = `${context.repo.owner}/${context.repo.repo}`;
+            const badgeBase = `https://github.com/${repo}/blob/${context.sha}/public/badges`;
+            const body = `${marker}\n` +
+`## Readiness Scorecard\n\n` +
+`| Track | Score | Δ vs last | Pass | Badge |\n` +
+`| --- | --- | --- | --- | --- |\n` +
+`| Prototype | ${prototypeScore} / 10 | ${prototypeDelta} | ${prototypePass} | ![Prototype badge](${badgeBase}/prototype.svg?raw=1) |\n` +
+`| Real | ${realScore} / 10 | ${realDelta} | ${realPass} | ![Real badge](${badgeBase}/real.svg?raw=1) |\n` +
+`\n[Read the full report](${repo ? `https://github.com/${repo}/blob/${context.sha}/${process.env.REPORT_PATH || 'artifacts/readiness/report.md'}` : '#'})`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Check score regressions
+        env:
+          PROTO_DELTA: ${{ steps.readiness.outputs.prototype_delta }}
+          REAL_DELTA: ${{ steps.readiness.outputs.real_delta }}
+          PROTOTYPE_ONLY: ${{ steps.scope.outputs.prototype_only || 'false' }}
+          REAL_RELATED: ${{ steps.scope.outputs.real_related || 'false' }}
+        run: |
+          node <<'NODE'
+          const protoDelta = Number(process.env.PROTO_DELTA);
+          const realDelta = Number(process.env.REAL_DELTA);
+          const prototypeOnly = process.env.PROTOTYPE_ONLY === 'true';
+          const realRelated = process.env.REAL_RELATED === 'true';
+          const failures = [];
+          if (!Number.isNaN(protoDelta) && prototypeOnly && protoDelta < 0) {
+            failures.push(`Prototype score regressed (${protoDelta.toFixed(2)})`);
+          }
+          if (!Number.isNaN(realDelta) && realRelated && realDelta < 0) {
+            failures.push(`Real score regressed (${realDelta.toFixed(2)})`);
+          }
+          if (failures.length) {
+            console.error(failures.join('\n'));
+            process.exit(1);
+          }
+          NODE

--- a/artifacts/readiness/.gitignore
+++ b/artifacts/readiness/.gitignore
@@ -1,0 +1,2 @@
+report.md
+summary.json

--- a/artifacts/readiness/last.json
+++ b/artifacts/readiness/last.json
@@ -1,0 +1,10 @@
+{
+  "generatedAt": "2025-10-06T17:37:40.212Z",
+  "rubricVersion": "1.0",
+  "prototype": {
+    "score": 2
+  },
+  "real": {
+    "score": 0
+  }
+}

--- a/docs/readiness/rubric.v1.json
+++ b/docs/readiness/rubric.v1.json
@@ -1,0 +1,47 @@
+{
+  "version": "1.0",
+  "prototype": {
+    "weights": {
+      "rails_sim": 2,
+      "evidence_v2": 2,
+      "rules_correct": 2,
+      "security_thin": 1,
+      "observability": 1,
+      "seed_smoke": 1,
+      "help_docs": 1
+    },
+    "descriptions": {
+      "rails_sim": "sim rail + idempotency + provider_ref + recon import",
+      "evidence_v2": "rules hash + settlement + narrative + approvals",
+      "rules_correct": "PAYGW/GST golden tests + RATES_VERSION + manifest sha",
+      "security_thin": "JWT+roles + MFA on mode/release + dual approval",
+      "observability": "healthz, metrics, and request-id logging",
+      "seed_smoke": "seed + smoke pass",
+      "help_docs": "in-app Help with coverage check"
+    },
+    "thresholds": {
+      "pass": 6,
+      "max": 10
+    }
+  },
+  "real": {
+    "weights": {
+      "kms_rpt": 2,
+      "sandbox_rail": 2,
+      "security_controls": 2,
+      "assurance": 2,
+      "pilot_ops": 2
+    },
+    "descriptions": {
+      "kms_rpt": "KMS Ed25519 + kid + rotation artifacts",
+      "sandbox_rail": "mTLS sandbox rail + receipts + recon import",
+      "security_controls": "MFA, dual approval, headers, rate limit, logs",
+      "assurance": "CI drift gate, vuln scan, basic IR/DR notes",
+      "pilot_ops": "SLO dashboard + DLQ replay + proofs endpoint"
+    },
+    "thresholds": {
+      "pass": 6,
+      "max": 10
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "readiness:score": "tsx scripts/scorecard/score.ts",
+        "readiness:badge": "tsx scripts/scorecard/badge.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/public/badges/prototype.svg
+++ b/public/badges/prototype.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="118" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity="0.1"/>
+    <stop offset="1" stop-opacity="0.1"/>
+  </linearGradient>
+  <mask id="round">
+    <rect width="118" height="20" rx="4" fill="#fff"/>
+  </mask>
+  <g mask="url(#round)">
+    <rect width="69" height="20" fill="#555"/>
+    <rect x="69" width="49" height="20" fill="#fe7d37"/>
+    <rect width="118" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle"
+     font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="34.5" y="15" fill="#010101" fill-opacity="0.3">prototype</text>
+    <text x="34.5" y="14">prototype</text>
+    <text x="93.5" y="15" fill="#010101" fill-opacity="0.3">2.0/10</text>
+    <text x="93.5" y="14">2.0/10</text>
+  </g>
+</svg>

--- a/public/badges/real.svg
+++ b/public/badges/real.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="85" height="20">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity="0.1"/>
+    <stop offset="1" stop-opacity="0.1"/>
+  </linearGradient>
+  <mask id="round">
+    <rect width="85" height="20" rx="4" fill="#fff"/>
+  </mask>
+  <g mask="url(#round)">
+    <rect width="36" height="20" fill="#555"/>
+    <rect x="36" width="49" height="20" fill="#e05d44"/>
+    <rect width="85" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle"
+     font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="18" y="15" fill="#010101" fill-opacity="0.3">real</text>
+    <text x="18" y="14">real</text>
+    <text x="60.5" y="15" fill="#010101" fill-opacity="0.3">0.0/10</text>
+    <text x="60.5" y="14">0.0/10</text>
+  </g>
+</svg>

--- a/scripts/scorecard/badge.ts
+++ b/scripts/scorecard/badge.ts
@@ -1,0 +1,100 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+type Summary = {
+  prototype: { score: number; maxScore: number };
+  real: { score: number; maxScore: number };
+};
+
+function scoreColor(score: number): string {
+  if (score >= 9) return "#4c1";
+  if (score >= 7) return "#97CA00";
+  if (score >= 6) return "#a4a61d";
+  if (score >= 4) return "#dfb317";
+  if (score >= 2) return "#fe7d37";
+  return "#e05d44";
+}
+
+function textWidth(text: string): number {
+  return Math.round(text.length * 6.5 + 10);
+}
+
+function buildBadge(label: string, value: string, color: string): string {
+  const labelWidth = textWidth(label);
+  const valueWidth = textWidth(value);
+  const width = labelWidth + valueWidth;
+  const height = 20;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity="0.1"/>
+    <stop offset="1" stop-opacity="0.1"/>
+  </linearGradient>
+  <mask id="round">
+    <rect width="${width}" height="${height}" rx="4" fill="#fff"/>
+  </mask>
+  <g mask="url(#round)">
+    <rect width="${labelWidth}" height="${height}" fill="#555"/>
+    <rect x="${labelWidth}" width="${valueWidth}" height="${height}" fill="${color}"/>
+    <rect width="${width}" height="${height}" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle"
+     font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+    <text x="${labelWidth / 2}" y="15" fill="#010101" fill-opacity="0.3">${label}</text>
+    <text x="${labelWidth / 2}" y="14">${label}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="15" fill="#010101" fill-opacity="0.3">${value}</text>
+    <text x="${labelWidth + valueWidth / 2}" y="14">${value}</text>
+  </g>
+</svg>`;
+}
+
+async function ensureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function loadSummary(rootDir: string): Promise<Summary | null> {
+  const summaryPath = path.join(rootDir, "artifacts", "readiness", "summary.json");
+  try {
+    const raw = await fs.readFile(summaryPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed?.prototype?.score === "number" && typeof parsed?.real?.score === "number") {
+      return {
+        prototype: { score: parsed.prototype.score, maxScore: parsed.prototype.maxScore ?? 10 },
+        real: { score: parsed.real.score, maxScore: parsed.real.maxScore ?? 10 },
+      };
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const rootDir = path.resolve(scriptDir, "..", "..");
+  const summary = await loadSummary(rootDir);
+  if (!summary) {
+    console.warn("readiness summary not found; generate badges skipped");
+    return;
+  }
+
+  const prototypeValue = `${summary.prototype.score.toFixed(1)}/${summary.prototype.maxScore}`;
+  const realValue = `${summary.real.score.toFixed(1)}/${summary.real.maxScore}`;
+
+  const prototypeSvg = buildBadge("prototype", prototypeValue, scoreColor(summary.prototype.score));
+  const realSvg = buildBadge("real", realValue, scoreColor(summary.real.score));
+
+  const badgeDir = path.join(rootDir, "public", "badges");
+  await ensureDir(badgeDir);
+  await fs.writeFile(path.join(badgeDir, "prototype.svg"), prototypeSvg);
+  await fs.writeFile(path.join(badgeDir, "real.svg"), realSvg);
+
+  console.log(JSON.stringify({ prototype: prototypeValue, real: realValue }, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/scorecard/checks.ts
+++ b/scripts/scorecard/checks.ts
@@ -1,0 +1,431 @@
+import { execFile } from "child_process";
+import { promises as fs } from "fs";
+import path from "path";
+import { promisify } from "util";
+
+export interface CheckResult {
+  key: string;
+  ok: boolean;
+  details: string;
+  points: number;
+  maxPoints: number;
+}
+
+export interface CheckContext {
+  rootDir: string;
+}
+
+type WeightMap = Record<string, number>;
+
+const execFileAsync = promisify(execFile);
+
+async function fetchWithTimeout(url: string, init: any, timeoutMs = 2000): Promise<any> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function findFiles(rootDir: string, matcher: (entryPath: string, isDir: boolean) => boolean): Promise<string[]> {
+  const results: string[] = [];
+  const queue: string[] = [rootDir];
+  const skip = new Set([".git", "node_modules", "artifacts", "public", ".venv"]);
+
+  while (queue.length) {
+    const current = queue.pop()!;
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        if (!skip.has(entry.name)) {
+          if (matcher(entryPath, true)) {
+            results.push(entryPath);
+          }
+          queue.push(entryPath);
+        }
+      } else {
+        if (matcher(entryPath, false)) {
+          results.push(entryPath);
+        }
+      }
+    }
+  }
+  return results;
+}
+
+async function runCommand(command: string, args: string[], cwd: string): Promise<{ ok: boolean; stdout: string; stderr: string; exitCode: number }>
+{
+  try {
+    const { stdout, stderr } = await execFileAsync(command, args, { cwd });
+    return { ok: true, stdout, stderr, exitCode: 0 };
+  } catch (error: any) {
+    return {
+      ok: false,
+      stdout: error?.stdout?.toString() ?? "",
+      stderr: error?.stderr?.toString() ?? String(error?.message ?? ""),
+      exitCode: typeof error?.code === "number" ? error.code : 1,
+    };
+  }
+}
+
+function asDetails(lines: string[]): string {
+  return lines.filter(Boolean).join("; ");
+}
+
+export async function runPrototypeChecks(context: CheckContext, weights: WeightMap): Promise<CheckResult[]> {
+  const { rootDir } = context;
+  const results: CheckResult[] = [];
+
+  // rails_sim check
+  {
+    const weight = weights["rails_sim"] ?? 0;
+    const endpoints: Array<{ method: string; url: string; ok: boolean; status?: number }> = [];
+    if (weight > 0) {
+      const targets = [
+        { method: "GET", url: "http://127.0.0.1:3000/sim/rail" },
+        { method: "POST", url: "http://127.0.0.1:3000/settlement/import", body: { dryRun: true } },
+      ];
+      for (const target of targets) {
+        try {
+          const res = await fetchWithTimeout(target.url, {
+            method: target.method,
+            headers: target.method === "POST" ? { "content-type": "application/json" } : undefined,
+            body: target.body ? JSON.stringify(target.body) : undefined,
+          });
+          endpoints.push({ method: target.method, url: target.url, ok: res.ok, status: res.status });
+        } catch (error: any) {
+          endpoints.push({ method: target.method, url: target.url, ok: false });
+        }
+      }
+    }
+    const ok = weight === 0 ? true : endpoints.every((ep) => ep.ok);
+    const details = weight === 0
+      ? "no weight configured"
+      : endpoints.length === 0
+        ? "no endpoints attempted"
+        : endpoints.map((ep) => `${ep.method} ${ep.url} ${ep.ok ? "ok" : "failed"}${ep.status ? ` (${ep.status})` : ""}`).join(", ");
+    results.push({ key: "rails_sim", ok, details, points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // evidence_v2 check
+  {
+    const weight = weights["evidence_v2"] ?? 0;
+    let ok = false;
+    let details = "no evidence files located";
+    if (weight > 0) {
+      const evidenceFiles = (await findFiles(rootDir, (entryPath, isDir) => !isDir && /evidence_.*\.json$/i.test(path.basename(entryPath)))).slice(0, 5);
+      if (evidenceFiles.length > 0) {
+        for (const file of evidenceFiles) {
+          try {
+            const raw = await fs.readFile(file, "utf8");
+            const parsed = JSON.parse(raw);
+            const hasFields = ["rulesHash", "settlement", "narrative", "approvals"].every((key) => key in parsed);
+            if (hasFields) {
+              ok = true;
+              details = `validated ${path.relative(rootDir, file)}`;
+              break;
+            }
+          } catch (error: any) {
+            details = `failed to parse ${path.relative(rootDir, file)}: ${error?.message ?? error}`;
+          }
+        }
+        if (!ok && evidenceFiles.length > 0 && details === "no evidence files located") {
+          details = `found ${evidenceFiles.length} evidence files but missing required fields`;
+        }
+      }
+    } else {
+      ok = true;
+      details = "no weight configured";
+    }
+    results.push({ key: "evidence_v2", ok, details, points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // rules_correct check
+  {
+    const weight = weights["rules_correct"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const testRun = await runCommand("npm", ["run", "test", "--if-present"], rootDir);
+      details.push(`npm run test --if-present exit ${testRun.exitCode}`);
+      if (!testRun.ok) {
+        details.push(testRun.stderr.trim() ? testRun.stderr.trim().split(/\n+/).slice(0, 2).join(" | ") : "no stderr");
+      }
+
+      const manifestPath = path.join(rootDir, "docs", "_codex_feed", "manifest.json");
+      const manifestExists = await pathExists(manifestPath);
+      details.push(manifestExists ? "manifest present" : "manifest missing");
+
+      const ratesVersionSource = await findFiles(rootDir, (entryPath, isDir) => !isDir && /RATES_VERSION/i.test(path.basename(entryPath)));
+      if (ratesVersionSource.length > 0) {
+        details.push(`rates marker found in ${path.relative(rootDir, ratesVersionSource[0])}`);
+      } else {
+        details.push("RATES_VERSION not found");
+      }
+
+      ok = testRun.ok && manifestExists && ratesVersionSource.length > 0;
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    results.push({ key: "rules_correct", ok, details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // security_thin check
+  {
+    const weight = weights["security_thin"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const securityFiles = await findFiles(rootDir, (entryPath, isDir) => {
+        if (isDir) return false;
+        const name = path.basename(entryPath).toLowerCase();
+        if (!name.endsWith(".md") && !name.endsWith(".ts") && !name.endsWith(".js")) return false;
+        return /mfa|dual approval|jwt|role/i.test(name) || /securitysettings/i.test(name);
+      });
+      if (securityFiles.length > 0) {
+        ok = true;
+        details.push(`found security references e.g. ${path.relative(rootDir, securityFiles[0])}`);
+      } else {
+        details.push("no MFA/JWT references detected");
+      }
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    results.push({ key: "security_thin", ok, details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // observability check
+  {
+    const weight = weights["observability"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const serverPath = path.join(rootDir, "server.js");
+      if (await pathExists(serverPath)) {
+        const serverSource = await fs.readFile(serverPath, "utf8");
+        const hasHealth = /\/health/.test(serverSource);
+        const hasMetrics = /\/metrics/.test(serverSource);
+        const hasRequestId = /request-id/i.test(serverSource) || /x-request-id/i.test(serverSource);
+        ok = hasHealth && hasMetrics && hasRequestId;
+        details.push(`health:${hasHealth ? "ok" : "missing"}`);
+        details.push(`metrics:${hasMetrics ? "ok" : "missing"}`);
+        details.push(`request-id:${hasRequestId ? "ok" : "missing"}`);
+      } else {
+        details.push("server.js missing");
+      }
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    results.push({ key: "observability", ok, details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // seed_smoke check
+  {
+    const weight = weights["seed_smoke"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const seedScript = path.join(rootDir, "seed_and_smoketest.ps1");
+      const smokeScript = path.join(rootDir, "Fix-Stack-And-Smoke.ps1");
+      const hasSeed = await pathExists(seedScript);
+      const hasSmoke = await pathExists(smokeScript);
+      ok = hasSeed && hasSmoke;
+      details.push(`seed script ${hasSeed ? "present" : "missing"}`);
+      details.push(`smoke script ${hasSmoke ? "present" : "missing"}`);
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    results.push({ key: "seed_smoke", ok, details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // help_docs check
+  {
+    const weight = weights["help_docs"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const helpPage = path.join(rootDir, "src", "pages", "Help.tsx");
+      const exists = await pathExists(helpPage);
+      if (exists) {
+        const contents = await fs.readFile(helpPage, "utf8");
+        const hasCoverage = /coverage|support|guide/i.test(contents);
+        ok = hasCoverage;
+        details.push(`help page ${hasCoverage ? "contains guidance" : "missing coverage references"}`);
+      } else {
+        details.push("help page missing");
+      }
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    results.push({ key: "help_docs", ok, details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  return results;
+}
+
+export async function runRealChecks(context: CheckContext, weights: WeightMap): Promise<CheckResult[]> {
+  const { rootDir } = context;
+  const results: CheckResult[] = [];
+  const featureReal = /^true$/i.test(process.env.FEATURE_REAL ?? "");
+
+  // kms_rpt check
+  {
+    const weight = weights["kms_rpt"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const rotationArtifacts = await findFiles(rootDir, (entryPath, isDir) => !isDir && /rotation/i.test(path.basename(entryPath)));
+      const ed25519Module = path.join(rootDir, "src", "crypto", "ed25519.ts");
+      const hasModule = await pathExists(ed25519Module);
+      if (hasModule) {
+        details.push("ed25519 module present");
+      } else {
+        details.push("ed25519 module missing");
+      }
+      if (rotationArtifacts.length > 0) {
+        details.push(`rotation artifact e.g. ${path.relative(rootDir, rotationArtifacts[0])}`);
+      } else {
+        details.push("no rotation artifacts detected");
+      }
+      const envConfigured = Boolean(process.env.RPT_ED25519_SECRET_BASE64 || process.env.KMS_RPT_KEY_PATH);
+      details.push(envConfigured ? "KMS env configured" : "KMS env missing");
+      ok = hasModule && rotationArtifacts.length > 0 && envConfigured;
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    if (!featureReal && weight > 0) {
+      details.push("FEATURE_REAL disabled");
+    }
+    results.push({ key: "kms_rpt", ok: ok && (featureReal || !weight), details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // sandbox_rail check
+  {
+    const weight = weights["sandbox_rail"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const sandboxDocs = await findFiles(rootDir, (entryPath, isDir) => !isDir && /sandbox/i.test(path.basename(entryPath)));
+      const receiptsMention = await findFiles(rootDir, (entryPath, isDir) => !isDir && /receipt/i.test(path.basename(entryPath)));
+      const hasRecon = await findFiles(rootDir, (entryPath, isDir) => !isDir && /recon/i.test(path.basename(entryPath))).then((r) => r.length > 0);
+      ok = sandboxDocs.length > 0 && receiptsMention.length > 0 && hasRecon;
+      details.push(sandboxDocs.length > 0 ? "sandbox docs found" : "sandbox docs missing");
+      details.push(receiptsMention.length > 0 ? "receipt artifacts found" : "receipt artifacts missing");
+      details.push(hasRecon ? "recon artifacts present" : "recon artifacts missing");
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    if (!featureReal && weight > 0) {
+      details.push("FEATURE_REAL disabled");
+    }
+    results.push({ key: "sandbox_rail", ok: ok && (featureReal || !weight), details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // security_controls check
+  {
+    const weight = weights["security_controls"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const securitySettings = path.join(rootDir, "src", "components", "SecuritySettings.tsx");
+      const releaseServer = path.join(rootDir, "server.js");
+      const hasSecuritySettings = await pathExists(securitySettings);
+      const releaseSource = (await pathExists(releaseServer)) ? await fs.readFile(releaseServer, "utf8") : "";
+      const headersConfigured = /x-release|authorization|x-api-key/i.test(releaseSource);
+      const dualApprovalMention = /dual approval/i.test(releaseSource) || /dual approval/i.test(await (async () => {
+        try {
+          return await fs.readFile(path.join(rootDir, "README.md"), "utf8");
+        } catch {
+          return "";
+        }
+      })());
+      const mfaMention = /MFA/i.test(releaseSource) || hasSecuritySettings;
+      ok = hasSecuritySettings && headersConfigured && dualApprovalMention && mfaMention;
+      details.push(hasSecuritySettings ? "security settings UI present" : "security settings UI missing");
+      details.push(headersConfigured ? "release headers configured" : "release headers missing");
+      details.push(dualApprovalMention ? "dual approval referenced" : "dual approval missing");
+      details.push(mfaMention ? "MFA referenced" : "MFA missing");
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    if (!featureReal && weight > 0) {
+      details.push("FEATURE_REAL disabled");
+    }
+    results.push({ key: "security_controls", ok: ok && (featureReal || !weight), details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // assurance check
+  {
+    const weight = weights["assurance"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const workflowPath = path.join(rootDir, ".github", "workflows");
+      const hasWorkflowDir = await pathExists(workflowPath);
+      const runbooks = await findFiles(path.join(rootDir, "ops"), (entryPath, isDir) => !isDir && /runbook|ir|dr/i.test(path.basename(entryPath))).catch(() => [] as string[]);
+      const vulnScanScripts = await findFiles(path.join(rootDir, "tools"), (entryPath, isDir) => !isDir && /scan|audit/i.test(path.basename(entryPath))).catch(() => [] as string[]);
+      ok = hasWorkflowDir && runbooks.length > 0 && vulnScanScripts.length > 0;
+      details.push(hasWorkflowDir ? "CI workflows present" : "CI workflows missing");
+      details.push(runbooks.length > 0 ? "IR/DR notes present" : "IR/DR notes missing");
+      details.push(vulnScanScripts.length > 0 ? "scan scripts present" : "scan scripts missing");
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    if (!featureReal && weight > 0) {
+      details.push("FEATURE_REAL disabled");
+    }
+    results.push({ key: "assurance", ok: ok && (featureReal || !weight), details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  // pilot_ops check
+  {
+    const weight = weights["pilot_ops"] ?? 0;
+    let ok = false;
+    let details: string[] = [];
+    if (weight > 0) {
+      const sloFiles = await findFiles(rootDir, (entryPath, isDir) => !isDir && /slo|dashboard/i.test(path.basename(entryPath)));
+      const dlqScripts = await findFiles(rootDir, (entryPath, isDir) => !isDir && /dlq|replay/i.test(path.basename(entryPath)));
+      const proofsEndpoint = await findFiles(rootDir, (entryPath, isDir) => !isDir && /proof/i.test(path.basename(entryPath)) && entryPath.endsWith(".ts"));
+      ok = sloFiles.length > 0 && dlqScripts.length > 0 && proofsEndpoint.length > 0;
+      details.push(sloFiles.length > 0 ? "SLO references present" : "SLO references missing");
+      details.push(dlqScripts.length > 0 ? "DLQ tooling present" : "DLQ tooling missing");
+      details.push(proofsEndpoint.length > 0 ? "proof endpoint present" : "proof endpoint missing");
+    } else {
+      ok = true;
+      details.push("no weight configured");
+    }
+    if (!featureReal && weight > 0) {
+      details.push("FEATURE_REAL disabled");
+    }
+    results.push({ key: "pilot_ops", ok: ok && (featureReal || !weight), details: asDetails(details), points: ok ? weight : 0, maxPoints: weight });
+  }
+
+  return results;
+}

--- a/scripts/scorecard/score.ts
+++ b/scripts/scorecard/score.ts
@@ -1,0 +1,200 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { runPrototypeChecks, runRealChecks, CheckResult } from "./checks";
+
+interface RubricTrack {
+  weights: Record<string, number>;
+  thresholds: { pass: number; max: number };
+}
+
+interface Rubric {
+  version: string;
+  prototype: RubricTrack;
+  real: RubricTrack;
+}
+
+interface TrackSummary {
+  score: number;
+  maxScore: number;
+  thresholdPass: number;
+  pass: boolean;
+  checks: CheckResult[];
+}
+
+interface ReportData {
+  generatedAt: string;
+  rubricVersion: string;
+  prototype: TrackSummary;
+  real: TrackSummary;
+  deltaPrototype: number | null;
+  deltaReal: number | null;
+}
+
+async function ensureDir(dir: string): Promise<void> {
+  await fs.mkdir(dir, { recursive: true });
+}
+
+function computeTrackSummary(checks: CheckResult[], thresholds: { pass: number; max: number }): TrackSummary {
+  const totalPoints = checks.reduce((acc, check) => acc + check.points, 0);
+  const maxPoints = checks.reduce((acc, check) => acc + check.maxPoints, 0);
+  const maxTarget = thresholds.max || (maxPoints === 0 ? 10 : maxPoints);
+  const score = maxPoints === 0 ? 0 : Number(((totalPoints / maxPoints) * maxTarget).toFixed(2));
+  const pass = score >= thresholds.pass;
+  return {
+    score,
+    maxScore: maxTarget,
+    thresholdPass: thresholds.pass,
+    pass,
+    checks,
+  };
+}
+
+function buildMarkdown(report: ReportData): string {
+  const summaryLines = [
+    "# Readiness Scorecard",
+    "",
+    `- Generated: ${report.generatedAt}`,
+    `- Rubric version: ${report.rubricVersion}`,
+    "",
+    "## Summary",
+    "",
+    "| Track | Score | Δ vs last | Pass? |",
+    "| --- | --- | --- | --- |",
+    `| Prototype | ${report.prototype.score.toFixed(2)} / ${report.prototype.maxScore} | ${formatDelta(report.deltaPrototype)} | ${report.prototype.pass ? "✅" : "❌"} |`,
+    `| Real | ${report.real.score.toFixed(2)} / ${report.real.maxScore} | ${formatDelta(report.deltaReal)} | ${report.real.pass ? "✅" : "❌"} |`,
+    "",
+    "## Prototype checks",
+    "",
+    "| Check | Points | Status | Details |",
+    "| --- | --- | --- | --- |",
+    ...report.prototype.checks.map((check) =>
+      `| ${check.key} | ${check.points}/${check.maxPoints} | ${check.ok ? "✅" : "❌"} | ${escapePipes(check.details)} |`
+    ),
+    "",
+    "## Real checks",
+    "",
+    "| Check | Points | Status | Details |",
+    "| --- | --- | --- | --- |",
+    ...report.real.checks.map((check) =>
+      `| ${check.key} | ${check.points}/${check.maxPoints} | ${check.ok ? "✅" : "❌"} | ${escapePipes(check.details)} |`
+    ),
+    "",
+    "## Raw report",
+    "",
+    "```json",
+    JSON.stringify(report, null, 2),
+    "```",
+    "",
+  ];
+  return summaryLines.join("\n");
+}
+
+function escapePipes(text: string): string {
+  return text.replace(/\|/g, "\\|");
+}
+
+function formatDelta(delta: number | null): string {
+  if (delta === null) return "n/a";
+  const prefix = delta > 0 ? "+" : "";
+  return `${prefix}${delta.toFixed(2)}`;
+}
+
+async function loadRubric(rootDir: string): Promise<Rubric> {
+  const rubricPath = path.join(rootDir, "docs", "readiness", "rubric.v1.json");
+  const raw = await fs.readFile(rubricPath, "utf8");
+  return JSON.parse(raw) as Rubric;
+}
+
+async function readLast(lastPath: string): Promise<{ prototypeScore: number; realScore: number } | null> {
+  try {
+    const raw = await fs.readFile(lastPath, "utf8");
+    const parsed = JSON.parse(raw);
+    if (typeof parsed.prototype?.score === "number" && typeof parsed.real?.score === "number") {
+      return { prototypeScore: parsed.prototype.score, realScore: parsed.real.score };
+    }
+    if (typeof parsed.prototypeScore === "number" && typeof parsed.realScore === "number") {
+      return { prototypeScore: parsed.prototypeScore, realScore: parsed.realScore };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeJson(filePath: string, data: unknown): Promise<void> {
+  await fs.writeFile(filePath, JSON.stringify(data, null, 2));
+}
+
+async function main(): Promise<void> {
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const rootDir = path.resolve(scriptDir, "..", "..");
+  const artifactsDir = path.join(rootDir, "artifacts", "readiness");
+  await ensureDir(artifactsDir);
+
+  const rubric = await loadRubric(rootDir);
+  const context = { rootDir };
+  const [prototypeChecks, realChecks] = await Promise.all([
+    runPrototypeChecks(context, rubric.prototype.weights),
+    runRealChecks(context, rubric.real.weights),
+  ]);
+
+  const prototypeSummary = computeTrackSummary(prototypeChecks, rubric.prototype.thresholds);
+  const realSummary = computeTrackSummary(realChecks, rubric.real.thresholds);
+
+  const lastPath = path.join(artifactsDir, "last.json");
+  const lastScores = await readLast(lastPath);
+  const deltaPrototype = lastScores ? Number((prototypeSummary.score - lastScores.prototypeScore).toFixed(2)) : null;
+  const deltaReal = lastScores ? Number((realSummary.score - lastScores.realScore).toFixed(2)) : null;
+
+  const report: ReportData = {
+    generatedAt: new Date().toISOString(),
+    rubricVersion: rubric.version,
+    prototype: prototypeSummary,
+    real: realSummary,
+    deltaPrototype,
+    deltaReal,
+  };
+
+  const reportPath = path.join(artifactsDir, "report.md");
+  const summaryPath = path.join(artifactsDir, "summary.json");
+
+  await fs.writeFile(reportPath, buildMarkdown(report));
+  await writeJson(summaryPath, {
+    generatedAt: report.generatedAt,
+    rubricVersion: report.rubricVersion,
+    prototype: {
+      score: prototypeSummary.score,
+      maxScore: prototypeSummary.maxScore,
+      pass: prototypeSummary.pass,
+      delta: deltaPrototype,
+    },
+    real: {
+      score: realSummary.score,
+      maxScore: realSummary.maxScore,
+      pass: realSummary.pass,
+      delta: deltaReal,
+    },
+  });
+  await writeJson(lastPath, {
+    generatedAt: report.generatedAt,
+    rubricVersion: report.rubricVersion,
+    prototype: { score: prototypeSummary.score },
+    real: { score: realSummary.score },
+  });
+
+  const consoleOutput = {
+    prototypeScore: prototypeSummary.score,
+    realScore: realSummary.score,
+    deltaPrototype,
+    deltaReal,
+    report: path.relative(rootDir, reportPath),
+  };
+
+  console.log(JSON.stringify(consoleOutput, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add a versioned readiness rubric and TypeScript checks to evaluate prototype and real scorecard signals
- generate markdown reports, badges, and persisted last-run scores for regression detection
- wire up a GitHub Actions workflow to post readiness comments on PRs and fail on guarded score regressions

## Testing
- npm run readiness:score
- npm run readiness:badge

------
https://chatgpt.com/codex/tasks/task_e_68e3fc5e8e648327a09e3fd572d273ed