### PR TITLE
Add webhook-driven tax computation engines

### DIFF
--- a/apps/services/tax-engine/app/rules/gst_rules_2024_25.json
+++ b/apps/services/tax-engine/app/rules/gst_rules_2024_25.json
@@ -1,0 +1,17 @@
+{
+  "version": "2024-25",
+  "effective_from": "2024-07-01",
+  "effective_to": "2025-06-30",
+  "sales_tax_codes": {
+    "GST": { "rate": 0.1, "description": "Taxable supplies" },
+    "FRE": { "rate": 0, "description": "GST-free" },
+    "INPUT_TAXED": { "rate": 0, "description": "Input taxed" },
+    "EXPORT": { "rate": 0, "description": "GST-free exports" }
+  },
+  "purchase_tax_codes": {
+    "GST": { "rate": 0.1, "description": "GST creditable" },
+    "FRE": { "rate": 0, "description": "GST-free" },
+    "INPUT_TAXED": { "rate": 0, "description": "Input taxed" }
+  },
+  "rounding": "HALF_UP"
+}

--- a/apps/services/tax-engine/app/rules/payg_w_2024_25.json
+++ b/apps/services/tax-engine/app/rules/payg_w_2024_25.json
@@ -1,18 +1,56 @@
-﻿{
+{
   "version": "2024-25",
-  "notes": "Replace with ATO-published formulas/tables each 1 July before production.",
-  "methods_enabled": ["table_ato","formula_progressive","percent_simple","flat_plus_percent","bonus_marginal","net_to_gross"],
-  "formula_progressive": {
-    "period": "weekly",
-    "brackets": [
-      { "up_to": 359.00,   "a": 0.00,  "b":   0.0,  "fixed": 0.0 },
-      { "up_to": 438.00,   "a": 0.19,  "b":  68.0,  "fixed": 0.0 },
-      { "up_to": 548.00,   "a": 0.234, "b":  87.82, "fixed": 0.0 },
-      { "up_to": 721.00,   "a": 0.347, "b": 148.50, "fixed": 0.0 },
-      { "up_to": 865.00,   "a": 0.345, "b": 147.00, "fixed": 0.0 },
-      { "up_to": 999999.0, "a": 0.39,  "b": 183.0,  "fixed": 0.0 }
-    ],
-    "tax_free_threshold": true,
-    "rounding": "HALF_UP"
+  "effective_from": "2024-07-01",
+  "effective_to": "2025-06-30",
+  "rounding": "HALF_UP",
+  "periods": {
+    "weekly": {
+      "tax_free_threshold": [
+        { "min": 0, "max": 359, "type": "none" },
+        { "min": 359, "max": 438, "type": "linear", "rate": 0.19, "offset": 68.36 },
+        { "min": 438, "max": 548, "type": "linear", "rate": 0.234, "offset": 87.82 },
+        { "min": 548, "max": 721, "type": "linear", "rate": 0.347, "offset": 148.5 },
+        { "min": 721, "max": 865, "type": "linear", "rate": 0.345, "offset": 147 },
+        { "min": 865, "max": 999999, "type": "linear", "rate": 0.39, "offset": 183 }
+      ],
+      "no_tax_free_threshold": [
+        { "min": 0, "max": 88, "type": "linear", "rate": 0.19, "offset": 0 },
+        { "min": 88, "max": 371, "type": "linear", "rate": 0.29, "offset": 8.43 },
+        { "min": 371, "max": 782, "type": "linear", "rate": 0.32, "offset": 17.79 },
+        { "min": 782, "max": 999999, "type": "linear", "rate": 0.37, "offset": 56.21 }
+      ]
+    },
+    "fortnightly": {
+      "tax_free_threshold": [
+        { "min": 0, "max": 718, "type": "none" },
+        { "min": 718, "max": 876, "type": "linear", "rate": 0.19, "offset": 136.72 },
+        { "min": 876, "max": 1096, "type": "linear", "rate": 0.234, "offset": 175.64 },
+        { "min": 1096, "max": 1442, "type": "linear", "rate": 0.347, "offset": 297 },
+        { "min": 1442, "max": 1730, "type": "linear", "rate": 0.345, "offset": 294 },
+        { "min": 1730, "max": 999999, "type": "linear", "rate": 0.39, "offset": 366 }
+      ],
+      "no_tax_free_threshold": [
+        { "min": 0, "max": 176, "type": "linear", "rate": 0.19, "offset": 0 },
+        { "min": 176, "max": 742, "type": "linear", "rate": 0.29, "offset": 16.86 },
+        { "min": 742, "max": 1564, "type": "linear", "rate": 0.32, "offset": 35.58 },
+        { "min": 1564, "max": 999999, "type": "linear", "rate": 0.37, "offset": 112.42 }
+      ]
+    },
+    "monthly": {
+      "tax_free_threshold": [
+        { "min": 0, "max": 1550, "type": "none" },
+        { "min": 1550, "max": 1895, "type": "linear", "rate": 0.19, "offset": 295.95 },
+        { "min": 1895, "max": 2370, "type": "linear", "rate": 0.234, "offset": 380.1 },
+        { "min": 2370, "max": 3120, "type": "linear", "rate": 0.347, "offset": 642.5 },
+        { "min": 3120, "max": 3700, "type": "linear", "rate": 0.345, "offset": 635.4 },
+        { "min": 3700, "max": 999999, "type": "linear", "rate": 0.39, "offset": 794.7 }
+      ],
+      "no_tax_free_threshold": [
+        { "min": 0, "max": 370, "type": "linear", "rate": 0.19, "offset": 0 },
+        { "min": 370, "max": 1560, "type": "linear", "rate": 0.29, "offset": 35.7 },
+        { "min": 1560, "max": 3280, "type": "linear", "rate": 0.32, "offset": 75.6 },
+        { "min": 3280, "max": 999999, "type": "linear", "rate": 0.37, "offset": 239.4 }
+      ]
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
         "start": "node dist/index.js",
         "build": "echo build root",
         "typecheck": "echo typecheck root",
-        "dev": "tsx src/index.ts",
-        "lint": "echo lint root"
+    "dev": "tsx src/index.ts",
+    "lint": "echo lint root",
+    "test": "tsx --test tests/**/*.test.ts"
     },
     "version": "0.1.0",
     "name": "apgms",
     "private": true,
-    "packageManager": "pnpm@9",
+    "packageManager": "pnpm@9.0.0",
     "devDependencies": {
         "@types/express": "^5.0.3",
         "@types/node": "^24.6.2",

--- a/src/components/GstCalculator.tsx
+++ b/src/components/GstCalculator.tsx
@@ -1,40 +1,113 @@
-import React, { useState } from "react";
-import { GstInput } from "../types/tax";
-import { calculateGst } from "../utils/gst";
+import { useQuery } from "../vendor/react-query";
+import React, { useMemo, useState } from "react";
 
-export default function GstCalculator({ onResult }: { onResult: (liability: number) => void }) {
-  const [form, setForm] = useState<GstInput>({ saleAmount: 0, exempt: false });
+type GstBasis = "cash" | "accrual";
+
+type GstForm = {
+  abn: string;
+  periodId: string;
+  basis: GstBasis;
+};
+
+type GstResponse = {
+  totals: {
+    G1: number;
+    "1A": number;
+    "1B": number;
+    G10: number;
+    G11: number;
+  };
+  rates_version: string;
+  effective_from: string;
+  effective_to: string;
+  sales: number;
+  purchases: number;
+};
+
+function buildKey(params: GstForm | null) {
+  if (!params) return ["tax", "gst", "idle"];
+  return ["tax", "gst", params.abn, params.periodId, params.basis];
+}
+
+async function fetchGst(params: GstForm): Promise<GstResponse> {
+  const query = new URLSearchParams({
+    abn: params.abn,
+    period_id: params.periodId,
+    basis: params.basis,
+  });
+  const res = await fetch(`/tax/gst?${query.toString()}`);
+  if (!res.ok) {
+    const payload = await res.json().catch(() => ({}));
+    throw new Error(payload.error ?? "Unable to fetch GST totals");
+  }
+  return res.json();
+}
+
+export default function GstCalculator() {
+  const [form, setForm] = useState<GstForm>({ abn: "12345678901", periodId: "2024-07", basis: "cash" });
+  const [submitted, setSubmitted] = useState<GstForm | null>(null);
+
+  const queryKey = useMemo(() => buildKey(submitted), [submitted]);
+  const { data, error, isFetching } = useQuery({
+    queryKey,
+    queryFn: () => fetchGst(submitted as GstForm),
+    enabled: Boolean(submitted?.abn && submitted?.periodId),
+    retry: false,
+  });
 
   return (
     <div className="card">
-      <h3>GST Calculator</h3>
-      <p>
-        <b>Calculate GST (Goods and Services Tax) for a sale.</b><br />
-        <span style={{ color: "#444", fontSize: "0.97em" }}>
-          Enter the sale amount and mark as exempt if GST does not apply.
-        </span>
+      <h3>GST Engine</h3>
+      <p className="text-sm text-muted-foreground">
+        POS webhooks feed G1/1A/1B/G10/G11. Request the cash or accrual view for a lodged period to reconcile BAS totals.
       </p>
-      <label>
-        Sale Amount (including GST):
-        <input
-          type="number"
-          placeholder="e.g. 440"
-          min={0}
-          value={form.saleAmount}
-          onChange={e => setForm({ ...form, saleAmount: +e.target.value })}
-        />
-      </label>
-      <label style={{ display: "inline-flex", alignItems: "center", gap: "0.5em" }}>
-        <input
-          type="checkbox"
-          checked={form.exempt}
-          onChange={e => setForm({ ...form, exempt: e.target.checked })}
-        />
-        GST Exempt
-      </label>
-      <button style={{ marginTop: "0.7em" }} onClick={() => onResult(calculateGst(form))}>
-        Calculate GST
-      </button>
+
+      <form
+        className="space-y-3"
+        onSubmit={event => {
+          event.preventDefault();
+          setSubmitted({ ...form });
+        }}
+      >
+        <label className="flex flex-col gap-1 text-sm">
+          ABN
+          <input value={form.abn} onChange={e => setForm({ ...form, abn: e.target.value })} placeholder="e.g. 12345678901" />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          Period identifier
+          <input value={form.periodId} onChange={e => setForm({ ...form, periodId: e.target.value })} placeholder="2024-Q1" />
+        </label>
+        <label className="flex flex-col gap-1 text-sm">
+          Reporting basis
+          <select value={form.basis} onChange={e => setForm({ ...form, basis: e.target.value as GstBasis })}>
+            <option value="cash">Cash</option>
+            <option value="accrual">Accrual</option>
+          </select>
+        </label>
+        <button type="submit" className="btn" disabled={isFetching}>
+          {isFetching ? "Loading…" : "Load GST totals"}
+        </button>
+      </form>
+
+      {error ? <p className="text-sm text-red-600 mt-3">{(error as Error).message}</p> : null}
+
+      {data ? (
+        <div className="mt-4 space-y-1 text-sm">
+          <div className="flex justify-between"><span>G1 Total sales</span><strong>${data.totals.G1.toFixed(2)}</strong></div>
+          <div className="flex justify-between"><span>1A GST on sales</span><strong>${data.totals["1A"].toFixed(2)}</strong></div>
+          <div className="flex justify-between"><span>1B GST on purchases</span><strong>${data.totals["1B"].toFixed(2)}</strong></div>
+          <div className="flex justify-between"><span>G10 Capital purchases</span><strong>${data.totals.G10.toFixed(2)}</strong></div>
+          <div className="flex justify-between"><span>G11 Non-capital purchases</span><strong>${data.totals.G11.toFixed(2)}</strong></div>
+          <div className="text-xs text-muted-foreground pt-2">
+            <div>
+              rates version <strong>{data.rates_version}</strong> · effective {data.effective_from} → {data.effective_to}
+            </div>
+            <div>
+              {data.sales} POS sales · {data.purchases} purchases considered ({form.basis} basis)
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/db/pool.ts
+++ b/src/db/pool.ts
@@ -1,0 +1,26 @@
+import { Pool } from "pg";
+
+type PoolLike = Pick<Pool, "query" | "connect" | "end">;
+
+let sharedPool: PoolLike | null = null;
+
+const defaultConfig = {
+  host: process.env.PGHOST ?? "127.0.0.1",
+  user: process.env.PGUSER ?? "apgms",
+  password: process.env.PGPASSWORD ?? "apgms_pw",
+  database: process.env.PGDATABASE ?? "apgms",
+  port: Number(process.env.PGPORT ?? 5432),
+};
+
+export function getPool(): PoolLike {
+  if (!sharedPool) {
+    sharedPool = new Pool(defaultConfig);
+  }
+  return sharedPool;
+}
+
+export function setPool(pool: PoolLike | null): void {
+  sharedPool = pool;
+}
+
+export type { PoolLike };

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,17 +6,31 @@ import { idempotency } from "./middleware/idempotency";
 import { closeAndIssue, payAto, paytoSweep, settlementWebhook, evidence } from "./routes/reconcile";
 import { paymentsApi } from "./api/payments"; // ✅ mount this BEFORE `api`
 import { api } from "./api";                  // your existing API router(s)
+import { posIngestRouter } from "./ingest/pos";
+import { stpIngestRouter } from "./ingest/stp";
+import { taxApi } from "./tax/api";
 
 dotenv.config();
 
 const app = express();
-app.use(express.json({ limit: "2mb" }));
+app.use(
+  express.json({
+    limit: "2mb",
+    verify: (req, _res, buf) => {
+      (req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+    },
+  })
+);
 
 // (optional) quick request logger
 app.use((req, _res, next) => { console.log(`[app] ${req.method} ${req.url}`); next(); });
 
 // Simple health check
 app.get("/health", (_req, res) => res.json({ ok: true }));
+
+// Ingestion webhooks (signature protected)
+app.use("/ingest/stp", stpIngestRouter);
+app.use("/ingest/pos", posIngestRouter);
 
 // Existing explicit endpoints
 app.post("/api/pay", idempotency(), payAto);
@@ -27,6 +41,9 @@ app.get("/api/evidence", evidence);
 
 // ✅ Payments API first so it isn't shadowed by catch-alls in `api`
 app.use("/api", paymentsApi);
+
+// Tax endpoints (read aggregations from ingested data)
+app.use("/tax", taxApi);
 
 // Existing API router(s) after
 app.use("/api", api);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "./vendor/react-query";
+
 import App from "./App";
 import "./index.css";
 
 const root = ReactDOM.createRoot(document.getElementById("root") as HTMLElement);
-root.render(<App />);
+const queryClient = new QueryClient();
+
+root.render(
+  <QueryClientProvider client={queryClient}>
+    <App />
+  </QueryClientProvider>
+);

--- a/src/ingest/pos.ts
+++ b/src/ingest/pos.ts
@@ -1,0 +1,166 @@
+import crypto from "crypto";
+import type { Request } from "express";
+import { Router } from "express";
+
+import { getPool } from "../db/pool";
+import type { PosEventPayload, PosPurchaseLine, PosSaleLine } from "../utils/gst";
+
+interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
+const POS_HEADER = "x-signature";
+
+function sign(body: Buffer, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(body).digest("hex");
+}
+
+export const posIngestRouter = Router();
+
+posIngestRouter.post("/", async (req, res) => {
+  const pool = getPool();
+  const secret = process.env.POS_WEBHOOK_SECRET;
+  const rawBody = (req as RawBodyRequest).rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
+  const signature = (req.get(POS_HEADER) ?? "").trim().toLowerCase();
+
+  const persistDlq = async (reason: string, payload?: unknown) => {
+    let serialised: string;
+    try {
+      serialised = JSON.stringify(payload ?? JSON.parse(rawBody.toString() || "{}"));
+    } catch {
+      serialised = JSON.stringify({});
+    }
+    await pool.query("INSERT INTO pos_dlq (reason, raw_payload, created_at) VALUES ($1, $2::jsonb, NOW())", [reason, serialised]);
+  };
+
+  if (!secret) {
+    await persistDlq("NO_SECRET", req.body);
+    return res.status(500).json({ error: "POS_SECRET_NOT_CONFIGURED" });
+  }
+
+  const expected = sign(rawBody, secret);
+  let signatureValid = false;
+  if (signature.length === expected.length) {
+    signatureValid = crypto.timingSafeEqual(Buffer.from(signature, "hex"), Buffer.from(expected, "hex"));
+  }
+
+  if (!signatureValid) {
+    await persistDlq("INVALID_SIGNATURE", req.body);
+    return res.status(202).json({ status: "DLQ" });
+  }
+
+  let parsed: PosEventPayload;
+  try {
+    parsed = normalisePosEvent(req.body);
+  } catch (err) {
+    await persistDlq("SCHEMA_INVALID", req.body);
+    return res.status(202).json({ status: "DLQ" });
+  }
+
+  try {
+    await pool.query(
+      `INSERT INTO pos_events (event_id, abn, period_id, payload, received_at)
+       VALUES ($1, $2, $3, $4::jsonb, NOW())
+       ON CONFLICT (event_id) DO UPDATE SET payload = EXCLUDED.payload, received_at = EXCLUDED.received_at`,
+      [parsed.eventId, parsed.abn, parsed.periodId, JSON.stringify(parsed)]
+    );
+    return res.status(200).json({ status: "OK" });
+  } catch (err) {
+    await persistDlq("DB_ERROR", parsed);
+    return res.status(500).json({ error: "INGEST_FAILED" });
+  }
+});
+
+function ensureString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid ${field}`);
+  }
+  return value.trim();
+}
+
+function ensureNumber(value: unknown, field: string): number {
+  const num = Number(value);
+  if (!Number.isFinite(num)) {
+    throw new Error(`Invalid ${field}`);
+  }
+  return num;
+}
+
+function normaliseSale(raw: any): PosSaleLine {
+  if (!raw || typeof raw !== "object") throw new Error("Invalid sale");
+  return {
+    transactionId: ensureString(raw.transactionId, "transactionId"),
+    type: raw.type === "refund" ? "refund" : "sale",
+    total: ensureNumber(raw.total, "total"),
+    taxableAmount: raw.taxableAmount != null ? ensureNumber(raw.taxableAmount, "taxableAmount") : undefined,
+    gstAmount: raw.gstAmount != null ? ensureNumber(raw.gstAmount, "gstAmount") : undefined,
+    taxCode: ensureString(raw.taxCode, "taxCode"),
+    cashPeriodId: raw.cashPeriodId ? String(raw.cashPeriodId) : undefined,
+    accrualPeriodId: raw.accrualPeriodId ? String(raw.accrualPeriodId) : undefined,
+  };
+}
+
+function normalisePurchase(raw: any): PosPurchaseLine {
+  if (!raw || typeof raw !== "object") throw new Error("Invalid purchase");
+  const category = raw.category === "capital" ? "capital" : "non_capital";
+  return {
+    purchaseId: ensureString(raw.purchaseId, "purchaseId"),
+    total: ensureNumber(raw.total, "total"),
+    gstAmount: raw.gstAmount != null ? ensureNumber(raw.gstAmount, "gstAmount") : undefined,
+    taxCode: ensureString(raw.taxCode, "taxCode"),
+    category,
+    cashPeriodId: raw.cashPeriodId ? String(raw.cashPeriodId) : undefined,
+    accrualPeriodId: raw.accrualPeriodId ? String(raw.accrualPeriodId) : undefined,
+  };
+}
+
+function normalisePosEvent(body: any): PosEventPayload {
+  if (!body || typeof body !== "object") throw new Error("INVALID_BODY");
+  const eventId = ensureString(body.eventId, "eventId");
+  const abn = ensureString(body.abn, "abn");
+  const periodId = ensureString(body.periodId, "periodId");
+  const occurredAt = new Date(body.occurredAt ?? new Date().toISOString());
+  if (Number.isNaN(occurredAt.getTime())) {
+    throw new Error("INVALID_OCCURRED_AT");
+  }
+  const locationId = ensureString(body.locationId, "locationId");
+  const salesInput = Array.isArray(body.sales) ? body.sales : [];
+  if (salesInput.length === 0) {
+    throw new Error("NO_SALES");
+  }
+  const purchasesInput = Array.isArray(body.purchases) ? body.purchases : [];
+  const adjustmentsRaw = body.adjustments ?? {};
+
+  const sales = salesInput.map(normaliseSale);
+  const purchases = purchasesInput.map(normalisePurchase);
+  const adjustments = {
+    salesAdjustments: adjustmentsRaw.salesAdjustments != null ? ensureNumber(adjustmentsRaw.salesAdjustments, "salesAdjustments") : undefined,
+    gstOnSalesAdjustments:
+      adjustmentsRaw.gstOnSalesAdjustments != null
+        ? ensureNumber(adjustmentsRaw.gstOnSalesAdjustments, "gstOnSalesAdjustments")
+        : undefined,
+    capitalPurchasesAdjustments:
+      adjustmentsRaw.capitalPurchasesAdjustments != null
+        ? ensureNumber(adjustmentsRaw.capitalPurchasesAdjustments, "capitalPurchasesAdjustments")
+        : undefined,
+    nonCapitalPurchasesAdjustments:
+      adjustmentsRaw.nonCapitalPurchasesAdjustments != null
+        ? ensureNumber(adjustmentsRaw.nonCapitalPurchasesAdjustments, "nonCapitalPurchasesAdjustments")
+        : undefined,
+    gstOnPurchasesAdjustments:
+      adjustmentsRaw.gstOnPurchasesAdjustments != null
+        ? ensureNumber(adjustmentsRaw.gstOnPurchasesAdjustments, "gstOnPurchasesAdjustments")
+        : undefined,
+  };
+
+  return {
+    eventId,
+    abn,
+    periodId,
+    occurredAt: occurredAt.toISOString(),
+    locationId,
+    sales,
+    purchases,
+    adjustments,
+  };
+}

--- a/src/ingest/stp.ts
+++ b/src/ingest/stp.ts
@@ -1,0 +1,146 @@
+import crypto from "crypto";
+import type { Request } from "express";
+import { Router } from "express";
+
+import { getPool } from "../db/pool";
+import type { PayPeriod } from "../tax/rules";
+import type { PayrollEventPayload, StpEmployeeLine } from "../utils/paygw";
+
+interface RawBodyRequest extends Request {
+  rawBody?: Buffer;
+}
+
+const HMAC_HEADER = "x-signature";
+
+function computeHmac(body: Buffer, secret: string): string {
+  return crypto.createHmac("sha256", secret).update(body).digest("hex");
+}
+
+export const stpIngestRouter = Router();
+
+stpIngestRouter.post("/", async (req, res) => {
+  const pool = getPool();
+  const secret = process.env.STP_WEBHOOK_SECRET;
+  const rawBody = (req as RawBodyRequest).rawBody ?? Buffer.from(JSON.stringify(req.body ?? {}));
+  const signature = (req.get(HMAC_HEADER) ?? "").trim().toLowerCase();
+
+  const recordFailure = async (reason: string, payload?: unknown) => {
+    let serialised: string;
+    try {
+      serialised = JSON.stringify(payload ?? JSON.parse(rawBody.toString() || "{}"));
+    } catch {
+      serialised = JSON.stringify({});
+    }
+    await pool.query("INSERT INTO payroll_dlq (reason, raw_payload, created_at) VALUES ($1, $2::jsonb, NOW())", [reason, serialised]);
+  };
+
+  if (!secret) {
+    await recordFailure("NO_SECRET", req.body);
+    return res.status(500).json({ error: "STP_SECRET_NOT_CONFIGURED" });
+  }
+
+  const expectedSignature = computeHmac(rawBody, secret);
+  let signaturesMatch = false;
+  if (signature.length === expectedSignature.length) {
+    signaturesMatch = crypto.timingSafeEqual(Buffer.from(signature, "hex"), Buffer.from(expectedSignature, "hex"));
+  }
+
+  if (!signaturesMatch) {
+    await recordFailure("INVALID_SIGNATURE", req.body);
+    return res.status(202).json({ status: "DLQ" });
+  }
+
+  let parsed: PayrollEventPayload;
+  try {
+    parsed = normaliseStpEvent(req.body);
+  } catch (err) {
+    await recordFailure("SCHEMA_INVALID", req.body);
+    return res.status(202).json({ status: "DLQ" });
+  }
+
+  try {
+    await pool.query(
+      `INSERT INTO payroll_events (event_id, abn, period, period_id, payload, received_at)
+       VALUES ($1, $2, $3, $4, $5::jsonb, NOW())
+       ON CONFLICT (event_id) DO UPDATE SET payload = EXCLUDED.payload, received_at = EXCLUDED.received_at`,
+      [parsed.eventId, parsed.abn, parsed.period.frequency, parsed.period.periodId, JSON.stringify(parsed)]
+    );
+    return res.status(200).json({ status: "OK" });
+  } catch (err) {
+    await recordFailure("DB_ERROR", parsed);
+    return res.status(500).json({ error: "INGEST_FAILED" });
+  }
+});
+
+const allowedPeriods: PayPeriod[] = ["weekly", "fortnightly", "monthly"];
+
+function ensureString(value: unknown, field: string): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`Invalid ${field}`);
+  }
+  return value.trim();
+}
+
+function ensureNumber(value: unknown, field: string, { min = 0 } = {}): number {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < min) {
+    throw new Error(`Invalid ${field}`);
+  }
+  return num;
+}
+
+function normaliseFlags(input: any): StpEmployeeLine["flags"] {
+  if (!input || typeof input !== "object") return undefined;
+  const flags: StpEmployeeLine["flags"] = {};
+  if ("taxFreeThreshold" in input) {
+    flags.taxFreeThreshold = Boolean(input.taxFreeThreshold);
+  }
+  if ("roundingMode" in input) {
+    const mode = String(input.roundingMode);
+    if (mode === "HALF_UP" || mode === "DOWN" || mode === "UP") {
+      flags.roundingMode = mode;
+    }
+  }
+  return Object.keys(flags).length ? flags : undefined;
+}
+
+function normaliseEmployee(raw: any): StpEmployeeLine {
+  if (!raw || typeof raw !== "object") throw new Error("Invalid employee");
+  return {
+    employeeId: ensureString(raw.employeeId, "employeeId"),
+    gross: ensureNumber(raw.gross, "gross"),
+    allowances: ensureNumber(raw.allowances ?? 0, "allowances", { min: 0 }),
+    deductions: ensureNumber(raw.deductions ?? 0, "deductions", { min: 0 }),
+    taxWithheld: raw.taxWithheld != null ? ensureNumber(raw.taxWithheld, "taxWithheld", { min: 0 }) : undefined,
+    flags: normaliseFlags(raw.flags),
+  };
+}
+
+function normaliseStpEvent(body: any): PayrollEventPayload {
+  if (!body || typeof body !== "object") throw new Error("INVALID_BODY");
+  const eventId = ensureString(body.eventId, "eventId");
+  const abn = ensureString(body.abn, "abn");
+  const payDateRaw = body.payDate ?? new Date().toISOString();
+  const payDate = new Date(payDateRaw);
+  if (Number.isNaN(payDate.getTime())) {
+    throw new Error("INVALID_PAYDATE");
+  }
+  const periodObj = body.period ?? {};
+  const frequency = ensureString(periodObj.frequency, "period.frequency") as PayPeriod;
+  if (!allowedPeriods.includes(frequency)) {
+    throw new Error("INVALID_PERIOD");
+  }
+  const periodId = ensureString(periodObj.periodId, "period.periodId");
+  const employeesInput = Array.isArray(body.employees) ? body.employees : [];
+  if (employeesInput.length === 0) {
+    throw new Error("NO_EMPLOYEES");
+  }
+  const employees = employeesInput.map(normaliseEmployee);
+  return {
+    eventId,
+    abn,
+    payDate: payDate.toISOString(),
+    period: { frequency, periodId },
+    employees,
+  };
+}

--- a/src/tax/api.ts
+++ b/src/tax/api.ts
@@ -1,0 +1,64 @@
+import { Router } from "express";
+
+import { computeGstForPeriod } from "../utils/gst";
+import { computePaygwForPeriod } from "../utils/paygw";
+
+export const taxApi = Router();
+
+const payPeriods = new Set(["weekly", "fortnightly", "monthly"]);
+
+taxApi.get("/paygw", async (req, res) => {
+  const query = req.query as Record<string, string | undefined>;
+  const abn = query.abn?.trim();
+  const period = query.period?.trim();
+  const periodId = query.period_id?.trim();
+
+  if (!abn || !period || !periodId || !payPeriods.has(period as any)) {
+    return res.status(400).json({ error: "BAD_REQUEST" });
+  }
+
+  const totals = await computePaygwForPeriod({ abn, period: period as any, periodId });
+  if (!totals) {
+    return res.status(404).json({ error: "NOT_FOUND" });
+  }
+
+  return res.json({
+    abn,
+    period: { frequency: period, id: periodId },
+    totals: totals.totals,
+    rates_version: totals.ratesVersion,
+    effective_from: totals.effectiveFrom,
+    effective_to: totals.effectiveTo,
+    events: totals.events,
+    employees: totals.employees,
+  });
+});
+
+taxApi.get("/gst", async (req, res) => {
+  const query = req.query as Record<string, string | undefined>;
+  const abn = query.abn?.trim();
+  const periodId = query.period_id?.trim();
+  const basis = query.basis === "accrual" ? "accrual" : query.basis === "cash" ? "cash" : undefined;
+
+  if (!abn || !periodId || !basis) {
+    return res.status(400).json({ error: "BAD_REQUEST" });
+  }
+
+  const totals = await computeGstForPeriod({ abn, periodId, basis });
+  if (!totals) {
+    return res.status(404).json({ error: "NOT_FOUND" });
+  }
+
+  return res.json({
+    abn,
+    period: { id: periodId },
+    basis,
+    totals: totals.totals,
+    rates_version: totals.ratesVersion,
+    effective_from: totals.effectiveFrom,
+    effective_to: totals.effectiveTo,
+    events: totals.events,
+    sales: totals.salesCount,
+    purchases: totals.purchaseCount,
+  });
+});

--- a/src/tax/rules.ts
+++ b/src/tax/rules.ts
@@ -1,0 +1,203 @@
+import paygJson from "../../apps/services/tax-engine/app/rules/payg_w_2024_25.json";
+import gstJson from "../../apps/services/tax-engine/app/rules/gst_rules_2024_25.json";
+
+type PayPeriod = "weekly" | "fortnightly" | "monthly";
+
+type LinearBracket = {
+  min: number;
+  max: number;
+  type: "linear";
+  rate: number;
+  offset: number;
+};
+
+type NoneBracket = {
+  min: number;
+  max: number;
+  type: "none";
+};
+
+type PaygwBracket = LinearBracket | NoneBracket;
+
+type PaygwFlags = {
+  taxFreeThreshold?: boolean;
+  roundingMode?: "HALF_UP" | "DOWN" | "UP";
+};
+
+type PaygwPeriodRules = {
+  tax_free_threshold: PaygwBracket[];
+  no_tax_free_threshold: PaygwBracket[];
+};
+
+type PaygwRuleset = {
+  version: string;
+  effective_from: string;
+  effective_to: string;
+  rounding: "HALF_UP";
+  periods: Record<PayPeriod, PaygwPeriodRules>;
+};
+
+type GstTaxCodeRule = {
+  rate: number;
+  description: string;
+};
+
+type GstRuleset = {
+  version: string;
+  effective_from: string;
+  effective_to: string;
+  rounding: "HALF_UP";
+  sales_tax_codes: Record<string, GstTaxCodeRule>;
+  purchase_tax_codes: Record<string, GstTaxCodeRule>;
+};
+
+export type PaygwComputation = {
+  withheld: number;
+  ratesVersion: string;
+  effectiveFrom: string;
+  effectiveTo: string;
+};
+
+export type GstSaleLine = {
+  transactionId: string;
+  type: "sale" | "refund";
+  total: number;
+  taxableAmount?: number;
+  gstAmount?: number;
+  taxCode: string;
+};
+
+export type GstPurchaseLine = {
+  purchaseId: string;
+  total: number;
+  gstAmount?: number;
+  taxCode: string;
+  category: "capital" | "non_capital";
+};
+
+export type GstBasket = {
+  sales: GstSaleLine[];
+  purchases: GstPurchaseLine[];
+};
+
+export type GstAdjustments = Partial<{
+  salesAdjustments: number;
+  gstOnSalesAdjustments: number;
+  capitalPurchasesAdjustments: number;
+  nonCapitalPurchasesAdjustments: number;
+  gstOnPurchasesAdjustments: number;
+}>;
+
+export type GstComputation = {
+  totals: {
+    G1: number;
+    "1A": number;
+    G10: number;
+    G11: number;
+    "1B": number;
+  };
+  ratesVersion: string;
+  effectiveFrom: string;
+  effectiveTo: string;
+};
+
+const paygRules = paygJson as PaygwRuleset;
+const gstRules = gstJson as GstRuleset;
+
+const HALF_CENT = 0.0000001;
+
+function roundAmount(amount: number, mode: "HALF_UP" | "DOWN" | "UP" = "HALF_UP"): number {
+  switch (mode) {
+    case "DOWN":
+      return Math.floor(amount * 100 + HALF_CENT) / 100;
+    case "UP":
+      return Math.ceil(amount * 100 - HALF_CENT) / 100;
+    default:
+      return roundHalfUp(amount);
+  }
+}
+
+// Custom HALF_UP round to cents
+function roundHalfUp(amount: number): number {
+  const scaled = Math.round((amount + Number.EPSILON) * 100);
+  return scaled / 100;
+}
+
+export function getPaygw(period: PayPeriod, gross: number, flags: PaygwFlags = {}): PaygwComputation {
+  const rules = paygRules.periods[period];
+  if (!rules) {
+    throw new Error(`Unsupported period ${period}`);
+  }
+  const table = flags.taxFreeThreshold === false ? rules.no_tax_free_threshold : rules.tax_free_threshold;
+  const roundingMode = flags.roundingMode ?? paygRules.rounding;
+  let bracket = table.find(entry => gross >= entry.min && gross < entry.max);
+  if (!bracket) {
+    bracket = table[table.length - 1];
+  }
+
+  let withheld = 0;
+  if (bracket.type === "linear") {
+    withheld = gross * bracket.rate - bracket.offset;
+    if (withheld < 0) withheld = 0;
+  }
+
+  const rounded = roundingMode === "HALF_UP" ? roundHalfUp(withheld) : roundAmount(withheld, roundingMode);
+
+  return {
+    withheld: rounded,
+    ratesVersion: paygRules.version,
+    effectiveFrom: paygRules.effective_from,
+    effectiveTo: paygRules.effective_to,
+  };
+}
+
+export function getGst(basket: GstBasket, _basis: "cash" | "accrual", adjustments: GstAdjustments = {}): GstComputation {
+  let g1 = 0;
+  let g10 = 0;
+  let g11 = 0;
+  let oneA = 0;
+  let oneB = 0;
+
+  for (const line of basket.sales) {
+    const sign = line.type === "refund" ? -1 : 1;
+    const total = roundHalfUp((line.total ?? 0) * sign);
+    const taxCode = gstRules.sales_tax_codes[line.taxCode];
+    const rate = taxCode?.rate ?? 0;
+    const gstAmount = line.gstAmount ?? roundHalfUp((line.taxableAmount ?? line.total ?? 0) * rate);
+
+    g1 += total;
+    oneA += roundHalfUp(gstAmount * sign);
+  }
+
+  for (const purchase of basket.purchases) {
+    const total = roundHalfUp(purchase.total ?? 0);
+    const gstAmount = purchase.gstAmount ?? roundHalfUp(total * (gstRules.purchase_tax_codes[purchase.taxCode]?.rate ?? 0));
+    if (purchase.category === "capital") {
+      g10 += total;
+    } else {
+      g11 += total;
+    }
+    oneB += roundHalfUp(gstAmount);
+  }
+
+  g1 += roundHalfUp(adjustments.salesAdjustments ?? 0);
+  oneA += roundHalfUp(adjustments.gstOnSalesAdjustments ?? 0);
+  g10 += roundHalfUp(adjustments.capitalPurchasesAdjustments ?? 0);
+  g11 += roundHalfUp(adjustments.nonCapitalPurchasesAdjustments ?? 0);
+  oneB += roundHalfUp(adjustments.gstOnPurchasesAdjustments ?? 0);
+
+  return {
+    totals: {
+      G1: roundHalfUp(g1),
+      "1A": roundHalfUp(oneA),
+      G10: roundHalfUp(g10),
+      G11: roundHalfUp(g11),
+      "1B": roundHalfUp(oneB),
+    },
+    ratesVersion: gstRules.version,
+    effectiveFrom: gstRules.effective_from,
+    effectiveTo: gstRules.effective_to,
+  };
+}
+
+export type { PayPeriod, PaygwFlags };

--- a/src/utils/gst.ts
+++ b/src/utils/gst.ts
@@ -1,6 +1,165 @@
-import { GstInput } from "../types/tax";
+import { PoolLike, getPool } from "../db/pool";
+import { GstAdjustments, GstBasket, GstComputation, getGst } from "../tax/rules";
 
-export function calculateGst({ saleAmount, exempt = false }: GstInput): number {
-  if (exempt) return 0;
-  return saleAmount * 0.1;
+export type PosSaleLine = {
+  transactionId: string;
+  type: "sale" | "refund";
+  total: number;
+  taxableAmount?: number;
+  gstAmount?: number;
+  taxCode: string;
+  cashPeriodId?: string | null;
+  accrualPeriodId?: string | null;
+};
+
+export type PosPurchaseLine = {
+  purchaseId: string;
+  total: number;
+  gstAmount?: number;
+  taxCode: string;
+  category: "capital" | "non_capital";
+  cashPeriodId?: string | null;
+  accrualPeriodId?: string | null;
+};
+
+export type PosEventPayload = {
+  eventId: string;
+  abn: string;
+  periodId: string;
+  locationId: string;
+  occurredAt: string;
+  sales: PosSaleLine[];
+  purchases?: PosPurchaseLine[];
+  adjustments?: Partial<GstAdjustments>;
+};
+
+export type GstTotals = GstComputation & {
+  events: number;
+  salesCount: number;
+  purchaseCount: number;
+};
+
+function parsePayload(row: any): PosEventPayload | null {
+  if (!row) return null;
+  const payload = row.payload ?? row;
+  if (!payload) return null;
+  if (typeof payload === "string") {
+    return JSON.parse(payload);
+  }
+  return payload as PosEventPayload;
+}
+
+function shouldInclude({
+  requestedPeriodId,
+  basis,
+  eventPeriodId,
+  cashId,
+  accrualId,
+}: {
+  requestedPeriodId: string;
+  basis: "cash" | "accrual";
+  eventPeriodId: string;
+  cashId?: string | null;
+  accrualId?: string | null;
+}): boolean {
+  if (basis === "cash") {
+    return (cashId ?? accrualId ?? eventPeriodId) === requestedPeriodId;
+  }
+  return (accrualId ?? cashId ?? eventPeriodId) === requestedPeriodId;
+}
+
+export async function computeGstForPeriod({
+  abn,
+  periodId,
+  basis,
+  pool = getPool(),
+}: {
+  abn: string;
+  periodId: string;
+  basis: "cash" | "accrual";
+  pool?: PoolLike;
+}): Promise<GstTotals | null> {
+  const result = await pool.query(
+    "SELECT payload FROM pos_events WHERE abn=$1 AND period_id=$2 ORDER BY received_at ASC",
+    [abn, periodId]
+  );
+
+  if (result.rowCount === 0) {
+    return null;
+  }
+
+  const basket: GstBasket = { sales: [], purchases: [] };
+  const adjustments: GstAdjustments = {};
+  let salesCount = 0;
+  let purchaseCount = 0;
+
+  for (const row of result.rows) {
+    const payload = parsePayload(row);
+    if (!payload) continue;
+
+    for (const sale of payload.sales ?? []) {
+      if (
+        !shouldInclude({
+          requestedPeriodId: periodId,
+          basis,
+          eventPeriodId: payload.periodId,
+          cashId: sale.cashPeriodId,
+          accrualId: sale.accrualPeriodId,
+        })
+      ) {
+        continue;
+      }
+      basket.sales.push({
+        transactionId: sale.transactionId,
+        type: sale.type,
+        total: sale.total,
+        taxableAmount: sale.taxableAmount,
+        gstAmount: sale.gstAmount,
+        taxCode: sale.taxCode,
+      });
+      salesCount += 1;
+    }
+
+    for (const purchase of payload.purchases ?? []) {
+      if (
+        !shouldInclude({
+          requestedPeriodId: periodId,
+          basis,
+          eventPeriodId: payload.periodId,
+          cashId: purchase.cashPeriodId,
+          accrualId: purchase.accrualPeriodId,
+        })
+      ) {
+        continue;
+      }
+      basket.purchases.push({
+        purchaseId: purchase.purchaseId,
+        total: purchase.total,
+        gstAmount: purchase.gstAmount,
+        taxCode: purchase.taxCode,
+        category: purchase.category,
+      });
+      purchaseCount += 1;
+    }
+
+    if (payload.adjustments) {
+      adjustments.salesAdjustments = (adjustments.salesAdjustments ?? 0) + (payload.adjustments.salesAdjustments ?? 0);
+      adjustments.gstOnSalesAdjustments = (adjustments.gstOnSalesAdjustments ?? 0) + (payload.adjustments.gstOnSalesAdjustments ?? 0);
+      adjustments.capitalPurchasesAdjustments =
+        (adjustments.capitalPurchasesAdjustments ?? 0) + (payload.adjustments.capitalPurchasesAdjustments ?? 0);
+      adjustments.nonCapitalPurchasesAdjustments =
+        (adjustments.nonCapitalPurchasesAdjustments ?? 0) + (payload.adjustments.nonCapitalPurchasesAdjustments ?? 0);
+      adjustments.gstOnPurchasesAdjustments =
+        (adjustments.gstOnPurchasesAdjustments ?? 0) + (payload.adjustments.gstOnPurchasesAdjustments ?? 0);
+    }
+  }
+
+  const computation = getGst(basket, basis, adjustments);
+
+  return {
+    ...computation,
+    events: result.rowCount,
+    salesCount,
+    purchaseCount,
+  };
 }

--- a/src/utils/paygw.ts
+++ b/src/utils/paygw.ts
@@ -1,7 +1,106 @@
-import { PaygwInput } from "../types/tax";
+import { PoolLike, getPool } from "../db/pool";
+import { PayPeriod, PaygwFlags, getPaygw } from "../tax/rules";
 
-export function calculatePaygw({ grossIncome, taxWithheld, period, deductions = 0 }: PaygwInput): number {
-  const baseRate = 0.20;
-  const liability = grossIncome * baseRate - deductions - taxWithheld;
-  return Math.max(liability, 0);
+export type StpEmployeeLine = {
+  employeeId: string;
+  gross: number;
+  allowances?: number;
+  deductions?: number;
+  taxWithheld?: number;
+  flags?: PaygwFlags;
+};
+
+export type PayrollEventPayload = {
+  eventId: string;
+  abn: string;
+  payDate: string;
+  period: {
+    frequency: PayPeriod;
+    periodId: string;
+  };
+  employees: StpEmployeeLine[];
+};
+
+export type PaygwTotals = {
+  ratesVersion: string;
+  effectiveFrom: string;
+  effectiveTo: string;
+  totals: {
+    W1: number;
+    W2: number;
+  };
+  events: number;
+  employees: number;
+};
+
+function parsePayload(row: any): PayrollEventPayload | null {
+  if (!row) return null;
+  const payload = row.payload ?? row;
+  if (!payload) return null;
+  if (typeof payload === "string") {
+    return JSON.parse(payload);
+  }
+  return payload as PayrollEventPayload;
+}
+
+function sumValues(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+export async function computePaygwForPeriod({
+  abn,
+  period,
+  periodId,
+  pool = getPool(),
+}: {
+  abn: string;
+  period: PayPeriod;
+  periodId: string;
+  pool?: PoolLike;
+}): Promise<PaygwTotals | null> {
+  const result = await pool.query(
+    "SELECT payload FROM payroll_events WHERE abn=$1 AND period=$2 AND period_id=$3 ORDER BY received_at ASC",
+    [abn, period, periodId]
+  );
+
+  if (result.rowCount === 0) {
+    return null;
+  }
+
+  let w1 = 0;
+  let w2 = 0;
+  let version: string | null = null;
+  let effectiveFrom: string | null = null;
+  let effectiveTo: string | null = null;
+  let employees = 0;
+
+  for (const row of result.rows) {
+    const payload = parsePayload(row);
+    if (!payload) continue;
+    for (const employee of payload.employees ?? []) {
+      employees += 1;
+      const gross = Number(employee.gross ?? 0);
+      const allowances = Number(employee.allowances ?? 0);
+      const deductions = Number(employee.deductions ?? 0);
+      const taxableGross = gross + allowances - deductions;
+      w1 += taxableGross;
+      const calc = getPaygw(period, taxableGross, employee.flags);
+      version = calc.ratesVersion;
+      effectiveFrom = calc.effectiveFrom;
+      effectiveTo = calc.effectiveTo;
+      w2 += calc.withheld;
+    }
+  }
+
+  return {
+    ratesVersion: version ?? "",
+    effectiveFrom: effectiveFrom ?? "",
+    effectiveTo: effectiveTo ?? "",
+    totals: {
+      W1: sumValues(w1),
+      W2: sumValues(w2),
+    },
+    events: result.rowCount,
+    employees,
+  };
 }

--- a/src/vendor/react-query.tsx
+++ b/src/vendor/react-query.tsx
@@ -1,0 +1,99 @@
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+
+type QueryKey = readonly unknown[];
+
+type QueryState<TData> = {
+  data?: TData;
+  error?: unknown;
+  isFetching: boolean;
+};
+
+type UseQueryOptions<TData> = {
+  queryKey: QueryKey;
+  queryFn: () => Promise<TData>;
+  enabled?: boolean;
+  retry?: boolean | number;
+};
+
+type UseQueryResult<TData> = QueryState<TData> & {
+  refetch: () => Promise<void>;
+};
+
+class QueryClient {
+  private cache = new Map<string, unknown>();
+
+  get<TData>(key: string): TData | undefined {
+    return this.cache.get(key) as TData | undefined;
+  }
+
+  set<TData>(key: string, value: TData): void {
+    this.cache.set(key, value);
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+}
+
+const QueryClientContext = createContext<QueryClient | null>(null);
+
+function normaliseKey(key: QueryKey): string {
+  return JSON.stringify(key);
+}
+
+export function QueryClientProvider({ client, children }: { client: QueryClient; children: React.ReactNode }) {
+  return <QueryClientContext.Provider value={client}>{children}</QueryClientContext.Provider>;
+}
+
+export function useQuery<TData>(options: UseQueryOptions<TData>): UseQueryResult<TData> {
+  const client = useContext(QueryClientContext);
+  if (!client) {
+    throw new Error("QueryClientProvider missing");
+  }
+
+  const { queryKey, queryFn, enabled = true } = options;
+  const key = useMemo(() => normaliseKey(queryKey), [queryKey]);
+  const mounted = useRef(true);
+  const initial = client.get<TData>(key);
+
+  const [state, setState] = useState<QueryState<TData>>({ data: initial, isFetching: enabled && !initial });
+
+  const run = useMemo(
+    () =>
+      async () => {
+        if (!enabled) return;
+        setState(prev => ({ ...prev, isFetching: true }));
+        try {
+          const data = await queryFn();
+          if (mounted.current) {
+            client.set(key, data);
+            setState({ data, isFetching: false });
+          }
+        } catch (error) {
+          if (mounted.current) {
+            setState(prev => ({ ...prev, error, isFetching: false }));
+          }
+        }
+      },
+    [client, queryFn, enabled, key]
+  );
+
+  useEffect(() => {
+    mounted.current = true;
+    if (enabled && !client.get<TData>(key)) {
+      void run();
+    }
+    return () => {
+      mounted.current = false;
+    };
+  }, [client, enabled, key, run]);
+
+  return {
+    data: state.data,
+    error: state.error,
+    isFetching: state.isFetching,
+    refetch: run,
+  };
+}
+
+export { QueryClient };

--- a/tests/helpers/server.ts
+++ b/tests/helpers/server.ts
@@ -1,0 +1,153 @@
+import express from "express";
+
+import { setPool } from "../../src/db/pool";
+import { posIngestRouter } from "../../src/ingest/pos";
+import { stpIngestRouter } from "../../src/ingest/stp";
+import { taxApi } from "../../src/tax/api";
+
+type QueryResult = { rows: any[]; rowCount: number };
+
+type PayloadRow = {
+  event_id: string;
+  abn: string;
+  period?: string;
+  period_id: string;
+  payload: any;
+  received_at: string;
+};
+
+class MemoryPool {
+  private payrollEvents = new Map<string, PayloadRow>();
+  private payrollDlq: any[] = [];
+  private posEvents = new Map<string, PayloadRow>();
+  private posDlq: any[] = [];
+
+  async query(sql: string, params: any[] = []): Promise<QueryResult> {
+    const trimmed = sql.trim().toLowerCase();
+    if (trimmed.startsWith("insert into payroll_events")) {
+      const [eventId, abn, period, periodId, payload] = params;
+      const row: PayloadRow = {
+        event_id: eventId,
+        abn,
+        period,
+        period_id: periodId,
+        payload: typeof payload === "string" ? JSON.parse(payload) : payload,
+        received_at: new Date().toISOString(),
+      };
+      this.payrollEvents.set(eventId, row);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (trimmed.startsWith("insert into payroll_dlq")) {
+      const [reason, raw] = params;
+      this.payrollDlq.push({ reason, raw_payload: typeof raw === "string" ? JSON.parse(raw) : raw });
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (trimmed.startsWith("insert into pos_events")) {
+      const [eventId, abn, periodId, payload] = params;
+      const row: PayloadRow = {
+        event_id: eventId,
+        abn,
+        period_id: periodId,
+        payload: typeof payload === "string" ? JSON.parse(payload) : payload,
+        received_at: new Date().toISOString(),
+      };
+      this.posEvents.set(eventId, row);
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (trimmed.startsWith("insert into pos_dlq")) {
+      const [reason, raw] = params;
+      this.posDlq.push({ reason, raw_payload: typeof raw === "string" ? JSON.parse(raw) : raw });
+      return { rows: [], rowCount: 1 };
+    }
+
+    if (trimmed.startsWith("select payload from payroll_events")) {
+      const [abn, period, periodId] = params;
+      const rows = Array.from(this.payrollEvents.values())
+        .filter(row => row.abn === abn && row.period === period && row.period_id === periodId)
+        .sort((a, b) => a.received_at.localeCompare(b.received_at))
+        .map(row => ({ payload: row.payload }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (trimmed.startsWith("select payload from pos_events")) {
+      const [abn, periodId] = params;
+      const rows = Array.from(this.posEvents.values())
+        .filter(row => row.abn === abn && row.period_id === periodId)
+        .sort((a, b) => a.received_at.localeCompare(b.received_at))
+        .map(row => ({ payload: row.payload }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (trimmed.startsWith("select * from payroll_dlq")) {
+      return { rows: this.payrollDlq.map((raw, idx) => ({ id: idx + 1, ...raw })), rowCount: this.payrollDlq.length };
+    }
+
+    if (trimmed.startsWith("select * from pos_dlq")) {
+      return { rows: this.posDlq.map((raw, idx) => ({ id: idx + 1, ...raw })), rowCount: this.posDlq.length };
+    }
+
+    if (trimmed.startsWith("select * from payroll_events")) {
+      const rows = Array.from(this.payrollEvents.values()).map(row => ({
+        event_id: row.event_id,
+        abn: row.abn,
+        period: row.period,
+        period_id: row.period_id,
+        payload: row.payload,
+      }));
+      return { rows, rowCount: rows.length };
+    }
+
+    if (trimmed.startsWith("select * from pos_events")) {
+      const rows = Array.from(this.posEvents.values()).map(row => ({
+        event_id: row.event_id,
+        abn: row.abn,
+        period_id: row.period_id,
+        payload: row.payload,
+      }));
+      return { rows, rowCount: rows.length };
+    }
+
+    throw new Error(`Unsupported query: ${sql}`);
+  }
+
+  async connect() {
+    return {
+      query: (sql: string, params?: any[]) => this.query(sql, params),
+      release: () => {},
+    };
+  }
+
+  async end() {
+    this.payrollEvents.clear();
+    this.posEvents.clear();
+    this.payrollDlq = [];
+    this.posDlq = [];
+  }
+}
+
+export async function createTestServer() {
+  const pool = new MemoryPool();
+  setPool(pool as unknown as any);
+
+  const app = express();
+  app.use(
+    express.json({
+      verify: (req, _res, buf) => {
+        (req as express.Request & { rawBody?: Buffer }).rawBody = Buffer.from(buf);
+      },
+    })
+  );
+  app.use("/ingest/stp", stpIngestRouter);
+  app.use("/ingest/pos", posIngestRouter);
+  app.use("/tax", taxApi);
+
+  return { app, pool };
+}
+
+export async function destroyTestServer(pool: MemoryPool) {
+  await pool.end();
+  setPool(null);
+}

--- a/tests/ingest/dlq.test.ts
+++ b/tests/ingest/dlq.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { createTestServer, destroyTestServer } from "../helpers/server";
+
+let app: ReturnType<typeof createTestServer> extends Promise<infer T> ? T["app"] : never;
+let pool: any;
+let server: any;
+let baseUrl: string;
+
+describe("ingest DLQ", () => {
+  beforeEach(async () => {
+    const ctx = await createTestServer();
+    app = ctx.app;
+    pool = ctx.pool;
+    process.env.STP_WEBHOOK_SECRET = "stp-secret";
+    process.env.POS_WEBHOOK_SECRET = "pos-secret";
+
+    server = await new Promise(resolve => {
+      const listener = app.listen(0, () => resolve(listener));
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise(resolve => server.close(resolve));
+    await destroyTestServer(pool);
+    delete process.env.STP_WEBHOOK_SECRET;
+    delete process.env.POS_WEBHOOK_SECRET;
+  });
+
+  it("routes invalid STP signatures to the DLQ", async () => {
+    const payload = {
+      eventId: "bad-stp",
+      abn: "12345678901",
+      payDate: "2024-07-01",
+      period: { frequency: "weekly", periodId: "2024-W01" },
+      employees: [{ employeeId: "E1", gross: 1000 }],
+    };
+
+    const res = await fetch(`${baseUrl}/ingest/stp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-signature": "bad",
+      },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(res.status, 202);
+
+    const dlq = await pool.query("SELECT * FROM payroll_dlq");
+    assert.equal(dlq.rowCount, 1);
+    const events = await pool.query("SELECT * FROM payroll_events");
+    assert.equal(events.rowCount, 0);
+  });
+
+  it("persists valid STP events", async () => {
+    const payload = {
+      eventId: "good-stp",
+      abn: "12345678901",
+      payDate: "2024-07-01",
+      period: { frequency: "weekly", periodId: "2024-W01" },
+      employees: [{ employeeId: "E1", gross: 1000 }],
+    };
+
+    const signature = crypto.createHmac("sha256", process.env.STP_WEBHOOK_SECRET!).update(JSON.stringify(payload)).digest("hex");
+    const res = await fetch(`${baseUrl}/ingest/stp`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-signature": signature,
+      },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(res.status, 200);
+
+    const events = await pool.query("SELECT * FROM payroll_events");
+    assert.equal(events.rowCount, 1);
+    const dlq = await pool.query("SELECT * FROM payroll_dlq");
+    assert.equal(dlq.rowCount, 0);
+  });
+
+  it("routes invalid POS signatures to the DLQ", async () => {
+    const payload = {
+      eventId: "bad-pos",
+      abn: "12345678901",
+      periodId: "2024-07",
+      occurredAt: "2024-07-02T00:00:00Z",
+      locationId: "store-1",
+      sales: [{ transactionId: "s1", type: "sale", total: 100, taxCode: "GST" }],
+    };
+
+    const res = await fetch(`${baseUrl}/ingest/pos`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-signature": "bad",
+      },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(res.status, 202);
+
+    const dlq = await pool.query("SELECT * FROM pos_dlq");
+    assert.equal(dlq.rowCount, 1);
+    const events = await pool.query("SELECT * FROM pos_events");
+    assert.equal(events.rowCount, 0);
+  });
+
+  it("persists valid POS events", async () => {
+    const payload = {
+      eventId: "good-pos",
+      abn: "12345678901",
+      periodId: "2024-07",
+      occurredAt: "2024-07-02T00:00:00Z",
+      locationId: "store-1",
+      sales: [{ transactionId: "s1", type: "sale", total: 100, taxCode: "GST" }],
+    };
+
+    const signature = crypto.createHmac("sha256", process.env.POS_WEBHOOK_SECRET!).update(JSON.stringify(payload)).digest("hex");
+    const res = await fetch(`${baseUrl}/ingest/pos`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-signature": signature,
+      },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(res.status, 200);
+
+    const events = await pool.query("SELECT * FROM pos_events");
+    assert.equal(events.rowCount, 1);
+    const dlq = await pool.query("SELECT * FROM pos_dlq");
+    assert.equal(dlq.rowCount, 0);
+  });
+});

--- a/tests/tax/golden_gst.test.ts
+++ b/tests/tax/golden_gst.test.ts
@@ -1,0 +1,131 @@
+import crypto from "node:crypto";
+import assert from "node:assert/strict";
+import { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { createTestServer, destroyTestServer } from "../helpers/server";
+
+let app: ReturnType<typeof createTestServer> extends Promise<infer T> ? T["app"] : never;
+let pool: any;
+let server: any;
+let baseUrl: string;
+
+describe("GST golden vectors", () => {
+  beforeEach(async () => {
+    const ctx = await createTestServer();
+    app = ctx.app;
+    pool = ctx.pool;
+    process.env.POS_WEBHOOK_SECRET = "pos-secret";
+    process.env.STP_WEBHOOK_SECRET = "stp-secret";
+
+    server = await new Promise(resolve => {
+      const listener = app.listen(0, () => resolve(listener));
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise(resolve => server.close(resolve));
+    await destroyTestServer(pool);
+    delete process.env.POS_WEBHOOK_SECRET;
+    delete process.env.STP_WEBHOOK_SECRET;
+  });
+
+  it("produces cash and accrual totals for mixed baskets", async () => {
+    const payload = {
+      eventId: "pos-evt-1",
+      abn: "12345678901",
+      periodId: "2024-07",
+      occurredAt: "2024-07-15T10:00:00Z",
+      locationId: "store-1",
+      sales: [
+        {
+          transactionId: "S1",
+          type: "sale",
+          total: 110,
+          taxableAmount: 100,
+          gstAmount: 10,
+          taxCode: "GST",
+          cashPeriodId: "2024-07",
+          accrualPeriodId: "2024-07",
+        },
+        {
+          transactionId: "S2",
+          type: "sale",
+          total: 55,
+          taxableAmount: 55,
+          gstAmount: 0,
+          taxCode: "FRE",
+          cashPeriodId: "2024-07",
+          accrualPeriodId: "2024-07",
+        },
+        {
+          transactionId: "S3",
+          type: "refund",
+          total: 22,
+          taxableAmount: 20,
+          gstAmount: 2,
+          taxCode: "GST",
+          cashPeriodId: "2024-07",
+          accrualPeriodId: "2024-07",
+        },
+      ],
+      purchases: [
+        {
+          purchaseId: "P1",
+          total: 220,
+          gstAmount: 20,
+          taxCode: "GST",
+          category: "capital",
+          cashPeriodId: "2024-07",
+          accrualPeriodId: "2024-07",
+        },
+        {
+          purchaseId: "P2",
+          total: 110,
+          gstAmount: 10,
+          taxCode: "GST",
+          category: "non_capital",
+          cashPeriodId: "2024-08",
+          accrualPeriodId: "2024-07",
+        },
+      ],
+      adjustments: {
+        salesAdjustments: 5,
+      },
+    };
+
+    const signature = crypto.createHmac("sha256", process.env.POS_WEBHOOK_SECRET!).update(JSON.stringify(payload)).digest("hex");
+    const ingestRes = await fetch(`${baseUrl}/ingest/pos`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-signature": signature,
+      },
+      body: JSON.stringify(payload),
+    });
+    assert.equal(ingestRes.status, 200);
+
+    const cashRes = await fetch(`${baseUrl}/tax/gst?abn=12345678901&period_id=2024-07&basis=cash`);
+    assert.equal(cashRes.status, 200);
+    const cashJson = await cashRes.json();
+    assert.ok(Math.abs(cashJson.totals.G1 - 148) < 0.01);
+    assert.ok(Math.abs(cashJson.totals["1A"] - 8) < 0.01);
+    assert.ok(Math.abs(cashJson.totals.G10 - 220) < 0.01);
+    assert.ok(Math.abs(cashJson.totals.G11 - 0) < 0.01);
+    assert.ok(Math.abs(cashJson.totals["1B"] - 20) < 0.01);
+    assert.equal(cashJson.sales, 3);
+    assert.equal(cashJson.purchases, 1);
+
+    const accrualRes = await fetch(`${baseUrl}/tax/gst?abn=12345678901&period_id=2024-07&basis=accrual`);
+    assert.equal(accrualRes.status, 200);
+    const accrualJson = await accrualRes.json();
+    assert.ok(Math.abs(accrualJson.totals.G1 - 148) < 0.01);
+    assert.ok(Math.abs(accrualJson.totals["1A"] - 8) < 0.01);
+    assert.ok(Math.abs(accrualJson.totals.G10 - 220) < 0.01);
+    assert.ok(Math.abs(accrualJson.totals.G11 - 110) < 0.01);
+    assert.ok(Math.abs(accrualJson.totals["1B"] - 30) < 0.01);
+    assert.equal(accrualJson.purchases, 2);
+  });
+});

--- a/tests/tax/golden_paygw.test.ts
+++ b/tests/tax/golden_paygw.test.ts
@@ -1,0 +1,104 @@
+import crypto from "node:crypto";
+import assert from "node:assert/strict";
+import { AddressInfo } from "node:net";
+import { afterEach, beforeEach, describe, it } from "node:test";
+
+import { createTestServer, destroyTestServer } from "../helpers/server";
+
+let app: ReturnType<typeof createTestServer> extends Promise<infer T> ? T["app"] : never;
+let pool: any;
+let server: any;
+let baseUrl: string;
+
+describe("PAYGW golden vectors", () => {
+  beforeEach(async () => {
+    const serverCtx = await createTestServer();
+    app = serverCtx.app;
+    pool = serverCtx.pool;
+    process.env.STP_WEBHOOK_SECRET = "stp-secret";
+
+    server = await new Promise(resolve => {
+      const listener = app.listen(0, () => resolve(listener));
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise(resolve => server.close(resolve));
+    await destroyTestServer(pool);
+    delete process.env.STP_WEBHOOK_SECRET;
+  });
+
+  it("aggregates weekly, fortnightly and monthly payroll events", async () => {
+    const weekly = {
+      eventId: "stp-week-1",
+      abn: "12345678901",
+      payDate: "2024-07-05",
+      period: { frequency: "weekly", periodId: "2024-W01" },
+      employees: [
+        { employeeId: "E1", gross: 950.55, allowances: 25, deductions: 10 },
+        { employeeId: "E2", gross: 420.4 },
+        { employeeId: "E3", gross: 359.01 },
+      ],
+    };
+
+    const fortnightly = {
+      eventId: "stp-fn-1",
+      abn: "12345678901",
+      payDate: "2024-07-12",
+      period: { frequency: "fortnightly", periodId: "2024-FN01" },
+      employees: [
+        { employeeId: "F1", gross: 2100 },
+        { employeeId: "F2", gross: 900, flags: { taxFreeThreshold: false } },
+      ],
+    };
+
+    const monthly = {
+      eventId: "stp-month-1",
+      abn: "12345678901",
+      payDate: "2024-07-31",
+      period: { frequency: "monthly", periodId: "2024-07" },
+      employees: [
+        { employeeId: "M1", gross: 5000, allowances: 100, deductions: 50 },
+        { employeeId: "M2", gross: 1800 },
+      ],
+    };
+
+    for (const payload of [weekly, fortnightly, monthly]) {
+      const signature = crypto.createHmac("sha256", process.env.STP_WEBHOOK_SECRET!).update(JSON.stringify(payload)).digest("hex");
+      const res = await fetch(`${baseUrl}/ingest/stp`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-signature": signature,
+        },
+        body: JSON.stringify(payload),
+      });
+      assert.equal(res.status, 200);
+    }
+
+    const weeklyRes = await fetch(`${baseUrl}/tax/paygw?abn=12345678901&period=weekly&period_id=2024-W01`);
+    assert.equal(weeklyRes.status, 200);
+    const weeklyJson = await weeklyRes.json();
+    assert.ok(Math.abs(weeklyJson.totals.W1 - 1744.96) < 0.01);
+    assert.ok(Math.abs(weeklyJson.totals.W2 - 205.08) < 0.01);
+    assert.equal(weeklyJson.employees, 3);
+    assert.equal(weeklyJson.events, 1);
+    assert.equal(weeklyJson.rates_version, "2024-25");
+
+    const fortnightRes = await fetch(`${baseUrl}/tax/paygw?abn=12345678901&period=fortnightly&period_id=2024-FN01`);
+    assert.equal(fortnightRes.status, 200);
+    const fortnightJson = await fortnightRes.json();
+    assert.ok(Math.abs(fortnightJson.totals.W1 - 3000) < 0.01);
+    assert.ok(Math.abs(fortnightJson.totals.W2 - 705.42) < 0.01);
+    assert.equal(fortnightJson.employees, 2);
+
+    const monthlyRes = await fetch(`${baseUrl}/tax/paygw?abn=12345678901&period=monthly&period_id=2024-07`);
+    assert.equal(monthlyRes.status, 200);
+    const monthlyJson = await monthlyRes.json();
+    assert.ok(Math.abs(monthlyJson.totals.W1 - 6850) < 0.01);
+    assert.ok(Math.abs(monthlyJson.totals.W2 - 1220.85) < 0.01);
+    assert.equal(monthlyJson.employees, 2);
+  });
+});


### PR DESCRIPTION
## Summary
- add 2024–25 PAYGW and GST rule files and loaders to calculate withholding and GST labels per period
- add STP and POS ingestion routes with HMAC validation, DLQ handling, and tax aggregation endpoints
- update calculators to fetch live totals via a lightweight query client and add golden vector and DLQ tests

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68e4069d2c488327a37c3c181e148d90