### PR TITLE
Clarify pnpm workflow in README and env guide

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,14 @@
+# Copy this file to .env.local (not committed) to configure local development.
+# Values here are safe defaults for running the prototype stack locally.
+
+APP_MODE=prototype
+FEATURE_SIM_OUTBOUND=true
+RATES_VERSION=2024-25
+
+# Browser/Next.js-compatible base URL for API requests.
+NEXT_PUBLIC_API_BASE_URL=http://localhost:3000
+# Optional: override the payments service base URL for the browser.
+#NEXT_PUBLIC_PAYMENTS_BASE_URL=http://localhost:3001
+
+# Shared secrets for signing/verifying tokens. Replace in non-dev environments.
+JWT_SECRET=dev-change-me

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,8 @@ Thumbs.db
 # IDE
 .vscode/
 .idea/
+
+# Environment overrides
+.env.local
+.env*
+!.env.local.example

--- a/README.md
+++ b/README.md
@@ -22,24 +22,68 @@ Security:
 Placeholder for MFA and encryption; easy to extend for production environments.
 
 Getting Started
-Clone the Repository
 
-git clone <your-repo-url>
-cd apgms
+1. **Clone the repository**
 
-Install Dependencies
+   ```bash
+   git clone <your-repo-url>
+   cd apgms
+   ```
 
-npm install
+2. **Install dependencies with pnpm**
 
-Run the Development Server
+   This workspace is configured for [pnpm](https://pnpm.io/) (see the
+   `packageManager` entry in `package.json`). If pnpm is not enabled on your
+   machine yet, run `corepack enable` once, then install dependencies:
 
-npm start
+   ```bash
+   pnpm install
+   ```
 
-The app will start on http://localhost:3000
+3. **Configure environment variables**
 
-Build for Production
+   ```bash
+   cp .env.local.example .env.local
+   # then edit .env.local as needed for your setup
+   ```
 
-npm run build
+   The variables in `.env.local` are described in detail in
+   [docs/environment.md](docs/environment.md).
+
+4. **Run the application**
+
+   For the TypeScript development server with automatic reload:
+
+   ```bash
+   pnpm dev
+   ```
+
+   To run the compiled JavaScript output (after building):
+
+   ```bash
+   pnpm start
+   ```
+
+5. **Build for production**
+
+   ```bash
+   pnpm build
+   ```
+
+The default API server listens on <http://localhost:3000>.
+
+### Available scripts
+
+The root `package.json` exposes a few scripts you can run with `pnpm` (or
+`npm run`/`yarn` if you prefer those CLIs):
+
+| Script | Command | When to use it |
+| --- | --- | --- |
+| `pnpm dev` | `tsx src/index.ts` | Start the TypeScript server with hot reloading during development. |
+| `pnpm start` | `node dist/index.js` | Run the compiled server output (make sure to run `pnpm build` first). |
+| `pnpm build` | `echo build root` | Placeholder build step; replace with a real bundler when you add one. |
+| `pnpm typecheck` | `echo typecheck root` | Stub that you can expand to run TypeScript type checks in CI. |
+| `pnpm lint` | `echo lint root` | Stub for linting. Hook up ESLint/biome/etc. as needed. |
 
 Project Structure
 apgms/
@@ -89,3 +133,5 @@ For demonstration and prototyping only—real-world deployments require further 
 Contributing
 Pull requests are welcome!
 For major changes, please open an issue first to discuss what you’d like to change.
+
+Additional documentation is available in [docs/environment.md](docs/environment.md).

--- a/docs/environment.md
+++ b/docs/environment.md
@@ -1,0 +1,54 @@
+# Environment configuration
+
+This project relies on a small set of environment variables so the different
+services (API, browser UI, and background workers) can discover each other
+without hard-coding URLs or secrets. The backend reads variables from a
+`.env.local` file at startup, while the browser bundles pick up variables with
+`NEXT_PUBLIC_` prefixes at build time.
+
+## Quick start
+
+1. Copy the example file into place:
+   ```bash
+   cp .env.local.example .env.local
+   ```
+2. Adjust any values as needed for your environment.
+3. Start the stack with the script that matches your workflow—`pnpm dev` for the
+   hot-reload TypeScript server, `pnpm start` for the compiled output, or your
+   preferred Docker compose target. The server automatically loads `.env.local`
+   via `dotenv` and exposes browser-facing values through your build tooling.
+
+> **Note**
+> `.env.local` is ignored by git so you can safely keep machine-specific values
+> without committing secrets to the repository.
+
+## Variables
+
+| Variable | Scope | Default | Purpose |
+| --- | --- | --- | --- |
+| `APP_MODE` | Server & UI | `prototype` | Enables prototype-friendly behaviour throughout the stack. Leave as `prototype` for local testing. |
+| `FEATURE_SIM_OUTBOUND` | Server & UI | `true` | Keeps the outbound payments rail in simulation mode. Switch to `false` only when you have a real payments adapter wired in. |
+| `RATES_VERSION` | Server & UI | `2024-25` | Identifies which PAYGW/GST rate table to display. Useful for toggling between compliance years in demos. |
+| `NEXT_PUBLIC_API_BASE_URL` | Browser | `http://localhost:3000` | Base URL that the front-end uses when calling the main API. Because it is `NEXT_PUBLIC_`, it is safe for browser consumption. |
+| `NEXT_PUBLIC_PAYMENTS_BASE_URL` | Browser | _(optional)_ | Override for the payments microservice. If omitted the UI falls back to the server's default (`http://localhost:3001`). |
+| `JWT_SECRET` | Server | `dev-change-me` | Secret used to sign JSON Web Tokens in development. Replace with a strong secret before deploying anywhere shared. |
+
+### Related server variables
+
+The repository already supports the standard Postgres variables (`PGHOST`,
+`PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, `DATABASE_URL`) plus optional
+ATO/payments configuration (`RPT_ED25519_SECRET_BASE64`, etc.). Those are still
+available if you need to customise the backend, but they are not required for
+the basic prototype setup above.
+
+### Verifying the configuration
+
+Run the health endpoint after starting the stack to confirm the server picked up
+your `.env.local` values:
+
+```bash
+curl http://localhost:3000/health
+```
+
+A JSON response (`{"ok": true}`) indicates the configuration loaded correctly
+and the server connected to the database.


### PR DESCRIPTION
## Summary
- rewrite the README getting started flow to emphasise pnpm usage and list the available scripts
- reference the environment guide from the setup steps and document when to use each script
- align the environment guide quick-start instructions with the pnpm workflow

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68e44126e1088327b29001b82b7e4a26