### PR TITLE
Add audit hash chain exports and UI integration

### DIFF
--- a/src/audit/appendOnly.ts
+++ b/src/audit/appendOnly.ts
@@ -1,15 +1,155 @@
-﻿import { sha256Hex } from "../crypto/merkle";
 import { Pool } from "pg";
+import { sha256Hex } from "../crypto/merkle";
+
 const pool = new Pool();
 
+export type AuditDigestInput = {
+  at: Date | string;
+  actor: string;
+  action: string;
+  payload: unknown;
+};
+
+export type AuditLogEntry = {
+  id: number;
+  at: string;
+  actor: string;
+  action: string;
+  payload: any;
+  prevHash: string;
+  runningHash: string;
+  entryHash: string;
+};
+
+export type AuditBundle = {
+  period: string;
+  entries: AuditLogEntry[];
+  runningHash: string;
+};
+
+export function computeEntryDigest({ at, actor, action, payload }: AuditDigestInput): string {
+  const isoAt = typeof at === "string" ? new Date(at).toISOString() : at.toISOString();
+  const normalized = JSON.stringify({ at: isoAt, actor, action, payload });
+  return sha256Hex(normalized);
+}
+
+export function computeRunningDigest(prevHash: string, entryDigest: string): string {
+  return sha256Hex((prevHash || "") + entryDigest);
+}
+
 export async function appendAudit(actor: string, action: string, payload: any) {
-  const { rows } = await pool.query("select terminal_hash from audit_log order by seq desc limit 1");
-  const prevHash = rows[0]?.terminal_hash || "";
-  const payloadHash = sha256Hex(JSON.stringify(payload));
-  const terminalHash = sha256Hex(prevHash + payloadHash);
-  await pool.query(
-    "insert into audit_log(actor,action,payload_hash,prev_hash,terminal_hash) values (,,,,)",
-    [actor, action, payloadHash, prevHash, terminalHash]
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const { rows: prevRows } = await client.query<{ running_hash: string | null }>(
+      "SELECT running_hash FROM audit_log ORDER BY id DESC LIMIT 1"
+    );
+    const prevRunningHash = prevRows[0]?.running_hash ?? "";
+    const at = new Date();
+    const entryHash = computeEntryDigest({ at, actor, action, payload });
+    const runningHash = computeRunningDigest(prevRunningHash, entryHash);
+    const payloadJson = JSON.stringify(payload ?? {});
+    const { rows } = await client.query<{
+      id: number;
+      at: string;
+      actor: string;
+      action: string;
+      payload_json: any;
+      prev_hash: string | null;
+      running_hash: string;
+    }>(
+      `INSERT INTO audit_log (at, actor, action, payload_json, prev_hash, running_hash)
+       VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+       RETURNING id, at, actor, action, payload_json, prev_hash, running_hash`,
+      [at, actor, action, payloadJson, prevRunningHash || null, runningHash]
+    );
+    await client.query("COMMIT");
+    const row = rows[0];
+    const payloadValue = typeof row.payload_json === "string" ? JSON.parse(row.payload_json) : row.payload_json;
+    return {
+      id: row.id,
+      at: new Date(row.at).toISOString(),
+      actor: row.actor,
+      action: row.action,
+      payload: payloadValue,
+      prevHash: row.prev_hash ?? "",
+      runningHash: row.running_hash,
+      entryHash,
+    } satisfies AuditLogEntry;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+async function resolvePeriod(period: string): Promise<string> {
+  if (period !== "latest") return period;
+  const { rows } = await pool.query<{ period_id: string | null }>(
+    `SELECT payload_json->>'periodId' AS period_id
+       FROM audit_log
+      WHERE payload_json ? 'periodId'
+      ORDER BY id DESC
+      LIMIT 1`
   );
-  return terminalHash;
+  return rows[0]?.period_id ?? "all";
+}
+
+export async function getAuditBundle(period: string): Promise<AuditBundle> {
+  const resolvedPeriod = await resolvePeriod(period);
+  const isAll = resolvedPeriod === "all";
+  const sql =
+    "SELECT id, at, actor, action, payload_json, prev_hash, running_hash FROM audit_log" +
+    (isAll ? " ORDER BY id ASC" : " WHERE payload_json->>'periodId' = $1 ORDER BY id ASC");
+  const params = isAll ? [] : [resolvedPeriod];
+  const { rows } = await pool.query<{
+    id: number;
+    at: string;
+    actor: string;
+    action: string;
+    payload_json: any;
+    prev_hash: string | null;
+    running_hash: string;
+  }>(sql, params);
+
+  const entries: AuditLogEntry[] = rows.map((row) => {
+    const payloadValue =
+      row.payload_json === null
+        ? null
+        : typeof row.payload_json === "string"
+        ? JSON.parse(row.payload_json)
+        : row.payload_json;
+    const entryHash = computeEntryDigest({
+      at: row.at,
+      actor: row.actor,
+      action: row.action,
+      payload: payloadValue,
+    });
+    return {
+      id: row.id,
+      at: new Date(row.at).toISOString(),
+      actor: row.actor,
+      action: row.action,
+      payload: payloadValue,
+      prevHash: row.prev_hash ?? "",
+      runningHash: row.running_hash ?? "",
+      entryHash,
+    };
+  });
+
+  const terminalHash =
+    entries.length > 0
+      ? entries[entries.length - 1].runningHash
+      : (await pool
+          .query<{ running_hash: string | null }>(
+            "SELECT running_hash FROM audit_log ORDER BY id DESC LIMIT 1"
+          ))
+          .rows[0]?.running_hash ?? "";
+
+  return {
+    period: resolvedPeriod,
+    entries,
+    runningHash: terminalHash ?? "",
+  };
 }

--- a/src/components/ComplianceReports.tsx
+++ b/src/components/ComplianceReports.tsx
@@ -1,15 +1,70 @@
-import React from "react";
+import React, { useState } from "react";
 import { TaxReport } from "../types/tax";
 
 export default function ComplianceReports({ history }: { history: TaxReport[] }) {
+  const [downloading, setDownloading] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function triggerExport(periodId: string | undefined, format: "json" | "zip") {
+    if (!periodId) {
+      setError("No period identifier available for this report.");
+      return;
+    }
+    try {
+      setError(null);
+      setDownloading(`${periodId}:${format}`);
+      const url = `/audit/bundle/${encodeURIComponent(periodId)}${format === "zip" ? "?format=zip" : ""}`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`Export failed (${response.status})`);
+      }
+      const blob = await response.blob();
+      const downloadUrl = window.URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = downloadUrl;
+      const extension = format === "zip" ? "zip" : "json";
+      anchor.download = `audit-${periodId}.${extension}`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      document.body.removeChild(anchor);
+      window.URL.revokeObjectURL(downloadUrl);
+    } catch (err: any) {
+      setError(err.message || "Failed to download audit export");
+    } finally {
+      setDownloading(null);
+    }
+  }
+
   return (
     <div className="card">
       <h3>Compliance Reports</h3>
+      {error ? <div className="text-sm text-destructive mb-2">{error}</div> : null}
       <ul>
         {history.map((rep, i) => (
           <li key={i}>
             PAYGW: ${rep.paygwLiability.toFixed(2)} | GST: ${rep.gstPayable.toFixed(2)} | Total: ${rep.totalPayable.toFixed(2)}
             | Status: {rep.complianceStatus}
+            <div className="mt-1 flex flex-wrap gap-2 text-xs">
+              <button
+                type="button"
+                className="rounded border border-gray-300 px-2 py-1"
+                onClick={() => triggerExport(rep.periodId, "json")}
+                disabled={downloading !== null}
+              >
+                {downloading === `${rep.periodId}:json` ? "Preparing…" : "Export JSON"}
+              </button>
+              <button
+                type="button"
+                className="rounded border border-gray-300 px-2 py-1"
+                onClick={() => triggerExport(rep.periodId, "zip")}
+                disabled={downloading !== null}
+              >
+                {downloading === `${rep.periodId}:zip` ? "Preparing…" : "Export ZIP"}
+              </button>
+              {!rep.periodId ? (
+                <span className="text-muted-foreground">Set a period ID to enable exports.</span>
+              ) : null}
+            </div>
           </li>
         ))}
       </ul>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 ﻿// src/index.ts
 import express from "express";
 import dotenv from "dotenv";
+import { deflateRawSync } from "zlib";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { getAuditBundle } from "./audit/appendOnly";
 
 dotenv.config();
 
@@ -17,6 +19,145 @@ app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); ne
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+app.get("/audit/bundle/:period", async (req, res) => {
+  try {
+    const { period } = req.params as { period: string };
+    const format = String(req.query.format || "json").toLowerCase();
+    const bundle = await getAuditBundle(period);
+    if (format === "zip") {
+      const buffer = createZipArchive(`audit-${bundle.period}.json`, JSON.stringify(bundle, null, 2));
+      res.setHeader("Content-Type", "application/zip");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="audit-${bundle.period || period}.zip"`
+      );
+      return res.send(buffer);
+    }
+    res.json(bundle);
+  } catch (err: any) {
+    console.error("[audit] export failed", err);
+    res.status(500).json({ error: "Failed to export audit bundle" });
+  }
+});
+
+const CRC_TABLE = (() => {
+  const table = new Uint32Array(256);
+  for (let i = 0; i < 256; i++) {
+    let crc = i;
+    for (let j = 0; j < 8; j++) {
+      if ((crc & 1) === 1) {
+        crc = (crc >>> 1) ^ 0xedb88320;
+      } else {
+        crc >>>= 1;
+      }
+    }
+    table[i] = crc >>> 0;
+  }
+  return table;
+})();
+
+function crc32(buffer: Buffer): number {
+  let crc = 0xffffffff;
+  for (let i = 0; i < buffer.length; i++) {
+    const byte = buffer[i];
+    crc = CRC_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function createZipArchive(fileName: string, content: string): Buffer {
+  const data = Buffer.from(content, "utf8");
+  const compressed = deflateRawSync(data);
+  const fileNameBytes = Buffer.from(fileName, "utf8");
+  const crc = crc32(data);
+
+  const localHeader = Buffer.alloc(30);
+  let offset = 0;
+  localHeader.writeUInt32LE(0x04034b50, offset); // Local file header signature
+  offset += 4;
+  localHeader.writeUInt16LE(20, offset); // Version needed to extract
+  offset += 2;
+  localHeader.writeUInt16LE(0, offset); // General purpose bit flag
+  offset += 2;
+  localHeader.writeUInt16LE(8, offset); // Compression method (deflate)
+  offset += 2;
+  localHeader.writeUInt16LE(0, offset); // File last mod time
+  offset += 2;
+  localHeader.writeUInt16LE(0, offset); // File last mod date
+  offset += 2;
+  localHeader.writeUInt32LE(crc, offset); // CRC-32
+  offset += 4;
+  localHeader.writeUInt32LE(compressed.length, offset); // Compressed size
+  offset += 4;
+  localHeader.writeUInt32LE(data.length, offset); // Uncompressed size
+  offset += 4;
+  localHeader.writeUInt16LE(fileNameBytes.length, offset); // File name length
+  offset += 2;
+  localHeader.writeUInt16LE(0, offset); // Extra field length
+  offset += 2;
+
+  const localFile = Buffer.concat([localHeader, fileNameBytes, compressed]);
+
+  const centralHeader = Buffer.alloc(46);
+  offset = 0;
+  centralHeader.writeUInt32LE(0x02014b50, offset); // Central file header signature
+  offset += 4;
+  centralHeader.writeUInt16LE(20, offset); // Version made by
+  offset += 2;
+  centralHeader.writeUInt16LE(20, offset); // Version needed to extract
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // General purpose bit flag
+  offset += 2;
+  centralHeader.writeUInt16LE(8, offset); // Compression method
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // Last mod file time
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // Last mod file date
+  offset += 2;
+  centralHeader.writeUInt32LE(crc, offset); // CRC-32
+  offset += 4;
+  centralHeader.writeUInt32LE(compressed.length, offset); // Compressed size
+  offset += 4;
+  centralHeader.writeUInt32LE(data.length, offset); // Uncompressed size
+  offset += 4;
+  centralHeader.writeUInt16LE(fileNameBytes.length, offset); // File name length
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // Extra field length
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // File comment length
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // Disk number start
+  offset += 2;
+  centralHeader.writeUInt16LE(0, offset); // Internal file attributes
+  offset += 2;
+  centralHeader.writeUInt32LE(0, offset); // External file attributes
+  offset += 4;
+  centralHeader.writeUInt32LE(0, offset); // Relative offset of local header
+  offset += 4;
+
+  const centralDirectory = Buffer.concat([centralHeader, fileNameBytes]);
+
+  const endRecord = Buffer.alloc(22);
+  offset = 0;
+  endRecord.writeUInt32LE(0x06054b50, offset); // End of central dir signature
+  offset += 4;
+  endRecord.writeUInt16LE(0, offset); // Number of this disk
+  offset += 2;
+  endRecord.writeUInt16LE(0, offset); // Disk where central directory starts
+  offset += 2;
+  endRecord.writeUInt16LE(1, offset); // Number of central directory records on this disk
+  offset += 2;
+  endRecord.writeUInt16LE(1, offset); // Total number of central directory records
+  offset += 2;
+  endRecord.writeUInt32LE(centralDirectory.length, offset); // Size of central directory
+  offset += 4;
+  endRecord.writeUInt32LE(localFile.length, offset); // Offset of start of central directory
+  offset += 4;
+  endRecord.writeUInt16LE(0, offset); // Comment length
+
+  return Buffer.concat([localFile, centralDirectory, endRecord]);
+}
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);

--- a/src/pages/Audit.tsx
+++ b/src/pages/Audit.tsx
@@ -1,41 +1,173 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from "react";
+
+type AuditEntry = {
+  id: number;
+  at: string;
+  actor: string;
+  action: string;
+  payload: Record<string, any> | null;
+  prevHash: string;
+  runningHash: string;
+  entryHash: string;
+};
+
+type AuditBundle = {
+  period: string;
+  entries: AuditEntry[];
+  runningHash: string;
+};
+
+const DEFAULT_PERIOD = "all";
 
 export default function Audit() {
-  const [logs] = useState([
-    { date: '1 May 2025', action: 'Transferred $1,000 to PAYGW buffer' },
-    { date: '10 May 2025', action: 'Lodged BAS (Q3 FY24-25)' },
-    { date: '15 May 2025', action: 'Audit log downloaded by user' },
-    { date: '22 May 2025', action: 'Reminder sent: PAYGW payment due' },
-    { date: '5 June 2025', action: 'Scheduled PAYGW transfer' },
-    { date: '29 May 2025', action: 'BAS lodged (on time)' },
-    { date: '16 May 2025', action: 'GST payment made' },
-  ]);
+  const [period, setPeriod] = useState(DEFAULT_PERIOD);
+  const [input, setInput] = useState("");
+  const [bundle, setBundle] = useState<AuditBundle | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    async function load() {
+      setLoading(true);
+      setError(null);
+      try {
+        const resp = await fetch(`/audit/bundle/${encodeURIComponent(period)}`, {
+          signal: controller.signal,
+        });
+        if (!resp.ok) {
+          throw new Error(`Request failed (${resp.status})`);
+        }
+        const data = (await resp.json()) as AuditBundle;
+        setBundle(data);
+      } catch (err: any) {
+        if (err.name === "AbortError") return;
+        setError(err.message || "Unable to load audit log");
+        setBundle(null);
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+    return () => controller.abort();
+  }, [period]);
+
+  const chainBreakIndex = useMemo(() => {
+    if (!bundle) return -1;
+    let expected = "";
+    for (let i = 0; i < bundle.entries.length; i++) {
+      const entry = bundle.entries[i];
+      if ((entry.prevHash || "") !== expected) {
+        return i;
+      }
+      expected = entry.runningHash || "";
+    }
+    return -1;
+  }, [bundle]);
+
+  const rows = bundle?.entries ?? [];
+  const periodLabel = bundle?.period || period;
 
   return (
     <div className="p-6 space-y-4">
-      <h1 className="text-2xl font-bold">Compliance & Audit</h1>
-      <p className="text-sm text-muted-foreground">
-        Track every action in your PAYGW and GST account for compliance.
-      </p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Compliance &amp; Audit</h1>
+          <p className="text-sm text-muted-foreground">
+            Track every action in your PAYGW and GST account with a verifiable hash chain.
+          </p>
+        </div>
+        <form
+          className="flex items-center gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            const next = input.trim();
+            if (next.length > 0) {
+              setPeriod(next);
+            } else {
+              setPeriod(DEFAULT_PERIOD);
+            }
+          }}
+        >
+          <input
+            type="text"
+            placeholder="Period (e.g. 2025-Q2 or latest)"
+            className="border rounded px-2 py-1 text-sm"
+            value={input}
+            onChange={(event) => setInput(event.target.value)}
+          />
+          <button
+            type="submit"
+            className="bg-primary text-white text-sm px-3 py-1 rounded"
+            disabled={loading}
+          >
+            {loading ? "Loading…" : "Load"}
+          </button>
+        </form>
+      </div>
+
+      {error ? (
+        <div className="rounded border border-destructive/60 bg-destructive/10 p-3 text-destructive text-sm">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="text-sm text-muted-foreground">
+        Viewing period: <span className="font-medium text-foreground">{periodLabel}</span>
+      </div>
+
+      {chainBreakIndex >= 0 ? (
+        <div className="rounded border border-yellow-400 bg-yellow-50 p-3 text-yellow-900 text-sm">
+          Hash chain break detected at entry #{chainBreakIndex + 1}. Please investigate immediately.
+        </div>
+      ) : null}
+
       <div className="overflow-x-auto">
-        <table className="min-w-full text-sm border border-gray-300 rounded-lg">
-          <thead className="bg-gray-100">
+        <table className="min-w-full text-sm border border-gray-200 rounded-lg">
+          <thead className="bg-gray-100 text-left">
             <tr>
-              <th className="px-4 py-2 text-left border-b">Date</th>
-              <th className="px-4 py-2 text-left border-b">Action</th>
+              <th className="px-4 py-2 border-b">Timestamp</th>
+              <th className="px-4 py-2 border-b">Actor</th>
+              <th className="px-4 py-2 border-b">Action</th>
+              <th className="px-4 py-2 border-b">Prev Hash</th>
+              <th className="px-4 py-2 border-b">Running Hash</th>
             </tr>
           </thead>
           <tbody>
-            {logs.map((log, i) => (
-              <tr key={i} className="border-t">
-                <td className="px-4 py-2">{log.date}</td>
-                <td className="px-4 py-2">{log.action}</td>
+            {rows.length === 0 ? (
+              <tr>
+                <td className="px-4 py-4 text-center text-muted-foreground" colSpan={5}>
+                  {loading ? "Fetching audit entries…" : "No audit records available for this period."}
+                </td>
               </tr>
-            ))}
+            ) : (
+              rows.map((entry) => (
+                <tr key={entry.id} className="border-t align-top">
+                  <td className="px-4 py-2 whitespace-nowrap">
+                    {new Date(entry.at).toLocaleString()}
+                  </td>
+                  <td className="px-4 py-2 whitespace-nowrap">{entry.actor}</td>
+                  <td className="px-4 py-2">
+                    <div className="font-medium">{entry.action}</div>
+                    {entry.payload ? (
+                      <pre className="mt-1 bg-muted/40 rounded p-2 text-[11px] whitespace-pre-wrap break-words">
+                        {JSON.stringify(entry.payload, null, 2)}
+                      </pre>
+                    ) : null}
+                  </td>
+                  <td className="px-4 py-2 font-mono text-[11px] break-all">{entry.prevHash || "∅"}</td>
+                  <td className="px-4 py-2 font-mono text-[11px] break-all">{entry.runningHash}</td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>
-      <button className="mt-4 bg-primary text-white p-2 rounded-md">Download Full Log</button>
+
+      <div className="rounded border border-gray-200 p-3 text-sm">
+        <div className="font-medium">Terminal running hash</div>
+        <div className="font-mono text-[11px] break-all">{bundle?.runningHash || "∅"}</div>
+      </div>
     </div>
   );
 }

--- a/src/types/tax.ts
+++ b/src/types/tax.ts
@@ -17,6 +17,7 @@ export type TaxReport = {
   totalPayable: number;
   discrepancies?: string[];
   complianceStatus: "OK" | "WARNING" | "ALERT";
+  periodId?: string;
 };
 
 export type BASHistory = {

--- a/tests/audit/hash_chain.test.ts
+++ b/tests/audit/hash_chain.test.ts
@@ -1,0 +1,65 @@
+import assert from "assert";
+import { computeEntryDigest, computeRunningDigest } from "../../src/audit/appendOnly";
+
+type Fixture = {
+  at: Date;
+  actor: string;
+  action: string;
+  payload: Record<string, unknown>;
+};
+
+const fixtures: Fixture[] = [
+  {
+    at: new Date("2025-05-01T08:00:00Z"),
+    actor: "rails",
+    action: "release",
+    payload: { abn: "123", taxType: "PAYGW", periodId: "2025-Q2", amountCents: -150000 },
+  },
+  {
+    at: new Date("2025-05-02T03:30:00Z"),
+    actor: "portal",
+    action: "download",
+    payload: { periodId: "2025-Q2", userId: "ops@example.com" },
+  },
+  {
+    at: new Date("2025-05-04T11:20:00Z"),
+    actor: "system",
+    action: "notify",
+    payload: { periodId: "2025-Q2", channel: "email", template: "lodgement-reminder" },
+  },
+];
+
+const digests = fixtures.map((entry) => computeEntryDigest(entry));
+
+digests.forEach((digest) => {
+  assert.strictEqual(digest.length, 64, "entry digest must be 64 hex characters");
+});
+
+let prevHash = "";
+const chain = digests.map((digest) => {
+  const running = computeRunningDigest(prevHash, digest);
+  const prev = prevHash;
+  prevHash = running;
+  return { digest, running, prev };
+});
+
+chain.forEach((link, index) => {
+  const expectedPrev = index === 0 ? "" : chain[index - 1].running;
+  assert.strictEqual(link.prev, expectedPrev, `link ${index} should reference previous running hash`);
+});
+
+const tamperedDigest = computeEntryDigest({
+  ...fixtures[1],
+  action: "download", // same action
+  payload: { periodId: "2025-Q2", userId: "threat@example.com" },
+});
+assert.notStrictEqual(tamperedDigest, chain[1].digest, "changing payload must change digest");
+
+const tamperedRunning = computeRunningDigest(chain[0].running, tamperedDigest);
+assert.notStrictEqual(
+  tamperedRunning,
+  chain[1].running,
+  "running hash should change when a link is tampered"
+);
+
+console.log("hash_chain.test.ts passed");


### PR DESCRIPTION
## Summary
- update the append-only audit writer to maintain a running hash and expose bundle retrieval helpers
- add `/audit/bundle/:period` API with JSON/ZIP export support and surface the log plus chain health in the UI
- wire compliance reports to trigger exports and add a regression test for the hash chain digest logic

## Testing
- npx tsx tests/audit/hash_chain.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e406c191f48327a99ac3d815fac30e