### PR TITLE
Implement ingestion-driven recon transitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
         "build": "echo build root",
         "typecheck": "echo typecheck root",
         "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+        "lint": "echo lint root",
+        "test": "tsx --test tests/**/*.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,5 +1,4 @@
 import React, { createContext, useState } from "react";
-import { mockPayroll, mockSales, mockBasHistory } from "../utils/mockData";
 import { BASHistory } from "../types/tax";
 
 export const AppContext = createContext<any>(null);
@@ -7,9 +6,9 @@ export const AppContext = createContext<any>(null);
 export function AppProvider({ children }: { children: React.ReactNode }) {
   const [vaultBalance, setVaultBalance] = useState(10000);
   const [businessBalance, setBusinessBalance] = useState(50000);
-  const [payroll, setPayroll] = useState(mockPayroll);
-  const [sales, setSales] = useState(mockSales);
-  const [basHistory, setBasHistory] = useState<BASHistory[]>(mockBasHistory);
+  const [payroll, setPayroll] = useState<{ employee: string; gross: number; withheld: number }[]>([]);
+  const [sales, setSales] = useState<{ id: string; amount: number; exempt: boolean }[]>([]);
+  const [basHistory, setBasHistory] = useState<BASHistory[]>([]);
   const [auditLog, setAuditLog] = useState<any[]>([]);
 
   return (

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import dotenv from "dotenv";
 
 import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
+import { ingestionApi } from "./routes/ingestion";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
 
@@ -25,7 +26,8 @@ app.post("/api/payto/sweep", paytoSweep);
 app.post("/api/settlement/webhook", settlementWebhook);
 app.get("/api/evidence", evidence);
 
-// ✅ Payments API first so it isn't shadowed by catch-alls in `api`
+// ✅ Payments and ingestion APIs first so they aren't shadowed by catch-alls in `api`
+app.use("/api", ingestionApi);
 app.use("/api", paymentsApi);
 
 // Existing API router(s) after

--- a/src/pages/Integrations.tsx
+++ b/src/pages/Integrations.tsx
@@ -1,9 +1,140 @@
-import React from "react";
+import React, { useCallback, useEffect, useState } from "react";
+
+type FeedStatus = {
+  feed: string;
+  total: number;
+  success: number;
+  failed: number;
+  lastEventAt?: string;
+};
+
+interface StatusResponse {
+  feeds?: FeedStatus[];
+  dlq?: { size?: number };
+}
+
+function formatTimestamp(iso?: string) {
+  if (!iso) return "—";
+  try {
+    const dt = new Date(iso);
+    if (Number.isNaN(dt.getTime())) return "—";
+    return dt.toLocaleString();
+  } catch {
+    return "—";
+  }
+}
 
 export default function Integrations() {
+  const [feeds, setFeeds] = useState<FeedStatus[]>([]);
+  const [dlqSize, setDlqSize] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [replayMessage, setReplayMessage] = useState<string | null>(null);
+  const [isReplaying, setIsReplaying] = useState(false);
+
+  const fetchStatus = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/ingest/status");
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data: StatusResponse = await res.json();
+      setFeeds(data.feeds ?? []);
+      setDlqSize(data.dlq?.size ?? 0);
+      setError(null);
+    } catch (err) {
+      setError((err as Error).message || "Unable to load statuses");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchStatus();
+  }, [fetchStatus]);
+
+  async function handleReplay() {
+    setIsReplaying(true);
+    setReplayMessage(null);
+    try {
+      const res = await fetch("/api/dlq/replay", { method: "POST" });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      const attempted = data?.summary?.attempted ?? 0;
+      const succeeded = data?.summary?.succeeded ?? 0;
+      setReplayMessage(`Replay attempted ${attempted} event(s); ${succeeded} succeeded.`);
+      await fetchStatus();
+    } catch (err) {
+      setReplayMessage(`Replay failed: ${(err as Error).message}`);
+    } finally {
+      setIsReplaying(false);
+    }
+  }
+
   return (
     <div className="main-card">
       <h1 style={{ color: "#00716b", fontWeight: 700, fontSize: 30, marginBottom: 28 }}>Integrations</h1>
+
+      <div className="card" style={{ marginBottom: 24 }}>
+        <h3 style={{ marginTop: 0 }}>Incoming feed status</h3>
+        <p style={{ color: "#444", marginBottom: 16 }}>
+          Live ingestion metrics reflect real events entering the platform. When feeds fail validation they move into the dead-letter queue (DLQ).
+        </p>
+        {loading ? (
+          <div>Loading feed status…</div>
+        ) : error ? (
+          <div style={{ color: "#b00020" }}>Unable to load feed status: {error}</div>
+        ) : (
+          <table style={{ width: "100%", borderCollapse: "collapse" }}>
+            <thead>
+              <tr style={{ textAlign: "left", borderBottom: "1px solid #e0e0e0" }}>
+                <th style={{ padding: "8px 4px" }}>Feed</th>
+                <th style={{ padding: "8px 4px" }}>Processed</th>
+                <th style={{ padding: "8px 4px" }}>Failed</th>
+                <th style={{ padding: "8px 4px" }}>Last event</th>
+              </tr>
+            </thead>
+            <tbody>
+              {feeds.map((feed) => (
+                <tr key={feed.feed} style={{ borderBottom: "1px solid #f2f2f2" }}>
+                  <td style={{ padding: "8px 4px", fontWeight: 600, textTransform: "capitalize" }}>{feed.feed}</td>
+                  <td style={{ padding: "8px 4px" }}>{feed.success}/{feed.total}</td>
+                  <td style={{ padding: "8px 4px", color: feed.failed ? "#b00020" : "#2e7d32" }}>{feed.failed}</td>
+                  <td style={{ padding: "8px 4px" }}>{formatTimestamp(feed.lastEventAt)}</td>
+                </tr>
+              ))}
+              {feeds.length === 0 && (
+                <tr>
+                  <td colSpan={4} style={{ padding: "12px 4px", color: "#666" }}>
+                    No feed activity yet.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        )}
+        <div style={{ marginTop: 16, display: "flex", alignItems: "center", gap: 12 }}>
+          <div>
+            DLQ items: <strong>{dlqSize}</strong>
+          </div>
+          <button
+            className="button"
+            disabled={isReplaying || dlqSize === 0}
+            onClick={handleReplay}
+          >
+            {isReplaying ? "Replaying…" : "Replay DLQ"}
+          </button>
+        </div>
+        {replayMessage && (
+          <div style={{ marginTop: 8, color: replayMessage.startsWith("Replay failed") ? "#b00020" : "#2e7d32" }}>
+            {replayMessage}
+          </div>
+        )}
+      </div>
+
       <h3>Connect to Providers</h3>
       <ul>
         <li>MYOB (Payroll) <button className="button" style={{ marginLeft: 12 }}>Connect</button></li>

--- a/src/recon/stateMachine.ts
+++ b/src/recon/stateMachine.ts
@@ -1,15 +1,53 @@
-﻿export type PeriodState = "OPEN"|"CLOSING"|"READY_RPT"|"BLOCKED_DISCREPANCY"|"BLOCKED_ANOMALY"|"RELEASED"|"FINALIZED";
-export interface Thresholds { epsilon_cents: number; variance_ratio: number; dup_rate: number; gap_minutes: number; }
+export type PeriodState =
+  | "OPEN"
+  | "CLOSING"
+  | "READY_RPT"
+  | "BLOCKED_DISCREPANCY"
+  | "BLOCKED_ANOMALY"
+  | "RELEASED"
+  | "FINALIZED";
 
-export function nextState(current: PeriodState, evt: string): PeriodState {
-  const t = ${current}:;
-  switch (t) {
-    case "OPEN:CLOSE": return "CLOSING";
-    case "CLOSING:PASS": return "READY_RPT";
-    case "CLOSING:FAIL_DISCREPANCY": return "BLOCKED_DISCREPANCY";
-    case "CLOSING:FAIL_ANOMALY": return "BLOCKED_ANOMALY";
-    case "READY_RPT:RELEASED": return "RELEASED";
-    case "RELEASED:FINALIZE": return "FINALIZED";
-    default: return current;
+export type GateEvent =
+  | "CLOSE"
+  | "PASS"
+  | "FAIL_DISCREPANCY"
+  | "FAIL_ANOMALY"
+  | "UNBLOCK"
+  | "RELEASE"
+  | "FINALIZE";
+
+export interface Thresholds {
+  epsilon_cents: number;
+  variance_ratio: number;
+  dup_rate: number;
+  gap_minutes: number;
+  delta_vs_baseline?: number;
+}
+
+/**
+ * Compute the next BAS gate state given the current state and a transition event.
+ * The implementation intentionally mirrors the state machine defined in the
+ * patent artefacts so the recon tests can assert on the same language used by
+ * the ops playbooks.
+ */
+export function nextState(current: PeriodState, event: GateEvent): PeriodState {
+  switch (current) {
+    case "OPEN":
+      return event === "CLOSE" ? "CLOSING" : current;
+    case "CLOSING":
+      if (event === "PASS") return "READY_RPT";
+      if (event === "FAIL_DISCREPANCY") return "BLOCKED_DISCREPANCY";
+      if (event === "FAIL_ANOMALY") return "BLOCKED_ANOMALY";
+      return current;
+    case "BLOCKED_DISCREPANCY":
+    case "BLOCKED_ANOMALY":
+      return event === "UNBLOCK" ? "CLOSING" : current;
+    case "READY_RPT":
+      return event === "RELEASE" ? "RELEASED" : current;
+    case "RELEASED":
+      return event === "FINALIZE" ? "FINALIZED" : current;
+    case "FINALIZED":
+    default:
+      return current;
   }
 }

--- a/src/recon/store.ts
+++ b/src/recon/store.ts
@@ -1,0 +1,311 @@
+import { GateEvent, PeriodState, nextState } from "./stateMachine";
+
+export type FeedType = "payroll" | "pos" | "bank";
+
+export interface IngestPayload {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  amountCents: number | string;
+  toleranceCents?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface PeriodSnapshot {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  state: PeriodState;
+  expectedCents: number;
+  actualCents: number;
+  deltaCents: number;
+  toleranceCents: number;
+  lastReason?: string;
+  lastGateEvent?: GateEvent;
+  updatedAt: string;
+}
+
+export interface ReconSummary {
+  event: GateEvent | null;
+  state: PeriodState;
+  deltaCents: number;
+  toleranceCents: number;
+}
+
+export interface IngestResult {
+  ok: boolean;
+  feed: FeedType;
+  period?: PeriodSnapshot;
+  recon?: ReconSummary | null;
+  error?: string;
+}
+
+export interface FeedStatus {
+  feed: FeedType;
+  total: number;
+  success: number;
+  failed: number;
+  lastEventAt?: string;
+}
+
+export interface DlqEntry {
+  id: string;
+  feed: FeedType;
+  payload: IngestPayload;
+  reason: string;
+  attempts: number;
+  failedAt: string;
+}
+
+export interface ReplaySummary {
+  attempted: number;
+  succeeded: number;
+  failed: number;
+  remaining: number;
+}
+
+export interface TransitionRequest {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  event: GateEvent;
+  reason?: string;
+}
+
+interface PeriodData {
+  abn: string;
+  taxType: string;
+  periodId: string;
+  state: PeriodState;
+  expectedCents: number;
+  actualCents: number;
+  toleranceCents: number;
+  lastDeltaCents: number;
+  lastReason?: string;
+  lastGateEvent?: GateEvent;
+  updatedAt: Date;
+}
+
+interface FeedCounters {
+  feed: FeedType;
+  total: number;
+  success: number;
+  failed: number;
+  lastEventAt?: Date;
+}
+
+const DEFAULT_TOLERANCE_CENTS = 500;
+
+const feedCounters: Record<FeedType, FeedCounters> = {
+  payroll: { feed: "payroll", total: 0, success: 0, failed: 0 },
+  pos: { feed: "pos", total: 0, success: 0, failed: 0 },
+  bank: { feed: "bank", total: 0, success: 0, failed: 0 },
+};
+
+const periods = new Map<string, PeriodData>();
+const dlq: DlqEntry[] = [];
+let dlqSeq = 0;
+
+function periodKey(payload: IngestPayload): string {
+  return `${payload.abn}::${payload.taxType}::${payload.periodId}`;
+}
+
+function toSnapshot(period: PeriodData): PeriodSnapshot {
+  return {
+    abn: period.abn,
+    taxType: period.taxType,
+    periodId: period.periodId,
+    state: period.state,
+    expectedCents: period.expectedCents,
+    actualCents: period.actualCents,
+    deltaCents: period.lastDeltaCents,
+    toleranceCents: period.toleranceCents,
+    lastReason: period.lastReason,
+    lastGateEvent: period.lastGateEvent,
+    updatedAt: period.updatedAt.toISOString(),
+  };
+}
+
+function ensurePeriod(payload: IngestPayload): PeriodData {
+  const key = periodKey(payload);
+  let existing = periods.get(key);
+  if (!existing) {
+    existing = {
+      abn: payload.abn,
+      taxType: payload.taxType,
+      periodId: payload.periodId,
+      state: "OPEN",
+      expectedCents: 0,
+      actualCents: 0,
+      toleranceCents: payload.toleranceCents ?? DEFAULT_TOLERANCE_CENTS,
+      lastDeltaCents: 0,
+      updatedAt: new Date(),
+    };
+    periods.set(key, existing);
+  }
+  if (typeof payload.toleranceCents === "number" && payload.toleranceCents >= 0) {
+    existing.toleranceCents = payload.toleranceCents;
+  }
+  return existing;
+}
+
+function applyGateEvent(period: PeriodData, event: GateEvent, reason?: string) {
+  const next = nextState(period.state, event);
+  if (next !== period.state) {
+    period.state = next;
+    period.lastGateEvent = event;
+  }
+  if (reason) {
+    period.lastReason = reason;
+  }
+  period.updatedAt = new Date();
+}
+
+function evaluatePeriod(period: PeriodData): ReconSummary | null {
+  if (period.expectedCents <= 0 || period.actualCents <= 0) {
+    return null;
+  }
+  const tolerance = period.toleranceCents ?? DEFAULT_TOLERANCE_CENTS;
+  const delta = Math.abs(period.expectedCents - period.actualCents);
+  period.lastDeltaCents = delta;
+  const withinTolerance = delta <= tolerance;
+  if (withinTolerance) {
+    applyGateEvent(period, "PASS", "within_tolerance");
+  } else {
+    applyGateEvent(period, "FAIL_DISCREPANCY", "delta_exceeds_tolerance");
+  }
+  return {
+    event: withinTolerance ? "PASS" : "FAIL_DISCREPANCY",
+    state: period.state,
+    deltaCents: delta,
+    toleranceCents: tolerance,
+  };
+}
+
+function processEvent(feed: FeedType, payload: IngestPayload): { ok: true; period: PeriodData; recon: ReconSummary | null } | { ok: false; error: string } {
+  const required = [payload.abn, payload.taxType, payload.periodId];
+  if (required.some((v) => typeof v !== "string" || v.trim() === "")) {
+    return { ok: false, error: "MISSING_FIELDS" };
+  }
+  const amount = Number(payload.amountCents);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    return { ok: false, error: "INVALID_AMOUNT" };
+  }
+
+  if (feed === "bank" && !periods.has(periodKey(payload))) {
+    return { ok: false, error: "UNKNOWN_PERIOD" };
+  }
+
+  const period = ensurePeriod(payload);
+  period.updatedAt = new Date();
+
+  if (period.state === "OPEN") {
+    applyGateEvent(period, "CLOSE");
+  }
+
+  if (feed === "bank") {
+    period.actualCents += Math.trunc(amount);
+  } else {
+    period.expectedCents += Math.trunc(amount);
+  }
+
+  const recon = evaluatePeriod(period);
+  return { ok: true, period, recon };
+}
+
+export function ingest(feed: FeedType, payload: IngestPayload, options: { replay?: boolean } = {}): IngestResult {
+  const counters = feedCounters[feed];
+  const now = new Date();
+  if (!options.replay) {
+    counters.total += 1;
+  }
+  const result = processEvent(feed, payload);
+  if (result.ok) {
+    counters.success += 1;
+    counters.lastEventAt = now;
+    return {
+      ok: true,
+      feed,
+      period: toSnapshot(result.period),
+      recon: result.recon,
+    };
+  }
+
+  if (!options.replay) {
+    counters.failed += 1;
+    counters.lastEventAt = now;
+    dlq.push({
+      id: `dlq_${++dlqSeq}`,
+      feed,
+      payload: { ...payload },
+      reason: result.error,
+      attempts: 1,
+      failedAt: now.toISOString(),
+    });
+  }
+
+  return { ok: false, feed, error: result.error };
+}
+
+export function replayDlq(): ReplaySummary {
+  if (!dlq.length) {
+    return { attempted: 0, succeeded: 0, failed: 0, remaining: 0 };
+  }
+  const pending = dlq.splice(0, dlq.length);
+  let succeeded = 0;
+  let failed = 0;
+  for (const entry of pending) {
+    const res = ingest(entry.feed, entry.payload, { replay: true });
+    if (res.ok) {
+      const counters = feedCounters[entry.feed];
+      counters.failed = Math.max(0, counters.failed - 1);
+      succeeded += 1;
+    } else {
+      entry.attempts += 1;
+      entry.reason = res.error || entry.reason;
+      failed += 1;
+      dlq.push(entry);
+    }
+  }
+  return { attempted: pending.length, succeeded, failed, remaining: dlq.length };
+}
+
+export function getFeedStatuses(): FeedStatus[] {
+  return Object.values(feedCounters).map((c) => ({
+    feed: c.feed,
+    total: c.total,
+    success: c.success,
+    failed: c.failed,
+    lastEventAt: c.lastEventAt ? c.lastEventAt.toISOString() : undefined,
+  }));
+}
+
+export function getPeriods(): PeriodSnapshot[] {
+  return Array.from(periods.values()).map(toSnapshot);
+}
+
+export function getDlq(): DlqEntry[] {
+  return dlq.map((entry) => ({ ...entry, payload: { ...entry.payload } }));
+}
+
+export function transitionGate(request: TransitionRequest): { ok: true; period: PeriodSnapshot } | { ok: false; error: string } {
+  const key = `${request.abn}::${request.taxType}::${request.periodId}`;
+  const period = periods.get(key);
+  if (!period) {
+    return { ok: false, error: "UNKNOWN_PERIOD" };
+  }
+  applyGateEvent(period, request.event, request.reason);
+  return { ok: true, period: toSnapshot(period) };
+}
+
+export function resetStore() {
+  for (const key of Object.keys(feedCounters) as FeedType[]) {
+    feedCounters[key].total = 0;
+    feedCounters[key].success = 0;
+    feedCounters[key].failed = 0;
+    feedCounters[key].lastEventAt = undefined;
+  }
+  periods.clear();
+  dlq.splice(0, dlq.length);
+  dlqSeq = 0;
+}

--- a/src/routes/ingestion.ts
+++ b/src/routes/ingestion.ts
@@ -1,0 +1,61 @@
+import { Router } from "express";
+import {
+  FeedType,
+  ingest,
+  getFeedStatuses,
+  getPeriods,
+  getDlq,
+  replayDlq,
+  transitionGate,
+  TransitionRequest,
+} from "../recon/store";
+
+const validFeeds: FeedType[] = ["payroll", "pos", "bank"];
+
+export const ingestionApi = Router();
+
+function asFeed(value: string | undefined): FeedType | null {
+  if (!value) return null;
+  return validFeeds.includes(value as FeedType) ? (value as FeedType) : null;
+}
+
+ingestionApi.post("/ingest/:feed", (req, res) => {
+  const feed = asFeed(String(req.params.feed || ""));
+  if (!feed) {
+    return res.status(404).json({ error: "UNKNOWN_FEED" });
+  }
+  const result = ingest(feed, req.body || {});
+  if (!result.ok) {
+    return res.status(400).json({ error: result.error });
+  }
+  return res.json({ ok: true, period: result.period, recon: result.recon });
+});
+
+ingestionApi.get("/ingest/status", (_req, res) => {
+  res.json({
+    feeds: getFeedStatuses(),
+    periods: getPeriods(),
+    dlq: { size: getDlq().length },
+  });
+});
+
+ingestionApi.get("/dlq", (_req, res) => {
+  res.json({ entries: getDlq() });
+});
+
+ingestionApi.post("/dlq/replay", (_req, res) => {
+  const summary = replayDlq();
+  res.json({ ok: true, summary });
+});
+
+ingestionApi.post("/gate/transition", (req, res) => {
+  const body = req.body as TransitionRequest;
+  if (!body?.abn || !body?.taxType || !body?.periodId || !body?.event) {
+    return res.status(400).json({ error: "MISSING_FIELDS" });
+  }
+  const result = transitionGate(body);
+  if (!result.ok) {
+    return res.status(404).json({ error: result.error });
+  }
+  res.json({ ok: true, period: result.period });
+});

--- a/tests/recon/flow.test.ts
+++ b/tests/recon/flow.test.ts
@@ -1,0 +1,96 @@
+import test, { describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  ingest,
+  getPeriods,
+  getDlq,
+  replayDlq,
+  resetStore,
+  getFeedStatuses,
+} from "../../src/recon/store";
+
+describe("recon flow", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  test("happy path transitions to READY_RPT when within tolerance", () => {
+    const payroll = ingest("payroll", {
+      abn: "123456789",
+      taxType: "PAYGW",
+      periodId: "2025-Q1",
+      amountCents: 10000,
+      toleranceCents: 500,
+    });
+    assert.equal(payroll.ok, true);
+
+    const bank = ingest("bank", {
+      abn: "123456789",
+      taxType: "PAYGW",
+      periodId: "2025-Q1",
+      amountCents: 10000,
+    });
+    assert.equal(bank.ok, true);
+    assert.equal(bank.recon?.event, "PASS");
+
+    const period = getPeriods().find((p) => p.periodId === "2025-Q1");
+    assert.ok(period);
+    assert.equal(period?.state, "READY_RPT");
+    assert.equal(period?.deltaCents, 0);
+
+    const payrollStatus = getFeedStatuses().find((s) => s.feed === "payroll");
+    assert.equal(payrollStatus?.success, 1);
+  });
+
+  test("fail path blocks the period when delta exceeds tolerance", () => {
+    ingest("payroll", {
+      abn: "123456789",
+      taxType: "PAYGW",
+      periodId: "2025-Q2",
+      amountCents: 10000,
+      toleranceCents: 400,
+    });
+
+    const bank = ingest("bank", {
+      abn: "123456789",
+      taxType: "PAYGW",
+      periodId: "2025-Q2",
+      amountCents: 9000,
+    });
+    assert.equal(bank.ok, true);
+    assert.equal(bank.recon?.event, "FAIL_DISCREPANCY");
+
+    const period = getPeriods().find((p) => p.periodId === "2025-Q2");
+    assert.ok(period);
+    assert.equal(period?.state, "BLOCKED_DISCREPANCY");
+    assert.equal(period?.deltaCents, 1000);
+  });
+
+  test("dlq replay reprocesses out-of-order bank events", () => {
+    const firstBank = ingest("bank", {
+      abn: "555555555",
+      taxType: "PAYGW",
+      periodId: "2025-Q3",
+      amountCents: 8500,
+    });
+    assert.equal(firstBank.ok, false);
+    assert.equal(getDlq().length, 1);
+
+    ingest("payroll", {
+      abn: "555555555",
+      taxType: "PAYGW",
+      periodId: "2025-Q3",
+      amountCents: 8500,
+    });
+
+    const summary = replayDlq();
+    assert.equal(summary.attempted, 1);
+    assert.equal(summary.succeeded, 1);
+    assert.equal(getDlq().length, 0);
+
+    const period = getPeriods().find((p) => p.periodId === "2025-Q3");
+    assert.ok(period);
+    assert.equal(period?.state, "READY_RPT");
+    assert.equal(period?.deltaCents, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- add an in-memory ingestion store that feeds recon deltas, DLQ replay, and gate transitions
- expose new ingestion, DLQ, and gate APIs and surface feed health with a replay button in Integrations
- remove mock data defaults and cover recon happy/fail flows with node:test coverage

## Testing
- npx tsx --test tests/recon/flow.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e406d1c06483279b5f5d55fe74bc07