### PR TITLE
Add parity simulation guardrails

### DIFF
--- a/apps/services/payments/jest.config.cjs
+++ b/apps/services/payments/jest.config.cjs
@@ -1,0 +1,16 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
+  testMatch: ['**/test/**/*.test.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: './tsconfig.json',
+    },
+  },
+};

--- a/apps/services/payments/src/config/features.ts
+++ b/apps/services/payments/src/config/features.ts
@@ -1,0 +1,45 @@
+// apps/services/payments/src/config/features.ts
+
+export type FeatureFlags = {
+  APP_MODE: string;
+  FEATURE_SIM_OUTBOUND: boolean;
+  ALLOW_UNSAFE: boolean;
+};
+
+const TRUE_VALUES = new Set(["1", "true", "yes", "on"]);
+
+function toBool(value: string | undefined): boolean {
+  if (!value) return false;
+  return TRUE_VALUES.has(value.trim().toLowerCase());
+}
+
+function normalizeMode(mode: string | undefined): string {
+  if (!mode) return "sim";
+  const lower = mode.trim().toLowerCase();
+  return lower === "real" ? "real" : lower || "sim";
+}
+
+export function loadFeatureFlags(env: NodeJS.ProcessEnv = process.env): FeatureFlags {
+  return {
+    APP_MODE: normalizeMode(env.APP_MODE),
+    FEATURE_SIM_OUTBOUND: toBool(env.FEATURE_SIM_OUTBOUND),
+    ALLOW_UNSAFE: toBool(env.ALLOW_UNSAFE),
+  };
+}
+
+export function assertSafeCombo(flags: FeatureFlags): void {
+  if (flags.APP_MODE === "real" && flags.FEATURE_SIM_OUTBOUND && !flags.ALLOW_UNSAFE) {
+    throw new Error(
+      "FEATURE_SIM_OUTBOUND cannot be enabled with APP_MODE=real unless ALLOW_UNSAFE=true"
+    );
+  }
+}
+
+type Logger = { log: (...args: any[]) => void };
+
+export function logFeatureFlags(flags: FeatureFlags, logger: Logger = console): void {
+  const line = Object.entries(flags)
+    .map(([key, value]) => `${key}=${typeof value === "boolean" ? (value ? "true" : "false") : value}`)
+    .join(" ");
+  logger.log(`[features] ${line}`);
+}

--- a/apps/services/payments/src/index.ts
+++ b/apps/services/payments/src/index.ts
@@ -2,6 +2,8 @@
 import 'dotenv/config';
 import './loadEnv.js'; // ensures .env.local is loaded when running with tsx
 
+import { assertSafeCombo, loadFeatureFlags, logFeatureFlags } from './config/features.js';
+
 import express from 'express';
 import pg from 'pg'; const { Pool } = pg;
 
@@ -12,6 +14,10 @@ import { balance } from './routes/balance';
 import { ledger } from './routes/ledger';
 
 // Port (defaults to 3000)
+const featureFlags = loadFeatureFlags();
+assertSafeCombo(featureFlags);
+logFeatureFlags(featureFlags);
+
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 
 // Prefer DATABASE_URL; else compose from PG* vars

--- a/apps/services/payments/src/sim/parity.ts
+++ b/apps/services/payments/src/sim/parity.ts
@@ -1,0 +1,101 @@
+// apps/services/payments/src/sim/parity.ts
+import { sendEftOrBpay } from '../bank/eftBpayAdapter.js';
+import { sha256Hex } from '../utils/crypto.js';
+
+export type ParitySimConfig = {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amount_cents: number;
+  idempotencyKey: string;
+  destination: {
+    bpay_biller?: string;
+    crn?: string;
+    bsb?: string;
+    acct?: string;
+  };
+  gateState: string;
+  kid: string;
+};
+
+export type ParityReconResult = {
+  provider_ref: string;
+  settlement_amount_cents: number;
+  manifest_sha256: string;
+  gate_state: string;
+  kid: string;
+};
+
+export type ParityEvidence = {
+  settlement: {
+    provider_ref: string;
+    amount_cents: number;
+    bank_receipt_hash: string;
+  };
+  rules: {
+    manifest_sha256: string;
+  };
+  narrative: string[];
+};
+
+export type ParitySimResult = {
+  release: {
+    provider_ref: string;
+    transfer_uuid: string;
+    bank_receipt_hash: string;
+    amount_cents: number;
+  };
+  recon: ParityReconResult;
+  evidence: ParityEvidence;
+};
+
+export async function runParitySimulation(config: ParitySimConfig): Promise<ParitySimResult> {
+  const transfer = await sendEftOrBpay({
+    abn: config.abn,
+    taxType: config.taxType,
+    periodId: config.periodId,
+    amount_cents: config.amount_cents,
+    destination: config.destination,
+    idempotencyKey: config.idempotencyKey,
+  });
+
+  const providerRef = transfer.provider_receipt_id;
+  const manifestInput = {
+    abn: config.abn,
+    taxType: config.taxType,
+    periodId: config.periodId,
+    gateState: config.gateState,
+    kid: config.kid,
+    providerRef,
+  };
+  const manifestSha = sha256Hex(JSON.stringify(manifestInput));
+
+  const recon: ParityReconResult = {
+    provider_ref: providerRef,
+    settlement_amount_cents: config.amount_cents,
+    manifest_sha256: manifestSha,
+    gate_state: config.gateState,
+    kid: config.kid,
+  };
+
+  const evidence: ParityEvidence = {
+    settlement: {
+      provider_ref: providerRef,
+      amount_cents: config.amount_cents,
+      bank_receipt_hash: transfer.bank_receipt_hash,
+    },
+    rules: { manifest_sha256: manifestSha },
+    narrative: [`gate_state:${config.gateState}`, `kid:${config.kid}`],
+  };
+
+  return {
+    release: {
+      provider_ref: providerRef,
+      transfer_uuid: transfer.transfer_uuid,
+      bank_receipt_hash: transfer.bank_receipt_hash,
+      amount_cents: config.amount_cents,
+    },
+    recon,
+    evidence,
+  };
+}

--- a/apps/services/payments/test/sim/parity.test.ts
+++ b/apps/services/payments/test/sim/parity.test.ts
@@ -1,0 +1,64 @@
+import type { MockedFunction } from 'jest-mock';
+import { runParitySimulation } from '../../src/sim/parity.js';
+
+type AxiosPost = MockedFunction<(
+  url: string,
+  payload: any,
+  options?: { headers?: Record<string, string> }
+) => Promise<{ data: { receipt_id: string } }>>;
+
+const receiptByKey = new Map<string, string>();
+let counter = 0;
+
+const nextSequence = () => (++counter).toString(16).padStart(6, '0');
+
+jest.mock('axios', () => {
+  return {
+    create: () => ({
+      post: ((url: string, _payload: any, options?: { headers?: Record<string, string> }) => {
+        const provided = options?.headers?.['Idempotency-Key'];
+        const key = provided ?? `missing-${nextSequence()}`;
+        if (!receiptByKey.has(key)) {
+          const receipt = `${url.replace(/[^a-z]/gi, '').slice(-8)}-${nextSequence()}`;
+          receiptByKey.set(key, receipt);
+        }
+        const receipt_id = receiptByKey.get(key)!;
+        return Promise.resolve({ data: { receipt_id } });
+      }) as AxiosPost,
+    }),
+  };
+});
+
+describe('prototype parity simulation', () => {
+  beforeEach(() => {
+    receiptByKey.clear();
+    counter = 0;
+  });
+
+  test('sim release → recon import → evidence stays consistent', async () => {
+    const config = {
+      abn: '12345678901',
+      taxType: 'PAYGW',
+      periodId: '2025-09',
+      amount_cents: 12500,
+      idempotencyKey: 'idem-key-123',
+      destination: { bpay_biller: '75556', crn: '12345678901' },
+      gateState: 'RPT-Issued',
+      kid: 'kid-prod-001',
+    } as const;
+
+    const first = await runParitySimulation(config);
+    const second = await runParitySimulation(config);
+
+    expect(first.recon.provider_ref).toBeTruthy();
+    expect(first.recon.provider_ref).toEqual(second.recon.provider_ref);
+
+    expect(first.evidence.settlement.amount_cents).toBe(config.amount_cents);
+    expect(first.evidence.settlement.provider_ref).toEqual(first.recon.provider_ref);
+
+    expect(first.evidence.rules.manifest_sha256).toMatch(/^[0-9a-f]{64}$/);
+
+    expect(first.evidence.narrative.some(line => line.includes(config.gateState))).toBe(true);
+    expect(first.evidence.narrative.some(line => line.includes(config.kid))).toBe(true);
+  });
+});

--- a/apps/services/payments/tsconfig.json
+++ b/apps/services/payments/tsconfig.json
@@ -10,5 +10,5 @@
     "outDir": "dist",
     "sourceMap": true
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "prototype:parity": "pnpm --filter payments test -- --runTestsByPath test/sim/parity.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",


### PR DESCRIPTION
## Summary
- enforce feature flag safety in the payments service and log active toggles on startup
- add a parity simulation helper plus Jest configuration to exercise the release→recon→evidence flow
- document the parity simulation check in CI via a dedicated prototype:parity script

## Testing
- ⚠️ `npx jest --runInBand --runTestsByPath test/sim/parity.test.ts` *(fails: npm registry access is forbidden in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3fc70031883279dd2b1ee697e6a87