### PR TITLE
Add ops telemetry endpoint and dashboard cards

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // src/App.tsx
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AppLayout from "./components/AppLayout";
 
 import Dashboard from "./pages/Dashboard";
@@ -12,21 +13,25 @@ import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
 
+const queryClient = new QueryClient();
+
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <QueryClientProvider client={queryClient}>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </QueryClientProvider>
   );
 }

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -2,3 +2,31 @@ declare module "*.svg" {
   const content: string;
   export default content;
 }
+
+declare module "@tanstack/react-query" {
+  import type React from "react";
+
+  export class QueryClient {}
+  export const QueryClientProvider: React.ComponentType<{
+    client: QueryClient;
+    children?: React.ReactNode;
+  }>;
+
+  export interface UseQueryResult<TData = unknown, TError = unknown> {
+    data: TData | undefined;
+    error: TError | null;
+    isError: boolean;
+    isLoading: boolean;
+    refetch: () => Promise<void>;
+  }
+
+  export interface UseQueryOptions<TData = unknown> {
+    queryKey: readonly unknown[];
+    queryFn: () => Promise<TData>;
+    refetchInterval?: number;
+  }
+
+  export function useQuery<TData = unknown>(
+    options: UseQueryOptions<TData>
+  ): UseQueryResult<TData>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { integrationsTelemetry } from "./ops/integrationsTelemetry";
 
 dotenv.config();
 
@@ -17,6 +18,9 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+// Ops telemetry
+app.get("/ops/integrations/telemetry", integrationsTelemetry);
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);

--- a/src/ops/integrationsTelemetry.ts
+++ b/src/ops/integrationsTelemetry.ts
@@ -1,0 +1,91 @@
+import type { RequestHandler } from "express";
+import { Pool } from "pg";
+
+const pool = new Pool();
+
+const toIso = (value: unknown): string | null => {
+  if (!value) return null;
+  const date = new Date(value as string);
+  return Number.isNaN(date.getTime()) ? null : date.toISOString();
+};
+
+type ReceiptRow = {
+  last_receipt_at: string | null;
+  abn: string | null;
+  tax_type: string | null;
+  period_id: string | null;
+};
+
+type ReconRow = {
+  last_recon_import_at: string | null;
+  id: number | null;
+};
+
+export const integrationsTelemetry: RequestHandler = async (_req, res) => {
+  try {
+    const [receiptResult, reconResult] = await Promise.all([
+      pool.query<ReceiptRow>(
+        `with latest as (
+           select max(paid_at) as paid_at
+           from settlements
+         )
+         select
+           latest.paid_at as last_receipt_at,
+           s.abn,
+           s.tax_type,
+           s.period_id
+         from latest
+         left join settlements s on s.paid_at = latest.paid_at
+         order by s.paid_at desc nulls last
+         limit 1`
+      ),
+      pool.query<ReconRow>(
+        `with latest as (
+           select max(imported_at) as imported_at
+           from recon_imports
+         )
+         select
+           latest.imported_at as last_recon_import_at,
+           r.id
+         from latest
+         left join recon_imports r on r.imported_at = latest.imported_at
+         order by r.imported_at desc nulls last, r.id desc nulls last
+         limit 1`
+      ),
+    ]);
+
+    const receiptRow = receiptResult.rows[0] || {
+      last_receipt_at: null,
+      abn: null,
+      tax_type: null,
+      period_id: null,
+    };
+
+    const reconRow = reconResult.rows[0] || {
+      last_recon_import_at: null,
+      id: null,
+    };
+
+    const evidenceLink =
+      receiptRow.abn && receiptRow.tax_type && receiptRow.period_id
+        ? `/api/evidence?abn=${encodeURIComponent(receiptRow.abn)}&taxType=${encodeURIComponent(receiptRow.tax_type)}&periodId=${encodeURIComponent(receiptRow.period_id)}`
+        : null;
+
+    const reconLogLink =
+      typeof reconRow.id === "number"
+        ? `/ops/recon/imports/${encodeURIComponent(String(reconRow.id))}`
+        : null;
+
+    res.json({
+      last_receipt_at: toIso(receiptRow.last_receipt_at),
+      last_recon_import_at: toIso(reconRow.last_recon_import_at),
+      links: {
+        evidence: evidenceLink,
+        recon_import_log: reconLogLink,
+      },
+    });
+  } catch (error) {
+    console.error("[ops] failed to load integration telemetry", error);
+    res.status(500).json({ error: "TELEMETRY_UNAVAILABLE" });
+  }
+};

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -1,18 +1,142 @@
 import React from "react";
+import { useQuery } from "@tanstack/react-query";
+
+type TelemetryResponse = {
+  last_receipt_at: string | null;
+  last_recon_import_at: string | null;
+  links?: {
+    evidence?: string | null;
+    recon_import_log?: string | null;
+  };
+};
+
+const cardStyle: React.CSSProperties = {
+  background: "#fff",
+  border: "1px solid #dbe4e6",
+  borderRadius: 16,
+  padding: 24,
+  flex: "1 1 320px",
+  boxShadow: "0 8px 18px rgba(0,0,0,0.05)",
+  display: "flex",
+  flexDirection: "column",
+  gap: 12,
+};
+
+const formatTimestamp = (value: string | null | undefined) => {
+  if (!value) return "No records yet";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("en-AU", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+};
+
+const relativeSince = (value: string | null | undefined) => {
+  if (!value) return "Waiting for first event";
+  const ts = new Date(value).getTime();
+  if (Number.isNaN(ts)) return "Unknown timing";
+  const deltaMs = Date.now() - ts;
+  if (deltaMs < 0) return "In the future";
+  const minutes = Math.floor(deltaMs / 60000);
+  if (minutes < 1) return "Just now";
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+};
+
+const LinkButton = ({ href, label }: { href?: string | null; label: string }) => {
+  if (!href) {
+    return (
+      <span style={{ color: "#708090", fontSize: 14 }}>No link available yet</span>
+    );
+  }
+  return (
+    <a
+      href={href}
+      style={{ color: "#00716b", fontWeight: 600, textDecoration: "none", fontSize: 14 }}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      {label}
+    </a>
+  );
+};
 
 export default function Integrations() {
+  const telemetryQuery = useQuery<TelemetryResponse>({
+    queryKey: ["ops", "integrations", "telemetry"],
+    queryFn: async () => {
+      const response = await fetch("/ops/integrations/telemetry");
+      if (!response.ok) {
+        throw new Error(`Request failed with ${response.status}`);
+      }
+      return (await response.json()) as TelemetryResponse;
+    },
+    refetchInterval: 30000,
+  });
+
+  const { data, isLoading, isError, error } = telemetryQuery;
+
   return (
     <div className="main-card">
-      <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
-      <h3>Connect to Providers</h3>
-      <ul>
-        <li>MYOB (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-        <li>QuickBooks (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-        <li>Square (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-        <li>Vend (POS) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>
-      </ul>
-      <div style={{ marginTop: 24, fontSize: 15, color: "#888" }}>
-        (More integrations coming soon.)
+      <h1
+        style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 12 }}
+      >
+        Integrations
+      </h1>
+      <p style={{ marginBottom: 24, color: "#425466" }}>
+        Keep an eye on the latest provider receipts and reconciliation imports to confirm the
+        pipeline is flowing.
+      </p>
+
+      {isLoading && (
+        <div style={{ marginBottom: 24, color: "#708090" }}>Loading telemetry…</div>
+      )}
+
+      {isError && (
+        <div style={{ marginBottom: 24, color: "#b00020" }}>
+          Unable to load telemetry. {error instanceof Error ? error.message : ""}
+        </div>
+      )}
+
+      <div
+        style={{
+          display: "flex",
+          flexWrap: "wrap",
+          gap: 24,
+          opacity: isLoading ? 0.7 : 1,
+        }}
+      >
+        <div style={cardStyle}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 18, color: "#0f172a" }}>Last provider receipt</h2>
+            <p style={{ margin: "6px 0 0", color: "#475569", fontSize: 14 }}>
+              {formatTimestamp(data?.last_receipt_at)}
+            </p>
+            <p style={{ margin: 0, color: "#64748b", fontSize: 13 }}>
+              {relativeSince(data?.last_receipt_at)}
+            </p>
+          </div>
+          <LinkButton href={data?.links?.evidence} label="View evidence" />
+        </div>
+
+        <div style={cardStyle}>
+          <div>
+            <h2 style={{ margin: 0, fontSize: 18, color: "#0f172a" }}>
+              Last reconciliation import
+            </h2>
+            <p style={{ margin: "6px 0 0", color: "#475569", fontSize: 14 }}>
+              {formatTimestamp(data?.last_recon_import_at)}
+            </p>
+            <p style={{ margin: 0, color: "#64748b", fontSize: 13 }}>
+              {relativeSince(data?.last_recon_import_at)}
+            </p>
+          </div>
+          <LinkButton href={data?.links?.recon_import_log} label="View import log" />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add an `/ops/integrations/telemetry` handler that surfaces the latest settlement receipt and reconciliation import timestamps with helpful links
- wrap the console in a React Query provider and replace the Integrations page with live telemetry cards fed by the new endpoint
- add minimal typings so TypeScript recognises the React Query API used by the UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3fd9b702483278f69043ef8da1e6c