### PR TITLE
Compute dashboard alerts from database data

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 // src/App.tsx
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AppLayout from "./components/AppLayout";
 
 import Dashboard from "./pages/Dashboard";
@@ -12,21 +13,25 @@ import Fraud from "./pages/Fraud";
 import Integrations from "./pages/Integrations";
 import Help from "./pages/Help";
 
+const queryClient = new QueryClient();
+
 export default function App() {
   return (
-    <Router>
-      <Routes>
-        <Route element={<AppLayout />}>
-          <Route path="/" element={<Dashboard />} />
-          <Route path="/bas" element={<BAS />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/wizard" element={<Wizard />} />
-          <Route path="/audit" element={<Audit />} />
-          <Route path="/fraud" element={<Fraud />} />
-          <Route path="/integrations" element={<Integrations />} />
-          <Route path="/help" element={<Help />} />
-        </Route>
-      </Routes>
-    </Router>
+    <QueryClientProvider client={queryClient}>
+      <Router>
+        <Routes>
+          <Route element={<AppLayout />}>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/bas" element={<BAS />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/wizard" element={<Wizard />} />
+            <Route path="/audit" element={<Audit />} />
+            <Route path="/fraud" element={<Fraud />} />
+            <Route path="/integrations" element={<Integrations />} />
+            <Route path="/help" element={<Help />} />
+          </Route>
+        </Routes>
+      </Router>
+    </QueryClientProvider>
   );
 }

--- a/src/alerts/engine.ts
+++ b/src/alerts/engine.ts
@@ -1,0 +1,351 @@
+// src/alerts/engine.ts
+import { isAnomalous, Thresholds as ReconThresholds } from "../anomaly/deterministic";
+import type { AlertCode, AlertSeverity, DashboardAlert } from "./types";
+
+export interface Queryable {
+  query<T = any>(text: string, params?: any[]): Promise<{ rows: T[] }>;
+}
+
+interface PeriodRow {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  final_liability_cents: number | string | null;
+  credited_to_owa_cents: number | string | null;
+  anomaly_vector: Record<string, number> | null;
+  thresholds: ReconThresholds | null;
+}
+
+interface PeriodEventRow {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  event_type: string;
+  event_at: string | Date;
+}
+
+interface StoredAlertRow {
+  id: number;
+  abn: string;
+  tax_type: string | null;
+  period_id: string | null;
+  code: AlertCode;
+  message: string;
+  severity: AlertSeverity;
+  details: any;
+  detected_at: string;
+  acknowledged_at: string | null;
+  resolved_at: string | null;
+}
+
+interface AlertCandidate {
+  code: AlertCode;
+  message: string;
+  severity: AlertSeverity;
+  periodId: string | null;
+  taxType: string | null;
+  details?: Record<string, unknown>;
+}
+
+const ACTIVE_INDEX_SQL = `
+CREATE UNIQUE INDEX IF NOT EXISTS ux_dashboard_alerts_active
+  ON dashboard_alerts (abn, COALESCE(tax_type, ''), COALESCE(period_id, ''), code)
+  WHERE resolved_at IS NULL;
+`;
+
+const VISIBLE_INDEX_SQL = `
+CREATE INDEX IF NOT EXISTS idx_dashboard_alerts_visible
+  ON dashboard_alerts (abn)
+  WHERE resolved_at IS NULL AND acknowledged_at IS NULL;
+`;
+
+function normalizeCents(value: number | string | null | undefined): number {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === "number") return value;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function toDate(value: string | Date | null | undefined): Date | null {
+  if (!value) return null;
+  if (value instanceof Date) return value;
+  const ts = Date.parse(value);
+  return Number.isNaN(ts) ? null : new Date(ts);
+}
+
+function formatCurrency(cents: number): string {
+  const dollars = cents / 100;
+  return dollars.toLocaleString("en-AU", { style: "currency", currency: "AUD" });
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString("en-AU", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+export async function ensureAlertsSchema(db: Queryable): Promise<void> {
+  await db.query(`
+    CREATE TABLE IF NOT EXISTS dashboard_alerts (
+      id              BIGSERIAL PRIMARY KEY,
+      abn             TEXT        NOT NULL,
+      tax_type        TEXT,
+      period_id       TEXT,
+      code            TEXT        NOT NULL,
+      message         TEXT        NOT NULL,
+      severity        TEXT        NOT NULL DEFAULT 'warning',
+      detected_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+      details         JSONB       NOT NULL DEFAULT '{}'::jsonb,
+      acknowledged_at TIMESTAMPTZ,
+      resolved_at     TIMESTAMPTZ
+    );
+  `);
+  await db.query(ACTIVE_INDEX_SQL);
+  await db.query(VISIBLE_INDEX_SQL);
+}
+
+async function fetchPeriods(db: Queryable, abn: string): Promise<PeriodRow[]> {
+  const { rows } = await db.query<PeriodRow>(
+    `SELECT abn, tax_type, period_id, state, final_liability_cents, credited_to_owa_cents, anomaly_vector, thresholds
+     FROM periods
+     WHERE abn=$1`,
+    [abn]
+  );
+  return rows;
+}
+
+async function fetchEvents(db: Queryable, abn: string): Promise<PeriodEventRow[]> {
+  try {
+    const { rows } = await db.query<PeriodEventRow>(
+      `SELECT abn, tax_type, period_id, event_type, event_at
+       FROM period_events
+       WHERE abn=$1`,
+      [abn]
+    );
+    return rows;
+  } catch (err: any) {
+    if (err?.code === "42P01") {
+      // period_events table missing; treat as no events
+      return [];
+    }
+    throw err;
+  }
+}
+
+function groupEvents(rows: PeriodEventRow[]) {
+  const map = new Map<string, { dueAt: Date | null; lodgedAt: Date | null }>();
+  for (const row of rows) {
+    const key = `${row.tax_type}::${row.period_id}`;
+    let entry = map.get(key);
+    if (!entry) {
+      entry = { dueAt: null, lodgedAt: null };
+      map.set(key, entry);
+    }
+    const when = toDate(row.event_at);
+    if (!when) continue;
+    if (row.event_type === "BAS_DUE") {
+      if (!entry.dueAt || entry.dueAt < when) entry.dueAt = when;
+    } else if (row.event_type === "BAS_LODGED") {
+      if (!entry.lodgedAt || entry.lodgedAt < when) entry.lodgedAt = when;
+    }
+  }
+  return map;
+}
+
+function buildAlertCandidates(
+  periods: PeriodRow[],
+  eventMap: Map<string, { dueAt: Date | null; lodgedAt: Date | null }>,
+  now: Date
+): AlertCandidate[] {
+  const out: AlertCandidate[] = [];
+  for (const period of periods) {
+    const key = `${period.tax_type}::${period.period_id}`;
+    const events = eventMap.get(key) ?? { dueAt: null, lodgedAt: null };
+    const dueAt = events.dueAt;
+    const lodgedAt = events.lodgedAt;
+    const state = period.state ?? "";
+    const finalLiability = normalizeCents(period.final_liability_cents);
+    const credited = normalizeCents(period.credited_to_owa_cents);
+
+    if (
+      dueAt &&
+      dueAt.getTime() <= now.getTime() &&
+      (!lodgedAt || lodgedAt.getTime() < dueAt.getTime()) &&
+      state !== "FINALIZED" &&
+      state !== "RELEASED"
+    ) {
+      out.push({
+        code: "OVERDUE_BAS",
+        severity: "critical",
+        periodId: period.period_id,
+        taxType: period.tax_type,
+        message: `BAS for ${period.period_id} is overdue since ${formatDate(dueAt)}.`,
+        details: {
+          dueDate: dueAt.toISOString(),
+          lodgedAt: lodgedAt ? lodgedAt.toISOString() : null,
+          state,
+        },
+      });
+    }
+
+    if (finalLiability > 0 && credited < finalLiability) {
+      const shortfall = finalLiability - credited;
+      out.push({
+        code: "OWA_SHORTFALL",
+        severity: "critical",
+        periodId: period.period_id,
+        taxType: period.tax_type,
+        message: `OWA balance is short by ${formatCurrency(shortfall)} for ${period.period_id}.`,
+        details: {
+          finalLiabilityCents: finalLiability,
+          creditedCents: credited,
+          shortfallCents: shortfall,
+        },
+      });
+    }
+
+    const vector = period.anomaly_vector ?? undefined;
+    if (vector) {
+      const thresholds = period.thresholds ?? {};
+      if (isAnomalous(vector as any, thresholds)) {
+        out.push({
+          code: "RECON_ANOMALY",
+          severity: "warning",
+          periodId: period.period_id,
+          taxType: period.tax_type,
+          message: `Reconciliation anomaly detected for ${period.period_id}.`,
+          details: {
+            anomalyVector: vector,
+            thresholds,
+          },
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function alertKey(alert: { code: AlertCode; taxType: string | null; periodId: string | null }): string {
+  return `${alert.taxType ?? ""}::${alert.periodId ?? ""}::${alert.code}`;
+}
+
+function normalizeDetails(details: any): Record<string, unknown> {
+  if (!details) return {};
+  if (typeof details === "string") {
+    try {
+      return JSON.parse(details);
+    } catch {
+      return {};
+    }
+  }
+  return details;
+}
+
+export async function refreshAlerts({ pool, abn, now = new Date() }: { pool: Queryable; abn: string; now?: Date }): Promise<void> {
+  await ensureAlertsSchema(pool);
+  const [periods, events] = await Promise.all([fetchPeriods(pool, abn), fetchEvents(pool, abn)]);
+  const eventMap = groupEvents(events);
+  const desired = buildAlertCandidates(periods, eventMap, now);
+
+  const existingRes = await pool.query<StoredAlertRow>(
+    `SELECT id, abn, tax_type, period_id, code, message, severity, details, detected_at, acknowledged_at, resolved_at
+     FROM dashboard_alerts
+     WHERE abn=$1 AND resolved_at IS NULL`,
+    [abn]
+  );
+  const existingMap = new Map<string, StoredAlertRow>();
+  for (const row of existingRes.rows) {
+    existingMap.set(alertKey(row), { ...row, details: normalizeDetails(row.details) });
+  }
+
+  for (const candidate of desired) {
+    const key = alertKey(candidate);
+    const current = existingMap.get(key);
+    if (current) {
+      const desiredDetails = candidate.details ?? {};
+      const existingDetails = normalizeDetails(current.details);
+      const detailsChanged = JSON.stringify(existingDetails) !== JSON.stringify(desiredDetails);
+      if (current.message !== candidate.message || current.severity !== candidate.severity || detailsChanged) {
+        await pool.query(
+          `UPDATE dashboard_alerts SET message=$1, severity=$2, details=$3::jsonb WHERE id=$4`,
+          [candidate.message, candidate.severity, JSON.stringify(desiredDetails), current.id]
+        );
+      }
+      existingMap.delete(key);
+      continue;
+    }
+
+    await pool.query(
+      `INSERT INTO dashboard_alerts (abn, tax_type, period_id, code, message, severity, detected_at, details)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb)` ,
+      [
+        abn,
+        candidate.taxType,
+        candidate.periodId,
+        candidate.code,
+        candidate.message,
+        candidate.severity,
+        now.toISOString(),
+        JSON.stringify(candidate.details ?? {}),
+      ]
+    );
+  }
+
+  for (const row of existingMap.values()) {
+    await pool.query(`UPDATE dashboard_alerts SET resolved_at=$1 WHERE id=$2`, [now.toISOString(), row.id]);
+  }
+}
+
+export async function listActiveAlerts({ pool, abn }: { pool: Queryable; abn: string }): Promise<DashboardAlert[]> {
+  await ensureAlertsSchema(pool);
+  const { rows } = await pool.query<StoredAlertRow>(
+    `SELECT id, abn, tax_type, period_id, code, message, severity, details, detected_at
+     FROM dashboard_alerts
+     WHERE abn=$1 AND resolved_at IS NULL AND acknowledged_at IS NULL
+     ORDER BY detected_at ASC`,
+    [abn]
+  );
+
+  return rows.map((row) => ({
+    id: row.id,
+    abn: row.abn,
+    taxType: row.tax_type,
+    periodId: row.period_id,
+    code: row.code,
+    message: row.message,
+    severity: row.severity,
+    detectedAt: row.detected_at,
+    details: normalizeDetails(row.details),
+  }));
+}
+
+export async function acknowledgeAlerts({
+  pool,
+  abn,
+  ids,
+  now = new Date(),
+}: {
+  pool: Queryable;
+  abn: string;
+  ids: number[];
+  now?: Date;
+}): Promise<number> {
+  if (!ids.length) return 0;
+  await ensureAlertsSchema(pool);
+  let count = 0;
+  const ts = now.toISOString();
+  for (const id of ids) {
+    const { rows } = await pool.query<{ id: number }>(
+      `UPDATE dashboard_alerts
+         SET acknowledged_at=$1
+       WHERE abn=$2 AND id=$3 AND acknowledged_at IS NULL
+       RETURNING id`,
+      [ts, abn, id]
+    );
+    if (rows.length) count += 1;
+  }
+  return count;
+}

--- a/src/alerts/types.ts
+++ b/src/alerts/types.ts
@@ -1,0 +1,16 @@
+// src/alerts/types.ts
+export type AlertCode = "OVERDUE_BAS" | "OWA_SHORTFALL" | "RECON_ANOMALY";
+
+export type AlertSeverity = "info" | "warning" | "critical";
+
+export interface DashboardAlert {
+  id: number;
+  abn: string;
+  taxType: string | null;
+  periodId: string | null;
+  code: AlertCode;
+  message: string;
+  severity: AlertSeverity;
+  detectedAt: string;
+  details: Record<string, unknown>;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,44 @@
+// src/api/index.ts
+import { Router } from "express";
+import { Pool } from "pg";
+import { acknowledgeAlerts, listActiveAlerts, refreshAlerts } from "../alerts/engine";
+
+const pool = new Pool();
+
+export const api = Router();
+
+api.get("/alerts", async (req, res) => {
+  const abn = String((req.query.abn ?? "")).trim();
+  if (!abn) {
+    return res.status(400).json({ error: "abn is required" });
+  }
+  try {
+    await refreshAlerts({ pool, abn });
+    const alerts = await listActiveAlerts({ pool, abn });
+    res.json({ alerts });
+  } catch (err: any) {
+    res.status(500).json({ error: "failed to load alerts", detail: err?.message ?? String(err) });
+  }
+});
+
+api.post("/alerts/ack", async (req, res) => {
+  const { abn, ids } = req.body ?? {};
+  if (!abn || !Array.isArray(ids) || ids.length === 0) {
+    return res.status(400).json({ error: "abn and ids are required" });
+  }
+
+  const numericIds = ids
+    .map((id: unknown) => (typeof id === "number" ? id : Number(id)))
+    .filter((id: number) => Number.isFinite(id)) as number[];
+
+  if (!numericIds.length) {
+    return res.status(400).json({ error: "ids must contain numeric values" });
+  }
+
+  try {
+    const acknowledged = await acknowledgeAlerts({ pool, abn: String(abn), ids: numericIds });
+    res.json({ acknowledged });
+  } catch (err: any) {
+    res.status(500).json({ error: "failed to acknowledge alerts", detail: err?.message ?? String(err) });
+  }
+});

--- a/src/components/AlertsPanel.tsx
+++ b/src/components/AlertsPanel.tsx
@@ -1,17 +1,86 @@
 import React from "react";
+import type { DashboardAlert, AlertSeverity } from "../alerts/types";
 
-export default function AlertsPanel({ alerts }: { alerts: string[] }) {
-  if (!alerts.length) return null;
+type Props = {
+  alerts: DashboardAlert[];
+  isLoading?: boolean;
+  error?: Error | null;
+};
+
+const severityStyles: Record<AlertSeverity, { background: string; border: string; color: string }> = {
+  critical: { background: "#fee2e2", border: "#ef4444", color: "#7f1d1d" },
+  warning: { background: "#fef3c7", border: "#f59e0b", color: "#78350f" },
+  info: { background: "#e0f2fe", border: "#3b82f6", color: "#1d4ed8" },
+};
+
+function SeverityBadge({ severity }: { severity: AlertSeverity }) {
+  const label = severity === "critical" ? "Critical" : severity === "warning" ? "Warning" : "Info";
   return (
-    <div
-      className="card"
-      style={{ background: "#fef3c7", border: "1px solid #fbbf24", color: "#78350f" }}
+    <span
+      style={{
+        display: "inline-block",
+        background: "rgba(0,0,0,0.05)",
+        color: "inherit",
+        padding: "2px 8px",
+        borderRadius: 999,
+        fontSize: 12,
+        marginRight: 8,
+      }}
     >
-      <h3>Alerts</h3>
-      <ul>
-        {alerts.map((msg, idx) => (
-          <li key={idx}>{msg}</li>
-        ))}
+      {label}
+    </span>
+  );
+}
+
+export default function AlertsPanel({ alerts, isLoading, error }: Props) {
+  if (isLoading) {
+    return (
+      <div className="card" style={{ background: "#fef3c7", border: "1px solid #f59e0b", color: "#78350f" }}>
+        <strong>Loading alerts…</strong>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="card" style={{ background: "#fee2e2", border: "1px solid #ef4444", color: "#7f1d1d" }}>
+        <strong>Unable to load alerts:</strong> {error.message}
+      </div>
+    );
+  }
+
+  if (!alerts.length) return null;
+
+  return (
+    <div className="card" style={{ padding: 16, marginBottom: 16 }}>
+      <h3 style={{ fontSize: 18, fontWeight: 600, marginBottom: 8 }}>Alerts</h3>
+      <ul style={{ listStyle: "none", padding: 0, margin: 0, display: "grid", gap: 12 }}>
+        {alerts.map((alert) => {
+          const styles = severityStyles[alert.severity] ?? severityStyles.warning;
+          return (
+            <li
+              key={`${alert.code}-${alert.id}`}
+              style={{
+                background: styles.background,
+                border: `1px solid ${styles.border}`,
+                color: styles.color,
+                padding: "12px 16px",
+                borderRadius: 12,
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+                <SeverityBadge severity={alert.severity} />
+                {alert.periodId && (
+                  <span style={{ fontSize: 12, fontWeight: 500 }}>
+                    {alert.taxType ? `${alert.taxType} • ` : ""}
+                    {alert.periodId}
+                  </span>
+                )}
+              </div>
+              <div style={{ fontSize: 14 }}>{alert.message}</div>
+            </li>
+          );
+        })}
       </ul>
     </div>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,24 +1,91 @@
 // src/pages/Dashboard.tsx
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useMemo } from "react";
+import { Link } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import AlertsPanel from "../components/AlertsPanel";
+import type { DashboardAlert } from "../alerts/types";
+
+const DEFAULT_ABN = "12345678901";
+
+async function fetchAlerts(abn: string): Promise<DashboardAlert[]> {
+  const url = new URL("/api/alerts", window.location.origin);
+  url.searchParams.set("abn", abn);
+  const res = await fetch(url.toString(), { headers: { accept: "application/json" } });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(detail || `Failed to load alerts (${res.status})`);
+  }
+  const json = await res.json();
+  return Array.isArray(json.alerts) ? (json.alerts as DashboardAlert[]) : [];
+}
+
+function formatCurrency(cents: number | undefined): string {
+  if (!Number.isFinite(cents)) return "$0.00";
+  return (Number(cents) / 100).toLocaleString("en-AU", {
+    style: "currency",
+    currency: "AUD",
+  });
+}
+
+function formatDateIso(iso?: string | null): string {
+  if (!iso) return "—";
+  const ts = Date.parse(iso);
+  if (Number.isNaN(ts)) return "—";
+  return new Date(ts).toLocaleDateString("en-AU", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
 
 export default function Dashboard() {
-  const complianceStatus = {
-    lodgmentsUpToDate: false,
-    paymentsUpToDate: false,
-    overallCompliance: 65,
-    lastBAS: '29 May 2025',
-    nextDue: '28 July 2025',
-    outstandingLodgments: ['Q4 FY23-24'],
-    outstandingAmounts: ['$1,200 PAYGW', '$400 GST']
-  };
+  const abn = DEFAULT_ABN;
+  const { data: alerts = [], isLoading, isError, error } = useQuery<DashboardAlert[]>({
+    queryKey: ["alerts", abn],
+    queryFn: () => fetchAlerts(abn),
+    staleTime: 30_000,
+  });
+
+  const overdue = useMemo(
+    () => alerts.filter((alert) => alert.code === "OVERDUE_BAS"),
+    [alerts]
+  );
+  const shortfalls = useMemo(
+    () => alerts.filter((alert) => alert.code === "OWA_SHORTFALL"),
+    [alerts]
+  );
+  const anomalies = useMemo(
+    () => alerts.filter((alert) => alert.code === "RECON_ANOMALY"),
+    [alerts]
+  );
+
+  const lodgmentsUpToDate = overdue.length === 0;
+  const paymentsUpToDate = shortfalls.length === 0;
+  const complianceScore = Math.max(
+    0,
+    100 - overdue.length * 30 - shortfalls.length * 25 - anomalies.length * 15
+  );
+
+  const outstandingLodgments = overdue.map((alert) => alert.periodId || "Unspecified period");
+  const outstandingAmounts = shortfalls
+    .map((alert) => {
+      const cents = Number((alert.details as any)?.shortfallCents ?? 0);
+      if (!Number.isFinite(cents) || cents <= 0) return null;
+      const label = alert.taxType ? `${alert.taxType} shortfall` : "Shortfall";
+      return `${formatCurrency(cents)} (${label})`;
+    })
+    .filter((item): item is string => Boolean(item));
+
+  const nextDue = overdue.length ? formatDateIso((overdue[0].details as any)?.dueDate) : "—";
 
   return (
     <div className="main-card">
+      <AlertsPanel alerts={alerts} isLoading={isLoading} error={isError ? (error as Error) : null} />
+
       <div className="bg-gradient-to-r from-[#00716b] to-[#009688] text-white p-6 rounded-xl shadow mb-6">
         <h1 className="text-3xl font-bold mb-2">Welcome to APGMS</h1>
         <p className="text-sm opacity-90">
-          Automating PAYGW & GST compliance with ATO standards. Stay on track with timely lodgments and payments.
+          Automating PAYGW &amp; GST compliance with ATO standards. Stay on track with timely lodgments and payments.
         </p>
         <div className="mt-4">
           <Link to="/wizard" className="bg-white text-[#00716b] font-semibold px-4 py-2 rounded shadow hover:bg-gray-100">
@@ -30,18 +97,22 @@ export default function Dashboard() {
       <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
         <div className="bg-white p-4 rounded-xl shadow space-y-2">
           <h2 className="text-lg font-semibold">Lodgments</h2>
-          <p className={complianceStatus.lodgmentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.lodgmentsUpToDate ? 'Up to date ✅' : 'Overdue ❌'}
+          <p className={lodgmentsUpToDate ? "text-green-600" : "text-red-600"}>
+            {lodgmentsUpToDate ? "Up to date ✅" : "Overdue ❌"}
           </p>
-          <Link to="/bas" className="text-blue-600 text-sm underline">View BAS</Link>
+          <Link to="/bas" className="text-blue-600 text-sm underline">
+            View BAS
+          </Link>
         </div>
 
         <div className="bg-white p-4 rounded-xl shadow space-y-2">
           <h2 className="text-lg font-semibold">Payments</h2>
-          <p className={complianceStatus.paymentsUpToDate ? 'text-green-600' : 'text-red-600'}>
-            {complianceStatus.paymentsUpToDate ? 'All paid ✅' : 'Outstanding ❌'}
+          <p className={paymentsUpToDate ? "text-green-600" : "text-red-600"}>
+            {paymentsUpToDate ? "All paid ✅" : "Outstanding ❌"}
           </p>
-          <Link to="/audit" className="text-blue-600 text-sm underline">View Audit</Link>
+          <Link to="/audit" className="text-blue-600 text-sm underline">
+            View Audit
+          </Link>
         </div>
 
         <div className="bg-white p-4 rounded-xl shadow text-center">
@@ -59,7 +130,7 @@ export default function Dashboard() {
                 fill="none"
                 stroke="url(#grad)"
                 strokeWidth="2"
-                strokeDasharray={`${complianceStatus.overallCompliance}, 100`}
+                strokeDasharray={`${complianceScore}, 100`}
               />
               <defs>
                 <linearGradient id="grad" x1="0" y1="0" x2="1" y2="0">
@@ -68,27 +139,35 @@ export default function Dashboard() {
                   <stop offset="100%" stopColor="green" />
                 </linearGradient>
               </defs>
-              <text x="18" y="20.35" textAnchor="middle" fontSize="5">{complianceStatus.overallCompliance}%</text>
+              <text x="18" y="20.35" textAnchor="middle" fontSize="5">
+                {complianceScore}%
+              </text>
             </svg>
           </div>
           <p className="text-sm mt-2 text-gray-600">
-            {complianceStatus.overallCompliance >= 90
-              ? 'Excellent'
-              : complianceStatus.overallCompliance >= 70
-              ? 'Good'
-              : 'Needs attention'}
+            {complianceScore >= 90 ? "Excellent" : complianceScore >= 70 ? "Good" : "Needs attention"}
           </p>
         </div>
       </div>
 
-      <div className="mt-6 text-sm text-gray-700">
-        <p>Last BAS lodged on <strong>{complianceStatus.lastBAS}</strong>. <Link to="/bas" className="text-blue-600 underline">Go to BAS</Link></p>
-        <p>Next BAS due by <strong>{complianceStatus.nextDue}</strong>.</p>
-        {complianceStatus.outstandingLodgments.length > 0 && (
-          <p className="text-red-600">Outstanding Lodgments: {complianceStatus.outstandingLodgments.join(', ')}</p>
+      <div className="mt-6 text-sm text-gray-700 space-y-1">
+        <p>
+          Next BAS due by <strong>{nextDue}</strong>.
+        </p>
+        {outstandingLodgments.length > 0 && (
+          <p className="text-red-600">
+            Outstanding Lodgments: {Array.from(new Set(outstandingLodgments)).join(", ")}
+          </p>
         )}
-        {complianceStatus.outstandingAmounts.length > 0 && (
-          <p className="text-red-600">Outstanding Payments: {complianceStatus.outstandingAmounts.join(', ')}</p>
+        {outstandingAmounts.length > 0 && (
+          <p className="text-red-600">
+            Outstanding Payments: {outstandingAmounts.join(", ")}
+          </p>
+        )}
+        {isError && (
+          <p className="text-red-600">
+            Unable to load alerts: {(error as Error)?.message || "unknown error"}
+          </p>
         )}
       </div>
 

--- a/src/vendor/react-query.ts
+++ b/src/vendor/react-query.ts
@@ -1,0 +1,211 @@
+// src/vendor/react-query.ts
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export type QueryKey = ReadonlyArray<unknown>;
+
+type QueryStatus = "idle" | "loading" | "success" | "error";
+
+interface QueryState<T> {
+  status: QueryStatus;
+  data?: T;
+  error?: unknown;
+  updatedAt?: number;
+}
+
+function keyToKeyString(key: QueryKey): string {
+  return JSON.stringify(key ?? []);
+}
+
+export class QueryClient {
+  private cache = new Map<string, QueryState<any>>();
+  private listeners = new Map<string, Set<() => void>>();
+
+  private ensureListeners(key: string): Set<() => void> {
+    let set = this.listeners.get(key);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(key, set);
+    }
+    return set;
+  }
+
+  getQueryState<T>(key: QueryKey): QueryState<T> | undefined {
+    return this.cache.get(keyToKeyString(key));
+  }
+
+  setQueryState<T>(key: QueryKey, state: QueryState<T>): void {
+    const k = keyToKeyString(key);
+    this.cache.set(k, state);
+    const listeners = this.listeners.get(k);
+    if (listeners) {
+      for (const listener of listeners) {
+        listener();
+      }
+    }
+  }
+
+  subscribe(key: QueryKey, listener: () => void): () => void {
+    const k = keyToKeyString(key);
+    const listeners = this.ensureListeners(k);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+      if (!listeners.size) {
+        this.listeners.delete(k);
+      }
+    };
+  }
+}
+
+const QueryClientContext = createContext<QueryClient | null>(null);
+
+export function QueryClientProvider({
+  client,
+  children,
+}: {
+  client: QueryClient;
+  children?: React.ReactNode;
+}) {
+  return (
+    <QueryClientContext.Provider value={client}>
+      {children}
+    </QueryClientContext.Provider>
+  );
+}
+
+export function useQueryClient(): QueryClient {
+  const client = useContext(QueryClientContext);
+  if (!client) {
+    throw new Error("useQueryClient must be used within a QueryClientProvider");
+  }
+  return client;
+}
+
+export interface UseQueryOptions<TData> {
+  queryKey: QueryKey;
+  queryFn: () => Promise<TData>;
+  staleTime?: number;
+  enabled?: boolean;
+}
+
+export interface UseQueryResult<TData, TError = unknown> {
+  data: TData | undefined;
+  error: TError | null;
+  isLoading: boolean;
+  isFetching: boolean;
+  isError: boolean;
+  refetch: () => Promise<void>;
+}
+
+export function useQuery<TData, TError = unknown>(
+  options: UseQueryOptions<TData>
+): UseQueryResult<TData, TError> {
+  const { queryKey, queryFn, staleTime = 0, enabled = true } = options;
+  const client = useQueryClient();
+  const keyString = useMemo(() => keyToKeyString(queryKey), [queryKey]);
+  const keyRef = useRef<QueryKey>(queryKey);
+  keyRef.current = queryKey;
+
+  const [state, setState] = useState<QueryState<TData>>(() => {
+    return client.getQueryState<TData>(queryKey) ?? { status: "idle" };
+  });
+
+  useEffect(() => {
+    return client.subscribe(queryKey, () => {
+      const next = client.getQueryState<TData>(queryKey);
+      if (next) setState(next);
+    });
+  }, [client, keyString, queryKey]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const current = client.getQueryState<TData>(queryKey);
+    const now = Date.now();
+    const isStale =
+      !current ||
+      current.status === "idle" ||
+      current.status === "error" ||
+      (staleTime > 0 && (!current.updatedAt || now - current.updatedAt > staleTime));
+    if (!isStale) {
+      setState(current);
+      return;
+    }
+
+    let cancelled = false;
+    client.setQueryState<TData>(queryKey, {
+      status: "loading",
+      data: current?.data,
+      error: undefined,
+      updatedAt: current?.updatedAt,
+    });
+
+    queryFn()
+      .then((data) => {
+        if (cancelled) return;
+        client.setQueryState<TData>(queryKey, {
+          status: "success",
+          data,
+          error: undefined,
+          updatedAt: Date.now(),
+        });
+      })
+      .catch((error: unknown) => {
+        if (cancelled) return;
+        client.setQueryState<TData>(queryKey, {
+          status: "error",
+          data: current?.data,
+          error,
+          updatedAt: Date.now(),
+        });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [client, keyString, queryFn, queryKey, staleTime, enabled]);
+
+  const refetch = useCallback(async () => {
+    const current = client.getQueryState<TData>(keyRef.current);
+    client.setQueryState<TData>(keyRef.current, {
+      status: "loading",
+      data: current?.data,
+      error: undefined,
+      updatedAt: Date.now(),
+    });
+    try {
+      const data = await queryFn();
+      client.setQueryState<TData>(keyRef.current, {
+        status: "success",
+        data,
+        error: undefined,
+        updatedAt: Date.now(),
+      });
+    } catch (error) {
+      client.setQueryState<TData>(keyRef.current, {
+        status: "error",
+        data: current?.data,
+        error,
+        updatedAt: Date.now(),
+      });
+      throw error;
+    }
+  }, [client, queryFn]);
+
+  const resultState = state ?? { status: "idle" as QueryStatus };
+  return {
+    data: resultState.data,
+    error: (resultState.error ?? null) as TError | null,
+    isLoading: resultState.status === "loading" && resultState.data === undefined,
+    isFetching: resultState.status === "loading",
+    isError: resultState.status === "error",
+    refetch,
+  };
+}

--- a/tests/alerts/alerts_engine.test.ts
+++ b/tests/alerts/alerts_engine.test.ts
@@ -1,0 +1,292 @@
+// tests/alerts/alerts_engine.test.ts
+import test from "node:test";
+import assert from "node:assert/strict";
+import { acknowledgeAlerts, listActiveAlerts, refreshAlerts, type Queryable } from "../../src/alerts/engine";
+import type { DashboardAlert } from "../../src/alerts/types";
+
+type PeriodRecord = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  state: string;
+  final_liability_cents: number;
+  credited_to_owa_cents: number;
+  anomaly_vector?: Record<string, number>;
+  thresholds?: Record<string, number>;
+};
+
+type PeriodEventRecord = {
+  abn: string;
+  tax_type: string;
+  period_id: string;
+  event_type: string;
+  event_at: Date;
+};
+
+type AlertRecord = {
+  id: number;
+  abn: string;
+  tax_type: string | null;
+  period_id: string | null;
+  code: string;
+  message: string;
+  severity: string;
+  details: Record<string, unknown>;
+  detected_at: string;
+  acknowledged_at: string | null;
+  resolved_at: string | null;
+};
+
+class InMemoryPool implements Queryable {
+  private periods: PeriodRecord[] = [];
+  private periodEvents: PeriodEventRecord[] = [];
+  private alerts: AlertRecord[] = [];
+  private nextAlertId = 1;
+
+  reset() {
+    this.periods = [];
+    this.periodEvents = [];
+    this.alerts = [];
+    this.nextAlertId = 1;
+  }
+
+  insertPeriod(record: PeriodRecord) {
+    this.periods.push({ ...record });
+  }
+
+  updatePeriod(abn: string, taxType: string, periodId: string, updates: Partial<PeriodRecord>) {
+    const row = this.periods.find(
+      (p) => p.abn === abn && p.tax_type === taxType && p.period_id === periodId
+    );
+    if (row) {
+      Object.assign(row, updates);
+    }
+  }
+
+  insertEvent(record: PeriodEventRecord) {
+    this.periodEvents.push({ ...record });
+  }
+
+  private normalize(sql: string): string {
+    return sql.trim().replace(/\s+/g, " ").toLowerCase();
+  }
+
+  async query<T = any>(sql: string, params: any[] = []): Promise<{ rows: T[] }> {
+    const normalized = this.normalize(sql);
+
+    if (normalized.startsWith("create table if not exists dashboard_alerts")) {
+      return { rows: [] as T[] };
+    }
+    if (normalized.startsWith("create unique index if not exists ux_dashboard_alerts_active")) {
+      return { rows: [] as T[] };
+    }
+    if (normalized.startsWith("create index if not exists idx_dashboard_alerts_visible")) {
+      return { rows: [] as T[] };
+    }
+
+    if (normalized.startsWith("select abn, tax_type, period_id, state")) {
+      const abn = params[0];
+      const rows = this.periods
+        .filter((p) => p.abn === abn)
+        .map((p) => ({
+          ...p,
+          anomaly_vector: p.anomaly_vector ?? null,
+          thresholds: p.thresholds ?? null,
+        }));
+      return { rows: rows as T[] };
+    }
+
+    if (normalized.startsWith("select abn, tax_type, period_id, event_type")) {
+      const abn = params[0];
+      const rows = this.periodEvents
+        .filter((e) => e.abn === abn)
+        .map((e) => ({
+          ...e,
+          event_at: e.event_at,
+        }));
+      return { rows: rows as T[] };
+    }
+
+    if (normalized.startsWith("select id, abn, tax_type, period_id, code, message, severity, details, detected_at, acknowledged_at, resolved_at from dashboard_alerts")) {
+      const abn = params[0];
+      const rows = this.alerts
+        .filter((a) => a.abn === abn && a.resolved_at === null)
+        .map((a) => ({ ...a }));
+      return { rows: rows as T[] };
+    }
+
+    if (normalized.startsWith("update dashboard_alerts set message=$1, severity=$2, details=$3::jsonb where id=$4")) {
+      const [message, severity, detailsJson, id] = params;
+      const row = this.alerts.find((a) => a.id === id);
+      if (row) {
+        row.message = message;
+        row.severity = severity;
+        try {
+          row.details = detailsJson ? JSON.parse(detailsJson) : {};
+        } catch {
+          row.details = {};
+        }
+      }
+      return { rows: [] as T[] };
+    }
+
+    if (normalized.startsWith("insert into dashboard_alerts")) {
+      const [abn, taxType, periodId, code, message, severity, detectedAt, detailsJson] = params;
+      const record: AlertRecord = {
+        id: this.nextAlertId++,
+        abn,
+        tax_type: taxType ?? null,
+        period_id: periodId ?? null,
+        code,
+        message,
+        severity,
+        detected_at: detectedAt,
+        acknowledged_at: null,
+        resolved_at: null,
+        details: {},
+      };
+      try {
+        record.details = detailsJson ? JSON.parse(detailsJson) : {};
+      } catch {
+        record.details = {};
+      }
+      this.alerts.push(record);
+      return { rows: [{ id: record.id }] as T[] };
+    }
+
+    if (normalized.startsWith("update dashboard_alerts set resolved_at=$1 where id=$2")) {
+      const [resolvedAt, id] = params;
+      const row = this.alerts.find((a) => a.id === id);
+      if (row) {
+        row.resolved_at = resolvedAt;
+      }
+      return { rows: [] as T[] };
+    }
+
+    if (normalized.startsWith("select id, abn, tax_type, period_id, code, message, severity, details, detected_at from dashboard_alerts")) {
+      const abn = params[0];
+      const rows = this.alerts
+        .filter((a) => a.abn === abn && a.resolved_at === null && a.acknowledged_at === null)
+        .sort((a, b) => a.detected_at.localeCompare(b.detected_at))
+        .map((a) => ({ ...a }));
+      return { rows: rows as T[] };
+    }
+
+    if (normalized.startsWith("update dashboard_alerts set acknowledged_at=$1 where abn=$2 and id=$3 and acknowledged_at is null returning id")) {
+      const [ts, abn, id] = params;
+      const row = this.alerts.find((a) => a.id === id && a.abn === abn && a.acknowledged_at === null);
+      if (row) {
+        row.acknowledged_at = ts;
+        return { rows: [{ id: row.id }] as T[] };
+      }
+      return { rows: [] as T[] };
+    }
+
+    throw new Error(`Unsupported SQL: ${sql}`);
+  }
+}
+
+const pool = new InMemoryPool();
+
+function shortfallAlert(alerts: DashboardAlert[]) {
+  return alerts.find((a) => a.code === "OWA_SHORTFALL");
+}
+
+function overdueAlert(alerts: DashboardAlert[]) {
+  return alerts.find((a) => a.code === "OVERDUE_BAS");
+}
+
+function anomalyAlert(alerts: DashboardAlert[]) {
+  return alerts.find((a) => a.code === "RECON_ANOMALY");
+}
+
+test("derives overdue and shortfall alerts from periods and events", async () => {
+  pool.reset();
+  pool.insertPeriod({
+    abn: "123",
+    tax_type: "GST",
+    period_id: "2025-Q1",
+    state: "OPEN",
+    final_liability_cents: 50000,
+    credited_to_owa_cents: 20000,
+    anomaly_vector: { variance_ratio: 0.1, dup_rate: 0.01, gap_minutes: 5, delta_vs_baseline: 0.02 },
+    thresholds: {},
+  });
+  pool.insertEvent({
+    abn: "123",
+    tax_type: "GST",
+    period_id: "2025-Q1",
+    event_type: "BAS_DUE",
+    event_at: new Date("2025-04-28T00:00:00Z"),
+  });
+
+  await refreshAlerts({ pool, abn: "123", now: new Date("2025-06-01T00:00:00Z") });
+  const alerts = await listActiveAlerts({ pool, abn: "123" });
+  assert.equal(alerts.length, 2);
+  assert.ok(shortfallAlert(alerts));
+  const overdue = overdueAlert(alerts);
+  assert.ok(overdue);
+  assert.match(String((overdue!.details as any).dueDate ?? ""), /2025/);
+});
+
+test("acknowledging hides alerts until the condition changes", async () => {
+  pool.reset();
+  pool.insertPeriod({
+    abn: "123",
+    tax_type: "GST",
+    period_id: "2025-Q2",
+    state: "OPEN",
+    final_liability_cents: 80000,
+    credited_to_owa_cents: 20000,
+    anomaly_vector: { variance_ratio: 0.1, dup_rate: 0.01, gap_minutes: 5, delta_vs_baseline: 0.02 },
+    thresholds: {},
+  });
+  pool.insertEvent({
+    abn: "123",
+    tax_type: "GST",
+    period_id: "2025-Q2",
+    event_type: "BAS_DUE",
+    event_at: new Date("2025-07-28T00:00:00Z"),
+  });
+
+  await refreshAlerts({ pool, abn: "123", now: new Date("2025-08-01T00:00:00Z") });
+  let alerts = await listActiveAlerts({ pool, abn: "123" });
+  const shortfall = shortfallAlert(alerts);
+  assert.ok(shortfall);
+
+  await acknowledgeAlerts({ pool, abn: "123", ids: [shortfall!.id], now: new Date("2025-08-02T00:00:00Z") });
+  alerts = await listActiveAlerts({ pool, abn: "123" });
+  assert.ok(!shortfallAlert(alerts));
+
+  pool.updatePeriod("123", "GST", "2025-Q2", { credited_to_owa_cents: 80000 });
+  await refreshAlerts({ pool, abn: "123", now: new Date("2025-08-05T00:00:00Z") });
+  alerts = await listActiveAlerts({ pool, abn: "123" });
+  assert.ok(!shortfallAlert(alerts));
+
+  pool.updatePeriod("123", "GST", "2025-Q2", { credited_to_owa_cents: 10000 });
+  await refreshAlerts({ pool, abn: "123", now: new Date("2025-08-10T00:00:00Z") });
+  alerts = await listActiveAlerts({ pool, abn: "123" });
+  const resurfaced = shortfallAlert(alerts);
+  assert.ok(resurfaced);
+  assert.notEqual(resurfaced!.id, shortfall!.id);
+});
+
+test("reconciliation anomalies surface as alerts", async () => {
+  pool.reset();
+  pool.insertPeriod({
+    abn: "555",
+    tax_type: "PAYGW",
+    period_id: "2025-Q3",
+    state: "OPEN",
+    final_liability_cents: 0,
+    credited_to_owa_cents: 0,
+    anomaly_vector: { variance_ratio: 0.6, dup_rate: 0.02, gap_minutes: 10, delta_vs_baseline: 0.15 },
+    thresholds: { variance_ratio: 0.3 },
+  });
+
+  await refreshAlerts({ pool, abn: "555", now: new Date("2025-09-15T00:00:00Z") });
+  const alerts = await listActiveAlerts({ pool, abn: "555" });
+  const anomaly = anomalyAlert(alerts);
+  assert.ok(anomaly);
+  assert.equal(anomaly!.severity, "warning");
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,11 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@tanstack/react-query": ["src/vendor/react-query"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Summary
- add an alerts engine that computes overdue BAS, OWA shortfall, and reconciliation anomaly alerts from period data and events while tracking acknowledgements
- expose /api/alerts and /api/alerts/ack endpoints backed by the engine and introduce a minimal QueryClient for React usage
- refresh the dashboard to consume the alerts API via React Query, update the alerts panel, and recalc compliance indicators from live data

## Testing
- npx tsx tests/alerts/alerts_engine.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e406b8f7d08327bb58915e5343b28d