### PR TITLE
Harden sensitive routes with JWT/MFA guards and secure logging

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const api = Router();

--- a/src/api/payments.ts
+++ b/src/api/payments.ts
@@ -1,6 +1,8 @@
 // src/api/payments.ts
 import express from "express";
 import { Payments } from "../../libs/paymentsClient"; // adjust if your libs path differs
+import { authenticate, requireRole } from "../http/auth";
+import { requireRealModeMfa } from "../security/guards";
 
 export const paymentsApi = express.Router();
 
@@ -50,7 +52,7 @@ paymentsApi.post("/deposit", async (req, res) => {
 });
 
 // POST /api/release  (calls payAto)
-paymentsApi.post("/release", async (req, res) => {
+paymentsApi.post("/release", authenticate, requireRole("admin", "accountant"), requireRealModeMfa, async (req, res) => {
   try {
     const { abn, taxType, periodId, amountCents } = req.body || {};
     if (!abn || !taxType || !periodId || typeof amountCents !== "number") {

--- a/src/api/payments/index.ts
+++ b/src/api/payments/index.ts
@@ -8,6 +8,8 @@ import { ledger } from "../../../apps/services/payments/src/routes/ledger.js";
 import { deposit } from "../../../apps/services/payments/src/routes/deposit.js";
 import { rptGate } from "../../../apps/services/payments/src/middleware/rptGate.js";
 import { payAtoRelease } from "../../../apps/services/payments/src/routes/payAto.js";
+import { authenticate, requireRole } from "../../http/auth";
+import { requireRealModeMfa } from "../../security/guards";
 
 export const paymentsApi = Router();
 
@@ -17,4 +19,11 @@ paymentsApi.get("/ledger", ledger);
 
 // write
 paymentsApi.post("/deposit", deposit);
-paymentsApi.post("/release", rptGate, payAtoRelease);
+paymentsApi.post(
+  "/release",
+  authenticate,
+  requireRole("admin", "accountant"),
+  requireRealModeMfa,
+  rptGate,
+  payAtoRelease
+);

--- a/src/http/auth.ts
+++ b/src/http/auth.ts
@@ -1,0 +1,158 @@
+import type { RequestHandler } from "express";
+import { createHmac } from "node:crypto";
+
+export type Role = "admin" | "accountant" | "auditor";
+
+type ModeClaim = "sandbox" | "real";
+
+type ExpiresIn = string | number;
+
+export interface AuthClaims {
+  sub: string;
+  role: Role;
+  mfa?: boolean;
+  mode?: ModeClaim;
+  iat?: number;
+  exp?: number;
+  [key: string]: unknown;
+}
+
+declare global {
+  namespace Express {
+    interface Request {
+      auth?: AuthClaims;
+    }
+  }
+}
+
+function requireSecret(): string {
+  const secret = process.env.AUTH_JWT_SECRET;
+  if (!secret) {
+    throw new Error("AUTH_JWT_SECRET must be configured");
+  }
+  return secret;
+}
+
+function base64url(input: Buffer | string): string {
+  return Buffer.from(input)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+}
+
+function parseBase64url(str: string): Buffer {
+  const pad = str.length % 4;
+  const normalized = pad ? str + "====".slice(pad) : str;
+  const base64 = normalized.replace(/-/g, "+").replace(/_/g, "/");
+  return Buffer.from(base64, "base64");
+}
+
+function parseExpiry(expiresIn: ExpiresIn, issuedAt: number): number | undefined {
+  if (expiresIn === undefined || expiresIn === null) {
+    return undefined;
+  }
+  if (typeof expiresIn === "number") {
+    return issuedAt + expiresIn;
+  }
+  const match = /^([0-9]+)([smhd])$/.exec(expiresIn);
+  if (!match) {
+    return undefined;
+  }
+  const value = Number(match[1]);
+  const unit = match[2];
+  const secondsMap: Record<string, number> = { s: 1, m: 60, h: 3600, d: 86400 };
+  return issuedAt + value * (secondsMap[unit] || 0);
+}
+
+function sign(data: string, secret: string): string {
+  return base64url(createHmac("sha256", secret).update(data).digest());
+}
+
+function verifySignature(data: string, signature: string, secret: string): boolean {
+  const expected = sign(data, secret);
+  return expected === signature;
+}
+
+function decodeTokenString(token: string): AuthClaims {
+  const secret = requireSecret();
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new Error("UNAUTHENTICATED");
+  }
+  const [headerPart, payloadPart, signaturePart] = parts;
+  if (!verifySignature(`${headerPart}.${payloadPart}`, signaturePart, secret)) {
+    throw new Error("UNAUTHENTICATED");
+  }
+  const payload = JSON.parse(parseBase64url(payloadPart).toString("utf8"));
+  const now = Math.floor(Date.now() / 1000);
+  if (payload.exp && now >= payload.exp) {
+    throw new Error("UNAUTHENTICATED");
+  }
+  if (!payload.sub || !payload.role) {
+    throw new Error("UNAUTHENTICATED");
+  }
+  return payload as AuthClaims;
+}
+
+function parseToken(header?: string): AuthClaims {
+  if (!header || !header.startsWith("Bearer ")) {
+    throw new Error("UNAUTHENTICATED");
+  }
+  const token = header.slice("Bearer ".length);
+  return decodeTokenString(token);
+}
+
+export const authenticate: RequestHandler = (req, res, next) => {
+  try {
+    req.auth = parseToken(req.headers.authorization);
+    next();
+  } catch (err) {
+    res.status(401).json({ error: "UNAUTHENTICATED" });
+  }
+};
+
+export const requireRole = (...roles: Role[]): RequestHandler => (req, res, next) => {
+  if (!req.auth) {
+    return res.status(401).json({ error: "UNAUTHENTICATED" });
+  }
+  if (!roles.includes(req.auth.role)) {
+    return res.status(403).json({ error: "FORBIDDEN" });
+  }
+  return next();
+};
+
+export const requireMfa: RequestHandler = (req, res, next) => {
+  if (!req.auth) {
+    return res.status(401).json({ error: "UNAUTHENTICATED" });
+  }
+  if (!req.auth.mfa) {
+    return res.status(403).json({ error: "MFA_REQUIRED" });
+  }
+  return next();
+};
+
+export function signJwt(claims: AuthClaims, expiresIn: ExpiresIn = "15m"): string {
+  const secret = requireSecret();
+  const header = {
+    alg: "HS256",
+    typ: "JWT",
+  };
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload: AuthClaims = {
+    ...claims,
+    iat: issuedAt,
+  };
+  const exp = parseExpiry(expiresIn, issuedAt);
+  if (exp) {
+    payload.exp = exp;
+  }
+  const headerPart = base64url(JSON.stringify(header));
+  const payloadPart = base64url(JSON.stringify(payload));
+  const signaturePart = sign(`${headerPart}.${payloadPart}`, secret);
+  return `${headerPart}.${payloadPart}.${signaturePart}`;
+}
+
+export function decodeJwt(token: string): AuthClaims {
+  return decodeTokenString(token);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,24 +6,72 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { httpLogger } from "./ops/logger";
+import { securityHeaders } from "./ops/headers";
+import { authenticate, requireRole } from "./http/auth";
+import { requireRealModeMfa } from "./security/guards";
+import { getMode, setMode } from "./security/mode";
 
 dotenv.config();
 
-const app = express();
-app.use(express.json({ limit: "2mb" }));
+export const app = express();
 
-// (optional) quick request logger
-app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
+app.use(httpLogger);
+for (const middleware of securityHeaders) {
+  app.use(middleware);
+}
+app.use(express.json({ limit: "2mb" }));
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
 
+// Admin mode controls
+app.get("/admin/mode", authenticate, requireRole("admin"), (_req, res) => {
+  res.json({ mode: getMode() });
+});
+
+app.post("/admin/mode", authenticate, requireRole("admin"), (req, res) => {
+  const mode = req.body?.mode;
+  if (mode !== "sandbox" && mode !== "real") {
+    return res.status(400).json({ error: "INVALID_MODE" });
+  }
+  if (mode === "real" && !req.auth?.mfa) {
+    return res.status(403).json({ error: "MFA_REQUIRED" });
+  }
+  res.json({ mode: setMode(mode) });
+});
+
 // Existing explicit endpoints
-app.post("/api/pay", idempotency(), payAto);
-app.post("/api/close-issue", closeAndIssue);
-app.post("/api/payto/sweep", paytoSweep);
-app.post("/api/settlement/webhook", settlementWebhook);
-app.get("/api/evidence", evidence);
+app.post(
+  "/api/pay",
+  authenticate,
+  requireRole("admin", "accountant"),
+  requireRealModeMfa,
+  idempotency(),
+  payAto
+);
+app.post(
+  "/api/close-issue",
+  authenticate,
+  requireRole("admin", "accountant"),
+  requireRealModeMfa,
+  closeAndIssue
+);
+app.post(
+  "/api/payto/sweep",
+  authenticate,
+  requireRole("admin", "accountant"),
+  requireRealModeMfa,
+  paytoSweep
+);
+app.post(
+  "/api/settlement/webhook",
+  authenticate,
+  requireRole("admin", "accountant"),
+  requireRealModeMfa,
+  settlementWebhook
+);
+app.get("/api/evidence", authenticate, requireRole("admin", "accountant", "auditor"), evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
@@ -35,4 +83,10 @@ app.use("/api", api);
 app.use((_req, res) => res.status(404).send("Not found"));
 
 const port = Number(process.env.PORT) || 3000;
-app.listen(port, () => console.log("APGMS server listening on", port));
+const envName = (process.env.NODE_ENV || "").toLowerCase().trim();
+const skipListenFlag = (process.env.SKIP_LISTEN || "").toLowerCase().trim();
+const shouldListen = envName !== "test" && skipListenFlag !== "true";
+
+if (shouldListen) {
+  app.listen(port, () => console.log("APGMS server listening on", port));
+}

--- a/src/ops/headers.ts
+++ b/src/ops/headers.ts
@@ -1,0 +1,104 @@
+import type { RequestHandler } from "express";
+
+type AllowCheck = (origin: string | undefined) => boolean;
+
+function buildCorsAllowList(): string[] {
+  const raw = process.env.CORS_ALLOW_ORIGINS || process.env.CORS_ALLOWLIST || "";
+  return raw.split(",").map((origin) => origin.trim()).filter(Boolean);
+}
+
+const allowList = buildCorsAllowList();
+
+function helmetMiddleware(): RequestHandler {
+  return (_req, res, next) => {
+    res.setHeader("X-DNS-Prefetch-Control", "off");
+    res.setHeader("X-Frame-Options", "SAMEORIGIN");
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Referrer-Policy", "no-referrer");
+    res.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+    next();
+  };
+}
+
+function makeAllowCheck(list: string[]): AllowCheck {
+  if (list.length === 0) {
+    return () => true;
+  }
+  return (origin) => {
+    if (!origin) return true;
+    return list.includes(origin);
+  };
+}
+
+function corsMiddleware(list: string[]): RequestHandler {
+  const isAllowed = makeAllowCheck(list);
+  return (req, res, next) => {
+    const origin = req.headers.origin as string | undefined;
+    const allowed = isAllowed(origin);
+    if (allowed && origin) {
+      res.setHeader("Access-Control-Allow-Origin", origin);
+      res.setHeader("Vary", "Origin");
+    }
+    if (allowed) {
+      res.setHeader("Access-Control-Allow-Credentials", "true");
+    }
+    if (req.method === "OPTIONS") {
+      if (!allowed) {
+        res.status(403).end();
+        return;
+      }
+      const methods = req.headers["access-control-request-method"] as string | undefined;
+      if (methods) {
+        res.setHeader("Access-Control-Allow-Methods", methods);
+      }
+      const reqHeaders = req.headers["access-control-request-headers"] as string | undefined;
+      if (reqHeaders) {
+        res.setHeader("Access-Control-Allow-Headers", reqHeaders);
+      }
+      res.status(204).end();
+      return;
+    }
+    if (!allowed) {
+      res.status(403).json({ error: "CORS_DENIED" });
+      return;
+    }
+    next();
+  };
+}
+
+function rateLimiter(windowMs: number, limit: number): RequestHandler {
+  const hits = new Map<string, { count: number; resetAt: number }>();
+
+  return (req, res, next) => {
+    const key = (req.ip || req.socket.remoteAddress || "global") as string;
+    const now = Date.now();
+    const existing = hits.get(key);
+    if (!existing || existing.resetAt <= now) {
+      hits.set(key, { count: 1, resetAt: now + windowMs });
+    } else {
+      existing.count += 1;
+      hits.set(key, existing);
+    }
+
+    const entry = hits.get(key)!;
+    const remaining = Math.max(limit - entry.count, 0);
+    const resetSeconds = Math.max(Math.ceil((entry.resetAt - now) / 1000), 0);
+
+    res.setHeader("RateLimit-Limit", String(limit));
+    res.setHeader("RateLimit-Remaining", String(remaining));
+    res.setHeader("RateLimit-Reset", String(resetSeconds));
+
+    if (entry.count > limit) {
+      res.status(429).json({ error: "RATE_LIMITED" });
+      return;
+    }
+
+    next();
+  };
+}
+
+export const securityHeaders: RequestHandler[] = [
+  helmetMiddleware(),
+  corsMiddleware(allowList),
+  rateLimiter(60_000, 120),
+];

--- a/src/ops/logger.ts
+++ b/src/ops/logger.ts
@@ -1,0 +1,77 @@
+import { randomUUID } from "node:crypto";
+import type { RequestHandler } from "express";
+
+const REDACT_KEYS = new Set([
+  "abn",
+  "account",
+  "accountnumber",
+  "account_reference",
+  "accountref",
+  "crn",
+  "customerreference",
+]);
+
+function scrub(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => scrub(entry));
+  }
+  if (value && typeof value === "object") {
+    const output: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value as Record<string, unknown>)) {
+      if (REDACT_KEYS.has(key.toLowerCase())) {
+        output[key] = "[REDACTED]";
+      } else {
+        output[key] = scrub(entry);
+      }
+    }
+    return output;
+  }
+  return value;
+}
+
+function levelFor(statusCode: number, error?: Error | null): "error" | "warn" | "info" {
+  if (error) return "error";
+  if (statusCode >= 500) return "error";
+  if (statusCode >= 400) return "warn";
+  return "info";
+}
+
+export const httpLogger: RequestHandler = (req, res, next) => {
+  const start = Date.now();
+  const incomingId = req.headers["x-request-id"];
+  const reqId = typeof incomingId === "string" && incomingId ? incomingId : randomUUID();
+  res.setHeader("x-request-id", reqId);
+
+  const logEntry = {
+    service: "apgms",
+    req: {
+      id: reqId,
+      method: req.method,
+      url: req.url,
+      query: scrub(req.query),
+      body: scrub(req.body),
+    },
+  };
+
+  res.on("finish", () => {
+    const duration = Date.now() - start;
+    const level = levelFor(res.statusCode, undefined);
+    const output = {
+      ...logEntry,
+      level,
+      res: {
+        statusCode: res.statusCode,
+      },
+      durationMs: duration,
+    };
+    if (level === "error") {
+      console.error(output);
+    } else if (level === "warn") {
+      console.warn(output);
+    } else {
+      console.log(output);
+    }
+  });
+
+  next();
+};

--- a/src/security/guards.ts
+++ b/src/security/guards.ts
@@ -1,0 +1,9 @@
+import type { RequestHandler } from "express";
+import { getMode } from "./mode";
+
+export const requireRealModeMfa: RequestHandler = (req, res, next) => {
+  if (getMode() === "real" && !req.auth?.mfa) {
+    return res.status(403).json({ error: "MFA_REQUIRED" });
+  }
+  return next();
+};

--- a/src/security/mfa.ts
+++ b/src/security/mfa.ts
@@ -1,0 +1,96 @@
+import { createHmac, randomBytes } from "node:crypto";
+import { AuthClaims, signJwt } from "../http/auth";
+
+export interface TotpSetup {
+  secret: string;
+  uri: string;
+}
+
+const BASE32_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+
+function toBase32(buffer: Buffer): string {
+  let bits = 0;
+  let value = 0;
+  let output = "";
+
+  for (const byte of buffer) {
+    value = (value << 8) | byte;
+    bits += 8;
+    while (bits >= 5) {
+      output += BASE32_ALPHABET[(value >>> (bits - 5)) & 31];
+      bits -= 5;
+    }
+  }
+  if (bits > 0) {
+    output += BASE32_ALPHABET[(value << (5 - bits)) & 31];
+  }
+  return output;
+}
+
+function fromBase32(secret: string): Buffer {
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+
+  for (const char of secret.toUpperCase().replace(/=+$/, "")) {
+    const idx = BASE32_ALPHABET.indexOf(char);
+    if (idx === -1) {
+      continue;
+    }
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(output);
+}
+
+function generateOtp(secret: Buffer, counter: number, digits = 6): string {
+  const buffer = Buffer.alloc(8);
+  for (let i = 7; i >= 0; i--) {
+    buffer[i] = counter & 0xff;
+    counter = Math.floor(counter / 256);
+  }
+  const digest = createHmac("sha1", secret).update(buffer).digest();
+  const offset = digest[digest.length - 1] & 0xf;
+  const code =
+    ((digest[offset] & 0x7f) << 24) |
+    ((digest[offset + 1] & 0xff) << 16) |
+    ((digest[offset + 2] & 0xff) << 8) |
+    (digest[offset + 3] & 0xff);
+  const otp = (code % 10 ** digits).toString().padStart(digits, "0");
+  return otp;
+}
+
+export function createTotpSecret(userId: string, issuer = "APGMS"): TotpSetup {
+  const secretBytes = randomBytes(20);
+  const secret = toBase32(secretBytes);
+  const label = encodeURIComponent(`${issuer}:${userId}`);
+  const uri = `otpauth://totp/${label}?secret=${secret}&issuer=${encodeURIComponent(issuer)}`;
+  return { secret, uri };
+}
+
+export function verifyTotp(token: string, secret: string): boolean {
+  if (!token || !secret) {
+    return false;
+  }
+  const key = fromBase32(secret);
+  const now = Math.floor(Date.now() / 1000);
+  const counter = Math.floor(now / 30);
+  for (let offset = -1; offset <= 1; offset += 1) {
+    const candidate = generateOtp(key, counter + offset);
+    if (candidate === token) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function issueStepUpToken(claims: AuthClaims, token: string, secret: string, expiresIn = "10m"): string {
+  if (!verifyTotp(token, secret)) {
+    throw new Error("INVALID_TOTP");
+  }
+  return signJwt({ ...claims, mfa: true }, expiresIn);
+}

--- a/src/security/mode.ts
+++ b/src/security/mode.ts
@@ -1,0 +1,12 @@
+export type RuntimeMode = "sandbox" | "real";
+
+let currentMode: RuntimeMode = process.env.APP_MODE === "real" ? "real" : "sandbox";
+
+export function getMode(): RuntimeMode {
+  return currentMode;
+}
+
+export function setMode(mode: RuntimeMode): RuntimeMode {
+  currentMode = mode;
+  return currentMode;
+}

--- a/tests/security/guards.test.ts
+++ b/tests/security/guards.test.ts
@@ -1,0 +1,133 @@
+process.env.NODE_ENV = "test";
+process.env.SKIP_LISTEN = "true";
+process.env.AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET || "test-secret";
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+type AuthClaims = import("../../src/http/auth").AuthClaims;
+type ExpressApp = import("express").Express;
+
+let app: ExpressApp;
+let signJwtFn: (claims: AuthClaims, expiresIn?: string | number) => string;
+let adminMfaToken: string;
+
+type HttpMethod = "GET" | "POST" | "PUT" | "DELETE";
+
+let server: Server;
+let baseUrl: string;
+
+test.before(async () => {
+  ({ app } = await import("../../src/index"));
+  ({ signJwt: signJwtFn } = await import("../../src/http/auth"));
+
+  server = createServer(app);
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const address = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${address.port}`;
+
+  adminMfaToken = signJwtFn({ sub: "admin-step", role: "admin", mfa: true } as AuthClaims, "5m");
+  await httpRequest("POST", "/admin/mode", { mode: "sandbox" }, {
+    Authorization: `Bearer ${adminMfaToken}`,
+  });
+});
+
+test.after(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+test.beforeEach(async () => {
+  await httpRequest("POST", "/admin/mode", { mode: "sandbox" }, {
+    Authorization: `Bearer ${adminMfaToken}`,
+  });
+});
+
+async function httpRequest(method: HttpMethod, path: string, body?: unknown, headers: Record<string, string> = {}) {
+  const init: RequestInit = {
+    method,
+    headers: { ...headers },
+  };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "content-type": "application/json", ...headers };
+  }
+  const res = await fetch(`${baseUrl}${path}`, init);
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = {};
+  }
+  const headerObj: Record<string, string> = {};
+  res.headers.forEach((value, key) => {
+    headerObj[key.toLowerCase()] = value;
+  });
+  return { status: res.status, body: json, headers: headerObj };
+}
+
+test("helmet and logger headers are applied", async () => {
+  const res = await httpRequest("GET", "/health");
+  assert.equal(res.status, 200);
+  assert.ok(res.headers["x-dns-prefetch-control"], "helmet header missing");
+  assert.ok(res.headers["x-request-id"], "request id header missing");
+});
+
+test("release rejects missing authentication", async () => {
+  const res = await httpRequest("POST", "/api/release", {});
+  assert.equal(res.status, 401);
+  assert.equal(res.body.error, "UNAUTHENTICATED");
+});
+
+test("release blocks unauthorized roles", async () => {
+  const token = signJwtFn({ sub: "auditor-1", role: "auditor" } as AuthClaims, "5m");
+  const res = await httpRequest("POST", "/api/release", {}, {
+    Authorization: `Bearer ${token}`,
+  });
+  assert.equal(res.status, 403);
+  assert.equal(res.body.error, "FORBIDDEN");
+});
+
+test("release requires MFA in real mode", async () => {
+  await httpRequest("POST", "/admin/mode", { mode: "real" }, {
+    Authorization: `Bearer ${adminMfaToken}`,
+  });
+  const token = signJwtFn({ sub: "acct-1", role: "accountant" } as AuthClaims, "5m");
+  const res = await httpRequest("POST", "/api/release", {}, {
+    Authorization: `Bearer ${token}`,
+  });
+  assert.equal(res.status, 403);
+  assert.equal(res.body.error, "MFA_REQUIRED");
+});
+
+test("release allows step-up token in real mode", async () => {
+  await httpRequest("POST", "/admin/mode", { mode: "real" }, {
+    Authorization: `Bearer ${adminMfaToken}`,
+  });
+  const token = signJwtFn({ sub: "acct-2", role: "accountant", mfa: true } as AuthClaims, "5m");
+  const res = await httpRequest("POST", "/api/release", {}, {
+    Authorization: `Bearer ${token}`,
+  });
+  assert.equal(res.status, 400);
+  assert.equal(res.body.error, "Missing fields");
+});
+
+test("admin mode transition to real requires MFA", async () => {
+  const token = signJwtFn({ sub: "admin-1", role: "admin" } as AuthClaims, "5m");
+  const res = await httpRequest("POST", "/admin/mode", { mode: "real" }, {
+    Authorization: `Bearer ${token}`,
+  });
+  assert.equal(res.status, 403);
+  assert.equal(res.body.error, "MFA_REQUIRED");
+});
+
+test("admin can view mode", async () => {
+  const token = signJwtFn({ sub: "admin-2", role: "admin", mfa: true } as AuthClaims, "5m");
+  const res = await httpRequest("GET", "/admin/mode", undefined, {
+    Authorization: `Bearer ${token}`,
+  });
+  assert.equal(res.status, 200);
+  assert.equal(res.body.mode, "sandbox");
+});


### PR DESCRIPTION
## Summary
- add JWT authentication helpers and real-mode MFA guard used across payment, period, and admin mode routes
- introduce security middleware for headers, CORS allow-listing, rate limiting, and redacted request logging with request IDs
- cover release/admin flows with integration tests verifying authentication, MFA enforcement, and security headers

## Testing
- `npx tsx --test tests/security/guards.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68e406c9a94c8327b0e4aefbe4d7cdee